### PR TITLE
Deprecate passing timezone information to methods where it is ignored

### DIFF
--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -35,6 +35,22 @@ class DateImmutableType extends DateType
         }
 
         if ($value instanceof DateTimeImmutable) {
+            $offset        = $value->format('O');
+            $defaultOffset = (new DateTimeImmutable())->format('O');
+
+            if ($offset !== $defaultOffset) {
+                Deprecation::triggerIfCalledFromOutside(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6020',
+                    'Passing a timezone offset (%s) different than the default one (%s) is deprecated'
+                    . ' as it will be lost, use %s::%s() instead.',
+                    $offset,
+                    $defaultOffset,
+                    DateTimeTzImmutableType::class,
+                    __FUNCTION__,
+                );
+            }
+
             return $value->format($platform->getDateFormatString());
         }
 
@@ -56,7 +72,27 @@ class DateImmutableType extends DateType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if ($value === null || $value instanceof DateTimeImmutable) {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof DateTimeImmutable) {
+            $offset        = $value->format('O');
+            $defaultOffset = (new DateTimeImmutable())->format('O');
+
+            if ($offset !== $defaultOffset) {
+                Deprecation::triggerIfCalledFromOutside(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6020',
+                    'Passing a timezone offset (%s) different than the default one (%s) is deprecated'
+                    . ' as it may be lost, use %s::%s() instead.',
+                    $offset,
+                    $defaultOffset,
+                    DateTimeTzImmutableType::class,
+                    __FUNCTION__,
+                );
+            }
+
             return $value;
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

The offset comparison is made against the default timezone instead of UTC because the user may be using a specific default timezone on purpose.

Related to #6014 and https://github.com/doctrine/dbal/pull/6017#issuecomment-1513773328.

<!-- Provide a summary of your change. -->
