### PR TITLE
Set default database schema for postgresql

### DIFF
--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -57,6 +57,12 @@ final class Driver extends AbstractPostgreSQLDriver
             $connection->exec('SET NAMES \'' . $params['charset'] . '\'');
         }
 
+        /* Defining default schema via SET SEARCH_PATH to avoid migration issues
+         */
+        if (!empty($params['schema'])) {
+            $connection->exec('SET SEARCH_PATH = "' . $params['schema'] . '"');
+        }
+
         return $connection;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Set default database schema for postgresql by config.
This will help fix issues with migrations (double migrations) if the migration table is outside the public schema.
