### PR TITLE
bug fix: keep length of -1 for nvarchar(max) columns in SqlServerSchemaManager

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -104,6 +104,11 @@ position of the variable to bind into the ``bindValue()`` method:
     $stmt->bindValue(1, $id);
     $stmt->bindValue(2, $status);
     $resultSet = $stmt->executeQuery();
+    
+.. note::
+
+    The numerical parameters in ``bindValue()`` start with the needle
+    ``1``. 
 
 Named parameters have the advantage that their labels can be re-used and only need to be bound once:
 

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -236,7 +236,7 @@ the following very common SQL statement:
     SELECT * FROM articles WHERE id IN (?)
 
 Since you are using an ``IN`` expression you would really like to use it in the following way
-(and I guess everybody has tried to do this once in his life, before realizing it doesn't work):
+(and I guess everybody has tried to do this once in their life, before realizing it doesn't work):
 
 .. code-block:: php
 

--- a/docs/en/reference/security.rst
+++ b/docs/en/reference/security.rst
@@ -63,7 +63,7 @@ SQL or DQL query. For Example:
     // Very wrong!
     $sql = "SELECT * FROM users WHERE name = '" . $_GET['username']. "'";
 
-An attacker could inject any value into the GET variable "username" to modify the query to his needs.
+An attacker could inject any value into the GET variable "username" to modify the query to their needs.
 
 Although DQL is a wrapper around SQL that can prevent some security implications, the previous
 example is also a threat to DQL queries.

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -85,7 +85,7 @@ SQL,
             case 'nchar':
             case 'nvarchar':
             case 'ntext':
-                // Unicode data requires 2 bytes per character
+                // Unicode data requires 2 bytes per character, MAX length remains -1
                 if ($length === -1) {
                     break;
                 }

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -86,6 +86,9 @@ SQL,
             case 'nvarchar':
             case 'ntext':
                 // Unicode data requires 2 bytes per character
+                if ($length === -1) {
+                    break;
+                }
                 $length /= 2;
                 break;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6038 

#### Summary

When generating the portable table column definition for a nchar, nvarchar or ntext with a length of -1 (indicating MAX) the length remains -1 instead of getting divided. This lead to a wrong length of -1.