### PR TITLE
Add support for unlogged tables in PostgreSQL

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -821,9 +821,9 @@ SQL
             $queryFields .= ', PRIMARY KEY(' . implode(', ', $keyColumns) . ')';
         }
 
-        $unlogged = (isset($options['unlogged']) && true === $options['unlogged']) ? ' UNLOGGED' : '';
+        $unlogged = isset($options['unlogged']) && $options['unlogged'] === true ? ' UNLOGGED' : '';
 
-        $query = 'CREATE'.$unlogged.' TABLE ' . $name . ' (' . $queryFields . ')';
+        $query = 'CREATE' . $unlogged . ' TABLE ' . $name . ' (' . $queryFields . ')';
 
         $sql = [$query];
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -821,7 +821,9 @@ SQL
             $queryFields .= ', PRIMARY KEY(' . implode(', ', $keyColumns) . ')';
         }
 
-        $query = 'CREATE TABLE ' . $name . ' (' . $queryFields . ')';
+        $unlogged = (isset($options['unlogged']) && true === $options['unlogged']) ? ' UNLOGGED' : '';
+
+        $query = 'CREATE'.$unlogged.' TABLE ' . $name . ' (' . $queryFields . ')';
 
         $sql = [$query];
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -733,6 +733,7 @@ SQL;
     {
         $sql = <<<'SQL'
 SELECT c.relname,
+       CASE c.relpersistence WHEN 'u' THEN true ELSE false END as unlogged,
        obj_description(c.oid, 'pg_class') AS comment
 FROM pg_class c
      INNER JOIN pg_namespace n

--- a/tests/Functional/Driver/DBAL6044Test.php
+++ b/tests/Functional/Driver/DBAL6044Test.php
@@ -32,9 +32,11 @@ class DBAL6044Test extends FunctionalTestCase
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $validationSchema = $schemaManager->introspectSchema();
-        $validationTable  = $validationSchema->getTable($unloggedTable->getName());
-        $this->assertEquals($unloggedTable->getName(), $validationTable->getName());
+        $validationSchema        = $schemaManager->introspectSchema();
+        $validationUnloggedTable = $validationSchema->getTable($unloggedTable->getName());
+        $this->assertTrue($validationUnloggedTable->getOption('unlogged'));
+        $validationLoggedTable = $validationSchema->getTable($loggedTable->getName());
+        $this->assertFalse($validationLoggedTable->getOption('unlogged'));
 
         $sql  = 'SELECT relpersistence FROM pg_class WHERE relname = ?';
         $stmt = $this->connection->prepare($sql);

--- a/tests/Functional/Driver/DBAL6044Test.php
+++ b/tests/Functional/Driver/DBAL6044Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\PgSQL;
+namespace Doctrine\DBAL\Tests\Functional\Driver;
 
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -12,11 +12,11 @@ class DBAL6044Test extends FunctionalTestCase
     {
         parent::setUp();
 
-        if (TestUtil::isDriverOneOf('pdo_pgsql')) {
+        if (TestUtil::isDriverOneOf('pdo_pgsql', 'pgsql')) {
             return;
         }
 
-        self::markTestSkipped('This test requires the pdo_pgsql driver.');
+        self::markTestSkipped('This test requires the pdo_pgsql or the pgsql driver.');
     }
 
     public function testUnloggedTables(): void

--- a/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
+++ b/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
@@ -35,7 +35,7 @@ class DBAL6044Test extends FunctionalTestCase
 
         $validationSchema = $schemaManager->introspectSchema();
         $validationTable  = $validationSchema->getTable($unloggedTable->getName());
-        $this->assertNotNull($validationTable);
+        $this->assertEquals($unloggedTable->getName(), $validationTable->getName());
 
         $sql  = 'SELECT relpersistence FROM pg_class WHERE relname = ?';
         $stmt = $this->connection->prepare($sql);

--- a/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
+++ b/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
@@ -6,14 +6,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
-/**
- * How to run this test with PostgreSQL:
- * 1) Start a PostgreSQLInstance
- * 2) If needed, change ci/github/phpunit/pdo_pgsql.xml according to your PostgreSQL local settings
- * 3) Run
- * vendor/bin/phpunit -c ci/github/phpunit/pdo_pgsql.xml tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
- */
-
 /** @requires extension pdo_pgsql */
 class DBAL6044Test extends FunctionalTestCase
 {

--- a/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
+++ b/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\PgSQL;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+
+/**
+ * How to run this test with PostgreSQL:
+ * 1) Start a PostgreSQLInstance
+ * 2) If needed, change ci/github/phpunit/pdo_pgsql.xml according to your PostgreSQL local settings
+ * 3) Run
+ * vendor/bin/phpunit -c ci/github/phpunit/pdo_pgsql.xml tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
+ */
+
+/** @requires extension pdo_pgsql */
+class DBAL6044Test extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('pdo_pgsql')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the pdo_pgsql driver.');
+    }
+
+    public function testUnloggedTables(): void
+    {
+        $unloggedTable = new Table('my_unlogged');
+        $unloggedTable->addOption('unlogged', true);
+        $unloggedTable->addColumn('foo', 'string');
+        $this->dropAndCreateTable($unloggedTable);
+
+        $loggedTable = new Table('my_logged');
+        $loggedTable->addColumn('foo', 'string');
+        $this->dropAndCreateTable($loggedTable);
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $validationSchema = $schemaManager->introspectSchema();
+        $validationTable  = $validationSchema->getTable($unloggedTable->getName());
+        $this->assertNotNull($validationTable);
+
+        $sql  = 'SELECT relpersistence FROM pg_class WHERE relname = ?';
+        $stmt = $this->connection->prepare($sql);
+
+        $stmt->bindValue(1, $unloggedTable->getName());
+        $unloggedTablePersistenceType = $stmt->executeQuery()->fetchOne();
+        $this->assertEquals('u', $unloggedTablePersistenceType);
+
+        $stmt->bindValue(1, $loggedTable->getName());
+        $loggedTablePersistenceType = $stmt->executeQuery()->fetchOne();
+        $this->assertEquals('p', $loggedTablePersistenceType);
+    }
+}

--- a/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
+++ b/tests/Functional/Driver/PDO/PgSQL/DBAL6044Test.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
-/** @requires extension pdo_pgsql */
 class DBAL6044Test extends FunctionalTestCase
 {
     protected function setUp(): void

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -189,7 +189,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 
     public function testGenerateUnloggedTable(): void
     {
-        $table  = new Table('mytable');
+        $table = new Table('mytable');
         $table->addOption('unlogged', true);
         $table->addColumn('foo', 'string');
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -187,6 +187,18 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testGenerateUnloggedTable(): void
+    {
+        $table  = new Table('mytable');
+        $table->addOption('unlogged', true);
+        $table->addColumn('foo', 'string');
+
+        self::assertEquals(
+            ['CREATE UNLOGGED TABLE mytable (foo VARCHAR(255) NOT NULL)'],
+            $this->platform->getCreateTableSQL($table),
+        );
+    }
+
     /** @return mixed[][] */
     public static function serialTypes(): iterable
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Feature | see #6044

#### Summary

Add support for creating unlogged PostgreSQL tables:
https://www.postgresql.org/docs/current/sql-createtable.html

I added a boolean `unlogged` option to `default_table_options` doctrine configuration
https://www.doctrine-project.org/projects/doctrine-bundle/en/latest/configuration.html
For example:

```yaml
doctrine:
    dbal:
        default_table_options:
            unlogged: true
```
