### PR TITLE
Use constants for DBAL types in tests

### DIFF
--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class AutoIncrementColumnTest extends FunctionalTestCase
 {
@@ -13,7 +14,7 @@ class AutoIncrementColumnTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('auto_increment_table');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function fopen;
 use function str_repeat;
@@ -23,9 +24,9 @@ class BlobTest extends FunctionalTestCase
         }
 
         $table = new Table('blob_table');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('clobcolumn', 'text', ['notnull' => false]);
-        $table->addColumn('blobcolumn', 'blob', ['notnull' => false]);
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('clobcolumn', Types::TEXT, ['notnull' => false]);
+        $table->addColumn('blobcolumn', Types::BLOB, ['notnull' => false]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -173,7 +174,10 @@ class BlobTest extends FunctionalTestCase
     {
         [, $blobValue] = $this->fetchRow();
 
-        $blobValue = Type::getType('blob')->convertToPHPValue($blobValue, $this->connection->getDatabasePlatform());
+        $blobValue = Type::getType(Types::BLOB)->convertToPHPValue(
+            $blobValue,
+            $this->connection->getDatabasePlatform(),
+        );
 
         self::assertIsResource($blobValue);
         self::assertEquals($text, stream_get_contents($blobValue));

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -433,7 +433,7 @@ class ConnectionTest extends FunctionalTestCase
     private function createTestTable(): void
     {
         $table = new Table(self::TABLE);
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -26,9 +26,9 @@ class DataAccessTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('fetch_table');
-        $table->addColumn('test_int', 'integer');
-        $table->addColumn('test_string', 'string');
-        $table->addColumn('test_datetime', 'datetime', ['notnull' => false]);
+        $table->addColumn('test_int', Types::INTEGER);
+        $table->addColumn('test_string', Types::STRING);
+        $table->addColumn('test_datetime', Types::DATETIME_MUTABLE, ['notnull' => false]);
         $table->setPrimaryKey(['test_int']);
 
         $this->dropAndCreateTable($table);
@@ -438,8 +438,8 @@ class DataAccessTest extends FunctionalTestCase
         }
 
         $table = new Table('fetch_table_date_math');
-        $table->addColumn('test_date', 'date');
-        $table->addColumn('test_days', 'integer');
+        $table->addColumn('test_date', Types::DATE_MUTABLE);
+        $table->addColumn('test_days', Types::INTEGER);
         $table->setPrimaryKey(['test_date']);
 
         $sm = $this->connection->getSchemaManager();

--- a/tests/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Functional/Driver/OCI8/ConnectionTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Driver\OCI8;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
 
 /** @requires extension oci8 */
 class ConnectionTest extends FunctionalTestCase
@@ -21,8 +22,8 @@ class ConnectionTest extends FunctionalTestCase
     public function testLastInsertIdAcceptsFqn(): void
     {
         $table = new Table('DBAL2595');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
 use Throwable;
 
 use function array_merge;
@@ -32,7 +33,7 @@ class ExceptionTest extends FunctionalTestCase
     public function testPrimaryConstraintViolationException(): void
     {
         $table = new Table('duplicatekey_table');
-        $table->addColumn('id', 'integer', []);
+        $table->addColumn('id', Types::INTEGER, []);
         $table->setPrimaryKey(['id']);
         $this->dropAndCreateTable($table);
 
@@ -54,7 +55,7 @@ class ExceptionTest extends FunctionalTestCase
     {
         $schemaManager = $this->connection->getSchemaManager();
         $table         = new Table('alreadyexist_table');
-        $table->addColumn('id', 'integer', []);
+        $table->addColumn('id', Types::INTEGER, []);
         $table->setPrimaryKey(['id']);
 
         $this->expectException(Exception\TableExistsException::class);
@@ -187,8 +188,8 @@ class ExceptionTest extends FunctionalTestCase
     public function testNotNullConstraintViolationException(): void
     {
         $table = new Table('notnull_table');
-        $table->addColumn('id', 'integer', []);
-        $table->addColumn('val', 'integer', ['notnull' => true]);
+        $table->addColumn('id', Types::INTEGER, []);
+        $table->addColumn('val', Types::INTEGER, ['notnull' => true]);
         $table->setPrimaryKey(['id']);
         $this->dropAndCreateTable($table);
 
@@ -199,7 +200,7 @@ class ExceptionTest extends FunctionalTestCase
     public function testInvalidFieldNameException(): void
     {
         $table = new Table('bad_columnname_table');
-        $table->addColumn('id', 'integer', []);
+        $table->addColumn('id', Types::INTEGER, []);
         $this->dropAndCreateTable($table);
 
         // prevent the PHPUnit error handler from handling the warning that db2_bind_param() may trigger
@@ -212,11 +213,11 @@ class ExceptionTest extends FunctionalTestCase
     public function testNonUniqueFieldNameException(): void
     {
         $table1 = new Table('ambiguous_list_table_1');
-        $table1->addColumn('id', 'integer');
+        $table1->addColumn('id', Types::INTEGER);
         $this->dropAndCreateTable($table1);
 
         $table2 = new Table('ambiguous_list_table_2');
-        $table2->addColumn('id', 'integer');
+        $table2->addColumn('id', Types::INTEGER);
         $this->dropAndCreateTable($table2);
 
         $sql = 'SELECT id FROM ambiguous_list_table_1, ambiguous_list_table_2';
@@ -227,7 +228,7 @@ class ExceptionTest extends FunctionalTestCase
     public function testUniqueConstraintViolationException(): void
     {
         $table = new Table('unique_column_table');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addUniqueIndex(['id']);
 
         $this->dropAndCreateTable($table);
@@ -240,7 +241,7 @@ class ExceptionTest extends FunctionalTestCase
     public function testSyntaxErrorException(): void
     {
         $table = new Table('syntax_error_table');
-        $table->addColumn('id', 'integer', []);
+        $table->addColumn('id', Types::INTEGER, []);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -280,7 +281,7 @@ class ExceptionTest extends FunctionalTestCase
 
         $schema = new Schema();
         $table  = $schema->createTable('no_connection');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         $this->expectException(Exception\ReadOnlyException::class);
         $this->expectExceptionMessage(
@@ -354,12 +355,12 @@ class ExceptionTest extends FunctionalTestCase
         $schemaManager = $this->connection->getSchemaManager();
 
         $table = new Table('constraint_error_table');
-        $table->addColumn('id', 'integer', []);
+        $table->addColumn('id', Types::INTEGER, []);
         $table->setPrimaryKey(['id']);
 
         $owningTable = new Table('owning_table');
-        $owningTable->addColumn('id', 'integer', []);
-        $owningTable->addColumn('constraint_id', 'integer', []);
+        $owningTable->addColumn('id', Types::INTEGER, []);
+        $owningTable->addColumn('constraint_id', Types::INTEGER, []);
         $owningTable->setPrimaryKey(['id']);
         $owningTable->addForeignKeyConstraint($table, ['constraint_id'], ['id']);
 

--- a/tests/Functional/LegacyAPITest.php
+++ b/tests/Functional/LegacyAPITest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use LogicException;
 
@@ -20,8 +21,8 @@ class LegacyAPITest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('legacy_table');
-        $table->addColumn('test_int', 'integer');
-        $table->addColumn('test_string', 'string');
+        $table->addColumn('test_int', Types::INTEGER);
+        $table->addColumn('test_string', Types::STRING);
         $table->setPrimaryKey(['test_int']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use Doctrine\DBAL\Types\Types;
 
 class NoneTest extends FunctionalTestCase
 {
@@ -37,7 +38,7 @@ class NoneTest extends FunctionalTestCase
         }
 
         $table = new Table('users');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
 use function count;
@@ -18,12 +19,12 @@ class ModifyLimitQueryTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('modify_limit_table');
-        $table->addColumn('test_int', 'integer');
+        $table->addColumn('test_int', Types::INTEGER);
         $table->setPrimaryKey(['test_int']);
 
         $table2 = new Table('modify_limit_table2');
-        $table2->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table2->addColumn('test_int', 'integer');
+        $table2->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table2->addColumn('test_int', Types::INTEGER);
         $table2->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 use Throwable;
 
 use function array_change_key_case;
@@ -154,9 +155,9 @@ class NamedParametersTest extends FunctionalTestCase
 
         try {
             $table = new Table('ddc1372_foobar');
-            $table->addColumn('id', 'integer');
-            $table->addColumn('foo', 'string');
-            $table->addColumn('bar', 'string');
+            $table->addColumn('id', Types::INTEGER);
+            $table->addColumn('foo', Types::STRING);
+            $table->addColumn('bar', Types::STRING);
             $table->setPrimaryKey(['id']);
 
             $sm = $this->connection->getSchemaManager();

--- a/tests/Functional/Platform/AlterColumnTest.php
+++ b/tests/Functional/Platform/AlterColumnTest.php
@@ -15,8 +15,8 @@ class AlterColumnTest extends FunctionalTestCase
     public function testColumnPositionRetainedAfterAltering(): void
     {
         $table = new Table('test_alter');
-        $table->addColumn('c1', 'integer');
-        $table->addColumn('c2', 'integer');
+        $table->addColumn('c1', Types::INTEGER);
+        $table->addColumn('c2', Types::INTEGER);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Platform/DateExpressionTest.php
+++ b/tests/Functional/Platform/DateExpressionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function sprintf;
 
@@ -13,8 +14,8 @@ class DateExpressionTest extends FunctionalTestCase
     public function testDifference(string $date1, string $date2, int $expected): void
     {
         $table = new Table('date_expr_test');
-        $table->addColumn('date1', 'datetime');
-        $table->addColumn('date2', 'datetime');
+        $table->addColumn('date1', Types::DATETIME_MUTABLE);
+        $table->addColumn('date2', Types::DATETIME_MUTABLE);
         $this->dropAndCreateTable($table);
         $this->connection->insert('date_expr_test', [
             'date1' => $date1,

--- a/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
+++ b/tests/Functional/Platform/NewPrimaryKeyWithNewAutoIncrementColumnTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCase
 {
@@ -39,14 +40,14 @@ final class NewPrimaryKeyWithNewAutoIncrementColumnTest extends FunctionalTestCa
         $schema        = $schemaManager->introspectSchema();
 
         $table = $schema->createTable('dbal2807');
-        $table->addColumn('initial_id', 'integer');
+        $table->addColumn('initial_id', Types::INTEGER);
         $table->setPrimaryKey(['initial_id']);
 
         $schemaManager->createTable($table);
 
         $newSchema = clone $schema;
         $newTable  = $newSchema->getTable($table->getName());
-        $newTable->addColumn('new_id', 'integer', ['autoincrement' => true]);
+        $newTable->addColumn('new_id', Types::INTEGER, ['autoincrement' => true]);
         $newTable->dropPrimaryKey();
         $newTable->setPrimaryKey(['new_id']);
 

--- a/tests/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Functional/Platform/PlatformRestrictionsTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function str_repeat;
 
@@ -23,7 +24,7 @@ class PlatformRestrictionsTest extends FunctionalTestCase
         $tableName  = str_repeat('x', $platform->getMaxIdentifierLength());
         $columnName = str_repeat('y', $platform->getMaxIdentifierLength());
         $table      = new Table($tableName);
-        $table->addColumn($columnName, 'integer', ['autoincrement' => true]);
+        $table->addColumn($columnName, Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey([$columnName]);
         $this->dropAndCreateTable($table);
         $createdTable = $this->connection->getSchemaManager()->introspectTable($tableName);

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function array_keys;
 use function strtolower;
@@ -15,13 +16,13 @@ class RenameColumnTest extends FunctionalTestCase
     public function testColumnPositionRetainedAfterRenaming(string $columnName, string $newColumnName): void
     {
         $table = new Table('test_rename');
-        $table->addColumn($columnName, 'string');
-        $table->addColumn('c2', 'integer');
+        $table->addColumn($columnName, Types::STRING);
+        $table->addColumn('c2', Types::INTEGER);
 
         $this->dropAndCreateTable($table);
 
         $table->dropColumn($columnName)
-            ->addColumn($newColumnName, 'string');
+            ->addColumn($newColumnName, Types::STRING);
 
         $sm         =  $this->connection->createSchemaManager();
         $comparator = new Comparator();

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Portability\Connection;
 use Doctrine\DBAL\Portability\Middleware;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function array_keys;
 use function array_merge;
@@ -158,9 +159,9 @@ class PortabilityTest extends FunctionalTestCase
     private function createTable(): void
     {
         $table = new Table('portability_table');
-        $table->addColumn('Test_Int', 'integer');
-        $table->addColumn('Test_String', 'string', ['fixed' => true, 'length' => 32]);
-        $table->addColumn('Test_Null', 'string', ['notnull' => false]);
+        $table->addColumn('Test_Int', Types::INTEGER);
+        $table->addColumn('Test_String', Types::STRING, ['fixed' => true, 'length' => 32]);
+        $table->addColumn('Test_Null', Types::STRING, ['notnull' => false]);
         $table->setPrimaryKey(['Test_Int']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 use Throwable;
 
 use function array_change_key_case;
@@ -24,7 +25,7 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
 
         try {
             $table = new Table('primary_replica_table');
-            $table->addColumn('test_int', 'integer');
+            $table->addColumn('test_int', Types::INTEGER);
             $table->setPrimaryKey(['test_int']);
 
             $sm = $this->connection->getSchemaManager();

--- a/tests/Functional/SQL/Builder/CreateAndDropSchemaObjectsSQLBuilderTest.php
+++ b/tests/Functional/SQL/Builder/CreateAndDropSchemaObjectsSQLBuilderTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\SQL\Builder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function strtolower;
 
@@ -31,8 +32,8 @@ class CreateAndDropSchemaObjectsSQLBuilderTest extends FunctionalTestCase
     private function createTable(Schema $schema, string $name, string $otherName): void
     {
         $table = $schema->createTable($name);
-        $table->addColumn('id', 'integer');
-        $table->addColumn($otherName . '_id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn($otherName . '_id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
         $table->addForeignKeyConstraint($otherName, [$otherName . '_id'], ['id']);
     }

--- a/tests/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Functional/Schema/Db2SchemaManagerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\BooleanType;
+use Doctrine\DBAL\Types\Types;
 
 class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -17,8 +18,8 @@ class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testGetBooleanColumn(): void
     {
         $table = new Table('boolean_column_test');
-        $table->addColumn('bool', 'boolean');
-        $table->addColumn('bool_commented', 'boolean', ['comment' => "That's a comment"]);
+        $table->addColumn('bool', Types::BOOLEAN);
+        $table->addColumn('bool_commented', Types::BOOLEAN, ['comment' => "That's a comment"]);
 
         $this->schemaManager->createTable($table);
 

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 use function sprintf;
 
@@ -14,10 +15,10 @@ class DefaultValueTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('default_value');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         foreach (self::columnProvider() as [$name, $default]) {
-            $table->addColumn($name, 'string', [
+            $table->addColumn($name, Types::STRING, [
                 'default' => $default,
                 'notnull' => false,
             ]);

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -156,7 +156,7 @@ final class ComparatorTest extends FunctionalTestCase
 
         $table = new Table('mariadb_json_upgrade');
 
-        $table->addColumn('json_col', 'json');
+        $table->addColumn('json_col', Types::JSON);
         $this->dropAndCreateTable($table);
 
         // Revert column to old LONGTEXT declaration

--- a/tests/Functional/Schema/MySQL/JsonCollationTest.php
+++ b/tests/Functional/Schema/MySQL/JsonCollationTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 use Iterator;
 
 use function array_filter;
@@ -101,9 +102,9 @@ final class JsonCollationTest extends FunctionalTestCase
 
         foreach ($columns as $column) {
             if (! isset($column['charset']) || ! isset($column['collation'])) {
-                $table->addColumn($column['name'], $column['type'] ?? 'json');
+                $table->addColumn($column['name'], $column['type'] ?? Types::JSON);
             } else {
-                $table->addColumn($column['name'], $column['type'] ?? 'json')
+                $table->addColumn($column['name'], $column['type'] ?? Types::JSON)
                       ->setPlatformOption('charset', $column['charset'])
                       ->setPlatformOption('collation', $column['collation']);
             }

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -30,8 +30,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testSwitchPrimaryKeyColumns(): void
     {
         $tableOld = new Table('switch_primary_key_columns');
-        $tableOld->addColumn('foo_id', 'integer');
-        $tableOld->addColumn('bar_id', 'integer');
+        $tableOld->addColumn('foo_id', Types::INTEGER);
+        $tableOld->addColumn('bar_id', Types::INTEGER);
 
         $this->schemaManager->createTable($tableOld);
         $tableFetched = $this->schemaManager->introspectTable('switch_primary_key_columns');
@@ -56,12 +56,12 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $schema = new Schema();
         $table  = $schema->createTable('diffbug_routing_translations');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('route', 'string');
-        $table->addColumn('locale', 'string');
-        $table->addColumn('attribute', 'string');
-        $table->addColumn('localized_value', 'string');
-        $table->addColumn('original_value', 'string');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('route', Types::STRING);
+        $table->addColumn('locale', Types::STRING);
+        $table->addColumn('attribute', Types::STRING);
+        $table->addColumn('localized_value', Types::STRING);
+        $table->addColumn('original_value', Types::STRING);
         $table->setPrimaryKey(['id']);
         $table->addUniqueIndex(['route', 'locale', 'attribute']);
         $table->addIndex(['localized_value']); // this is much more selective than the unique index
@@ -78,7 +78,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testFulltextIndex(): void
     {
         $table = new Table('fulltext_index');
-        $table->addColumn('text', 'text');
+        $table->addColumn('text', Types::TEXT);
         $table->addIndex(['text'], 'f_index');
         $table->addOption('engine', 'MyISAM');
 
@@ -116,7 +116,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testIndexWithLength(): void
     {
         $table = new Table('index_length');
-        $table->addColumn('text', 'string', ['length' => 255]);
+        $table->addColumn('text', Types::STRING, ['length' => 255]);
         $table->addIndex(['text'], 'text_index', [], ['lengths' => [128]]);
 
         $this->dropAndCreateTable($table);
@@ -129,8 +129,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testAlterTableAddPrimaryKey(): void
     {
         $table = new Table('alter_table_add_pk');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('foo', Types::INTEGER);
         $table->addIndex(['id'], 'idx_id');
 
         $this->schemaManager->createTable($table);
@@ -155,8 +155,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testDropPrimaryKeyWithAutoincrementColumn(): void
     {
         $table = new Table('drop_primary_key');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
         $table->setPrimaryKey(['id', 'foo']);
 
         $this->dropAndCreateTable($table);
@@ -186,10 +186,10 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         }
 
         $table = new Table('text_blob_default_value');
-        $table->addColumn('def_text', 'text', ['default' => 'def']);
-        $table->addColumn('def_text_null', 'text', ['notnull' => false, 'default' => 'def']);
-        $table->addColumn('def_blob', 'blob', ['default' => 'def']);
-        $table->addColumn('def_blob_null', 'blob', ['notnull' => false, 'default' => 'def']);
+        $table->addColumn('def_text', Types::TEXT, ['default' => 'def']);
+        $table->addColumn('def_text_null', Types::TEXT, ['notnull' => false, 'default' => 'def']);
+        $table->addColumn('def_blob', Types::BLOB, ['default' => 'def']);
+        $table->addColumn('def_blob_null', Types::BLOB, ['notnull' => false, 'default' => 'def']);
 
         $this->dropAndCreateTable($table);
 
@@ -210,9 +210,9 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testColumnCharset(): void
     {
         $table = new Table('test_column_charset');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('foo', 'text')->setPlatformOption('charset', 'ascii');
-        $table->addColumn('bar', 'text')->setPlatformOption('charset', 'latin1');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('foo', Types::TEXT)->setPlatformOption('charset', 'ascii');
+        $table->addColumn('bar', Types::TEXT)->setPlatformOption('charset', 'latin1');
         $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_column_charset');
@@ -227,7 +227,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'test_alter_column_charset';
 
         $table = new Table($tableName);
-        $table->addColumn('col_text', 'text')->setPlatformOption('charset', 'utf8');
+        $table->addColumn('col_text', Types::TEXT)->setPlatformOption('charset', 'utf8');
 
         $this->dropAndCreateTable($table);
 
@@ -248,7 +248,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testColumnCharsetChange(): void
     {
         $table = new Table('test_column_charset_change');
-        $table->addColumn('col_string', 'string')
+        $table->addColumn('col_string', Types::STRING)
             ->setLength(100)
             ->setNotnull(true)
             ->setPlatformOption('charset', 'utf8');
@@ -272,11 +272,11 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table('test_collation');
         $table->addOption('collation', 'latin1_swedish_ci');
         $table->addOption('charset', 'latin1');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('text', 'text');
-        $table->addColumn('foo', 'text')->setPlatformOption('collation', 'latin1_swedish_ci');
-        $table->addColumn('bar', 'text')->setPlatformOption('collation', 'utf8mb4_general_ci');
-        $table->addColumn('baz', 'text')->setPlatformOption('collation', 'binary');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('text', Types::TEXT);
+        $table->addColumn('foo', Types::TEXT)->setPlatformOption('collation', 'latin1_swedish_ci');
+        $table->addColumn('bar', Types::TEXT)->setPlatformOption('collation', 'utf8mb4_general_ci');
+        $table->addColumn('baz', Types::TEXT)->setPlatformOption('collation', 'binary');
         $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_collation');
@@ -293,15 +293,15 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'lob_type_columns';
         $table     = new Table($tableName);
 
-        $table->addColumn('col_tinytext', 'text', ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
-        $table->addColumn('col_text', 'text', ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_TEXT]);
-        $table->addColumn('col_mediumtext', 'text', ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
-        $table->addColumn('col_longtext', 'text');
+        $table->addColumn('col_tinytext', Types::TEXT, ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_TINYTEXT]);
+        $table->addColumn('col_text', Types::TEXT, ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_TEXT]);
+        $table->addColumn('col_mediumtext', Types::TEXT, ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT]);
+        $table->addColumn('col_longtext', Types::TEXT);
 
-        $table->addColumn('col_tinyblob', 'text', ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
-        $table->addColumn('col_blob', 'blob', ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_BLOB]);
-        $table->addColumn('col_mediumblob', 'blob', ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
-        $table->addColumn('col_longblob', 'blob');
+        $table->addColumn('col_tinyblob', Types::TEXT, ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_TINYBLOB]);
+        $table->addColumn('col_blob', Types::BLOB, ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_BLOB]);
+        $table->addColumn('col_mediumblob', Types::BLOB, ['length' => AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB]);
+        $table->addColumn('col_longblob', Types::BLOB);
 
         $this->dropAndCreateTable($table);
 
@@ -347,7 +347,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testDiffListGuidTableColumn(): void
     {
         $offlineTable = new Table('list_guid_table_column');
-        $offlineTable->addColumn('col_guid', 'guid');
+        $offlineTable->addColumn('col_guid', Types::GUID);
 
         $this->dropAndCreateTable($offlineTable);
 
@@ -364,8 +364,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'test_list_decimal_columns';
         $table     = new Table($tableName);
 
-        $table->addColumn('col', 'decimal');
-        $table->addColumn('col_unsigned', 'decimal', ['unsigned' => true]);
+        $table->addColumn('col', Types::DECIMAL);
+        $table->addColumn('col_unsigned', Types::DECIMAL, ['unsigned' => true]);
 
         $this->dropAndCreateTable($table);
 
@@ -382,8 +382,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'test_list_float_columns';
         $table     = new Table($tableName);
 
-        $table->addColumn('col', 'float');
-        $table->addColumn('col_unsigned', 'float', ['unsigned' => true]);
+        $table->addColumn('col', Types::FLOAT);
+        $table->addColumn('col_unsigned', Types::FLOAT, ['unsigned' => true]);
 
         $this->dropAndCreateTable($table);
 
@@ -398,7 +398,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testJsonColumnType(): void
     {
         $table = new Table('test_mysql_json');
-        $table->addColumn('col_json', 'json');
+        $table->addColumn('col_json', Types::JSON);
         $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_mysql_json');
@@ -414,8 +414,12 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $currentTimeStampSql = $platform->getCurrentTimestampSQL();
 
-        $table->addColumn('col_datetime', 'datetime', ['notnull' => true, 'default' => $currentTimeStampSql]);
-        $table->addColumn('col_datetime_nullable', 'datetime', ['default' => $currentTimeStampSql]);
+        $table->addColumn(
+            'col_datetime',
+            Types::DATETIME_MUTABLE,
+            ['notnull' => true, 'default' => $currentTimeStampSql],
+        );
+        $table->addColumn('col_datetime_nullable', Types::DATETIME_MUTABLE, ['default' => $currentTimeStampSql]);
 
         $this->dropAndCreateTable($table);
 
@@ -432,13 +436,13 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table('test_column_defaults_are_valid');
 
         $currentTimeStampSql = $this->connection->getDatabasePlatform()->getCurrentTimestampSQL();
-        $table->addColumn('col_datetime', 'datetime', ['default' => $currentTimeStampSql]);
-        $table->addColumn('col_datetime_null', 'datetime', ['notnull' => false, 'default' => null]);
-        $table->addColumn('col_int', 'integer', ['default' => 1]);
-        $table->addColumn('col_neg_int', 'integer', ['default' => -1]);
-        $table->addColumn('col_string', 'string', ['default' => 'A']);
-        $table->addColumn('col_decimal', 'decimal', ['scale' => 3, 'precision' => 6, 'default' => -2.3]);
-        $table->addColumn('col_date', 'date', ['default' => '2012-12-12']);
+        $table->addColumn('col_datetime', Types::DATETIME_MUTABLE, ['default' => $currentTimeStampSql]);
+        $table->addColumn('col_datetime_null', Types::DATETIME_MUTABLE, ['notnull' => false, 'default' => null]);
+        $table->addColumn('col_int', Types::INTEGER, ['default' => 1]);
+        $table->addColumn('col_neg_int', Types::INTEGER, ['default' => -1]);
+        $table->addColumn('col_string', Types::STRING, ['default' => 'A']);
+        $table->addColumn('col_decimal', Types::DECIMAL, ['scale' => 3, 'precision' => 6, 'default' => -2.3]);
+        $table->addColumn('col_date', Types::DATE_MUTABLE, ['default' => '2012-12-12']);
 
         $this->dropAndCreateTable($table);
 
@@ -485,9 +489,9 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $currentTimeSql      = $platform->getCurrentTimeSQL();
         $currentDateSql      = $platform->getCurrentDateSQL();
 
-        $table->addColumn('col_datetime', 'datetime', ['default' => $currentTimestampSql]);
-        $table->addColumn('col_date', 'date', ['default' => $currentDateSql]);
-        $table->addColumn('col_time', 'time', ['default' => $currentTimeSql]);
+        $table->addColumn('col_datetime', Types::DATETIME_MUTABLE, ['default' => $currentTimestampSql]);
+        $table->addColumn('col_date', Types::DATE_MUTABLE, ['default' => $currentDateSql]);
+        $table->addColumn('col_time', Types::TIME_MUTABLE, ['default' => $currentTimeSql]);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -42,9 +42,9 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $tableName = 'list_table_column_notnull';
         $table     = new Table($tableName);
 
-        $table->addColumn('id', 'integer');
-        $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'string');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('foo', Types::INTEGER);
+        $table->addColumn('bar', Types::STRING);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -77,13 +77,13 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $offlinePrimaryTable = new Table($primaryTableName);
         $offlinePrimaryTable->addColumn(
             '"Id"',
-            'integer',
+            Types::INTEGER,
             ['autoincrement' => true, 'comment' => 'Explicit casing.'],
         );
-        $offlinePrimaryTable->addColumn('select', 'integer', ['comment' => 'Reserved keyword.']);
-        $offlinePrimaryTable->addColumn('foo', 'integer', ['comment' => 'Implicit uppercasing.']);
-        $offlinePrimaryTable->addColumn('BAR', 'integer');
-        $offlinePrimaryTable->addColumn('"BAZ"', 'integer');
+        $offlinePrimaryTable->addColumn('select', Types::INTEGER, ['comment' => 'Reserved keyword.']);
+        $offlinePrimaryTable->addColumn('foo', Types::INTEGER, ['comment' => 'Implicit uppercasing.']);
+        $offlinePrimaryTable->addColumn('BAR', Types::INTEGER);
+        $offlinePrimaryTable->addColumn('"BAZ"', Types::INTEGER);
         $offlinePrimaryTable->addIndex(['select'], 'from');
         $offlinePrimaryTable->addIndex(['foo'], 'foo_index');
         $offlinePrimaryTable->addIndex(['BAR'], 'BAR_INDEX');
@@ -92,8 +92,8 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $foreignTableName    = 'foreign';
         $offlineForeignTable = new Table($foreignTableName);
-        $offlineForeignTable->addColumn('id', 'integer', ['autoincrement' => true]);
-        $offlineForeignTable->addColumn('"Fk"', 'integer');
+        $offlineForeignTable->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $offlineForeignTable->addColumn('"Fk"', Types::INTEGER);
         $offlineForeignTable->addIndex(['"Fk"'], '"Fk_index"');
         $offlineForeignTable->addForeignKeyConstraint(
             $primaryTableName,
@@ -214,7 +214,7 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $table = new Table('list_table_indexes_pk_id_test');
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', 'integer', ['notnull' => true]);
+        $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $table->addUniqueIndex(['id'], 'id_unique_index');
         $this->dropAndCreateTable($table);
 
@@ -234,17 +234,17 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testListTableDateTypeColumns(): void
     {
         $table = new Table('tbl_date');
-        $table->addColumn('col_date', 'date');
-        $table->addColumn('col_datetime', 'datetime');
-        $table->addColumn('col_datetimetz', 'datetimetz');
+        $table->addColumn('col_date', Types::DATE_MUTABLE);
+        $table->addColumn('col_datetime', Types::DATETIME_MUTABLE);
+        $table->addColumn('col_datetimetz', Types::DATETIMETZ_MUTABLE);
 
         $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('tbl_date');
 
-        self::assertSame('date', $columns['col_date']->getType()->getName());
-        self::assertSame('datetime', $columns['col_datetime']->getType()->getName());
-        self::assertSame('datetimetz', $columns['col_datetimetz']->getType()->getName());
+        self::assertSame(Types::DATE_MUTABLE, $columns['col_date']->getType()->getName());
+        self::assertSame(Types::DATETIME_MUTABLE, $columns['col_datetime']->getType()->getName());
+        self::assertSame(Types::DATETIMETZ_MUTABLE, $columns['col_datetimetz']->getType()->getName());
     }
 
     public function testCreateAndListSequences(): void

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -84,7 +84,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testDetectsAutoIncrement(): void
     {
         $autoincTable = new Table('autoinc_table');
-        $column       = $autoincTable->addColumn('id', 'integer');
+        $column       = $autoincTable->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($autoincTable);
         $autoincTable = $this->schemaManager->introspectTable('autoinc_table');
@@ -106,13 +106,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         }
 
         $tableFrom = new Table('autoinc_table_add');
-        $tableFrom->addColumn('id', 'integer');
+        $tableFrom->addColumn('id', Types::INTEGER);
         $this->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->introspectTable('autoinc_table_add');
         self::assertFalse($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_add');
-        $column  = $tableTo->addColumn('id', 'integer');
+        $column  = $tableTo->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
 
         $platform = $this->connection->getDatabasePlatform();
@@ -139,14 +139,14 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testAlterTableAutoIncrementDrop(callable $comparatorFactory): void
     {
         $tableFrom = new Table('autoinc_table_drop');
-        $column    = $tableFrom->addColumn('id', 'integer');
+        $column    = $tableFrom->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
         $this->dropAndCreateTable($tableFrom);
         $tableFrom = $this->schemaManager->introspectTable('autoinc_table_drop');
         self::assertTrue($tableFrom->getColumn('id')->getAutoincrement());
 
         $tableTo = new Table('autoinc_table_drop');
-        $tableTo->addColumn('id', 'integer');
+        $tableTo->addColumn('id', Types::INTEGER);
 
         $platform = $this->connection->getDatabasePlatform();
         $diff     = $comparatorFactory($this->schemaManager)->diffTable($tableFrom, $tableTo);
@@ -167,12 +167,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->connection->executeStatement('CREATE SCHEMA nested');
 
         $nestedRelatedTable = new Table('nested.schemarelated');
-        $column             = $nestedRelatedTable->addColumn('id', 'integer');
+        $column             = $nestedRelatedTable->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
         $nestedRelatedTable->setPrimaryKey(['id']);
 
         $nestedSchemaTable = new Table('nested.schematable');
-        $column            = $nestedSchemaTable->addColumn('id', 'integer');
+        $column            = $nestedSchemaTable->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
         $nestedSchemaTable->setPrimaryKey(['id']);
         $nestedSchemaTable->addForeignKeyConstraint($nestedRelatedTable, ['id'], ['id']);
@@ -204,13 +204,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $this->connection->executeStatement('CREATE SCHEMA another');
         $table = new Table('table');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('name', 'text');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('name', Types::TEXT);
         $this->schemaManager->createTable($table);
 
         $anotherSchemaTable = new Table('another.table');
-        $anotherSchemaTable->addColumn('id', 'text');
-        $anotherSchemaTable->addColumn('email', 'text');
+        $anotherSchemaTable->addColumn('id', Types::TEXT);
+        $anotherSchemaTable->addColumn('email', Types::TEXT);
         $this->schemaManager->createTable($anotherSchemaTable);
 
         $table = $this->schemaManager->listTableDetails('table');
@@ -255,7 +255,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $foreignKeys = [];
         $fkTable     = $this->getTestTable('test_create_fk1');
         for ($i = 0; $i < count($fkOptions); $i++) {
-            $fkTable->addColumn('foreign_key_test' . $i, 'integer');
+            $fkTable->addColumn('foreign_key_test' . $i, Types::INTEGER);
             $foreignKeys[] = new ForeignKeyConstraint(
                 ['foreign_key_test' . $i],
                 'test_create_fk2',
@@ -290,8 +290,8 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testDefaultValueCharacterVarying(): void
     {
         $testTable = new Table('dbal511_default');
-        $testTable->addColumn('id', 'integer');
-        $testTable->addColumn('def', 'string', ['default' => 'foo']);
+        $testTable->addColumn('id', Types::INTEGER);
+        $testTable->addColumn('def', Types::STRING, ['default' => 'foo']);
         $testTable->setPrimaryKey(['id']);
         $this->dropAndCreateTable($testTable);
 
@@ -308,8 +308,8 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testBooleanDefault(callable $comparatorFactory): void
     {
         $table = new Table('ddc2843_bools');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('checked', 'boolean', ['default' => false]);
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('checked', Types::BOOLEAN, ['default' => false]);
 
         $this->dropAndCreateTable($table);
 
@@ -355,7 +355,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $schema = new Schema();
         $table  = $schema->createTable('test_autoincrement');
-        $table->addColumn('id', 'integer', [
+        $table->addColumn('id', Types::INTEGER, [
             'notnull' => true,
             'autoincrement' => true,
         ]);
@@ -408,9 +408,9 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testPartialIndexes(): void
     {
         $offlineTable = new Table('person');
-        $offlineTable->addColumn('id', 'integer');
-        $offlineTable->addColumn('name', 'string');
-        $offlineTable->addColumn('email', 'string');
+        $offlineTable->addColumn('id', Types::INTEGER);
+        $offlineTable->addColumn('name', Types::STRING);
+        $offlineTable->addColumn('email', Types::STRING);
         $offlineTable->addUniqueIndex(['id', 'name'], 'simple_partial_index', ['where' => '(id IS NULL)']);
 
         $this->dropAndCreateTable($offlineTable);
@@ -439,7 +439,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testItTriggersADeprecationWhenAttemptingToUseJsonbWithATypeNotExtendingJsonType(): void
     {
-        $backedUpType = Type::getType('json');
+        $backedUpType = Type::getType(Types::JSON);
         try {
             Type::getTypeRegistry()->override(Types::JSON, new class extends Type {
                 /**
@@ -452,7 +452,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
                 public function getName(): string
                 {
-                    return 'json';
+                    return Types::JSON;
                 }
             });
             $table = new Table('test_jsonb');
@@ -472,12 +472,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testListNegativeColumnDefaultValue(): void
     {
         $table = new Table('test_default_negative');
-        $table->addColumn('col_smallint', 'smallint', ['default' => -1]);
-        $table->addColumn('col_integer', 'integer', ['default' => -1]);
-        $table->addColumn('col_bigint', 'bigint', ['default' => -1]);
-        $table->addColumn('col_float', 'float', ['default' => -1.1]);
-        $table->addColumn('col_decimal', 'decimal', ['default' => -1.1]);
-        $table->addColumn('col_string', 'string', ['default' => '(-1)']);
+        $table->addColumn('col_smallint', Types::SMALLINT, ['default' => -1]);
+        $table->addColumn('col_integer', Types::INTEGER, ['default' => -1]);
+        $table->addColumn('col_bigint', Types::BIGINT, ['default' => -1]);
+        $table->addColumn('col_float', Types::FLOAT, ['default' => -1.1]);
+        $table->addColumn('col_decimal', Types::DECIMAL, ['default' => -1.1]);
+        $table->addColumn('col_string', Types::STRING, ['default' => '(-1)']);
 
         $this->dropAndCreateTable($table);
 
@@ -495,8 +495,8 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public static function serialTypes(): iterable
     {
         return [
-            ['integer'],
-            ['bigint'],
+            [Types::INTEGER],
+            [Types::BIGINT],
         ];
     }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -270,13 +270,17 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function createListTableColumns(): Table
     {
         $table = new Table('list_table_columns');
-        $table->addColumn('id', 'integer', ['notnull' => true]);
-        $table->addColumn('test', 'string', ['length' => 255, 'notnull' => false, 'default' => 'expected default']);
-        $table->addColumn('foo', 'text', ['notnull' => true]);
-        $table->addColumn('bar', 'decimal', ['precision' => 10, 'scale' => 4, 'notnull' => false]);
-        $table->addColumn('baz1', 'datetime');
-        $table->addColumn('baz2', 'time');
-        $table->addColumn('baz3', 'date');
+        $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn(
+            'test',
+            Types::STRING,
+            ['length' => 255, 'notnull' => false, 'default' => 'expected default'],
+        );
+        $table->addColumn('foo', Types::TEXT, ['notnull' => true]);
+        $table->addColumn('bar', Types::DECIMAL, ['precision' => 10, 'scale' => 4, 'notnull' => false]);
+        $table->addColumn('baz1', Types::DATETIME_MUTABLE);
+        $table->addColumn('baz2', Types::TIME_MUTABLE);
+        $table->addColumn('baz3', Types::DATE_MUTABLE);
         $table->setPrimaryKey(['id']);
 
         return $table;
@@ -340,14 +344,20 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertEquals('baz2', strtolower($columns['baz2']->getname()));
         self::assertEquals(5, array_search('baz2', $columnsKeys, true));
-        self::assertContains($columns['baz2']->gettype()->getName(), ['time', 'date', 'datetime']);
+        self::assertContains(
+            $columns['baz2']->gettype()->getName(),
+            [Types::TIME_MUTABLE, Types::DATE_MUTABLE, Types::DATETIME_MUTABLE],
+        );
         self::assertEquals(true, $columns['baz2']->getnotnull());
         self::assertEquals(null, $columns['baz2']->getdefault());
         self::assertIsArray($columns['baz2']->getPlatformOptions());
 
         self::assertEquals('baz3', strtolower($columns['baz3']->getname()));
         self::assertEquals(6, array_search('baz3', $columnsKeys, true));
-        self::assertContains($columns['baz3']->gettype()->getName(), ['time', 'date', 'datetime']);
+        self::assertContains(
+            $columns['baz3']->gettype()->getName(),
+            [Types::TIME_MUTABLE, Types::DATE_MUTABLE, Types::DATETIME_MUTABLE],
+        );
         self::assertEquals(true, $columns['baz3']->getnotnull());
         self::assertEquals(null, $columns['baz3']->getdefault());
         self::assertIsArray($columns['baz3']->getPlatformOptions());
@@ -358,7 +368,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableName = 'test_list_table_fixed_string';
 
         $table = new Table($tableName);
-        $table->addColumn('column_char', 'string', ['fixed' => true, 'length' => 2]);
+        $table->addColumn('column_char', Types::STRING, ['fixed' => true, 'length' => 2]);
 
         $this->schemaManager->createTable($table);
 
@@ -507,7 +517,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $table = new Table('test_unique_constraint');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $this->dropAndCreateTable($table);
 
         $uniqueConstraint = new UniqueConstraint('uniq_id', ['id']);
@@ -631,12 +641,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tableToAlter = $schema->getTable('table_to_alter');
         $tableToAlter->dropColumn('foreign_key_test');
-        $tableToAlter->addColumn('number', 'integer');
+        $tableToAlter->addColumn('number', Types::INTEGER);
 
         $schema->dropTable('table_to_drop');
 
         $tableToCreate = $schema->createTable('table_to_create');
-        $tableToCreate->addColumn('id', 'integer', ['notnull' => true]);
+        $tableToCreate->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $tableToCreate->setPrimaryKey(['id']);
 
         $this->schemaManager->migrateSchema($schema);
@@ -667,7 +677,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertCount(1, $table->getIndexes());
 
         $newTable = clone $table;
-        $newTable->addColumn('foo', 'integer');
+        $newTable->addColumn('foo', Types::INTEGER);
         $newTable->dropColumn('test');
 
         $comparator = $this->schemaManager->createComparator();
@@ -813,7 +823,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $table = new Table('test_autoincrement');
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -831,8 +841,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $table = new Table('test_not_autoincrement');
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', 'integer');
-        $table->addColumn('other_id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('other_id', Types::INTEGER);
         $table->setPrimaryKey(['id', 'other_id']);
 
         $this->schemaManager->createTable($table);
@@ -850,13 +860,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testUpdateSchemaWithForeignKeyRenaming(callable $comparatorFactory): void
     {
         $table = new Table('test_fk_base');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $tableFK = new Table('test_fk_rename');
         $tableFK->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $tableFK->addColumn('id', 'integer');
-        $tableFK->addColumn('fk_id', 'integer');
+        $tableFK->addColumn('id', Types::INTEGER);
+        $tableFK->addColumn('fk_id', Types::INTEGER);
         $tableFK->setPrimaryKey(['id']);
         $tableFK->addIndex(['fk_id'], 'fk_idx');
         $tableFK->addForeignKeyConstraint('test_fk_base', ['fk_id'], ['id']);
@@ -869,8 +879,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tableFKNew = new Table('test_fk_rename');
         $tableFKNew->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $tableFKNew->addColumn('id', 'integer');
-        $tableFKNew->addColumn('rename_fk_id', 'integer');
+        $tableFKNew->addColumn('id', Types::INTEGER);
+        $tableFKNew->addColumn('rename_fk_id', Types::INTEGER);
         $tableFKNew->setPrimaryKey(['id']);
         $tableFKNew->addIndex(['rename_fk_id'], 'fk_idx');
         $tableFKNew->addForeignKeyConstraint('test_fk_base', ['rename_fk_id'], ['id']);
@@ -896,11 +906,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testRenameIndexUsedInForeignKeyConstraint(callable $comparatorFactory): void
     {
         $primaryTable = new Table('test_rename_index_primary');
-        $primaryTable->addColumn('id', 'integer');
+        $primaryTable->addColumn('id', Types::INTEGER);
         $primaryTable->setPrimaryKey(['id']);
 
         $foreignTable = new Table('test_rename_index_foreign');
-        $foreignTable->addColumn('fk', 'integer');
+        $foreignTable->addColumn('fk', Types::INTEGER);
         $foreignTable->addIndex(['fk'], 'rename_index_fk_idx');
         $foreignTable->addForeignKeyConstraint(
             'test_rename_index_primary',
@@ -944,7 +954,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $table = new Table('column_comment_test');
-        $table->addColumn('id', 'integer', ['comment' => 'This is a comment']);
+        $table->addColumn('id', Types::INTEGER, ['comment' => 'This is a comment']);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -967,6 +977,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEmpty($columns['id']->getComment());
     }
 
+    /** @psalm-suppress DeprecatedConstant */
     public function testAutomaticallyAppendCommentOnMarkedColumns(): void
     {
         $platform = $this->connection->getDatabasePlatform();
@@ -980,9 +991,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $table = new Table('column_comment_test2');
-        $table->addColumn('id', 'integer', ['comment' => 'This is a comment']);
-        $table->addColumn('obj', 'object', ['comment' => 'This is a comment']);
-        $table->addColumn('arr', 'array', ['comment' => 'This is a comment']);
+        $table->addColumn('id', Types::INTEGER, ['comment' => 'This is a comment']);
+        $table->addColumn('obj', Types::OBJECT, ['comment' => 'This is a comment']);
+        $table->addColumn('arr', Types::ARRAY, ['comment' => 'This is a comment']);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -1009,8 +1020,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $table = new Table('column_dateinterval_comment');
-        $table->addColumn('id', 'integer', ['comment' => 'This is a comment']);
-        $table->addColumn('date_interval', 'dateinterval', ['comment' => 'This is a comment']);
+        $table->addColumn('id', Types::INTEGER, ['comment' => 'This is a comment']);
+        $table->addColumn('date_interval', Types::DATEINTERVAL, ['comment' => 'This is a comment']);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -1027,13 +1038,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableName = 'column_def_change_type';
         $table     = new Table($tableName);
 
-        $table->addColumn('col_int', 'smallint', ['default' => 666]);
-        $table->addColumn('col_string', 'string', ['default' => 'foo']);
+        $table->addColumn('col_int', Types::SMALLINT, ['default' => 666]);
+        $table->addColumn('col_string', Types::STRING, ['default' => 'foo']);
 
         $this->dropAndCreateTable($table);
 
         $newTable = clone $table;
-        $newTable->changeColumn('col_int', ['type' => Type::getType('integer')]);
+        $newTable->changeColumn('col_int', ['type' => Type::getType(Types::INTEGER)]);
         $newTable->changeColumn('col_string', ['fixed' => true]);
 
         $diff = $this->schemaManager->createComparator()
@@ -1054,7 +1065,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testListTableWithBlob(): void
     {
         $table = new Table('test_blob_table');
-        $table->addColumn('binarydata', 'blob', []);
+        $table->addColumn('binarydata', Types::BLOB, []);
 
         $this->schemaManager->createTable($table);
 
@@ -1081,10 +1092,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $table = new Table($name, [], [], [], [], $options);
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', 'integer', ['notnull' => true]);
+        $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $table->setPrimaryKey(['id']);
-        $table->addColumn('test', 'string', ['length' => 255]);
-        $table->addColumn('foreign_key_test', 'integer');
+        $table->addColumn('test', Types::STRING, ['length' => 255]);
+        $table->addColumn('foreign_key_test', Types::INTEGER);
 
         return $table;
     }
@@ -1093,10 +1104,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $table = new Table($name, [], [], [], [], []);
         $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', 'integer', ['notnull' => true]);
-        $table->addColumn('other_id', 'integer', ['notnull' => true]);
+        $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('other_id', Types::INTEGER, ['notnull' => true]);
         $table->setPrimaryKey(['id', 'other_id']);
-        $table->addColumn('test', 'string', ['length' => 255]);
+        $table->addColumn('test', Types::STRING, ['length' => 255]);
 
         return $table;
     }
@@ -1148,14 +1159,14 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testColumnDefaultLifecycle(callable $comparatorFactory): void
     {
         $table = new Table('col_def_lifecycle');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('column1', 'string', ['default' => null]);
-        $table->addColumn('column2', 'string', ['default' => false]);
-        $table->addColumn('column3', 'string', ['default' => true]);
-        $table->addColumn('column4', 'string', ['default' => 0]);
-        $table->addColumn('column5', 'string', ['default' => '']);
-        $table->addColumn('column6', 'string', ['default' => 'def']);
-        $table->addColumn('column7', 'integer', ['default' => 0]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('column1', Types::STRING, ['default' => null]);
+        $table->addColumn('column2', Types::STRING, ['default' => false]);
+        $table->addColumn('column3', Types::STRING, ['default' => true]);
+        $table->addColumn('column4', Types::STRING, ['default' => 0]);
+        $table->addColumn('column5', Types::STRING, ['default' => '']);
+        $table->addColumn('column6', Types::STRING, ['default' => 'def']);
+        $table->addColumn('column7', Types::INTEGER, ['default' => 0]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -1202,8 +1213,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $tableName = 'test_binary_table';
 
         $table = new Table($tableName);
-        $table->addColumn('column_binary', 'binary', ['length' => 16, 'fixed' => true]);
-        $table->addColumn('column_varbinary', 'binary', ['length' => 32]);
+        $table->addColumn('column_binary', Types::BINARY, ['length' => 16, 'fixed' => true]);
+        $table->addColumn('column_varbinary', Types::BINARY, ['length' => 32]);
 
         $this->schemaManager->createTable($table);
 
@@ -1245,15 +1256,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $foreignTableName  = 'foreign_table';
 
         $table = new Table($foreignTableName);
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
 
         $table = new Table($primaryTableName);
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'string');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
+        $table->addColumn('bar', Types::STRING);
         $table->addForeignKeyConstraint($foreignTableName, ['foo'], ['id']);
         $table->addIndex(['bar']);
         $table->setPrimaryKey(['id']);
@@ -1289,7 +1300,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->dropTableIfExists('my_table');
 
         $table = new Table('my_table');
-        $table->addColumn('id', 'integer', ['comment' => "It's a comment with a quote"]);
+        $table->addColumn('id', Types::INTEGER, ['comment' => "It's a comment with a quote"]);
         $table->setPrimaryKey(['id']);
 
         $this->schemaManager->createTable($table);
@@ -1307,7 +1318,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->dropTableIfExists('my_table');
 
         $options = [
-            'type' => Type::getType('integer'),
+            'type' => Type::getType(Types::INTEGER),
             'default' => 0,
             'notnull' => true,
             'comment' => 'expected+column+comment',
@@ -1319,7 +1330,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
 
         $table = new Table('my_table');
-        $table->addColumn('id', 'integer', [
+        $table->addColumn('id', Types::INTEGER, [
             'columnDefinition' => $columnDefinition,
             'comment' => 'unexpected_column_comment',
         ]);
@@ -1353,10 +1364,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $offlineTable = new Table('alter_column_comment_test');
-        $offlineTable->addColumn('comment1', 'integer', ['comment' => $comment1]);
-        $offlineTable->addColumn('comment2', 'integer', ['comment' => $comment2]);
-        $offlineTable->addColumn('no_comment1', 'integer');
-        $offlineTable->addColumn('no_comment2', 'integer');
+        $offlineTable->addColumn('comment1', Types::INTEGER, ['comment' => $comment1]);
+        $offlineTable->addColumn('comment2', Types::INTEGER, ['comment' => $comment2]);
+        $offlineTable->addColumn('no_comment1', Types::INTEGER);
+        $offlineTable->addColumn('no_comment2', Types::INTEGER);
         $this->dropAndCreateTable($offlineTable);
 
         $onlineTable = $this->schemaManager->introspectTable('alter_column_comment_test');
@@ -1413,12 +1424,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testDoesNotListIndexesImplicitlyCreatedByForeignKeys(): void
     {
         $primaryTable = new Table('test_list_index_impl_primary');
-        $primaryTable->addColumn('id', 'integer');
+        $primaryTable->addColumn('id', Types::INTEGER);
         $primaryTable->setPrimaryKey(['id']);
 
         $foreignTable = new Table('test_list_index_impl_foreign');
-        $foreignTable->addColumn('fk1', 'integer');
-        $foreignTable->addColumn('fk2', 'integer');
+        $foreignTable->addColumn('fk1', Types::INTEGER);
+        $foreignTable->addColumn('fk2', Types::INTEGER);
         $foreignTable->addIndex(['fk1'], 'explicit_fk1_idx');
         $foreignTable->addForeignKeyConstraint('test_list_index_impl_primary', ['fk1'], ['id']);
         $foreignTable->addForeignKeyConstraint('test_list_index_impl_primary', ['fk2'], ['id']);
@@ -1450,7 +1461,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->connection->executeQuery('CREATE TABLE json_test (parameters JSON NOT NULL)');
 
         $table = new Table('json_test');
-        $table->addColumn('parameters', 'json');
+        $table->addColumn('parameters', Types::JSON);
 
         $tableDiff = $comparatorFactory($this->schemaManager)
             ->diffTable($this->schemaManager->introspectTable('json_test'), $table);
@@ -1561,8 +1572,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testPrimaryKeyAutoIncrement(): void
     {
         $table = new Table('test_pk_auto_increment');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('text', 'string');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('text', Types::STRING);
         $table->setPrimaryKey(['id']);
         $this->dropAndCreateTable($table);
 
@@ -1592,8 +1603,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $table = new Table('test_partial_column_index');
-        $table->addColumn('long_column', 'string', ['length' => 40]);
-        $table->addColumn('standard_column', 'integer');
+        $table->addColumn('long_column', Types::STRING, ['length' => 40]);
+        $table->addColumn('standard_column', Types::INTEGER);
         $table->addIndex(['long_column'], 'partial_long_column_idx', [], ['lengths' => [4]]);
         $table->addIndex(['standard_column', 'long_column'], 'standard_and_partial_idx', [], ['lengths' => [null, 2]]);
 
@@ -1608,7 +1619,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testCommentInTable(): void
     {
         $table = new Table('table_with_comment');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setComment('Foo with control characters \'\\');
         $this->dropAndCreateTable($table);
 
@@ -1693,13 +1704,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $schema = new Schema();
 
         $user = $schema->createTable('user');
-        $user->addColumn('id', 'integer');
-        $user->addColumn('group_id', 'integer');
+        $user->addColumn('id', Types::INTEGER);
+        $user->addColumn('group_id', Types::INTEGER);
         $user->setPrimaryKey(['id']);
         $user->addForeignKeyConstraint('group', ['group_id'], ['id']);
 
         $group = $schema->createTable('group');
-        $group->addColumn('id', 'integer');
+        $group->addColumn('id', Types::INTEGER);
         $group->setPrimaryKey(['id']);
 
         $schemaManager = $this->connection->createSchemaManager();
@@ -1714,12 +1725,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $schema = new Schema();
 
         $parent = $schema->createTable('parent');
-        $parent->addColumn('id', 'integer');
+        $parent->addColumn('id', Types::INTEGER);
         $parent->setPrimaryKey(['id']);
 
         $child = $schema->createTable('child');
-        $child->addColumn('id', 'integer');
-        $child->addColumn('parent_id', 'integer');
+        $child->addColumn('id', Types::INTEGER);
+        $child->addColumn('parent_id', Types::INTEGER);
         $child->addIndex(['parent_id'], 'idx_1');
         $child->addForeignKeyConstraint('parent', ['parent_id'], ['id']);
 
@@ -1746,8 +1757,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testSwitchPrimaryKeyOrder(): void
     {
         $prototype = new Table('test_switch_pk_order');
-        $prototype->addColumn('foo_id', 'integer');
-        $prototype->addColumn('bar_id', 'integer');
+        $prototype->addColumn('foo_id', Types::INTEGER);
+        $prototype->addColumn('bar_id', Types::INTEGER);
 
         $table = clone $prototype;
         $table->setPrimaryKey(['foo_id', 'bar_id']);
@@ -1773,8 +1784,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     public function testDropColumnWithDefault(): void
     {
         $table = new Table('drop_column_with_default');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('todrop', 'decimal', ['default' => 10.2]);
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('todrop', Types::DECIMAL, ['default' => 10.2]);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -91,10 +91,10 @@ EOS);
     public function testColumnCollation(): void
     {
         $table = new Table('test_collation');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('text', 'text');
-        $table->addColumn('foo', 'text')->setPlatformOption('collation', 'BINARY');
-        $table->addColumn('bar', 'text')->setPlatformOption('collation', 'NOCASE');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('text', Types::TEXT);
+        $table->addColumn('foo', Types::TEXT)->setPlatformOption('collation', 'BINARY');
+        $table->addColumn('bar', Types::TEXT)->setPlatformOption('collation', 'NOCASE');
         $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_collation');
@@ -149,8 +149,8 @@ SQL;
     public function testPrimaryKeyNoAutoIncrement(): void
     {
         $table = new Table('test_pk_auto_increment');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('text', 'text');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('text', Types::TEXT);
         $table->setPrimaryKey(['id']);
         $this->dropAndCreateTable($table);
 
@@ -171,9 +171,9 @@ SQL;
     public function testOnlyOwnCommentIsParsed(): void
     {
         $table = new Table('own_column_comment');
-        $table->addColumn('col1', 'string', ['length' => 16]);
-        $table->addColumn('col2', 'string', ['length' => 16, 'comment' => 'Column #2']);
-        $table->addColumn('col3', 'string', ['length' => 16]);
+        $table->addColumn('col1', Types::STRING, ['length' => 16]);
+        $table->addColumn('col2', Types::STRING, ['length' => 16, 'comment' => 'Column #2']);
+        $table->addColumn('col3', Types::STRING, ['length' => 16]);
 
         $sm = $this->connection->getSchemaManager();
         $sm->createTable($table);

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function base64_decode;
 use function stream_get_contents;
@@ -21,8 +22,8 @@ class StatementTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('stmt_test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('name', 'text', ['notnull' => false]);
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('name', Types::TEXT, ['notnull' => false]);
         $this->dropAndCreateTable($table);
     }
 
@@ -56,8 +57,8 @@ class StatementTest extends FunctionalTestCase
         }
 
         $table = new Table('stmt_longer_results');
-        $table->addColumn('param', 'string');
-        $table->addColumn('val', 'text');
+        $table->addColumn('param', Types::STRING);
+        $table->addColumn('val', Types::TEXT);
         $this->dropAndCreateTable($table);
 
         $row1 = [
@@ -98,7 +99,7 @@ class StatementTest extends FunctionalTestCase
         $this->iniSet('memory_limit', '4G');
 
         $table = new Table('stmt_long_blob');
-        $table->addColumn('contents', 'blob', ['length' => 0xFFFFFFFF]);
+        $table->addColumn('contents', Types::BLOB, ['length' => 0xFFFFFFFF]);
         $this->dropAndCreateTable($table);
 
         $contents = base64_decode(<<<'EOF'
@@ -123,7 +124,7 @@ EOF
         $result = $this->connection->prepare('SELECT contents FROM stmt_long_blob')
             ->execute();
 
-        $stream = Type::getType('blob')
+        $stream = Type::getType(Types::BLOB)
             ->convertToPHPValue(
                 $result->fetchOne(),
                 $this->connection->getDatabasePlatform(),

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Throwable;
 
 class TemporaryTableTest extends FunctionalTestCase
@@ -19,7 +20,7 @@ class TemporaryTableTest extends FunctionalTestCase
             self::markTestSkipped('Test does not work on Oracle.');
         }
 
-        $columnDefinitions = ['id' => ['type' => Type::getType('integer'), 'notnull' => true]];
+        $columnDefinitions = ['id' => ['type' => Type::getType(Types::INTEGER), 'notnull' => true]];
         $tempTable         = $platform->getTemporaryTableName('my_temporary');
 
         $createTempTableSQL = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
@@ -27,7 +28,7 @@ class TemporaryTableTest extends FunctionalTestCase
         $this->connection->executeStatement($createTempTableSQL);
 
         $table = new Table('nontemporary');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -51,14 +52,14 @@ class TemporaryTableTest extends FunctionalTestCase
             self::markTestSkipped('Test does not work on Oracle.');
         }
 
-        $columnDefinitions = ['id' => ['type' => Type::getType('integer'), 'notnull' => true]];
+        $columnDefinitions = ['id' => ['type' => Type::getType(Types::INTEGER), 'notnull' => true]];
         $tempTable         = $platform->getTemporaryTableName('my_temporary');
 
         $createTempTableSQL = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
                 . $platform->getColumnDeclarationListSQL($columnDefinitions) . ')';
 
         $table = new Table('nontemporary');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Ticket/DBAL168Test.php
+++ b/tests/Functional/Ticket/DBAL168Test.php
@@ -4,14 +4,15 @@ namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class DBAL168Test extends FunctionalTestCase
 {
     public function testDomainsTable(): void
     {
         $table = new Table('domains');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('parent_id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('parent_id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
         $table->addForeignKeyConstraint('domains', ['parent_id'], ['id']);
 

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Ticket;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class DBAL202Test extends FunctionalTestCase
 {
@@ -18,7 +19,7 @@ class DBAL202Test extends FunctionalTestCase
             $this->connection->executeStatement('DELETE FROM DBAL202');
         } else {
             $table = new Table('DBAL202');
-            $table->addColumn('id', 'integer');
+            $table->addColumn('id', Types::INTEGER);
             $table->setPrimaryKey(['id']);
 
             $this->connection->getSchemaManager()->createTable($table);

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Types\DecimalType;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -15,7 +16,7 @@ class DBAL461Test extends TestCase
     {
         $conn     = $this->createMock(Connection::class);
         $platform = $this->getMockForAbstractClass(SQLServer2012Platform::class);
-        $platform->registerDoctrineTypeMapping('numeric', 'decimal');
+        $platform->registerDoctrineTypeMapping('numeric', Types::DECIMAL);
 
         $schemaManager = new SQLServerSchemaManager($conn, $platform);
 

--- a/tests/Functional/Ticket/DBAL510Test.php
+++ b/tests/Functional/Ticket/DBAL510Test.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class DBAL510Test extends FunctionalTestCase
 {
@@ -27,7 +28,7 @@ class DBAL510Test extends FunctionalTestCase
     public function testSearchPathSchemaChanges(callable $comparatorFactory): void
     {
         $table = new Table('dbal510tbl');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Ticket/DBAL752Test.php
+++ b/tests/Functional/Ticket/DBAL752Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class DBAL752Test extends FunctionalTestCase
 {
@@ -35,14 +36,14 @@ SQL);
 
         $fetchedTable = $schemaManager->introspectTable('dbal752_unsigneds');
 
-        self::assertEquals('smallint', $fetchedTable->getColumn('small')->getType()->getName());
-        self::assertEquals('smallint', $fetchedTable->getColumn('small_unsigned')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('medium')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('medium_unsigned')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('integer')->getType()->getName());
-        self::assertEquals('integer', $fetchedTable->getColumn('integer_unsigned')->getType()->getName());
-        self::assertEquals('bigint', $fetchedTable->getColumn('big')->getType()->getName());
-        self::assertEquals('bigint', $fetchedTable->getColumn('big_unsigned')->getType()->getName());
+        self::assertEquals(Types::SMALLINT, $fetchedTable->getColumn('small')->getType()->getName());
+        self::assertEquals(Types::SMALLINT, $fetchedTable->getColumn('small_unsigned')->getType()->getName());
+        self::assertEquals(Types::INTEGER, $fetchedTable->getColumn('medium')->getType()->getName());
+        self::assertEquals(Types::INTEGER, $fetchedTable->getColumn('medium_unsigned')->getType()->getName());
+        self::assertEquals(Types::INTEGER, $fetchedTable->getColumn('integer')->getType()->getName());
+        self::assertEquals(Types::INTEGER, $fetchedTable->getColumn('integer_unsigned')->getType()->getName());
+        self::assertEquals(Types::BIGINT, $fetchedTable->getColumn('big')->getType()->getName());
+        self::assertEquals(Types::BIGINT, $fetchedTable->getColumn('big_unsigned')->getType()->getName());
 
         self::assertTrue($fetchedTable->getColumn('small_unsigned')->getUnsigned());
         self::assertTrue($fetchedTable->getColumn('medium_unsigned')->getUnsigned());

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use stdClass;
 
 use function str_repeat;
@@ -15,24 +16,25 @@ class TypeConversionTest extends FunctionalTestCase
 {
     private static int $typeCounter = 0;
 
+    /** @psalm-suppress DeprecatedConstant */
     protected function setUp(): void
     {
         $table = new Table('type_conversion');
-        $table->addColumn('id', 'integer', ['notnull' => false]);
-        $table->addColumn('test_string', 'string', ['notnull' => false]);
-        $table->addColumn('test_boolean', 'boolean', ['notnull' => false]);
-        $table->addColumn('test_bigint', 'bigint', ['notnull' => false]);
-        $table->addColumn('test_smallint', 'bigint', ['notnull' => false]);
-        $table->addColumn('test_datetime', 'datetime', ['notnull' => false]);
-        $table->addColumn('test_datetimetz', 'datetimetz', ['notnull' => false]);
-        $table->addColumn('test_date', 'date', ['notnull' => false]);
-        $table->addColumn('test_time', 'time', ['notnull' => false]);
-        $table->addColumn('test_text', 'text', ['notnull' => false]);
-        $table->addColumn('test_array', 'array', ['notnull' => false]);
-        $table->addColumn('test_json', 'json', ['notnull' => false]);
-        $table->addColumn('test_object', 'object', ['notnull' => false]);
-        $table->addColumn('test_float', 'float', ['notnull' => false]);
-        $table->addColumn('test_decimal', 'decimal', ['notnull' => false, 'scale' => 2, 'precision' => 10]);
+        $table->addColumn('id', Types::INTEGER, ['notnull' => false]);
+        $table->addColumn('test_string', Types::STRING, ['notnull' => false]);
+        $table->addColumn('test_boolean', Types::BOOLEAN, ['notnull' => false]);
+        $table->addColumn('test_bigint', Types::BIGINT, ['notnull' => false]);
+        $table->addColumn('test_smallint', Types::BIGINT, ['notnull' => false]);
+        $table->addColumn('test_datetime', Types::DATETIME_MUTABLE, ['notnull' => false]);
+        $table->addColumn('test_datetimetz', Types::DATETIMETZ_MUTABLE, ['notnull' => false]);
+        $table->addColumn('test_date', Types::DATE_MUTABLE, ['notnull' => false]);
+        $table->addColumn('test_time', Types::TIME_MUTABLE, ['notnull' => false]);
+        $table->addColumn('test_text', Types::TEXT, ['notnull' => false]);
+        $table->addColumn('test_array', Types::ARRAY, ['notnull' => false]);
+        $table->addColumn('test_json', Types::JSON, ['notnull' => false]);
+        $table->addColumn('test_object', Types::OBJECT, ['notnull' => false]);
+        $table->addColumn('test_float', Types::FLOAT, ['notnull' => false]);
+        $table->addColumn('test_decimal', Types::DECIMAL, ['notnull' => false, 'scale' => 2, 'precision' => 10]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -55,8 +57,8 @@ class TypeConversionTest extends FunctionalTestCase
     public static function booleanProvider(): iterable
     {
         return [
-            'true' => ['boolean', true],
-            'false' => ['boolean', false],
+            'true' => [Types::BOOLEAN, true],
+            'false' => [Types::BOOLEAN, false],
         ];
     }
 
@@ -77,7 +79,7 @@ class TypeConversionTest extends FunctionalTestCase
     public static function integerProvider(): iterable
     {
         return [
-            'smallint' => ['smallint', 123],
+            'smallint' => [Types::SMALLINT, 123],
         ];
     }
 
@@ -98,7 +100,7 @@ class TypeConversionTest extends FunctionalTestCase
     public static function floatProvider(): iterable
     {
         return [
-            'float' => ['float', 1.5],
+            'float' => [Types::FLOAT, 1.5],
         ];
     }
 
@@ -109,7 +111,7 @@ class TypeConversionTest extends FunctionalTestCase
      */
     public function testIdempotentConversionToString(string $type, $originalValue): void
     {
-        if ($type === 'text' && TestUtil::isDriverOneOf('pdo_oci')) {
+        if ($type === Types::TEXT && TestUtil::isDriverOneOf('pdo_oci')) {
             // inserting BLOBs as streams on Oracle requires Oracle-specific SQL syntax which is currently not supported
             // see http://php.net/manual/en/pdo.lobs.php#example-1035
             self::markTestSkipped("DBAL doesn't support storing LOBs represented as streams using PDO_OCI");
@@ -125,8 +127,8 @@ class TypeConversionTest extends FunctionalTestCase
     public static function toStringProvider(): iterable
     {
         return [
-            'string' => ['string', 'ABCDEFGabcdefg'],
-            'text' => ['text', str_repeat('foo ', 1000)],
+            'string' => [Types::STRING, 'ABCDEFGabcdefg'],
+            'text' => [Types::TEXT, str_repeat('foo ', 1000)],
         ];
     }
 
@@ -143,12 +145,16 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertEquals($originalValue, $dbValue);
     }
 
-    /** @return mixed[][] */
+    /**
+     * @return mixed[][]
+     *
+     * @psalm-suppress DeprecatedConstant
+     */
     public static function toArrayProvider(): iterable
     {
         return [
-            'array' => ['array', ['foo' => 'bar']],
-            'json' => ['json', ['foo' => 'bar']],
+            'array' => [Types::ARRAY, ['foo' => 'bar']],
+            'json' => [Types::JSON, ['foo' => 'bar']],
         ];
     }
 
@@ -165,7 +171,11 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertEquals($originalValue, $dbValue);
     }
 
-    /** @return mixed[][] */
+    /**
+     * @return mixed[][]
+     *
+     * @psalm-suppress DeprecatedConstant
+     */
     public static function toObjectProvider(): iterable
     {
         $obj      = new stdClass();
@@ -173,7 +183,7 @@ class TypeConversionTest extends FunctionalTestCase
         $obj->bar = 'baz';
 
         return [
-            'object' => ['object', $obj],
+            'object' => [Types::OBJECT, $obj],
         ];
     }
 
@@ -184,7 +194,7 @@ class TypeConversionTest extends FunctionalTestCase
 
         self::assertInstanceOf(DateTime::class, $dbValue);
 
-        if ($type === 'datetimetz') {
+        if ($type === Types::DATETIMETZ_MUTABLE) {
             return;
         }
 
@@ -199,10 +209,10 @@ class TypeConversionTest extends FunctionalTestCase
     public static function toDateTimeProvider(): iterable
     {
         return [
-            'datetime' => ['datetime', new DateTime('2010-04-05 10:10:10')],
-            'datetimetz' => ['datetimetz', new DateTime('2010-04-05 10:10:10')],
-            'date' => ['date', new DateTime('2010-04-05')],
-            'time' => ['time', new DateTime('1970-01-01 10:10:10')],
+            'datetime' => [Types::DATETIME_MUTABLE, new DateTime('2010-04-05 10:10:10')],
+            'datetimetz' => [Types::DATETIMETZ_MUTABLE, new DateTime('2010-04-05 10:10:10')],
+            'date' => [Types::DATE_MUTABLE, new DateTime('2010-04-05')],
+            'time' => [Types::TIME_MUTABLE, new DateTime('1970-01-01 10:10:10')],
         ];
     }
 

--- a/tests/Functional/Types/AsciiStringTest.php
+++ b/tests/Functional/Types/AsciiStringTest.php
@@ -7,18 +7,19 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class AsciiStringTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
         $table = new Table('ascii_table');
-        $table->addColumn('id', 'ascii_string', [
+        $table->addColumn('id', Types::ASCII_STRING, [
             'length' => 3,
             'fixed' => true,
         ]);
 
-        $table->addColumn('val', 'ascii_string', ['length' => 4]);
+        $table->addColumn('val', Types::ASCII_STRING, ['length' => 4]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Types/BinaryTest.php
+++ b/tests/Functional/Types/BinaryTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
 
 use function is_resource;
 use function random_bytes;
@@ -23,11 +24,11 @@ class BinaryTest extends FunctionalTestCase
         }
 
         $table = new Table('binary_table');
-        $table->addColumn('id', 'binary', [
+        $table->addColumn('id', Types::BINARY, [
             'length' => 16,
             'fixed' => true,
         ]);
-        $table->addColumn('val', 'binary', ['length' => 64]);
+        $table->addColumn('val', Types::BINARY, ['length' => 64]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Types/GuidTest.php
+++ b/tests/Functional/Types/GuidTest.php
@@ -6,13 +6,14 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 
 class GuidTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
         $table = new Table('guid_table');
-        $table->addColumn('guid', 'guid');
+        $table->addColumn('guid', Types::GUID);
 
         $this->dropAndCreateTable($table);
     }

--- a/tests/Functional/Types/JsonTest.php
+++ b/tests/Functional/Types/JsonTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function is_resource;
 use function json_decode;
@@ -19,9 +20,9 @@ class JsonTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('json_test_table');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
-        $table->addColumn('val', 'json');
+        $table->addColumn('val', Types::JSON);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -66,7 +67,7 @@ class JsonTest extends FunctionalTestCase
             'val' => $value,
         ], [
             ParameterType::INTEGER,
-            Type::getType('json'),
+            Type::getType(Types::JSON),
         ]);
 
         self::assertSame(1, $result);

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Throwable;
 
 use function array_filter;
@@ -19,9 +20,9 @@ class WriteTest extends FunctionalTestCase
     protected function setUp(): void
     {
         $table = new Table('write_table');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('test_int', 'integer');
-        $table->addColumn('test_string', 'string', ['notnull' => false]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('test_int', Types::INTEGER);
+        $table->addColumn('test_string', Types::STRING, ['notnull' => false]);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
@@ -85,8 +86,8 @@ class WriteTest extends FunctionalTestCase
         $sql  = 'INSERT INTO write_table (test_int, test_string) VALUES (?, ?)';
         $stmt = $this->connection->prepare($sql);
 
-        $stmt->bindValue(1, 1, Type::getType('integer'));
-        $stmt->bindValue(2, 'foo', Type::getType('string'));
+        $stmt->bindValue(1, 1, Type::getType(Types::INTEGER));
+        $stmt->bindValue(2, 'foo', Type::getType(Types::STRING));
 
         self::assertEquals(1, $stmt->execute()->rowCount());
     }
@@ -278,7 +279,7 @@ class WriteTest extends FunctionalTestCase
         }
 
         $table = new Table('test_empty_identity');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         try {

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use Doctrine\DBAL\Types\Types;
 
 use function array_shift;
 
@@ -27,7 +28,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testGenerateMixedCaseTableCreate(): void
     {
         $table = new Table('Foo');
-        $table->addColumn('Bar', 'integer');
+        $table->addColumn('Bar', Types::INTEGER);
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals(
@@ -162,14 +163,14 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testUniquePrimaryKey(Comparator $comparator): void
     {
         $keyTable = new Table('foo');
-        $keyTable->addColumn('bar', 'integer');
-        $keyTable->addColumn('baz', 'string');
+        $keyTable->addColumn('bar', Types::INTEGER);
+        $keyTable->addColumn('baz', Types::STRING);
         $keyTable->setPrimaryKey(['bar']);
         $keyTable->addUniqueIndex(['baz']);
 
         $oldTable = new Table('foo');
-        $oldTable->addColumn('bar', 'integer');
-        $oldTable->addColumn('baz', 'string');
+        $oldTable->addColumn('bar', Types::INTEGER);
+        $oldTable->addColumn('baz', Types::STRING);
 
         $diff = $comparator->diffTable($oldTable, $keyTable);
         self::assertNotFalse($diff);
@@ -282,7 +283,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         $table = new Table('fulltext_table');
         $table->addOption('engine', 'MyISAM');
-        $table->addColumn('text', 'text');
+        $table->addColumn('text', Types::TEXT);
         $table->addIndex(['text'], 'fulltext_text');
 
         $index = $table->getIndex('fulltext_text');
@@ -303,7 +304,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         $table = new Table('spatial_table');
         $table->addOption('engine', 'MyISAM');
-        $table->addColumn('point', 'text'); // This should be a point type
+        $table->addColumn('point', Types::TEXT); // This should be a point type
         $table->addIndex(['point'], 'spatial_text');
 
         $index = $table->getIndex('spatial_text');
@@ -347,8 +348,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testAlterTableAddPrimaryKey(Comparator $comparator): void
     {
         $table = new Table('alter_table_add_pk');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('foo', Types::INTEGER);
         $table->addIndex(['id'], 'idx_id');
 
         $diffTable = clone $table;
@@ -369,8 +370,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testAlterPrimaryKeyWithAutoincrementColumn(Comparator $comparator): void
     {
         $table = new Table('alter_primary_key');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $diffTable = clone $table;
@@ -395,9 +396,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testDropPrimaryKeyWithAutoincrementColumn(Comparator $comparator): void
     {
         $table = new Table('drop_primary_key');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
         $table->setPrimaryKey(['id', 'foo']);
 
         $diffTable = clone $table;
@@ -421,9 +422,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         Comparator $comparator
     ): void {
         $table = new Table('tbl');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
         $table->setPrimaryKey(['id', 'foo']);
 
         $diffTable = clone $table;
@@ -448,9 +449,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testAddNonAutoincrementColumnToPrimaryKeyWithAutoincrementColumn(Comparator $comparator): void
     {
         $table = new Table('tbl');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('foo', Types::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $diffTable = clone $table;
@@ -475,12 +476,12 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testAddAutoIncrementPrimaryKey(Comparator $comparator): void
     {
         $keyTable = new Table('foo');
-        $keyTable->addColumn('id', 'integer', ['autoincrement' => true]);
-        $keyTable->addColumn('baz', 'string');
+        $keyTable->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $keyTable->addColumn('baz', Types::STRING);
         $keyTable->setPrimaryKey(['id']);
 
         $oldTable = new Table('foo');
-        $oldTable->addColumn('baz', 'string');
+        $oldTable->addColumn('baz', Types::STRING);
 
         $diff = $comparator->diffTable($oldTable, $keyTable);
         self::assertNotFalse($diff);
@@ -507,13 +508,13 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testAlterPrimaryKeyWithNewColumn(Comparator $comparator): void
     {
         $table = new Table('yolo');
-        $table->addColumn('pkc1', 'integer');
-        $table->addColumn('col_a', 'integer');
+        $table->addColumn('pkc1', Types::INTEGER);
+        $table->addColumn('col_a', Types::INTEGER);
         $table->setPrimaryKey(['pkc1']);
 
         $diffTable = clone $table;
 
-        $diffTable->addColumn('pkc2', 'integer');
+        $diffTable->addColumn('pkc2', Types::INTEGER);
         $diffTable->dropPrimaryKey();
         $diffTable->setPrimaryKey(['pkc1', 'pkc2']);
 
@@ -533,10 +534,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testInitializesDoctrineTypeMappings(): void
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('binary'));
-        self::assertSame('binary', $this->platform->getDoctrineTypeMapping('binary'));
+        self::assertSame(Types::BINARY, $this->platform->getDoctrineTypeMapping('binary'));
 
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('varbinary'));
-        self::assertSame('binary', $this->platform->getDoctrineTypeMapping('varbinary'));
+        self::assertSame(Types::BINARY, $this->platform->getDoctrineTypeMapping('varbinary'));
     }
 
     protected function getBinaryMaxLength(): int
@@ -584,8 +585,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testDoesNotPropagateForeignKeyCreationForNonSupportingEngines(): void
     {
         $table = new Table('foreign_table');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('fk_id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('fk_id', Types::INTEGER);
         $table->addForeignKeyConstraint('foreign_table', ['fk_id'], ['id']);
         $table->setPrimaryKey(['id']);
         $table->addOption('engine', 'MyISAM');
@@ -623,8 +624,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testDoesNotPropagateForeignKeyAlterationForNonSupportingEngines(): void
     {
         $table = new Table('foreign_table');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('fk_id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('fk_id', Types::INTEGER);
         $table->addForeignKeyConstraint('foreign_table', ['fk_id'], ['id']);
         $table->setPrimaryKey(['id']);
         $table->addOption('engine', 'MyISAM');
@@ -713,10 +714,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testIgnoresDifferenceInDefaultValuesForUnsupportedColumnTypes(): void
     {
         $table = new Table('text_blob_default_value');
-        $table->addColumn('def_text', 'text', ['default' => 'def']);
-        $table->addColumn('def_text_null', 'text', ['notnull' => false, 'default' => 'def']);
-        $table->addColumn('def_blob', 'blob', ['default' => 'def']);
-        $table->addColumn('def_blob_null', 'blob', ['notnull' => false, 'default' => 'def']);
+        $table->addColumn('def_text', Types::TEXT, ['default' => 'def']);
+        $table->addColumn('def_text_null', Types::TEXT, ['notnull' => false, 'default' => 'def']);
+        $table->addColumn('def_blob', Types::BLOB, ['default' => 'def']);
+        $table->addColumn('def_blob_null', Types::BLOB, ['notnull' => false, 'default' => 'def']);
 
         self::assertSame(
             [
@@ -959,8 +960,8 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');
-        $table->addColumn('no_collation', 'string');
-        $table->addColumn('column_collation', 'string')->setPlatformOption('collation', 'ascii_general_ci');
+        $table->addColumn('no_collation', Types::STRING);
+        $table->addColumn('column_collation', Types::STRING)->setPlatformOption('collation', 'ascii_general_ci');
 
         self::assertSame(
             [

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -102,8 +102,8 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testRegisterDoctrineMappingType(): void
     {
-        $this->platform->registerDoctrineTypeMapping('foo', 'integer');
-        self::assertEquals('integer', $this->platform->getDoctrineTypeMapping('foo'));
+        $this->platform->registerDoctrineTypeMapping('foo', Types::INTEGER);
+        self::assertEquals(Types::INTEGER, $this->platform->getDoctrineTypeMapping('foo'));
     }
 
     public function testRegisterUnknownDoctrineMappingType(): void
@@ -112,10 +112,11 @@ abstract class AbstractPlatformTestCase extends TestCase
         $this->platform->registerDoctrineTypeMapping('foo', 'bar');
     }
 
+    /** @psalm-suppress DeprecatedConstant */
     public function testRegistersCommentedDoctrineMappingTypeImplicitly(): void
     {
-        $type = Type::getType('array');
-        $this->platform->registerDoctrineTypeMapping('foo', 'array');
+        $type = Type::getType(Types::ARRAY);
+        $this->platform->registerDoctrineTypeMapping('foo', Types::ARRAY);
 
         self::assertTrue($this->platform->isCommentedDoctrineType($type));
     }
@@ -156,8 +157,8 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGeneratesTableCreationSql(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer', ['notnull' => true, 'autoincrement' => true]);
-        $table->addColumn('test', 'string', ['notnull' => false, 'length' => 255]);
+        $table->addColumn('id', Types::INTEGER, ['notnull' => true, 'autoincrement' => true]);
+        $table->addColumn('test', Types::STRING, ['notnull' => false, 'length' => 255]);
         $table->setPrimaryKey(['id']);
 
         $sql = $this->platform->getCreateTableSQL($table);
@@ -169,8 +170,8 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGenerateTableWithMultiColumnUniqueIndex(): void
     {
         $table = new Table('test');
-        $table->addColumn('foo', 'string', ['notnull' => false, 'length' => 255]);
-        $table->addColumn('bar', 'string', ['notnull' => false, 'length' => 255]);
+        $table->addColumn('foo', Types::STRING, ['notnull' => false, 'length' => 255]);
+        $table->addColumn('bar', Types::STRING, ['notnull' => false, 'length' => 255]);
         $table->addUniqueIndex(['foo', 'bar']);
 
         $sql = $this->platform->getCreateTableSQL($table);
@@ -328,8 +329,8 @@ abstract class AbstractPlatformTestCase extends TestCase
         $this->platform->setEventManager($eventManager);
 
         $table = new Table('test');
-        $table->addColumn('foo', 'string', ['notnull' => false, 'length' => 255]);
-        $table->addColumn('bar', 'string', ['notnull' => false, 'length' => 255]);
+        $table->addColumn('foo', Types::STRING, ['notnull' => false, 'length' => 255]);
+        $table->addColumn('bar', Types::STRING, ['notnull' => false, 'length' => 255]);
 
         $this->platform->getCreateTableSQL($table);
     }
@@ -381,24 +382,24 @@ abstract class AbstractPlatformTestCase extends TestCase
         $this->platform->setEventManager($eventManager);
 
         $table = new Table('mytable');
-        $table->addColumn('removed', 'integer');
-        $table->addColumn('changed', 'integer');
-        $table->addColumn('renamed', 'integer');
+        $table->addColumn('removed', Types::INTEGER);
+        $table->addColumn('changed', Types::INTEGER);
+        $table->addColumn('renamed', Types::INTEGER);
 
         $tableDiff                            = new TableDiff('mytable');
         $tableDiff->fromTable                 = $table;
-        $tableDiff->addedColumns['added']     = new Column('added', Type::getType('integer'), []);
-        $tableDiff->removedColumns['removed'] = new Column('removed', Type::getType('integer'), []);
+        $tableDiff->addedColumns['added']     = new Column('added', Type::getType(Types::INTEGER), []);
+        $tableDiff->removedColumns['removed'] = new Column('removed', Type::getType(Types::INTEGER), []);
         $tableDiff->changedColumns['changed'] = new ColumnDiff(
             'changed',
             new Column(
                 'changed2',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
                 [],
             ),
             [],
         );
-        $tableDiff->renamedColumns['renamed'] = new Column('renamed2', Type::getType('integer'), []);
+        $tableDiff->renamedColumns['renamed'] = new Column('renamed2', Type::getType(Types::INTEGER), []);
 
         $this->platform->getAlterTableSQL($tableDiff);
     }
@@ -406,7 +407,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testCreateTableColumnComments(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer', ['comment' => 'This is a comment']);
+        $table->addColumn('id', Types::INTEGER, ['comment' => 'This is a comment']);
         $table->setPrimaryKey(['id']);
 
         self::assertEquals($this->getCreateTableColumnCommentsSQL(), $this->platform->getCreateTableSQL($table));
@@ -415,12 +416,16 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testAlterTableColumnComments(): void
     {
         $tableDiff                        = new TableDiff('mytable');
-        $tableDiff->addedColumns['quota'] = new Column('quota', Type::getType('integer'), ['comment' => 'A comment']);
+        $tableDiff->addedColumns['quota'] = new Column(
+            'quota',
+            Type::getType(Types::INTEGER),
+            ['comment' => 'A comment'],
+        );
         $tableDiff->changedColumns['foo'] = new ColumnDiff(
             'foo',
             new Column(
                 'foo',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
             ),
             ['comment'],
         );
@@ -428,7 +433,7 @@ abstract class AbstractPlatformTestCase extends TestCase
             'bar',
             new Column(
                 'baz',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
                 ['comment' => 'B comment'],
             ),
             ['comment'],
@@ -440,8 +445,9 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testCreateTableColumnTypeComments(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('data', 'array');
+        $table->addColumn('id', Types::INTEGER);
+        /** @psalm-suppress DeprecatedConstant */
+        $table->addColumn('data', Types::ARRAY);
         $table->setPrimaryKey(['id']);
 
         self::assertEquals($this->getCreateTableColumnTypeCommentsSQL(), $this->platform->getCreateTableSQL($table));
@@ -469,15 +475,21 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         // non-timestamp value will get single quotes
         self::assertEquals(" DEFAULT 'non_timestamp'", $this->platform->getDefaultValueDeclarationSQL([
-            'type' => Type::getType('string'),
+            'type' => Type::getType(Types::STRING),
             'default' => 'non_timestamp',
         ]));
     }
 
     public function testGetDefaultValueDeclarationSQLDateTime(): void
     {
+        $types = [
+            Types::DATETIME_MUTABLE,
+            Types::DATETIMETZ_MUTABLE,
+            Types::DATETIME_IMMUTABLE,
+            Types::DATETIMETZ_IMMUTABLE,
+        ];
         // timestamps on datetime types should not be quoted
-        foreach (['datetime', 'datetimetz', 'datetime_immutable', 'datetimetz_immutable'] as $type) {
+        foreach ($types as $type) {
             self::assertSame(
                 ' DEFAULT ' . $this->platform->getCurrentTimestampSQL(),
                 $this->platform->getDefaultValueDeclarationSQL([
@@ -490,7 +502,7 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testGetDefaultValueDeclarationSQLForIntegerTypes(): void
     {
-        foreach (['bigint', 'integer', 'smallint'] as $type) {
+        foreach ([Types::BIGINT, Types::INTEGER, Types::SMALLINT] as $type) {
             self::assertEquals(
                 ' DEFAULT 1',
                 $this->platform->getDefaultValueDeclarationSQL([
@@ -504,7 +516,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGetDefaultValueDeclarationSQLForDateType(): void
     {
         $currentDateSql = $this->platform->getCurrentDateSQL();
-        foreach (['date', 'date_immutable'] as $type) {
+        foreach ([Types::DATE_MUTABLE, Types::DATE_IMMUTABLE] as $type) {
             self::assertSame(
                 ' DEFAULT ' . $currentDateSql,
                 $this->platform->getDefaultValueDeclarationSQL([
@@ -526,7 +538,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuotedColumnInPrimaryKeyPropagation(): void
     {
         $table = new Table('`quoted`');
-        $table->addColumn('create', 'string');
+        $table->addColumn('create', Types::STRING);
         $table->setPrimaryKey(['create']);
 
         $sql = $this->platform->getCreateTableSQL($table);
@@ -548,7 +560,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuotedColumnInIndexPropagation(): void
     {
         $table = new Table('`quoted`');
-        $table->addColumn('create', 'string');
+        $table->addColumn('create', Types::STRING);
         $table->addIndex(['create']);
 
         $sql = $this->platform->getCreateTableSQL($table);
@@ -558,7 +570,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuotedNameInIndexSQL(): void
     {
         $table = new Table('test');
-        $table->addColumn('column1', 'string');
+        $table->addColumn('column1', Types::STRING);
         $table->addIndex(['column1'], '`key`');
 
         $sql = $this->platform->getCreateTableSQL($table);
@@ -568,21 +580,21 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testQuotedColumnInForeignKeyPropagation(): void
     {
         $table = new Table('`quoted`');
-        $table->addColumn('create', 'string');
-        $table->addColumn('foo', 'string');
-        $table->addColumn('`bar`', 'string');
+        $table->addColumn('create', Types::STRING);
+        $table->addColumn('foo', Types::STRING);
+        $table->addColumn('`bar`', Types::STRING);
 
         // Foreign table with reserved keyword as name (needs quotation).
         $foreignTable = new Table('foreign');
 
         // Foreign column with reserved keyword as name (needs quotation).
-        $foreignTable->addColumn('create', 'string');
+        $foreignTable->addColumn('create', Types::STRING);
 
         // Foreign column with non-reserved keyword as name (does not need quotation).
-        $foreignTable->addColumn('bar', 'string');
+        $foreignTable->addColumn('bar', Types::STRING);
 
         // Foreign table with special character in name (needs quotation on some platforms, e.g. Sqlite).
-        $foreignTable->addColumn('`foo-bar`', 'string');
+        $foreignTable->addColumn('`foo-bar`', Types::STRING);
 
         $table->addForeignKeyConstraint(
             $foreignTable,
@@ -596,13 +608,13 @@ abstract class AbstractPlatformTestCase extends TestCase
         $foreignTable = new Table('foo');
 
         // Foreign column with reserved keyword as name (needs quotation).
-        $foreignTable->addColumn('create', 'string');
+        $foreignTable->addColumn('create', Types::STRING);
 
         // Foreign column with non-reserved keyword as name (does not need quotation).
-        $foreignTable->addColumn('bar', 'string');
+        $foreignTable->addColumn('bar', Types::STRING);
 
         // Foreign table with special character in name (needs quotation on some platforms, e.g. Sqlite).
-        $foreignTable->addColumn('`foo-bar`', 'string');
+        $foreignTable->addColumn('`foo-bar`', Types::STRING);
 
         $table->addForeignKeyConstraint(
             $foreignTable,
@@ -616,13 +628,13 @@ abstract class AbstractPlatformTestCase extends TestCase
         $foreignTable = new Table('`foo-bar`');
 
         // Foreign column with reserved keyword as name (needs quotation).
-        $foreignTable->addColumn('create', 'string');
+        $foreignTable->addColumn('create', Types::STRING);
 
         // Foreign column with non-reserved keyword as name (does not need quotation).
-        $foreignTable->addColumn('bar', 'string');
+        $foreignTable->addColumn('bar', Types::STRING);
 
         // Foreign table with special character in name (needs quotation on some platforms, e.g. Sqlite).
-        $foreignTable->addColumn('`foo-bar`', 'string');
+        $foreignTable->addColumn('`foo-bar`', Types::STRING);
 
         $table->addForeignKeyConstraint(
             $foreignTable,
@@ -702,7 +714,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testAlterTableChangeQuotedColumn(): void
     {
         $table = new Table('mytable');
-        $table->addColumn('select', 'integer');
+        $table->addColumn('select', Types::INTEGER);
 
         $tableDiff                           = new TableDiff('mytable');
         $tableDiff->fromTable                = $table;
@@ -710,7 +722,7 @@ abstract class AbstractPlatformTestCase extends TestCase
             'select',
             new Column(
                 'select',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
             ),
             ['type'],
         );
@@ -776,7 +788,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $column = [
             'length'  => 666,
             'notnull' => true,
-            'type'    => Type::getType('json'),
+            'type'    => Type::getType(Types::JSON),
         ];
 
         self::assertSame(
@@ -789,7 +801,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $tableDiff            = new TableDiff('mytable');
         $tableDiff->fromTable = new Table('mytable');
-        $tableDiff->fromTable->addColumn('id', 'integer');
+        $tableDiff->fromTable->addColumn('id', Types::INTEGER);
         $tableDiff->fromTable->setPrimaryKey(['id']);
         $tableDiff->renamedIndexes = [
             'idx_foo' => new Index('idx_bar', ['id']),
@@ -814,7 +826,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $tableDiff            = new TableDiff('table');
         $tableDiff->fromTable = new Table('table');
-        $tableDiff->fromTable->addColumn('id', 'integer');
+        $tableDiff->fromTable->addColumn('id', Types::INTEGER);
         $tableDiff->fromTable->setPrimaryKey(['id']);
         $tableDiff->renamedIndexes = [
             'create' => new Index('select', ['id']),
@@ -842,46 +854,46 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $fromTable = new Table('mytable');
 
-        $fromTable->addColumn('unquoted1', 'integer', ['comment' => 'Unquoted 1']);
-        $fromTable->addColumn('unquoted2', 'integer', ['comment' => 'Unquoted 2']);
-        $fromTable->addColumn('unquoted3', 'integer', ['comment' => 'Unquoted 3']);
+        $fromTable->addColumn('unquoted1', Types::INTEGER, ['comment' => 'Unquoted 1']);
+        $fromTable->addColumn('unquoted2', Types::INTEGER, ['comment' => 'Unquoted 2']);
+        $fromTable->addColumn('unquoted3', Types::INTEGER, ['comment' => 'Unquoted 3']);
 
-        $fromTable->addColumn('create', 'integer', ['comment' => 'Reserved keyword 1']);
-        $fromTable->addColumn('table', 'integer', ['comment' => 'Reserved keyword 2']);
-        $fromTable->addColumn('select', 'integer', ['comment' => 'Reserved keyword 3']);
+        $fromTable->addColumn('create', Types::INTEGER, ['comment' => 'Reserved keyword 1']);
+        $fromTable->addColumn('table', Types::INTEGER, ['comment' => 'Reserved keyword 2']);
+        $fromTable->addColumn('select', Types::INTEGER, ['comment' => 'Reserved keyword 3']);
 
-        $fromTable->addColumn('`quoted1`', 'integer', ['comment' => 'Quoted 1']);
-        $fromTable->addColumn('`quoted2`', 'integer', ['comment' => 'Quoted 2']);
-        $fromTable->addColumn('`quoted3`', 'integer', ['comment' => 'Quoted 3']);
+        $fromTable->addColumn('`quoted1`', Types::INTEGER, ['comment' => 'Quoted 1']);
+        $fromTable->addColumn('`quoted2`', Types::INTEGER, ['comment' => 'Quoted 2']);
+        $fromTable->addColumn('`quoted3`', Types::INTEGER, ['comment' => 'Quoted 3']);
 
         $toTable = new Table('mytable');
 
         // unquoted -> unquoted
-        $toTable->addColumn('unquoted', 'integer', ['comment' => 'Unquoted 1']);
+        $toTable->addColumn('unquoted', Types::INTEGER, ['comment' => 'Unquoted 1']);
 
         // unquoted -> reserved keyword
-        $toTable->addColumn('where', 'integer', ['comment' => 'Unquoted 2']);
+        $toTable->addColumn('where', Types::INTEGER, ['comment' => 'Unquoted 2']);
 
         // unquoted -> quoted
-        $toTable->addColumn('`foo`', 'integer', ['comment' => 'Unquoted 3']);
+        $toTable->addColumn('`foo`', Types::INTEGER, ['comment' => 'Unquoted 3']);
 
         // reserved keyword -> unquoted
-        $toTable->addColumn('reserved_keyword', 'integer', ['comment' => 'Reserved keyword 1']);
+        $toTable->addColumn('reserved_keyword', Types::INTEGER, ['comment' => 'Reserved keyword 1']);
 
         // reserved keyword -> reserved keyword
-        $toTable->addColumn('from', 'integer', ['comment' => 'Reserved keyword 2']);
+        $toTable->addColumn('from', Types::INTEGER, ['comment' => 'Reserved keyword 2']);
 
         // reserved keyword -> quoted
-        $toTable->addColumn('`bar`', 'integer', ['comment' => 'Reserved keyword 3']);
+        $toTable->addColumn('`bar`', Types::INTEGER, ['comment' => 'Reserved keyword 3']);
 
         // quoted -> unquoted
-        $toTable->addColumn('quoted', 'integer', ['comment' => 'Quoted 1']);
+        $toTable->addColumn('quoted', Types::INTEGER, ['comment' => 'Quoted 1']);
 
         // quoted -> reserved keyword
-        $toTable->addColumn('and', 'integer', ['comment' => 'Quoted 2']);
+        $toTable->addColumn('and', Types::INTEGER, ['comment' => 'Quoted 2']);
 
         // quoted -> quoted
-        $toTable->addColumn('`baz`', 'integer', ['comment' => 'Quoted 3']);
+        $toTable->addColumn('`baz`', Types::INTEGER, ['comment' => 'Quoted 3']);
 
         $diff = (new Comparator())->diffTable($fromTable, $toTable);
         self::assertNotFalse($diff);
@@ -903,23 +915,23 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $fromTable = new Table('mytable');
 
-        $fromTable->addColumn('unquoted1', 'string', ['comment' => 'Unquoted 1', 'length' => 10]);
-        $fromTable->addColumn('unquoted2', 'string', ['comment' => 'Unquoted 2', 'length' => 10]);
-        $fromTable->addColumn('unquoted3', 'string', ['comment' => 'Unquoted 3', 'length' => 10]);
+        $fromTable->addColumn('unquoted1', Types::STRING, ['comment' => 'Unquoted 1', 'length' => 10]);
+        $fromTable->addColumn('unquoted2', Types::STRING, ['comment' => 'Unquoted 2', 'length' => 10]);
+        $fromTable->addColumn('unquoted3', Types::STRING, ['comment' => 'Unquoted 3', 'length' => 10]);
 
-        $fromTable->addColumn('create', 'string', ['comment' => 'Reserved keyword 1', 'length' => 10]);
-        $fromTable->addColumn('table', 'string', ['comment' => 'Reserved keyword 2', 'length' => 10]);
-        $fromTable->addColumn('select', 'string', ['comment' => 'Reserved keyword 3', 'length' => 10]);
+        $fromTable->addColumn('create', Types::STRING, ['comment' => 'Reserved keyword 1', 'length' => 10]);
+        $fromTable->addColumn('table', Types::STRING, ['comment' => 'Reserved keyword 2', 'length' => 10]);
+        $fromTable->addColumn('select', Types::STRING, ['comment' => 'Reserved keyword 3', 'length' => 10]);
 
         $toTable = new Table('mytable');
 
-        $toTable->addColumn('unquoted1', 'string', ['comment' => 'Unquoted 1', 'length' => 255]);
-        $toTable->addColumn('unquoted2', 'string', ['comment' => 'Unquoted 2', 'length' => 255]);
-        $toTable->addColumn('unquoted3', 'string', ['comment' => 'Unquoted 3', 'length' => 255]);
+        $toTable->addColumn('unquoted1', Types::STRING, ['comment' => 'Unquoted 1', 'length' => 255]);
+        $toTable->addColumn('unquoted2', Types::STRING, ['comment' => 'Unquoted 2', 'length' => 255]);
+        $toTable->addColumn('unquoted3', Types::STRING, ['comment' => 'Unquoted 3', 'length' => 255]);
 
-        $toTable->addColumn('create', 'string', ['comment' => 'Reserved keyword 1', 'length' => 255]);
-        $toTable->addColumn('table', 'string', ['comment' => 'Reserved keyword 2', 'length' => 255]);
-        $toTable->addColumn('select', 'string', ['comment' => 'Reserved keyword 3', 'length' => 255]);
+        $toTable->addColumn('create', Types::STRING, ['comment' => 'Reserved keyword 1', 'length' => 255]);
+        $toTable->addColumn('table', Types::STRING, ['comment' => 'Reserved keyword 2', 'length' => 255]);
+        $toTable->addColumn('select', Types::STRING, ['comment' => 'Reserved keyword 3', 'length' => 255]);
 
         $diff = (new Comparator())->diffTable($fromTable, $toTable);
         self::assertNotFalse($diff);
@@ -941,7 +953,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $tableDiff            = new TableDiff('myschema.mytable');
         $tableDiff->fromTable = new Table('myschema.mytable');
-        $tableDiff->fromTable->addColumn('id', 'integer');
+        $tableDiff->fromTable->addColumn('id', Types::INTEGER);
         $tableDiff->fromTable->setPrimaryKey(['id']);
         $tableDiff->renamedIndexes = [
             'idx_foo' => new Index('idx_bar', ['id']),
@@ -966,7 +978,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $tableDiff            = new TableDiff('`schema`.table');
         $tableDiff->fromTable = new Table('`schema`.table');
-        $tableDiff->fromTable->addColumn('id', 'integer');
+        $tableDiff->fromTable->addColumn('id', Types::INTEGER);
         $tableDiff->fromTable->setPrimaryKey(['id']);
         $tableDiff->renamedIndexes = [
             'create' => new Index('select', ['id']),
@@ -1187,7 +1199,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $table = new Table('foo');
         $table->addColumn(
             'bar',
-            'integer',
+            Types::INTEGER,
             ['notnull' => true, 'default' => 666, 'comment' => 'rename test'],
         );
 
@@ -1195,7 +1207,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $tableDiff->fromTable             = $table;
         $tableDiff->renamedColumns['bar'] = new Column(
             'baz',
-            Type::getType('integer'),
+            Type::getType(Types::INTEGER),
             ['notnull' => true, 'default' => 666, 'comment' => 'rename test'],
         );
 
@@ -1208,7 +1220,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testAlterStringToFixedString(): void
     {
         $table = new Table('mytable');
-        $table->addColumn('name', 'string', ['length' => 2]);
+        $table->addColumn('name', Types::STRING, ['length' => 2]);
 
         $tableDiff            = new TableDiff('mytable');
         $tableDiff->fromTable = $table;
@@ -1217,7 +1229,7 @@ abstract class AbstractPlatformTestCase extends TestCase
             'name',
             new Column(
                 'name',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
                 ['fixed' => true, 'length' => 2],
             ),
             ['fixed'],
@@ -1236,13 +1248,13 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): void
     {
         $foreignTable = new Table('foreign_table');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
         $foreignTable->setPrimaryKey(['id']);
 
         $primaryTable = new Table('mytable');
-        $primaryTable->addColumn('foo', 'integer');
-        $primaryTable->addColumn('bar', 'integer');
-        $primaryTable->addColumn('baz', 'integer');
+        $primaryTable->addColumn('foo', Types::INTEGER);
+        $primaryTable->addColumn('bar', Types::INTEGER);
+        $primaryTable->addColumn('baz', Types::INTEGER);
         $primaryTable->addIndex(['foo'], 'idx_foo');
         $primaryTable->addIndex(['bar'], 'idx_bar');
         $primaryTable->addForeignKeyConstraint($foreignTable, ['foo'], ['id'], [], 'fk_foo');

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -155,8 +155,8 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     public function testGeneratesCreateTableSQLWithCommonIndexes(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('name', 'string', ['length' => 50]);
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('name', Types::STRING, ['length' => 50]);
         $table->setPrimaryKey(['id']);
         $table->addIndex(['name']);
         $table->addIndex(['id', 'name'], 'composite_idx');
@@ -174,9 +174,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     public function testGeneratesCreateTableSQLWithForeignKeyConstraints(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('fk_1', 'integer');
-        $table->addColumn('fk_2', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('fk_1', Types::INTEGER);
+        $table->addColumn('fk_2', Types::INTEGER);
         $table->setPrimaryKey(['id']);
         $table->addForeignKeyConstraint('foreign_table', ['fk_1', 'fk_2'], ['pk_1', 'pk_2']);
         $table->addForeignKeyConstraint(
@@ -207,9 +207,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     public function testGeneratesCreateTableSQLWithCheckConstraints(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('check_max', 'integer', ['platformOptions' => ['max' => 10]]);
-        $table->addColumn('check_min', 'integer', ['platformOptions' => ['min' => 10]]);
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('check_max', Types::INTEGER, ['platformOptions' => ['max' => 10]]);
+        $table->addColumn('check_min', Types::INTEGER, ['platformOptions' => ['min' => 10]]);
         $table->setPrimaryKey(['id']);
 
         self::assertEquals(
@@ -564,57 +564,57 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         return [
             [
                 'columnDefinition',
-                new Column('bar', Type::getType('decimal'), ['columnDefinition' => 'MONEY NOT NULL']),
+                new Column('bar', Type::getType(Types::DECIMAL), ['columnDefinition' => 'MONEY NOT NULL']),
                 'MONEY NOT NULL',
             ],
             [
                 'type',
-                new Column('bar', Type::getType('integer')),
+                new Column('bar', Type::getType(Types::INTEGER)),
                 'SET DATA TYPE INTEGER',
             ],
             [
                 'length',
-                new Column('bar', Type::getType('string'), ['length' => 100]),
+                new Column('bar', Type::getType(Types::STRING), ['length' => 100]),
                 'SET DATA TYPE VARCHAR(100)',
             ],
             [
                 'precision',
-                new Column('bar', Type::getType('decimal'), ['precision' => 10, 'scale' => 2]),
+                new Column('bar', Type::getType(Types::DECIMAL), ['precision' => 10, 'scale' => 2]),
                 'SET DATA TYPE NUMERIC(10, 2)',
             ],
             [
                 'scale',
-                new Column('bar', Type::getType('decimal'), ['precision' => 5, 'scale' => 4]),
+                new Column('bar', Type::getType(Types::DECIMAL), ['precision' => 5, 'scale' => 4]),
                 'SET DATA TYPE NUMERIC(5, 4)',
             ],
             [
                 'fixed',
-                new Column('bar', Type::getType('string'), ['length' => 20, 'fixed' => true]),
+                new Column('bar', Type::getType(Types::STRING), ['length' => 20, 'fixed' => true]),
                 'SET DATA TYPE CHAR(20)',
             ],
             [
                 'notnull',
-                new Column('bar', Type::getType('string'), ['notnull' => true]),
+                new Column('bar', Type::getType(Types::STRING), ['notnull' => true]),
                 'SET NOT NULL',
             ],
             [
                 'notnull',
-                new Column('bar', Type::getType('string'), ['notnull' => false]),
+                new Column('bar', Type::getType(Types::STRING), ['notnull' => false]),
                 'DROP NOT NULL',
             ],
             [
                 'default',
-                new Column('bar', Type::getType('string'), ['default' => 'foo']),
+                new Column('bar', Type::getType(Types::STRING), ['default' => 'foo']),
                 "SET DEFAULT 'foo'",
             ],
             [
                 'default',
-                new Column('bar', Type::getType('integer'), ['autoincrement' => true, 'default' => 666]),
+                new Column('bar', Type::getType(Types::INTEGER), ['autoincrement' => true, 'default' => 666]),
                 null,
             ],
             [
                 'default',
-                new Column('bar', Type::getType('string')),
+                new Column('bar', Type::getType(Types::STRING)),
                 'DROP DEFAULT',
             ],
         ];

--- a/tests/Platforms/MySQL/MariaDbJsonComparatorTest.php
+++ b/tests/Platforms/MySQL/MariaDbJsonComparatorTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\Comparator;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 use function sprintf;
@@ -39,28 +40,28 @@ class MariaDbJsonComparatorTest extends TestCase
             ['charset' => 'latin1', 'collation' => 'latin1_swedish_ci'],
         );
 
-        $this->tables['A']->addColumn('json_1', 'json')->setPlatformOption('collation', 'latin1_swedish_ci');
-        $this->tables['A']->addColumn('json_2', 'json')->setPlatformOption('collation', 'utf8_general_ci');
-        $this->tables['A']->addColumn('json_3', 'json');
+        $this->tables['A']->addColumn('json_1', Types::JSON)->setPlatformOption('collation', 'latin1_swedish_ci');
+        $this->tables['A']->addColumn('json_2', Types::JSON)->setPlatformOption('collation', 'utf8_general_ci');
+        $this->tables['A']->addColumn('json_3', Types::JSON);
 
         // TableB has no table-level collation and various column collations
         $this->tables['B'] = new Table('foo');
-        $this->tables['B']->addColumn('json_1', 'json')->setPlatformOption('collation', 'latin1_swedish_ci');
-        $this->tables['B']->addColumn('json_2', 'json')->setPlatformOption('collation', 'utf8_general_ci');
-        $this->tables['B']->addColumn('json_3', 'json');
+        $this->tables['B']->addColumn('json_1', Types::JSON)->setPlatformOption('collation', 'latin1_swedish_ci');
+        $this->tables['B']->addColumn('json_2', Types::JSON)->setPlatformOption('collation', 'utf8_general_ci');
+        $this->tables['B']->addColumn('json_3', Types::JSON);
 
         // Table C has no table-level collation and column collations as MariaDb would return for columns declared
         // as JSON
         $this->tables['C'] = new Table('foo');
-        $this->tables['C']->addColumn('json_1', 'json')->setPlatformOption('collation', 'utf8mb4_bin');
-        $this->tables['C']->addColumn('json_2', 'json')->setPlatformOption('collation', 'utf8mb4_bin');
-        $this->tables['C']->addColumn('json_3', 'json')->setPlatformOption('collation', 'utf8mb4_bin');
+        $this->tables['C']->addColumn('json_1', Types::JSON)->setPlatformOption('collation', 'utf8mb4_bin');
+        $this->tables['C']->addColumn('json_2', Types::JSON)->setPlatformOption('collation', 'utf8mb4_bin');
+        $this->tables['C']->addColumn('json_3', Types::JSON)->setPlatformOption('collation', 'utf8mb4_bin');
 
         // Table D has no table or column collations set
         $this->tables['D'] = new Table('foo');
-        $this->tables['D']->addColumn('json_1', 'json');
-        $this->tables['D']->addColumn('json_2', 'json');
-        $this->tables['D']->addColumn('json_3', 'json');
+        $this->tables['D']->addColumn('json_1', Types::JSON);
+        $this->tables['D']->addColumn('json_2', Types::JSON);
+        $this->tables['D']->addColumn('json_3', Types::JSON);
     }
 
     /** @return array{string, string}[] */

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use InvalidArgumentException;
 
@@ -35,7 +36,7 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
     public function testCollationOptionIsTakenIntoAccount(): void
     {
         $table = new Table('quotations');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addOption('collation', 'my_collation');
         self::assertStringContainsString(
             'my_collation',
@@ -46,7 +47,7 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
     public function testCollateOptionIsStillSupportedButDeprecated(): void
     {
         $table = new Table('quotations');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addOption('collate', 'my_collation');
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/issues/5214');
         self::assertStringContainsString(

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function sprintf;
 use function strtoupper;
@@ -303,7 +304,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         $columnName = strtoupper('id' . uniqid());
         $tableName  = strtoupper('table' . uniqid());
         $table      = new Table($tableName);
-        $column     = $table->addColumn($columnName, 'integer');
+        $column     = $table->addColumn($columnName, Types::INTEGER);
         $column->setAutoincrement(true);
 
         self::assertSame([
@@ -470,7 +471,7 @@ SQL
             'foo',
             new Column(
                 'foo',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
                 ['default' => 'bla', 'notnull' => true],
             ),
             ['type'],
@@ -479,7 +480,7 @@ SQL
             'bar',
             new Column(
                 'baz',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
                 ['default' => 'bla', 'notnull' => true],
             ),
             ['type', 'notnull'],
@@ -488,7 +489,7 @@ SQL
             'metar',
             new Column(
                 'metar',
-                Type::getType('string'),
+                Type::getType(Types::STRING),
                 ['length' => 2000, 'notnull' => false],
             ),
             ['notnull'],
@@ -505,13 +506,13 @@ SQL
     public function testInitializesDoctrineTypeMappings(): void
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('long raw'));
-        self::assertSame('blob', $this->platform->getDoctrineTypeMapping('long raw'));
+        self::assertSame(Types::BLOB, $this->platform->getDoctrineTypeMapping('long raw'));
 
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('raw'));
-        self::assertSame('binary', $this->platform->getDoctrineTypeMapping('raw'));
+        self::assertSame(Types::BINARY, $this->platform->getDoctrineTypeMapping('raw'));
 
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('date'));
-        self::assertSame('date', $this->platform->getDoctrineTypeMapping('date'));
+        self::assertSame(Types::DATE_MUTABLE, $this->platform->getDoctrineTypeMapping('date'));
     }
 
     protected function getBinaryMaxLength(): int
@@ -543,12 +544,12 @@ SQL
     public function testDoesNotPropagateUnnecessaryTableAlterationOnBinaryType(): void
     {
         $table1 = new Table('mytable');
-        $table1->addColumn('column_varbinary', 'binary');
-        $table1->addColumn('column_binary', 'binary', ['fixed' => true]);
+        $table1->addColumn('column_varbinary', Types::BINARY);
+        $table1->addColumn('column_binary', Types::BINARY, ['fixed' => true]);
 
         $table2 = new Table('mytable');
-        $table2->addColumn('column_varbinary', 'binary', ['fixed' => true]);
-        $table2->addColumn('column_binary', 'binary');
+        $table2->addColumn('column_varbinary', Types::BINARY, ['fixed' => true]);
+        $table2->addColumn('column_binary', Types::BINARY);
 
         self::assertFalse((new Comparator($this->platform))->diffTable($table1, $table2));
     }
@@ -720,8 +721,8 @@ SQL
 
     public function testAltersTableColumnCommentWithExplicitlyQuotedIdentifiers(): void
     {
-        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType('integer'))]);
-        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType('integer'), ['comment' => 'baz'])]);
+        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType(Types::INTEGER))]);
+        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType(Types::INTEGER), ['comment' => 'baz'])]);
 
         $comparator = new Comparator();
 
@@ -737,7 +738,7 @@ SQL
     public function testQuotedTableNames(): void
     {
         $table = new Table('"test"');
-        $table->addColumn('"id"', 'integer', ['autoincrement' => true]);
+        $table->addColumn('"id"', Types::INTEGER, ['autoincrement' => true]);
 
         // assert tabel
         self::assertTrue($table->isQuoted());

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -178,7 +178,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testGenerateTableWithAutoincrement(): void
     {
         $table  = new Table('autoinc_table');
-        $column = $table->addColumn('id', 'integer');
+        $column = $table->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
 
         self::assertEquals(
@@ -501,10 +501,10 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testAlterDecimalPrecisionScale(): void
     {
         $table = new Table('mytable');
-        $table->addColumn('dfoo1', 'decimal');
-        $table->addColumn('dfoo2', 'decimal', ['precision' => 10, 'scale' => 6]);
-        $table->addColumn('dfoo3', 'decimal', ['precision' => 10, 'scale' => 6]);
-        $table->addColumn('dfoo4', 'decimal', ['precision' => 10, 'scale' => 6]);
+        $table->addColumn('dfoo1', Types::DECIMAL);
+        $table->addColumn('dfoo2', Types::DECIMAL, ['precision' => 10, 'scale' => 6]);
+        $table->addColumn('dfoo3', Types::DECIMAL, ['precision' => 10, 'scale' => 6]);
+        $table->addColumn('dfoo4', Types::DECIMAL, ['precision' => 10, 'scale' => 6]);
 
         $tableDiff            = new TableDiff('mytable');
         $tableDiff->fromTable = $table;
@@ -513,7 +513,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'dloo1',
             new Column(
                 'dloo1',
-                Type::getType('decimal'),
+                Type::getType(Types::DECIMAL),
                 ['precision' => 16, 'scale' => 6],
             ),
             ['precision'],
@@ -522,7 +522,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'dloo2',
             new Column(
                 'dloo2',
-                Type::getType('decimal'),
+                Type::getType(Types::DECIMAL),
                 ['precision' => 10, 'scale' => 4],
             ),
             ['scale'],
@@ -531,7 +531,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'dloo3',
             new Column(
                 'dloo3',
-                Type::getType('decimal'),
+                Type::getType(Types::DECIMAL),
                 ['precision' => 10, 'scale' => 6],
             ),
             [],
@@ -540,7 +540,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'dloo4',
             new Column(
                 'dloo4',
-                Type::getType('decimal'),
+                Type::getType(Types::DECIMAL),
                 ['precision' => 16, 'scale' => 8],
             ),
             ['precision', 'scale'],
@@ -560,11 +560,11 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testDroppingConstraintsBeforeColumns(): void
     {
         $newTable = new Table('mytable');
-        $newTable->addColumn('id', 'integer');
+        $newTable->addColumn('id', Types::INTEGER);
         $newTable->setPrimaryKey(['id']);
 
         $oldTable = clone $newTable;
-        $oldTable->addColumn('parent_id', 'integer');
+        $oldTable->addColumn('parent_id', Types::INTEGER);
         $oldTable->addForeignKeyConstraint('mytable', ['parent_id'], ['id']);
 
         $diff = (new Comparator())->diffTable($oldTable, $newTable);
@@ -630,14 +630,14 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testDoesNotPropagateUnnecessaryTableAlterationOnBinaryType(): void
     {
         $table1 = new Table('mytable');
-        $table1->addColumn('column_varbinary', 'binary');
-        $table1->addColumn('column_binary', 'binary', ['fixed' => true]);
-        $table1->addColumn('column_blob', 'blob');
+        $table1->addColumn('column_varbinary', Types::BINARY);
+        $table1->addColumn('column_binary', Types::BINARY, ['fixed' => true]);
+        $table1->addColumn('column_blob', Types::BLOB);
 
         $table2 = new Table('mytable');
-        $table2->addColumn('column_varbinary', 'binary', ['fixed' => true]);
-        $table2->addColumn('column_binary', 'binary');
-        $table2->addColumn('column_blob', 'binary');
+        $table2->addColumn('column_varbinary', Types::BINARY, ['fixed' => true]);
+        $table2->addColumn('column_binary', Types::BINARY);
+        $table2->addColumn('column_blob', Types::BINARY);
 
         $comparator = new Comparator();
 
@@ -649,9 +649,9 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertEmpty($this->platform->getAlterTableSQL($diff));
 
         $table2 = new Table('mytable');
-        $table2->addColumn('column_varbinary', 'binary', ['length' => 42]);
-        $table2->addColumn('column_binary', 'blob');
-        $table2->addColumn('column_blob', 'binary', ['length' => 11, 'fixed' => true]);
+        $table2->addColumn('column_varbinary', Types::BINARY, ['length' => 42]);
+        $table2->addColumn('column_binary', Types::BLOB);
+        $table2->addColumn('column_blob', Types::BINARY, ['length' => 11, 'fixed' => true]);
 
         // VARBINARY -> VARBINARY with changed length
         // BINARY    -> BLOB
@@ -661,9 +661,9 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertEmpty($this->platform->getAlterTableSQL($diff));
 
         $table2 = new Table('mytable');
-        $table2->addColumn('column_varbinary', 'blob');
-        $table2->addColumn('column_binary', 'binary', ['length' => 42, 'fixed' => true]);
-        $table2->addColumn('column_blob', 'blob');
+        $table2->addColumn('column_varbinary', Types::BLOB);
+        $table2->addColumn('column_binary', Types::BINARY, ['length' => 42, 'fixed' => true]);
+        $table2->addColumn('column_blob', Types::BLOB);
 
         // VARBINARY -> BLOB
         // BINARY    -> BINARY with changed length
@@ -813,8 +813,8 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 
     public function testAltersTableColumnCommentWithExplicitlyQuotedIdentifiers(): void
     {
-        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType('integer'))]);
-        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType('integer'), ['comment' => 'baz'])]);
+        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType(Types::INTEGER))]);
+        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType(Types::INTEGER), ['comment' => 'baz'])]);
 
         $comparator = new Comparator();
 
@@ -829,8 +829,8 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 
     public function testAltersTableColumnCommentIfRequiredByType(): void
     {
-        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType('datetime'))]);
-        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType('datetime_immutable'))]);
+        $table1 = new Table('"foo"', [new Column('"bar"', Type::getType(Types::DATETIME_MUTABLE))]);
+        $table2 = new Table('"foo"', [new Column('"bar"', Type::getType(Types::DATETIME_IMMUTABLE))]);
 
         $comparator = new Comparator();
 
@@ -880,7 +880,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testInitializesTsvectorTypeMapping(): void
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('tsvector'));
-        self::assertEquals('text', $this->platform->getDoctrineTypeMapping('tsvector'));
+        self::assertEquals(Types::TEXT, $this->platform->getDoctrineTypeMapping('tsvector'));
     }
 
     public function testQuotesTableNameInListTableForeignKeysSQL(): void
@@ -947,7 +947,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testGetCreateTableSQLWithUniqueConstraints(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'string');
+        $table->addColumn('id', Types::STRING);
         $table->addUniqueConstraint(['id'], 'test_unique_constraint');
         self::assertSame(
             [
@@ -962,7 +962,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'string');
+        $table->addColumn('id', Types::STRING);
         $table->addOption('comment', 'foo');
         self::assertSame(
             [

--- a/tests/Platforms/ReservedKeywordsValidatorTest.php
+++ b/tests/Platforms/ReservedKeywordsValidatorTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Platforms\Keywords\ReservedKeywordsValidator;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class ReservedKeywordsValidatorTest extends TestCase
@@ -30,7 +31,7 @@ class ReservedKeywordsValidatorTest extends TestCase
     public function testReservedColumnName(): void
     {
         $table  = new Table('TABLE');
-        $column = $table->addColumn('table', 'string');
+        $column = $table->addColumn('table', Types::STRING);
 
         $this->validator->acceptColumn($table, $column);
 

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -18,7 +18,7 @@ class ColumnTest extends TestCase
         $column = $this->createColumn();
 
         self::assertEquals('foo', $column->getName());
-        self::assertSame(Type::getType('string'), $column->getType());
+        self::assertSame(Type::getType(Types::STRING), $column->getType());
 
         self::assertEquals(200, $column->getLength());
         self::assertEquals(5, $column->getPrecision());
@@ -43,7 +43,7 @@ class ColumnTest extends TestCase
     {
         $expected = [
             'name' => 'foo',
-            'type' => Type::getType('string'),
+            'type' => Type::getType(Types::STRING),
             'default' => 'baz',
             'notnull' => false,
             'length' => 200,
@@ -95,14 +95,14 @@ class ColumnTest extends TestCase
             'customSchemaOptions' => ['bar' => 'baz'],
         ];
 
-        $string = Type::getType('string');
+        $string = Type::getType(Types::STRING);
 
         return new Column('foo', $string, $options);
     }
 
     public function testQuotedColumnName(): void
     {
-        $string = Type::getType('string');
+        $string = Type::getType(Types::STRING);
         $column = new Column('`bar`', $string, []);
 
         $mysqlPlatform  = new MySQLPlatform();
@@ -123,7 +123,7 @@ class ColumnTest extends TestCase
     /** @dataProvider getIsQuoted */
     public function testIsQuoted(string $columnName, bool $isQuoted): void
     {
-        $type   = Type::getType('string');
+        $type   = Type::getType(Types::STRING);
         $column = new Column($columnName, $type);
 
         self::assertSame($isQuoted, $column->isQuoted());
@@ -142,7 +142,7 @@ class ColumnTest extends TestCase
 
     public function testColumnComment(): void
     {
-        $column = new Column('bar', Type::getType('string'));
+        $column = new Column('bar', Type::getType(Types::STRING));
         self::assertNull($column->getComment());
 
         $column->setComment('foo');

--- a/tests/Schema/ComparatorTest.php
+++ b/tests/Schema/ComparatorTest.php
@@ -38,7 +38,7 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -46,7 +46,7 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -62,8 +62,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -71,8 +71,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -86,7 +86,7 @@ class ComparatorTest extends TestCase
     {
         $schemaConfig = new SchemaConfig();
 
-        $table = new Table('bugdb', ['integercolumn1' => new Column('integercolumn1', Type::getType('integer'))]);
+        $table = new Table('bugdb', ['integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER))]);
         $table->setSchemaConfig($schemaConfig);
 
         $schema1 = new Schema([$table], [], $schemaConfig);
@@ -101,7 +101,7 @@ class ComparatorTest extends TestCase
     {
         $schemaConfig = new SchemaConfig();
 
-        $table = new Table('bugdb', ['integercolumn1' => new Column('integercolumn1', Type::getType('integer'))]);
+        $table = new Table('bugdb', ['integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER))]);
         $table->setSchemaConfig($schemaConfig);
 
         $schema1 = new Schema([], [], $schemaConfig);
@@ -114,8 +114,8 @@ class ComparatorTest extends TestCase
 
     public function testCompareOnlyAutoincrementChanged(): void
     {
-        $column1 = new Column('foo', Type::getType('integer'), ['autoincrement' => true]);
-        $column2 = new Column('foo', Type::getType('integer'), ['autoincrement' => false]);
+        $column1 = new Column('foo', Type::getType(Types::INTEGER), ['autoincrement' => true]);
+        $column2 = new Column('foo', Type::getType(Types::INTEGER), ['autoincrement' => false]);
 
         $changedProperties = $this->comparator->diffColumn($column1, $column2);
 
@@ -124,13 +124,13 @@ class ComparatorTest extends TestCase
 
     public function testCompareMissingField(): void
     {
-        $missingColumn = new Column('integercolumn1', Type::getType('integer'));
+        $missingColumn = new Column('integercolumn1', Type::getType(Types::INTEGER));
         $schema1       = new Schema([
             'bugdb' => new Table(
                 'bugdb',
                 [
                     'integercolumn1' => $missingColumn,
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -138,7 +138,7 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -166,7 +166,7 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -174,8 +174,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -186,7 +186,7 @@ class ComparatorTest extends TestCase
                 'bugdb' => new TableDiff(
                     'bugdb',
                     [
-                        'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                        'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                     ],
                 ),
             ],
@@ -199,8 +199,8 @@ class ComparatorTest extends TestCase
 
     public function testCompareChangedColumnsChangeType(): void
     {
-        $column1 = new Column('charcolumn1', Type::getType('string'));
-        $column2 = new Column('charcolumn1', Type::getType('integer'));
+        $column1 = new Column('charcolumn1', Type::getType(Types::STRING));
+        $column2 = new Column('charcolumn1', Type::getType(Types::INTEGER));
 
         self::assertEquals(['type'], $this->comparator->diffColumn($column1, $column2));
         self::assertEquals([], $this->comparator->diffColumn($column1, $column1));
@@ -208,9 +208,9 @@ class ComparatorTest extends TestCase
 
     public function testCompareColumnsMultipleTypeInstances(): void
     {
-        $integerType1 = Type::getType('integer');
-        Type::overrideType('integer', get_class($integerType1));
-        $integerType2 = Type::getType('integer');
+        $integerType1 = Type::getType(Types::INTEGER);
+        Type::overrideType(Types::INTEGER, get_class($integerType1));
+        $integerType2 = Type::getType(Types::INTEGER);
 
         $column1 = new Column('integercolumn1', $integerType1);
         $column2 = new Column('integercolumn1', $integerType2);
@@ -220,13 +220,13 @@ class ComparatorTest extends TestCase
 
     public function testCompareColumnsOverriddenType(): void
     {
-        $oldStringInstance = Type::getType('string');
-        $integerType       = Type::getType('integer');
+        $oldStringInstance = Type::getType(Types::STRING);
+        $integerType       = Type::getType(Types::INTEGER);
 
-        Type::overrideType('string', get_class($integerType));
-        $overriddenStringType = Type::getType('string');
+        Type::overrideType(Types::STRING, get_class($integerType));
+        $overriddenStringType = Type::getType(Types::STRING);
 
-        Type::overrideType('string', get_class($oldStringInstance));
+        Type::overrideType(Types::STRING, get_class($oldStringInstance));
 
         $column1 = new Column('integercolumn1', $integerType);
         $column2 = new Column('integercolumn1', $overriddenStringType);
@@ -236,8 +236,8 @@ class ComparatorTest extends TestCase
 
     public function testCompareChangedColumnsChangeCustomSchemaOption(): void
     {
-        $column1 = new Column('charcolumn1', Type::getType('string'));
-        $column2 = new Column('charcolumn1', Type::getType('string'));
+        $column1 = new Column('charcolumn1', Type::getType(Types::STRING));
+        $column2 = new Column('charcolumn1', Type::getType(Types::STRING));
 
         $column1->setCustomSchemaOption('foo', 'bar');
         $column2->setCustomSchemaOption('foo', 'bar');
@@ -252,11 +252,11 @@ class ComparatorTest extends TestCase
     public function testCompareChangeColumnsMultipleNewColumnsRename(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('datecolumn1', 'datetime');
+        $tableA->addColumn('datecolumn1', Types::DATETIME_MUTABLE);
 
         $tableB = new Table('foo');
-        $tableB->addColumn('new_datecolumn1', 'datetime');
-        $tableB->addColumn('new_datecolumn2', 'datetime');
+        $tableB->addColumn('new_datecolumn1', Types::DATETIME_MUTABLE);
+        $tableB->addColumn('new_datecolumn2', Types::DATETIME_MUTABLE);
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
@@ -275,8 +275,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
                 [
                     'primary' => new Index(
@@ -291,8 +291,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -329,8 +329,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -338,8 +338,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
                 [
                     'primary' => new Index(
@@ -381,8 +381,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
                 [
                     'primary' => new Index(
@@ -397,8 +397,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
                 [
                     'primary' => new Index(
@@ -444,8 +444,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
                 [
                     'primary' => new Index('primary', ['integercolumn1', 'integercolumn2'], true),
@@ -456,8 +456,8 @@ class ComparatorTest extends TestCase
             'bugdb' => new Table(
                 'bugdb',
                 [
-                    'integercolumn1' => new Column('integercolumn1', Type::getType('integer')),
-                    'integercolumn2' => new Column('integercolumn2', Type::getType('integer')),
+                    'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+                    'integercolumn2' => new Column('integercolumn2', Type::getType(Types::INTEGER)),
                 ],
                 [
                     'primary' => new Index('primary', ['integercolumn2', 'integercolumn1'], true),
@@ -527,13 +527,13 @@ class ComparatorTest extends TestCase
     public function testTableAddForeignKey(): void
     {
         $tableForeign = new Table('bar');
-        $tableForeign->addColumn('id', 'integer');
+        $tableForeign->addColumn('id', Types::INTEGER);
 
         $table1 = new Table('foo');
-        $table1->addColumn('fk', 'integer');
+        $table1->addColumn('fk', Types::INTEGER);
 
         $table2 = new Table('foo');
-        $table2->addColumn('fk', 'integer');
+        $table2->addColumn('fk', Types::INTEGER);
         $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
 
         $tableDiff = $this->comparator->diffTable($table1, $table2);
@@ -545,13 +545,13 @@ class ComparatorTest extends TestCase
     public function testTableRemoveForeignKey(): void
     {
         $tableForeign = new Table('bar');
-        $tableForeign->addColumn('id', 'integer');
+        $tableForeign->addColumn('id', Types::INTEGER);
 
         $table1 = new Table('foo');
-        $table1->addColumn('fk', 'integer');
+        $table1->addColumn('fk', Types::INTEGER);
 
         $table2 = new Table('foo');
-        $table2->addColumn('fk', 'integer');
+        $table2->addColumn('fk', Types::INTEGER);
         $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
 
         $tableDiff = $this->comparator->diffTable($table2, $table1);
@@ -563,14 +563,14 @@ class ComparatorTest extends TestCase
     public function testTableUpdateForeignKey(): void
     {
         $tableForeign = new Table('bar');
-        $tableForeign->addColumn('id', 'integer');
+        $tableForeign->addColumn('id', Types::INTEGER);
 
         $table1 = new Table('foo');
-        $table1->addColumn('fk', 'integer');
+        $table1->addColumn('fk', Types::INTEGER);
         $table1->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
 
         $table2 = new Table('foo');
-        $table2->addColumn('fk', 'integer');
+        $table2->addColumn('fk', Types::INTEGER);
         $table2->addForeignKeyConstraint($tableForeign, ['fk'], ['id'], ['onUpdate' => 'CASCADE']);
 
         $tableDiff = $this->comparator->diffTable($table1, $table2);
@@ -582,17 +582,17 @@ class ComparatorTest extends TestCase
     public function testMovedForeignKeyForeignTable(): void
     {
         $tableForeign = new Table('bar');
-        $tableForeign->addColumn('id', 'integer');
+        $tableForeign->addColumn('id', Types::INTEGER);
 
         $tableForeign2 = new Table('bar2');
-        $tableForeign2->addColumn('id', 'integer');
+        $tableForeign2->addColumn('id', Types::INTEGER);
 
         $table1 = new Table('foo');
-        $table1->addColumn('fk', 'integer');
+        $table1->addColumn('fk', Types::INTEGER);
         $table1->addForeignKeyConstraint($tableForeign, ['fk'], ['id']);
 
         $table2 = new Table('foo');
-        $table2->addColumn('fk', 'integer');
+        $table2->addColumn('fk', Types::INTEGER);
         $table2->addForeignKeyConstraint($tableForeign2, ['fk'], ['id']);
 
         $tableDiff = $this->comparator->diffTable($table1, $table2);
@@ -642,10 +642,10 @@ class ComparatorTest extends TestCase
     public function testCompareColumnCompareCaseInsensitive(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('id', 'integer');
+        $tableA->addColumn('id', Types::INTEGER);
 
         $tableB = new Table('foo');
-        $tableB->addColumn('ID', 'integer');
+        $tableB->addColumn('ID', Types::INTEGER);
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
 
@@ -655,11 +655,11 @@ class ComparatorTest extends TestCase
     public function testCompareIndexBasedOnPropertiesNotName(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('id', 'integer');
+        $tableA->addColumn('id', Types::INTEGER);
         $tableA->addIndex(['id'], 'foo_bar_idx');
 
         $tableB = new Table('foo');
-        $tableB->addColumn('ID', 'integer');
+        $tableB->addColumn('ID', Types::INTEGER);
         $tableB->addIndex(['id'], 'bar_foo_idx');
 
         $tableDiff                                = new TableDiff('foo');
@@ -675,11 +675,11 @@ class ComparatorTest extends TestCase
     public function testCompareForeignKeyBasedOnPropertiesNotName(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('id', 'integer');
+        $tableA->addColumn('id', Types::INTEGER);
         $tableA->addForeignKeyConstraint('bar', ['id'], ['id'], [], 'foo_constraint');
 
         $tableB = new Table('foo');
-        $tableB->addColumn('ID', 'integer');
+        $tableB->addColumn('ID', Types::INTEGER);
         $tableB->addForeignKeyConstraint('bar', ['id'], ['id'], [], 'bar_constraint');
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
@@ -706,10 +706,10 @@ class ComparatorTest extends TestCase
     public function testDetectRenameColumn(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('foo', 'integer');
+        $tableA->addColumn('foo', Types::INTEGER);
 
         $tableB = new Table('foo');
-        $tableB->addColumn('bar', 'integer');
+        $tableB->addColumn('bar', Types::INTEGER);
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
@@ -728,11 +728,11 @@ class ComparatorTest extends TestCase
     public function testDetectRenameColumnAmbiguous(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('foo', 'integer');
-        $tableA->addColumn('bar', 'integer');
+        $tableA->addColumn('foo', Types::INTEGER);
+        $tableA->addColumn('bar', Types::INTEGER);
 
         $tableB = new Table('foo');
-        $tableB->addColumn('baz', 'integer');
+        $tableB->addColumn('baz', Types::INTEGER);
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
@@ -748,7 +748,7 @@ class ComparatorTest extends TestCase
     public function testDetectRenameIndex(): void
     {
         $table1 = new Table('foo');
-        $table1->addColumn('foo', 'integer');
+        $table1->addColumn('foo', Types::INTEGER);
 
         $table2 = clone $table1;
 
@@ -773,7 +773,7 @@ class ComparatorTest extends TestCase
     public function testDetectRenameIndexAmbiguous(): void
     {
         $table1 = new Table('foo');
-        $table1->addColumn('foo', 'integer');
+        $table1->addColumn('foo', Types::INTEGER);
 
         $table2 = clone $table1;
 
@@ -796,10 +796,10 @@ class ComparatorTest extends TestCase
     public function testDetectChangeIdentifierType(): void
     {
         $tableA = new Table('foo');
-        $tableA->addColumn('id', 'integer', ['autoincrement' => false]);
+        $tableA->addColumn('id', Types::INTEGER, ['autoincrement' => false]);
 
         $tableB = new Table('foo');
-        $tableB->addColumn('id', 'integer', ['autoincrement' => true]);
+        $tableB->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
 
@@ -810,16 +810,16 @@ class ComparatorTest extends TestCase
     public function testDiff(): void
     {
         $table = new Table('twitter_users');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
-        $table->addColumn('twitterId', 'integer');
-        $table->addColumn('displayName', 'string');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('twitterId', Types::INTEGER);
+        $table->addColumn('displayName', Types::STRING);
         $table->setPrimaryKey(['id']);
 
         $newtable = new Table('twitter_users');
-        $newtable->addColumn('id', 'integer', ['autoincrement' => true]);
-        $newtable->addColumn('twitter_id', 'integer');
-        $newtable->addColumn('display_name', 'string');
-        $newtable->addColumn('logged_in_at', 'datetime');
+        $newtable->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $newtable->addColumn('twitter_id', Types::INTEGER);
+        $newtable->addColumn('display_name', Types::STRING);
+        $newtable->addColumn('logged_in_at', Types::DATETIME_MUTABLE);
         $newtable->setPrimaryKey(['id']);
 
         $tableDiff = $this->comparator->diffTable($table, $newtable);
@@ -846,10 +846,10 @@ class ComparatorTest extends TestCase
     /** @psalm-suppress NullArgument */
     public function testDiffDecimalWithNullPrecision(): void
     {
-        $column = new Column('foo', Type::getType('decimal'));
+        $column = new Column('foo', Type::getType(Types::DECIMAL));
         $column->setPrecision(null);
 
-        $column2 = new Column('foo', Type::getType('decimal'));
+        $column2 = new Column('foo', Type::getType(Types::DECIMAL));
 
         self::assertEquals([], $this->comparator->diffColumn($column, $column2));
     }
@@ -932,13 +932,13 @@ class ComparatorTest extends TestCase
     {
         $oldSchema = new Schema();
         $table     = $oldSchema->createTable('foo');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
         $oldSchema->createSequence('foo_id_seq');
 
         $newSchema = new Schema();
         $table     = $newSchema->createTable('foo');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         $diff = $this->comparator->compare($oldSchema, $newSchema);
@@ -953,12 +953,12 @@ class ComparatorTest extends TestCase
     {
         $oldSchema = new Schema();
         $table     = $oldSchema->createTable('foo');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         $newSchema = new Schema();
         $table     = $newSchema->createTable('foo');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
         $newSchema->createSequence('foo_id_seq');
 
@@ -978,15 +978,15 @@ class ComparatorTest extends TestCase
         $oldSchema = new Schema();
 
         $tableA = $oldSchema->createTable('table_a');
-        $tableA->addColumn('id', 'integer');
+        $tableA->addColumn('id', Types::INTEGER);
 
         $tableB = $oldSchema->createTable('table_b');
-        $tableB->addColumn('id', 'integer');
+        $tableB->addColumn('id', Types::INTEGER);
 
         $tableC = $oldSchema->createTable('table_c');
-        $tableC->addColumn('id', 'integer');
-        $tableC->addColumn('table_a_id', 'integer');
-        $tableC->addColumn('table_b_id', 'integer');
+        $tableC->addColumn('id', Types::INTEGER);
+        $tableC->addColumn('table_a_id', Types::INTEGER);
+        $tableC->addColumn('table_b_id', Types::INTEGER);
 
         $tableC->addForeignKeyConstraint($tableA, ['table_a_id'], ['id']);
         $tableC->addForeignKeyConstraint($tableB, ['table_b_id'], ['id']);
@@ -994,10 +994,10 @@ class ComparatorTest extends TestCase
         $newSchema = new Schema();
 
         $tableB = $newSchema->createTable('table_b');
-        $tableB->addColumn('id', 'integer');
+        $tableB->addColumn('id', Types::INTEGER);
 
         $tableC = $newSchema->createTable('table_c');
-        $tableC->addColumn('id', 'integer');
+        $tableC->addColumn('id', Types::INTEGER);
 
         $schemaDiff = $this->comparator->compare($oldSchema, $newSchema);
 
@@ -1010,11 +1010,11 @@ class ComparatorTest extends TestCase
         $oldSchema = new Schema();
 
         $tableFoo = $oldSchema->createTable('foo');
-        $tableFoo->addColumn('id', 'integer');
+        $tableFoo->addColumn('id', Types::INTEGER);
 
         $newSchema = new Schema();
         $table     = $newSchema->createTable('foo');
-        $table->addColumn('id', 'string');
+        $table->addColumn('id', Types::STRING);
 
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
@@ -1035,11 +1035,11 @@ class ComparatorTest extends TestCase
         $oldSchema = new Schema();
 
         $tableFoo = $oldSchema->createTable('foo');
-        $tableFoo->addColumn('id', 'binary');
+        $tableFoo->addColumn('id', Types::BINARY);
 
         $newSchema = new Schema();
         $table     = $newSchema->createTable('foo');
-        $table->addColumn('id', 'binary', ['length' => 42, 'fixed' => true]);
+        $table->addColumn('id', Types::BINARY, ['length' => 42, 'fixed' => true]);
 
         $expected             = new SchemaDiff();
         $expected->fromSchema = $oldSchema;
@@ -1089,28 +1089,28 @@ class ComparatorTest extends TestCase
 
     public function testDiffColumnPlatformOptions(): void
     {
-        $column1 = new Column('foo', Type::getType('string'), [
+        $column1 = new Column('foo', Type::getType(Types::STRING), [
             'platformOptions' => [
                 'foo' => 'foo',
                 'bar' => 'bar',
             ],
         ]);
 
-        $column2 = new Column('foo', Type::getType('string'), [
+        $column2 = new Column('foo', Type::getType(Types::STRING), [
             'platformOptions' => [
                 'foo' => 'foo',
                 'foobar' => 'foobar',
             ],
         ]);
 
-        $column3 = new Column('foo', Type::getType('string'), [
+        $column3 = new Column('foo', Type::getType(Types::STRING), [
             'platformOptions' => [
                 'foo' => 'foo',
                 'bar' => 'rab',
             ],
         ]);
 
-        $column4 = new Column('foo', Type::getType('string'));
+        $column4 = new Column('foo', Type::getType(Types::STRING));
 
         self::assertEquals([], $this->comparator->diffColumn($column1, $column2));
         self::assertEquals([], $this->comparator->diffColumn($column2, $column1));
@@ -1122,12 +1122,12 @@ class ComparatorTest extends TestCase
 
     public function testComplexDiffColumn(): void
     {
-        $column1 = new Column('foo', Type::getType('string'), [
+        $column1 = new Column('foo', Type::getType(Types::STRING), [
             'platformOptions' => ['foo' => 'foo'],
             'customSchemaOptions' => ['foo' => 'bar'],
         ]);
 
-        $column2 = new Column('foo', Type::getType('string'), [
+        $column2 = new Column('foo', Type::getType(Types::STRING), [
             'platformOptions' => ['foo' => 'bar'],
         ]);
 
@@ -1170,10 +1170,10 @@ class ComparatorTest extends TestCase
 
     public function testCompareGuidColumns(): void
     {
-        $column1 = new Column('foo', Type::getType('guid'), ['comment' => 'GUID 1']);
+        $column1 = new Column('foo', Type::getType(Types::GUID), ['comment' => 'GUID 1']);
         $column2 = new Column(
             'foo',
-            Type::getType('guid'),
+            Type::getType(Types::GUID),
             ['notnull' => false, 'length' => '36', 'fixed' => true, 'default' => 'NEWID()', 'comment' => 'GUID 2.'],
         );
 
@@ -1184,8 +1184,8 @@ class ComparatorTest extends TestCase
     /** @dataProvider getCompareColumnComments */
     public function testCompareColumnComments(?string $comment1, ?string $comment2, bool $equals): void
     {
-        $column1 = new Column('foo', Type::getType('integer'), ['comment' => $comment1]);
-        $column2 = new Column('foo', Type::getType('integer'), ['comment' => $comment2]);
+        $column1 = new Column('foo', Type::getType(Types::INTEGER), ['comment' => $comment1]);
+        $column2 = new Column('foo', Type::getType(Types::INTEGER), ['comment' => $comment2]);
 
         $expectedDiff = $equals ? [] : ['comment'];
 
@@ -1224,6 +1224,7 @@ class ComparatorTest extends TestCase
         ];
     }
 
+    /** @psalm-suppress DeprecatedConstant */
     public function testCompareCommentedTypes(): void
     {
         $column1 = new Column('foo', Type::getType(Types::ARRAY));
@@ -1238,14 +1239,14 @@ class ComparatorTest extends TestCase
             'table1' => new Table(
                 'table1',
                 [
-                    'id' => new Column('id', Type::getType('integer')),
+                    'id' => new Column('id', Type::getType(Types::INTEGER)),
                 ],
             ),
             'table2' => new Table(
                 'table2',
                 [
-                    'id' => new Column('id', Type::getType('integer')),
-                    'id_table1' => new Column('id_table1', Type::getType('integer')),
+                    'id' => new Column('id', Type::getType(Types::INTEGER)),
+                    'id_table1' => new Column('id_table1', Type::getType(Types::INTEGER)),
                 ],
                 [],
                 [],
@@ -1258,8 +1259,8 @@ class ComparatorTest extends TestCase
             'table2' => new Table(
                 'table2',
                 [
-                    'id' => new Column('id', Type::getType('integer')),
-                    'id_table3' => new Column('id_table3', Type::getType('integer')),
+                    'id' => new Column('id', Type::getType(Types::INTEGER)),
+                    'id_table3' => new Column('id_table3', Type::getType(Types::INTEGER)),
                 ],
                 [],
                 [],
@@ -1270,7 +1271,7 @@ class ComparatorTest extends TestCase
             'table3' => new Table(
                 'table3',
                 [
-                    'id' => new Column('id', Type::getType('integer')),
+                    'id' => new Column('id', Type::getType(Types::INTEGER)),
                 ],
             ),
         ]);
@@ -1296,7 +1297,7 @@ class ComparatorTest extends TestCase
                 new Table(
                     'a_table',
                     [
-                        new Column('is_default', Type::getType('string')),
+                        new Column('is_default', Type::getType(Types::STRING)),
                     ],
                 ),
             ],
@@ -1306,7 +1307,11 @@ class ComparatorTest extends TestCase
                 new Table(
                     'a_table',
                     [
-                        new Column('is_default', Type::getType('string'), ['columnDefinition' => 'ENUM(\'default\')']),
+                        new Column(
+                            'is_default',
+                            Type::getType(Types::STRING),
+                            ['columnDefinition' => 'ENUM(\'default\')'],
+                        ),
                     ],
                 ),
             ],
@@ -1324,11 +1329,11 @@ class ComparatorTest extends TestCase
         $schema1 = new Schema();
 
         $parent = $schema1->createTable('parent');
-        $parent->addColumn('id', 'integer');
+        $parent->addColumn('id', Types::INTEGER);
 
         $child = $schema1->createTable('child');
-        $child->addColumn('id', 'integer');
-        $child->addColumn('parent_id', 'integer');
+        $child->addColumn('id', Types::INTEGER);
+        $child->addColumn('parent_id', Types::INTEGER);
         $child->addForeignKeyConstraint('parent', ['parent_id'], ['id']);
 
         $schema2 = new Schema();

--- a/tests/Schema/MySQLInheritCharsetTest.php
+++ b/tests/Schema/MySQLInheritCharsetTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -44,7 +45,7 @@ class MySQLInheritCharsetTest extends TestCase
         $platform = new MySQLPlatform();
 
         // default, no overrides
-        $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
+        $table = new Table('foobar', [new Column('aa', Type::getType(Types::INTEGER))]);
         self::assertSame(
             [
                 'CREATE TABLE foobar (aa INT NOT NULL)'
@@ -54,7 +55,7 @@ class MySQLInheritCharsetTest extends TestCase
         );
 
         // explicit utf8
-        $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
+        $table = new Table('foobar', [new Column('aa', Type::getType(Types::INTEGER))]);
         $table->addOption('charset', 'utf8');
         self::assertSame(
             [
@@ -65,7 +66,7 @@ class MySQLInheritCharsetTest extends TestCase
         );
 
         // explicit utf8mb4
-        $table = new Table('foobar', [new Column('aa', Type::getType('integer'))]);
+        $table = new Table('foobar', [new Column('aa', Type::getType(Types::INTEGER))]);
         $table->addOption('charset', 'utf8mb4');
         self::assertSame(
             ['CREATE TABLE foobar (aa INT NOT NULL)'

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class MySQLSchemaTest extends TestCase
@@ -22,7 +23,7 @@ class MySQLSchemaTest extends TestCase
     public function testGenerateForeignKeySQL(): void
     {
         $tableOld = new Table('test');
-        $tableOld->addColumn('foo_id', 'integer');
+        $tableOld->addColumn('foo_id', Types::INTEGER);
         $tableOld->addForeignKeyConstraint('test_foreign', ['foo_id'], ['foo_id']);
 
         $sqls = [];
@@ -43,8 +44,8 @@ class MySQLSchemaTest extends TestCase
     public function testClobNoAlterTable(Comparator $comparator): void
     {
         $tableOld = new Table('test');
-        $tableOld->addColumn('id', 'integer');
-        $tableOld->addColumn('description', 'string', ['length' => 65536]);
+        $tableOld->addColumn('id', Types::INTEGER);
+        $tableOld->addColumn('description', Types::STRING, ['length' => 65536]);
         $tableNew = clone $tableOld;
 
         $tableNew->setPrimaryKey(['id']);

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\AbstractVisitor;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -181,7 +182,7 @@ class SchemaTest extends TestCase
 
         $schema = new Schema([], [], $schemaConfig);
         $table  = $schema->createTable('smalltable');
-        $table->addColumn('long_id', 'integer');
+        $table->addColumn('long_id', Types::INTEGER);
         $table->addIndex(['long_id']);
 
         $index = current($table->getIndexes());
@@ -194,11 +195,11 @@ class SchemaTest extends TestCase
         $sequence = $schema->createSequence('baz');
 
         $tableA = $schema->createTable('foo');
-        $tableA->addColumn('id', 'integer');
+        $tableA->addColumn('id', Types::INTEGER);
 
         $tableB = $schema->createTable('bar');
-        $tableB->addColumn('id', 'integer');
-        $tableB->addColumn('foo_id', 'integer');
+        $tableB->addColumn('id', Types::INTEGER);
+        $tableB->addColumn('foo_id', Types::INTEGER);
         $tableB->addForeignKeyConstraint($tableA, ['foo_id'], ['id']);
 
         $schemaNew = clone $schema;
@@ -225,7 +226,7 @@ class SchemaTest extends TestCase
         $schema = new Schema();
 
         $tableA = $schema->createTable('foo');
-        $tableA->addColumn('id', 'integer');
+        $tableA->addColumn('id', Types::INTEGER);
 
         self::assertTrue($schema->hasTable('`foo`'));
     }

--- a/tests/Schema/SequenceTest.php
+++ b/tests/Schema/SequenceTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class SequenceTest extends TestCase
@@ -11,7 +12,7 @@ class SequenceTest extends TestCase
     public function testIsAutoincrementFor(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
         $sequence  = new Sequence('foo_id_seq');
@@ -26,7 +27,7 @@ class SequenceTest extends TestCase
     public function testIsAutoincrementForCaseInsensitive(): void
     {
         $table = new Table('foo');
-        $table->addColumn('ID', 'integer', ['autoincrement' => true]);
+        $table->addColumn('ID', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['ID']);
 
         $sequence  = new Sequence('foo_id_seq');

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
@@ -33,7 +34,7 @@ class TableTest extends TestCase
 
     public function testColumns(): void
     {
-        $type      = Type::getType('integer');
+        $type      = Type::getType(Types::INTEGER);
         $columns   = [];
         $columns[] = new Column('foo', $type);
         $columns[] = new Column('bar', $type);
@@ -52,7 +53,7 @@ class TableTest extends TestCase
     public function testColumnsCaseInsensitive(): void
     {
         $table  = new Table('foo');
-        $column = $table->addColumn('Foo', 'integer');
+        $column = $table->addColumn('Foo', Types::INTEGER);
 
         self::assertTrue($table->hasColumn('Foo'));
         self::assertTrue($table->hasColumn('foo'));
@@ -65,19 +66,19 @@ class TableTest extends TestCase
 
     public function testCreateColumn(): void
     {
-        $type = Type::getType('integer');
+        $type = Type::getType(Types::INTEGER);
 
         $table = new Table('foo');
 
         self::assertFalse($table->hasColumn('bar'));
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         self::assertTrue($table->hasColumn('bar'));
         self::assertSame($type, $table->getColumn('bar')->getType());
     }
 
     public function testDropColumn(): void
     {
-        $type      = Type::getType('integer');
+        $type      = Type::getType(Types::INTEGER);
         $columns   = [];
         $columns[] = new Column('foo', $type);
         $columns[] = new Column('bar', $type);
@@ -104,7 +105,7 @@ class TableTest extends TestCase
     {
         $this->expectException(SchemaException::class);
 
-        $type      = Type::getType('integer');
+        $type      = Type::getType(Types::INTEGER);
         $columns   = [];
         $columns[] = new Column('foo', $type);
         $columns[] = new Column('foo', $type);
@@ -113,7 +114,7 @@ class TableTest extends TestCase
 
     public function testCreateIndex(): void
     {
-        $type    = Type::getType('integer');
+        $type    = Type::getType(Types::INTEGER);
         $columns = [new Column('foo', $type), new Column('bar', $type), new Column('baz', $type)];
         $table   = new Table('foo', $columns);
 
@@ -126,7 +127,7 @@ class TableTest extends TestCase
 
     public function testIndexCaseInsensitive(): void
     {
-        $type    = Type::getType('integer');
+        $type    = Type::getType(Types::INTEGER);
         $columns = [
             new Column('foo', $type),
             new Column('bar', $type),
@@ -143,7 +144,7 @@ class TableTest extends TestCase
 
     public function testAddIndexes(): void
     {
-        $type    = Type::getType('integer');
+        $type    = Type::getType(Types::INTEGER);
         $columns = [
             new Column('foo', $type),
             new Column('bar', $type),
@@ -175,7 +176,7 @@ class TableTest extends TestCase
     {
         $this->expectException(SchemaException::class);
 
-        $type    = Type::getType('integer');
+        $type    = Type::getType(Types::INTEGER);
         $columns = [new Column('foo', $type), new Column('bar', $type)];
         $indexes = [
             new Index('the_primary', ['foo'], true, true),
@@ -188,7 +189,7 @@ class TableTest extends TestCase
     {
         $this->expectException(SchemaException::class);
 
-        $type    = Type::getType('integer');
+        $type    = Type::getType(Types::INTEGER);
         $columns = [new Column('foo', $type), new Column('bar', $type)];
         $indexes = [
             new Index('an_idx', ['foo'], false, false),
@@ -220,7 +221,7 @@ class TableTest extends TestCase
     {
         $table = new Table('foo');
 
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->setPrimaryKey(['bar']);
 
         self::assertTrue($table->hasIndex('primary'));
@@ -233,7 +234,7 @@ class TableTest extends TestCase
     {
         $table = new Table('foo');
 
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->addUniqueIndex(['bar'], 'my_idx');
 
         self::assertTrue($table->hasIndex('my_idx'));
@@ -245,7 +246,7 @@ class TableTest extends TestCase
     {
         $table = new Table('foo');
 
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->addIndex(['bar'], 'my_idx');
 
         self::assertTrue($table->hasIndex('my_idx'));
@@ -258,7 +259,7 @@ class TableTest extends TestCase
         $this->expectException(SchemaException::class);
 
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->addIndex(['bar'], 'invalid name %&/');
     }
 
@@ -283,10 +284,10 @@ class TableTest extends TestCase
         $this->expectException(SchemaException::class);
 
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         $foreignTable = new Table('bar');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $table->addForeignKeyConstraint($foreignTable, ['foo'], ['id']);
     }
@@ -296,10 +297,10 @@ class TableTest extends TestCase
         $this->expectException(SchemaException::class);
 
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         $foreignTable = new Table('bar');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $table->addForeignKeyConstraint($foreignTable, ['id'], ['foo']);
     }
@@ -307,10 +308,10 @@ class TableTest extends TestCase
     public function testAddForeignKeyConstraint(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         $foreignTable = new Table('bar');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $table->addForeignKeyConstraint($foreignTable, ['id'], ['id'], ['foo' => 'bar']);
 
@@ -327,7 +328,7 @@ class TableTest extends TestCase
     public function testAddIndexWithCaseSensitiveColumnProblem(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         $table->addIndex(['ID'], 'my_idx');
 
@@ -339,7 +340,7 @@ class TableTest extends TestCase
     public function testAddPrimaryKeyColumnsAreExplicitlySetToNotNull(): void
     {
         $table  = new Table('foo');
-        $column = $table->addColumn('id', 'integer', ['notnull' => false]);
+        $column = $table->addColumn('id', Types::INTEGER, ['notnull' => false]);
 
         self::assertFalse($column->getNotnull());
 
@@ -351,7 +352,7 @@ class TableTest extends TestCase
     public function testAllowImplicitSchemaTableInAutogeneratedIndexNames(): void
     {
         $table = new Table('foo.bar');
-        $table->addColumn('baz', 'integer', []);
+        $table->addColumn('baz', Types::INTEGER, []);
         $table->addIndex(['baz']);
 
         self::assertCount(1, $table->getIndexes());
@@ -360,10 +361,10 @@ class TableTest extends TestCase
     public function testAddForeignKeyIndexImplicitly(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
 
         $foreignTable = new Table('bar');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $table->addForeignKeyConstraint($foreignTable, ['id'], ['id'], ['foo' => 'bar']);
 
@@ -378,11 +379,11 @@ class TableTest extends TestCase
     public function testAddForeignKeyDoesNotCreateDuplicateIndex(): void
     {
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->addIndex(['bar'], 'bar_idx');
 
         $foreignTable = new Table('bar');
-        $foreignTable->addColumn('foo', 'integer');
+        $foreignTable->addColumn('foo', Types::INTEGER);
 
         $table->addForeignKeyConstraint($foreignTable, ['bar'], ['foo']);
 
@@ -394,15 +395,15 @@ class TableTest extends TestCase
     public function testAddForeignKeyAddsImplicitIndexIfIndexColumnsDoNotSpan(): void
     {
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
-        $table->addColumn('baz', 'string');
-        $table->addColumn('bloo', 'string');
+        $table->addColumn('bar', Types::INTEGER);
+        $table->addColumn('baz', Types::STRING);
+        $table->addColumn('bloo', Types::STRING);
         $table->addIndex(['baz', 'bar'], 'composite_idx');
         $table->addIndex(['bar', 'baz', 'bloo'], 'full_idx');
 
         $foreignTable = new Table('bar');
-        $foreignTable->addColumn('foo', 'integer');
-        $foreignTable->addColumn('baz', 'string');
+        $foreignTable->addColumn('foo', Types::INTEGER);
+        $foreignTable->addColumn('baz', Types::STRING);
 
         $table->addForeignKeyConstraint($foreignTable, ['bar', 'baz'], ['foo', 'baz']);
 
@@ -418,7 +419,7 @@ class TableTest extends TestCase
     public function testOverrulingIndexDoesNotDropOverruledIndex(): void
     {
         $table = new Table('bar');
-        $table->addColumn('baz', 'integer', []);
+        $table->addColumn('baz', Types::INTEGER, []);
         $table->addIndex(['baz']);
 
         $indexes = $table->getIndexes();
@@ -433,7 +434,7 @@ class TableTest extends TestCase
     public function testAllowsAddingDuplicateIndexesBasedOnColumns(): void
     {
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->addIndex(['bar'], 'bar_idx');
         $table->addIndex(['bar'], 'duplicate_idx');
 
@@ -447,8 +448,8 @@ class TableTest extends TestCase
     public function testAllowsAddingFulfillingIndexesBasedOnColumns(): void
     {
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
-        $table->addColumn('baz', 'string');
+        $table->addColumn('bar', Types::INTEGER);
+        $table->addColumn('baz', Types::STRING);
         $table->addIndex(['bar'], 'bar_idx');
         $table->addIndex(['bar', 'baz'], 'fulfilling_idx');
 
@@ -462,7 +463,7 @@ class TableTest extends TestCase
     public function testPrimaryKeyOverrulingUniqueIndexDoesNotDropUniqueIndex(): void
     {
         $table = new Table('bar');
-        $table->addColumn('baz', 'integer', []);
+        $table->addColumn('baz', Types::INTEGER, []);
         $table->addUniqueIndex(['baz'], 'idx_unique');
 
         $table->setPrimaryKey(['baz']);
@@ -479,10 +480,10 @@ class TableTest extends TestCase
     public function testAddingFulfillingRegularIndexOverridesImplicitForeignKeyConstraintIndex(): void
     {
         $foreignTable = new Table('foreign');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $localTable = new Table('local');
-        $localTable->addColumn('id', 'integer');
+        $localTable->addColumn('id', Types::INTEGER);
         $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
@@ -496,10 +497,10 @@ class TableTest extends TestCase
     public function testAddingFulfillingUniqueIndexOverridesImplicitForeignKeyConstraintIndex(): void
     {
         $foreignTable = new Table('foreign');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $localTable = new Table('local');
-        $localTable->addColumn('id', 'integer');
+        $localTable->addColumn('id', Types::INTEGER);
         $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
@@ -513,10 +514,10 @@ class TableTest extends TestCase
     public function testAddingFulfillingPrimaryKeyOverridesImplicitForeignKeyConstraintIndex(): void
     {
         $foreignTable = new Table('foreign');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $localTable = new Table('local');
-        $localTable->addColumn('id', 'integer');
+        $localTable->addColumn('id', Types::INTEGER);
         $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
@@ -530,10 +531,10 @@ class TableTest extends TestCase
     public function testAddingFulfillingExplicitIndexOverridingImplicitForeignKeyConstraintIndexWithSameName(): void
     {
         $foreignTable = new Table('foreign');
-        $foreignTable->addColumn('id', 'integer');
+        $foreignTable->addColumn('id', Types::INTEGER);
 
         $localTable = new Table('local');
-        $localTable->addColumn('id', 'integer');
+        $localTable->addColumn('id', Types::INTEGER);
         $localTable->addForeignKeyConstraint($foreignTable, ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
@@ -566,7 +567,7 @@ class TableTest extends TestCase
 
         self::assertFalse($table->hasPrimaryKey());
 
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('foo', Types::INTEGER);
         $table->setPrimaryKey(['foo']);
 
         self::assertTrue($table->hasPrimaryKey());
@@ -575,8 +576,8 @@ class TableTest extends TestCase
     public function testAddIndexWithQuotedColumns(): void
     {
         $table = new Table('test');
-        $table->addColumn('"foo"', 'integer');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('"foo"', Types::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
         $table->addIndex(['"foo"', '"bar"']);
 
         self::assertTrue($table->columnsAreIndexed(['"foo"', '"bar"']));
@@ -585,8 +586,8 @@ class TableTest extends TestCase
     public function testAddForeignKeyWithQuotedColumnsAndTable(): void
     {
         $table = new Table('test');
-        $table->addColumn('"foo"', 'integer');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('"foo"', Types::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
         $table->addForeignKeyConstraint('"boing"', ['"foo"', '"bar"'], ['id']);
 
         self::assertCount(1, $table->getForeignKeys());
@@ -613,7 +614,7 @@ class TableTest extends TestCase
     public function testDropIndex(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addIndex(['id'], 'idx');
 
         self::assertTrue($table->hasIndex('idx'));
@@ -625,7 +626,7 @@ class TableTest extends TestCase
     public function testDropPrimaryKey(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         self::assertTrue($table->hasPrimaryKey());
@@ -637,10 +638,10 @@ class TableTest extends TestCase
     public function testRenameIndex(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('foo', 'integer');
-        $table->addColumn('bar', 'integer');
-        $table->addColumn('baz', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('foo', Types::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
+        $table->addColumn('baz', Types::INTEGER);
         $table->setPrimaryKey(['id'], 'pk');
         $table->addIndex(['foo'], 'idx', ['flag']);
         $table->addUniqueIndex(['bar', 'baz'], 'uniq');
@@ -706,7 +707,7 @@ class TableTest extends TestCase
     public function testKeepsIndexOptionsOnRenamingRegularIndex(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addIndex(['id'], 'idx_bar', [], ['where' => '1 = 1']);
 
         $table->renameIndex('idx_bar', 'idx_baz');
@@ -717,7 +718,7 @@ class TableTest extends TestCase
     public function testKeepsIndexOptionsOnRenamingUniqueIndex(): void
     {
         $table = new Table('foo');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addUniqueIndex(['id'], 'idx_bar', ['where' => '1 = 1']);
 
         $table->renameIndex('idx_bar', 'idx_baz');
@@ -728,7 +729,7 @@ class TableTest extends TestCase
     public function testThrowsExceptionOnRenamingNonExistingIndex(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', Types::INTEGER);
         $table->addIndex(['id'], 'idx');
 
         $this->expectException(SchemaException::class);
@@ -739,8 +740,8 @@ class TableTest extends TestCase
     public function testThrowsExceptionOnRenamingToAlreadyExistingIndex(): void
     {
         $table = new Table('test');
-        $table->addColumn('id', 'integer');
-        $table->addColumn('foo', 'integer');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('foo', Types::INTEGER);
         $table->addIndex(['id'], 'idx_id');
         $table->addIndex(['foo'], 'idx_foo');
 
@@ -754,7 +755,7 @@ class TableTest extends TestCase
     {
         $table = new Table('test');
 
-        $table->addColumn($assetName, 'integer');
+        $table->addColumn($assetName, Types::INTEGER);
         $table->addIndex([$assetName], $assetName);
         $table->addForeignKeyConstraint('test', [$assetName], [$assetName], [], $assetName);
 
@@ -831,7 +832,7 @@ class TableTest extends TestCase
     public function testRemoveUniqueConstraint(): void
     {
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
         $table->addUniqueConstraint(['bar'], 'unique_constraint');
 
         $table->removeUniqueConstraint('unique_constraint');
@@ -844,7 +845,7 @@ class TableTest extends TestCase
         $this->expectException(SchemaException::class);
 
         $table = new Table('foo');
-        $table->addColumn('bar', 'integer');
+        $table->addColumn('bar', Types::INTEGER);
 
         $table->removeUniqueConstraint('unique_constraint');
     }

--- a/tests/Schema/Visitor/RemoveNamespacedAssetsTest.php
+++ b/tests/Schema/Visitor/RemoveNamespacedAssetsTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
@@ -35,10 +36,10 @@ class RemoveNamespacedAssetsTest extends TestCase
         $schema = new Schema([], [], $config);
 
         $fooTable = $schema->createTable('foo.bar');
-        $fooTable->addColumn('id', 'integer');
+        $fooTable->addColumn('id', Types::INTEGER);
 
         $testTable = $schema->createTable('test.test');
-        $testTable->addColumn('id', 'integer');
+        $testTable->addColumn('id', Types::INTEGER);
 
         $testTable->addForeignKeyConstraint('foo.bar', ['id'], ['id']);
 
@@ -55,10 +56,10 @@ class RemoveNamespacedAssetsTest extends TestCase
         $schema = new Schema([], [], $config);
 
         $testTable = $schema->createTable('test.test');
-        $testTable->addColumn('id', 'integer');
+        $testTable->addColumn('id', Types::INTEGER);
 
         $fooTable = $schema->createTable('foo.bar');
-        $fooTable->addColumn('id', 'integer');
+        $fooTable->addColumn('id', Types::INTEGER);
 
         $testTable->addForeignKeyConstraint('foo.bar', ['id'], ['id']);
 

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,7 +34,7 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testReturnsName(): void
     {
-        self::assertSame('datetime_immutable', $this->type->getName());
+        self::assertSame(Types::DATETIME_IMMUTABLE, $this->type->getName());
     }
 
     public function testReturnsBindingType(): void

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzImmutableType;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,7 +34,7 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testReturnsName(): void
     {
-        self::assertSame('datetimetz_immutable', $this->type->getName());
+        self::assertSame(Types::DATETIMETZ_IMMUTABLE, $this->type->getName());
     }
 
     public function testReturnsBindingType(): void

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\DBAL\Types\VarDateTimeImmutableType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ class VarDateTimeImmutableTypeTest extends TestCase
 
     public function testReturnsName(): void
     {
-        self::assertSame('datetime_immutable', $this->type->getName());
+        self::assertSame(Types::DATETIME_IMMUTABLE, $this->type->getName());
     }
 
     public function testReturnsBindingType(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

The only places where these values were not replaced are the calls to `Statement::bindValue()` and `Statement::bindParam()`.

Follows #6018.
Related to #5998.

<!-- Provide a summary of your change. -->
