### PR TITLE
trigger if called outside for AbstractPlatform::supportsCreateDropDatabase

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4155,7 +4155,7 @@ abstract class AbstractPlatform
      */
     public function supportsCreateDropDatabase()
     {
-        Deprecation::trigger(
+        Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5513',
             '%s is deprecated.',


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | https://github.com/doctrine/dbal/issues/6063

#### Summary

See https://github.com/doctrine/dbal/issues/6063. This makes sure we silence the deprecation if the method is called from within AbstractPlatform itself. 
