### PR TITLE
Allow `DsnParser` to parse `driverClass` via `$schemeMapping`

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -134,6 +134,20 @@ name.
 
     $conn = DriverManager::getConnection($connectionParams);
 
+You can also use the mapping table to map a DSN's scheme to a custom driver
+class:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\DBAL\Tools\DsnParser;
+    use App\DBAL\CustomDriver; // implements Doctrine\DBAL\Driver
+
+    //..
+    $dsnParser = new DsnParser(['custom' => CustomDriver::class]);
+    $connectionParams = $dsnParser
+        ->parse('custom://user:secret@localhost/mydb');
+
 Driver
 ~~~~~~
 

--- a/src/Tools/DsnParser.php
+++ b/src/Tools/DsnParser.php
@@ -2,12 +2,14 @@
 
 namespace Doctrine\DBAL\Tools;
 
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\MalformedDsnException;
 use SensitiveParameter;
 
 use function array_merge;
 use function assert;
+use function is_a;
 use function is_string;
 use function parse_str;
 use function parse_url;
@@ -20,10 +22,10 @@ use function substr;
 /** @psalm-import-type Params from DriverManager */
 final class DsnParser
 {
-    /** @var array<string, string> */
+    /** @var array<string, string|class-string<Driver>> */
     private array $schemeMapping;
 
-    /** @param array<string, string> $schemeMapping An array used to map DSN schemes to DBAL drivers */
+    /** @param array<string, string|class-string<Driver>> $schemeMapping An array used to map DSN schemes to DBAL drivers */
     public function __construct(array $schemeMapping = [])
     {
         $this->schemeMapping = $schemeMapping;
@@ -76,6 +78,11 @@ final class DsnParser
 
         if (isset($url['pass'])) {
             $params['password'] = $url['pass'];
+        }
+
+        if (isset($params['driver']) && is_a($params['driver'], Driver::class, true)) {
+            $params['driverClass'] = $params['driver'];
+            unset($params['driver']);
         }
 
         $params = $this->parseDatabaseUrlPath($url, $params);

--- a/tests/Tools/DsnParserTest.php
+++ b/tests/Tools/DsnParserTest.php
@@ -2,10 +2,12 @@
 
 namespace Doctrine\DBAL\Tests\Tools;
 
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Tools\DsnParser;
 use PHPUnit\Framework\TestCase;
 
+use function get_class;
 use function ksort;
 
 /** @psalm-import-type Params from DriverManager */
@@ -171,5 +173,23 @@ final class DsnParserTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testDriverClassScheme(): void
+    {
+        $driverClass = get_class($this->createMock(Driver::class));
+        $parser      = new DsnParser(['custom' => $driverClass]);
+        $actual      = $parser->parse('custom://foo:bar@localhost/baz');
+
+        self::assertSame(
+            [
+                'host'        => 'localhost',
+                'user'        => 'foo',
+                'password'    => 'bar',
+                'driverClass' => $driverClass,
+                'dbname'      => 'baz',
+            ],
+            $actual,
+        );
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | https://github.com/doctrine/DoctrineBundle/pull/1673

#### Summary

The latest version of dbal & doctrine-bundle remove the ability to use a dsn (url param) to configure a custom `driverClass`.

This is a proposal to allow `DsnParser::$schemeMapping` to map an _alias_ to a `driverClass`. With doctrine-bundle, these custom drivers could be added to the `doctrine.dbal.driver_schemes` config:

```yaml
doctrine:
    dbal:
        driver_schemes:
            custom: My\Custom\Driver # implements Doctrine\DBAL\Driver
```

If this feature isn't desired, any other ideas?