### PR TITLE
[Tests] Update calls to deprecated method `Statement::execute()`

### DIFF
--- a/tests/Connection/LoggingTest.php
+++ b/tests/Connection/LoggingTest.php
@@ -37,7 +37,7 @@ final class LoggingTest extends TestCase
 
         $this->createConnection($driverConnection, 'UPDATE table SET foo = ?')
             ->prepare('UPDATE table SET foo = ?')
-            ->execute();
+            ->executeStatement();
     }
 
     private function createConnection(DriverConnection $driverConnection, string $expectedSQL): Connection

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -165,7 +165,7 @@ class BlobTest extends FunctionalTestCase
         // Bind param does late binding (bind by reference), so create the stream only now:
         $stream = fopen('data://text/plain,test', 'r');
 
-        $stmt->execute();
+        $stmt->executeStatement();
 
         $this->assertBlobContains('test');
     }

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -48,7 +48,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindValue(1, 1);
         $stmt->bindValue(2, 'foo');
 
-        $row = $stmt->execute()->fetchAssociative();
+        $row = $stmt->executeQuery()->fetchAssociative();
 
         self::assertIsArray($row);
         $row = array_change_key_case($row, CASE_LOWER);
@@ -66,7 +66,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindParam(1, $paramInt);
         $stmt->bindParam(2, $paramStr);
 
-        $row = $stmt->execute()->fetchAssociative();
+        $row = $stmt->executeQuery()->fetchAssociative();
 
         self::assertIsArray($row);
         $row = array_change_key_case($row, CASE_LOWER);
@@ -84,7 +84,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindParam(1, $paramInt);
         $stmt->bindParam(2, $paramStr);
 
-        $rows    = $stmt->execute()->fetchAllAssociative();
+        $rows    = $stmt->executeQuery()->fetchAllAssociative();
         $rows[0] = array_change_key_case($rows[0], CASE_LOWER);
         self::assertEquals(['test_int' => 1, 'test_string' => 'foo'], $rows[0]);
     }
@@ -100,7 +100,7 @@ class DataAccessTest extends FunctionalTestCase
         $stmt->bindParam(1, $paramInt);
         $stmt->bindParam(2, $paramStr);
 
-        $column = $stmt->execute()->fetchOne();
+        $column = $stmt->executeQuery()->fetchOne();
         self::assertEquals(1, $column);
     }
 
@@ -288,7 +288,7 @@ class DataAccessTest extends FunctionalTestCase
         $sql  = 'SELECT count(*) AS c FROM fetch_table WHERE test_datetime = ?';
         $stmt = $this->connection->prepare($sql);
         $stmt->bindValue(1, new DateTime('2010-01-01 10:10:10'), Types::DATETIME_MUTABLE);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
 
         self::assertEquals(1, $result->fetchOne());
     }

--- a/tests/Functional/Driver/OCI8/ResultTest.php
+++ b/tests/Functional/Driver/OCI8/ResultTest.php
@@ -84,7 +84,7 @@ class ResultTest extends FunctionalTestCase
             'SELECT * FROM TABLE(%s.test_oracle_fetch_failure())',
             $this->connectionParams['user'],
         ));
-        $result    = $statement->execute();
+        $result    = $statement->executeQuery();
 
         // Access the first result to cause the first X rows to be prefetched
         // as defined by oci8.default_prefetch (often 100 rows)

--- a/tests/Functional/LikeWildcardsEscapingTest.php
+++ b/tests/Functional/LikeWildcardsEscapingTest.php
@@ -23,7 +23,7 @@ final class LikeWildcardsEscapingTest extends FunctionalTestCase
                     $escapeChar,
                 ),
             ),
-        )->execute();
+        )->executeQuery();
 
         self::assertTrue((bool) $result->fetchOne());
     }

--- a/tests/Functional/ParameterTypes/AsciiTest.php
+++ b/tests/Functional/ParameterTypes/AsciiTest.php
@@ -19,7 +19,7 @@ class AsciiTest extends FunctionalTestCase
         $statement = $this->connection->prepare('SELECT sql_variant_property(?, \'BaseType\')');
 
         $statement->bindValue(1, 'test', ParameterType::ASCII);
-        $results = $statement->execute()->fetchOne();
+        $results = $statement->executeQuery()->fetchOne();
 
         self::assertEquals('varchar', $results);
     }

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -39,7 +39,7 @@ class PortabilityTest extends FunctionalTestCase
 
         $result = $this->connection
             ->prepare('SELECT * FROM portability_table')
-            ->execute();
+            ->executeQuery();
 
         while (($row = $result->fetchAssociative())) {
             $this->assertFetchResultRow($row);

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -38,14 +38,14 @@ class StatementTest extends FunctionalTestCase
 
         $stmt = $this->connection->prepare('SELECT id FROM stmt_test ORDER BY id');
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
 
         $id = $result->fetchOne();
         self::assertEquals(1, $id);
 
         $result->free();
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
         self::assertEquals(2, $result->fetchOne());
     }
@@ -68,7 +68,7 @@ class StatementTest extends FunctionalTestCase
         $this->connection->insert('stmt_longer_results', $row1);
 
         $stmt   = $this->connection->prepare('SELECT param, val FROM stmt_longer_results ORDER BY param');
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals([
             ['param1', 'X'],
         ], $result->fetchAllNumeric());
@@ -79,7 +79,7 @@ class StatementTest extends FunctionalTestCase
         ];
         $this->connection->insert('stmt_longer_results', $row2);
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals([
             ['param1', 'X'],
             ['param2', 'A bit longer value'],
@@ -122,7 +122,7 @@ EOF
         $this->connection->insert('stmt_long_blob', ['contents' => $contents], [ParameterType::LARGE_OBJECT]);
 
         $result = $this->connection->prepare('SELECT contents FROM stmt_long_blob')
-            ->execute();
+            ->executeQuery();
 
         $stream = Type::getType(Types::BLOB)
             ->convertToPHPValue(
@@ -139,15 +139,15 @@ EOF
         $this->connection->insert('stmt_test', ['id' => 2]);
 
         $stmt1  = $this->connection->prepare('SELECT id FROM stmt_test');
-        $result = $stmt1->execute();
+        $result = $stmt1->executeQuery();
         $result->fetchAssociative();
 
-        $result = $stmt1->execute();
+        $result = $stmt1->executeQuery();
         // fetching only one record out of two
         $result->fetchAssociative();
 
         $stmt2  = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
-        $result = $stmt2->execute([1]);
+        $result = $stmt2->executeQuery([1]);
         self::assertEquals(1, $result->fetchOne());
     }
 
@@ -162,14 +162,14 @@ EOF
 
         $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
 
-        $result = $stmt->execute([1]);
+        $result = $stmt->executeQuery([1]);
 
         $id = $result->fetchOne();
         self::assertEquals(1, $id);
 
         $result->free();
 
-        $result = $stmt->execute([2]);
+        $result = $stmt->executeQuery([2]);
 
         $id = $result->fetchOne();
         self::assertEquals(2, $id);
@@ -185,12 +185,12 @@ EOF
 
         $id = 1;
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
 
         $id = 2;
 
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
     }
 
@@ -202,11 +202,11 @@ EOF
         $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
 
         $stmt->bindValue(1, 1);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
 
         $stmt->bindValue(1, 2);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
     }
 
@@ -219,12 +219,12 @@ EOF
 
         $x = 1;
         $stmt->bindParam(1, $x);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(1, $result->fetchOne());
 
         $y = 2;
         $stmt->bindParam(1, $y);
-        $result = $stmt->execute();
+        $result = $stmt->executeQuery();
         self::assertEquals(2, $result->fetchOne());
     }
 

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -30,7 +30,7 @@ class DBAL202Test extends FunctionalTestCase
     {
         $stmt = $this->connection->prepare('INSERT INTO DBAL202 VALUES (8)');
         $this->connection->beginTransaction();
-        $stmt->execute();
+        $stmt->executeStatement();
         $this->connection->rollBack();
 
         self::assertEquals(0, $this->connection->fetchOne('SELECT COUNT(1) FROM DBAL202'));
@@ -40,7 +40,7 @@ class DBAL202Test extends FunctionalTestCase
     {
         $stmt = $this->connection->prepare('INSERT INTO DBAL202 VALUES (8)');
         $this->connection->beginTransaction();
-        $stmt->execute();
+        $stmt->executeStatement();
         $this->connection->commit();
 
         self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM DBAL202'));

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -67,7 +67,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1);
         $stmt->bindValue(2, 'foo');
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeQuery()->rowCount());
     }
 
     public function testPrepareWithPrimitiveTypes(): void
@@ -78,7 +78,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1, ParameterType::INTEGER);
         $stmt->bindValue(2, 'foo', ParameterType::STRING);
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeQuery()->rowCount());
     }
 
     public function testPrepareWithDoctrineMappingTypes(): void
@@ -89,7 +89,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1, Type::getType(Types::INTEGER));
         $stmt->bindValue(2, 'foo', Type::getType(Types::STRING));
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeQuery()->rowCount());
     }
 
     public function testPrepareWithDoctrineMappingTypeNames(): void
@@ -100,7 +100,7 @@ class WriteTest extends FunctionalTestCase
         $stmt->bindValue(1, 1, 'integer');
         $stmt->bindValue(2, 'foo', 'string');
 
-        self::assertEquals(1, $stmt->execute()->rowCount());
+        self::assertEquals(1, $stmt->executeQuery()->rowCount());
     }
 
     public function insertRows(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -967,7 +967,7 @@ class QueryBuilderTest extends TestCase
         $result = $qb
             ->select('id')
             ->from('foo')
-            ->execute();
+            ->executeQuery();
 
         self::assertInstanceOf(Result::class, $result);
     }

--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -65,7 +65,7 @@ class StatementTest extends TestCase
 
         $statement = new Statement($this->conn, $this->driverStatement, $sql);
         $statement->bindValue($name, $var, $type);
-        $statement->execute();
+        $statement->executeStatement();
     }
 
     public function testExecuteCallsLoggerStartQueryWithParametersWhenParamsPassedToExecute(): void
@@ -108,7 +108,7 @@ class StatementTest extends TestCase
 
         $statement = new Statement($this->conn, $this->driverStatement, $sql);
         $statement->bindParam($name, $var);
-        $statement->execute();
+        $statement->executeStatement();
     }
 
     public function testExecuteCallsLoggerStopQueryOnException(): void
@@ -135,6 +135,6 @@ class StatementTest extends TestCase
 
         $this->expectException(Exception::class);
 
-        $statement->execute();
+        $statement->executeStatement();
     }
 }


### PR DESCRIPTION
v<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Update calls to deprecated method `Doctrine\DBAL\Statement::execute()`.

