### PR TITLE
Remove redundant initialization of column options

### DIFF
--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -148,17 +148,13 @@ class DB2SchemaManager extends AbstractSchemaManager
 
         $options = [
             'length'        => $length,
-            'unsigned'      => false,
             'fixed'         => (bool) $fixed,
             'default'       => $default,
             'autoincrement' => (bool) $tableColumn['autoincrement'],
             'notnull'       => $tableColumn['nulls'] === 'N',
-            'scale'         => null,
-            'precision'     => null,
             'comment'       => isset($tableColumn['comment']) && $tableColumn['comment'] !== ''
                 ? $tableColumn['comment']
                 : null,
-            'platformOptions' => [],
         ];
 
         if ($scale !== null && $precision !== null) {

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -530,7 +530,6 @@ SQL,
             'precision'     => $precision,
             'scale'         => $scale,
             'fixed'         => $fixed,
-            'unsigned'      => false,
             'autoincrement' => $autoincrement,
             'comment'       => isset($tableColumn['comment']) && $tableColumn['comment'] !== ''
                 ? $tableColumn['comment']
@@ -539,7 +538,7 @@ SQL,
 
         $column = new Column($tableColumn['field'], Type::getType($type), $options);
 
-        if (isset($tableColumn['collation']) && ! empty($tableColumn['collation'])) {
+        if (! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }
 

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -417,14 +417,13 @@ class SqliteSchemaManager extends AbstractSchemaManager
         }
 
         $options = [
-            'length'   => $length,
-            'unsigned' => $unsigned,
-            'fixed'    => $fixed,
-            'notnull'  => $notnull,
-            'default'  => $default,
+            'length'    => $length,
+            'unsigned'  => $unsigned,
+            'fixed'     => $fixed,
+            'notnull'   => $notnull,
+            'default'   => $default,
             'precision' => $precision,
             'scale'     => $scale,
-            'autoincrement' => false,
         ];
 
         return new Column($tableColumn['name'], Type::getType($type), $options);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | Code cleanup

Some schema managers unconditionally set some column values to their default values during schema introspection. This is unnecessary.