### PR TITLE
Add explicit renameColumn method for Table

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -26,6 +26,9 @@ class Table extends AbstractAsset
     /** @var Column[] */
     protected $_columns = [];
 
+    /** @var string[] */
+    protected array $_renamedColumns = [];
+
     /** @var Index[] */
     protected $_indexes = [];
 
@@ -342,6 +345,34 @@ class Table extends AbstractAsset
         $column = new Column($name, Type::getType($typeName), $options);
 
         $this->_addColumn($column);
+
+        return $column;
+    }
+
+    /** @return string[] */
+    public function getRenamedColumns(): array
+    {
+        return $this->_renamedColumns;
+    }
+
+    public function renameColumn(string $oldName, string $newName): Column
+    {
+        $oldName = $this->normalizeIdentifier($oldName);
+        $newName = $this->normalizeIdentifier($newName);
+
+        $column = $this->getColumn($oldName);
+        $column->_setName($newName);
+        unset($this->_columns[$oldName]);
+        $this->_addColumn($column);
+
+        // If a column is renamed multiple times, we only want to know the original and last new name
+        if (isset($this->_renamedColumns[$oldName])) {
+            $toRemove = $oldName;
+            $oldName  = $this->_renamedColumns[$oldName];
+            unset($this->_renamedColumns[$toRemove]);
+        }
+
+        $this->_renamedColumns[$newName] = $oldName;
 
         return $column;
     }

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -5,15 +5,17 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_keys;
+use function array_values;
 use function strtolower;
 
 class RenameColumnTest extends FunctionalTestCase
 {
     /** @dataProvider columnNameProvider */
-    public function testColumnPositionRetainedAfterRenaming(string $columnName, string $newColumnName): void
+    public function testColumnPositionRetainedAfterImplicitRenaming(string $columnName, string $newColumnName): void
     {
         $table = new Table('test_rename');
         $table->addColumn($columnName, Types::STRING);
@@ -33,6 +35,35 @@ class RenameColumnTest extends FunctionalTestCase
 
         $table = $sm->introspectTable('test_rename');
         self::assertSame([strtolower($newColumnName), 'c2'], array_keys($table->getColumns()));
+        self::assertCount(1, $diff->renamedColumns);
+    }
+
+    /** @dataProvider columnNameProvider */
+    public function testColumnPositionRetainedAfterExplicitRenaming(string $columnName, string $newColumnName): void
+    {
+        $table = new Table('test_rename');
+        $table->addColumn($columnName, Types::STRING, ['length' => 16]);
+        $table->addColumn('c2', Types::INTEGER);
+
+        $this->dropAndCreateTable($table);
+
+        // Force a different type to make sure it's not being caught implicitly
+        $table->renameColumn($columnName, $newColumnName)->setType(Type::getType(Types::TEXT));
+
+        $sm   =  $this->connection->createSchemaManager();
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('test_rename'), $table);
+
+        $sm->alterTable($diff);
+
+        $table   = $sm->introspectTable('test_rename');
+        $columns = array_values($table->getColumns());
+
+        self::assertCount(0, $diff->renamedColumns);
+        self::assertCount(1, $diff->getModifiedColumns());
+        self::assertCount(2, $columns);
+        self::assertEqualsIgnoringCase($newColumnName, $columns[0]->getName());
+        self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
     }
 
     /** @return iterable<array{string}> */

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -50,6 +50,32 @@ class TableTest extends TestCase
         self::assertCount(2, $table->getColumns());
     }
 
+    public function testRenameColumn(): void
+    {
+        $typeStr   = Type::getType(Types::STRING);
+        $typeTxt   = Type::getType(Types::TEXT);
+        $columns   = [];
+        $columns[] = new Column('foo', $typeStr);
+        $table     = new Table('foo', $columns, [], []);
+
+        self::assertFalse($table->hasColumn('bar'));
+        self::assertTrue($table->hasColumn('foo'));
+
+        $column = $table->renameColumn('foo', 'bar');
+        $column->setType($typeTxt);
+        self::assertTrue($table->hasColumn('bar'), 'Should now have bar column');
+        self::assertFalse($table->hasColumn('foo'), 'Should not have foo column anymore');
+        self::assertCount(1, $table->getColumns());
+
+        self::assertEquals(['bar' => 'foo'], $table->getRenamedColumns());
+        $table->renameColumn('bar', 'baz');
+
+        self::assertTrue($table->hasColumn('baz'), 'Should now have baz column');
+        self::assertFalse($table->hasColumn('bar'), 'Should not have bar column anymore');
+        self::assertEquals(['baz' => 'foo'], $table->getRenamedColumns());
+        self::assertCount(1, $table->getColumns());
+    }
+
     public function testColumnsCaseInsensitive(): void
     {
         $table  = new Table('foo');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | https://github.com/doctrine/migrations/issues/57

#### Summary

<!-- Provide a summary of your change. -->

Add a `renameColumn` in the `Table` class

This allow to create migration with schemas that rename columns explicitely, which is a missing feature

Right now only implicit detection is done (it looks for added columns with the same definition as a dropped column), and that means if you change an option or the type of the column, it will not consider it as a rename anymore and instead will drop and recreate, by being explicit, this is not a problem anymore


This PR allows the following migration, without losing the column data
```php

    public function up(Schema $schema): void
    {
        $schema->getTable('test')->renameColumn('foo', 'bar')->setType(Type::getType('text'));
    }
    
    public function down(Schema $schema): void
    {
        $schema->getTable('test')->renameColumn('bar', 'foo')->setType(Type::getType('string'));
    }
 ```
 
 Which before would have to drop the column and recreate it, as well as needing a full redefinition of the column, and losing the data in the process
 
```php

    public function up(Schema $schema): void
    {
        $schema->getTable('test')->dropColumn('foo')->addColumn('bar', 'text');
    }
    
    public function down(Schema $schema): void
    {
        $schema->getTable('test')->dropColumn('bar')->addColumn('foo', 'string');
    }
 ```
 
 PS: I'm building a feature for the `doctrine/migration` package to generate diffs of schema, directly using `Schema` instead of platform specific sql and without this `renameColumn` this would be impossible