### PR TITLE
partial fix for json field with default value

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3107,6 +3107,10 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $this->convertBooleans($default);
         }
 
+        if ($type instanceof Types\JsonType && in_array(strtoupper($default), ['JSON_ARRAY()', 'JSON_OBJECT()'])) {
+            return ' DEFAULT ('.$default.')';
+        }
+
         return ' DEFAULT ' . $this->quoteStringLiteral($default);
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -3107,7 +3107,7 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $this->convertBooleans($default);
         }
 
-        if ($type instanceof Types\JsonType && in_array(strtoupper($default), ['JSON_ARRAY()', 'JSON_OBJECT()'])) {
+        if ($type instanceof Types\JsonType && in_array(strtoupper($default), ['JSON_ARRAY()', 'JSON_OBJECT()'], true)) {
             return ' DEFAULT ('.$default.')';
         }
 


### PR DESCRIPTION
1. fixes #6037
2. the affected function `getDefaultValueDeclarationSQL` was never directly referenced in any tests
3. all other tests are passing


