### PR TITLE
Fix binding unused parameter

### DIFF
--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -403,7 +403,7 @@ WHERE type = 'U'
 ORDER BY name
 SQL;
 
-        return $this->_conn->executeQuery($sql, [$databaseName]);
+        return $this->_conn->executeQuery($sql);
     }
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5816

#### Summary

`SQLServerSchemaManager::selectTableNames()` binds a parameter that does not exist in the query. I don't know how we can make the CI catch this issue. This piece is covered by a test that fails on my machine, but apparently the SQL Server and driver setup that I use locally is more picky about extra parameter than the one we use on GitHub actions. 🤷🏻 
