### PR TITLE
Note on bindValue positional needle

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -104,6 +104,11 @@ position of the variable to bind into the ``bindValue()`` method:
     $stmt->bindValue(1, $id);
     $stmt->bindValue(2, $status);
     $resultSet = $stmt->executeQuery();
+    
+.. note::
+
+    The numerical parameters in ``bindValue()`` start with the needle
+    ``1``. 
 
 Named parameters have the advantage that their labels can be re-used and only need to be bound once:
 


### PR DESCRIPTION
There is a note on https://github.com/doctrine/dbal/blob/3.6.x/docs/en/reference/query-builder.rst to say that the QueryBuilder uses a needle of 0. This edit adds a similar note to this document.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Make it more obvious that this isn't a zero based needle.
