### PR TITLE
[BUGFIX] postgresSQL partition table not exists issue

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -739,7 +739,7 @@ FROM pg_class c
          ON n.oid = c.relnamespace
 SQL;
 
-        $conditions = array_merge(["c.relkind = 'r'"], $this->buildQueryConditions($tableName));
+        $conditions = $this->buildQueryConditions($tableName);
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions);
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 

#### Summary

While upgrading v2 to v3 I found that for PostgresSQL(table partitioning), the `fetchTableOptionsByTable` method returned empty array because of adding this `["c.relkind = 'r'"]` extra condition. For that reason it's giving error that table does not exist. 

<img width="998" alt="Screenshot 2023-06-07 at 10 53 51 PM" src="https://github.com/doctrine/dbal/assets/21066418/3e433d14-0be5-4d89-8408-b381f85d412c">

