### PR TITLE
Improve phpdoc related to asset filtering

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Logging\SQLLogger;
+use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\Deprecations\Deprecation;
 use Psr\Cache\CacheItemPoolInterface;
@@ -153,6 +154,8 @@ class Configuration
 
     /**
      * Sets the callable to use to filter schema assets.
+     *
+     * @param callable(AbstractAsset|string): bool $callable
      */
     public function setSchemaAssetsFilter(?callable $callable = null): void
     {
@@ -177,6 +180,8 @@ class Configuration
 
     /**
      * Returns the callable to use to filter schema assets.
+     *
+     * @return callable(AbstractAsset|string): bool
      */
     public function getSchemaAssetsFilter(): ?callable
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -363,9 +363,11 @@ abstract class AbstractSchemaManager
      * Filters asset names if they are configured to return only a subset of all
      * the found elements.
      *
-     * @param mixed[] $assetNames
+     * @param N $assetNames
      *
-     * @return mixed[]
+     * @return N
+     *
+     * @template N of list<string>|list<AbstractAsset>
      */
     protected function filterAssetNames($assetNames)
     {
@@ -1340,7 +1342,7 @@ abstract class AbstractSchemaManager
     /**
      * @param mixed[][] $sequences
      *
-     * @return Sequence[]
+     * @return list<Sequence>
      *
      * @throws Exception
      */
@@ -1520,7 +1522,7 @@ abstract class AbstractSchemaManager
     /**
      * @param mixed[][] $tables
      *
-     * @return string[]
+     * @return list<string>
      */
     protected function _getPortableTablesList($tables)
     {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -46,6 +46,7 @@ use function array_values;
 use function count;
 use function current;
 use function get_class;
+use function is_string;
 use function sprintf;
 use function strcasecmp;
 use function strlen;
@@ -242,7 +243,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->markConnectionNotReusable();
 
         $this->connection->getConfiguration()->setSchemaAssetsFilter(
-            static function (string $name) use ($prefix): bool {
+            /** @param AbstractAsset|string $name */
+            static function ($name) use ($prefix): bool {
+                if (! is_string($name)) {
+                    return true;
+                }
+
                 return substr(strtolower($name), 0, strlen($prefix)) === $prefix;
             },
         );


### PR DESCRIPTION
While reviewing https://github.com/doctrine/orm/pull/10776, I had trouble checking what was a correct definition for an asset filter callback.

This should allow users to detect issues when defining the asset filter. Aside from that, there were  types that could be made more precise. I could have used `list<Sequence>` instead of `list<AbstractAsset>`, but I elected to use `AbstractAsset` in case more filtering features are added in the future. Also, this is how the now removed
`Configuration::buildSchemaAssetsFilterFromExpression()` method used to work.