### PR TITLE
Keep the length -1 in portable table column definition. Generate SQL …

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -869,6 +869,9 @@ class SQLServerPlatform extends AbstractPlatform
         if ($length === null) {
             throw ColumnLengthRequired::new($this, 'NVARCHAR');
         }
+        if ($length == -1) {
+        return 'NVARCHAR(MAX)';
+    }
 
         return sprintf('NVARCHAR(%d)', $length);
     }

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -85,6 +85,10 @@ SQL,
             case 'nchar':
             case 'nvarchar':
             case 'ntext':
+                // keep MAX length at -1
+                if ($length === -1) {
+                    break;
+                }
                 // Unicode data requires 2 bytes per character
                 $length /= 2;
                 break;


### PR DESCRIPTION
…Snippet with NVARCHAR(MAX) for length -1.

The portable Column Definition keeps a length of -1 for nchar, nvarchar, ntext instead of dividing by 2. 
A length of -1 is then considered in the sql varchar type decleration.

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | #6038 
