### PR TITLE
Add explicit renameColumn method for Table

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -517,6 +517,13 @@
                 <!-- TODO for PHPUnit 10 -->
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>
 
+                <!--
+                    TODO: remove in 4.0.0
+                    See https://github.com/doctrine/dbal/pull/6080
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getModifiedColumns"/>
+                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getRenamedColumns"/>
+
                 <!-- TODO: remove in 4.0.0 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getForUpdateSQL"/>
             </errorLevel>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2941,6 +2941,20 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Returns the SQL for renaming a column
+     *
+     * @param string $tableName     The table to rename the column on.
+     * @param string $oldColumnName The name of the column we want to rename.
+     * @param string $newColumnName The name we should rename it to.
+     *
+     * @return string[] The sequence of SQL statements for renaming the given column.
+     */
+    protected function getRenameColumnSQL(string $tableName, string $oldColumnName, string $newColumnName): array
+    {
+        return [sprintf('ALTER TABLE %s RENAME COLUMN %s TO %s', $tableName, $oldColumnName, $newColumnName)];
+    }
+
+    /**
      * Gets declaration of a number of columns in bulk.
      *
      * @param mixed[][] $columns A multidimensional associative array.

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -567,16 +567,37 @@ class SQLServerPlatform extends AbstractPlatform
             $queryParts[] = 'DROP COLUMN ' . $column->getQuotedName($this);
         }
 
-        foreach ($diff->getModifiedColumns() as $columnDiff) {
-            if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
+        $tableNameSQL = $table->getQuotedName($this);
+
+        foreach ($diff->getChangedColumns() as $columnDiff) {
+            $newColumn     = $columnDiff->getNewColumn();
+            $newColumnName = $newColumn->getQuotedName($this);
+
+            $oldColumn     = $columnDiff->getOldColumn() ?? $columnDiff->getOldColumnName();
+            $oldColumnName = $oldColumn->getQuotedName($this);
+            $nameChanged   = $columnDiff->hasNameChanged();
+
+            // Column names in SQL server are case insensitive and automatically uppercased on the server.
+            if ($nameChanged) {
+                if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $newColumn, $diff, $columnSql)) {
+                    continue;
+                }
+
+                $sql = array_merge(
+                    $sql,
+                    $this->getRenameColumnSQL($tableNameSQL, $oldColumnName, $newColumnName),
+                );
+
+                // Recreate default constraint with new column name if necessary (for future reference).
+                if ($newColumn->getDefault() === null) {
+                    continue;
+                }
+            } elseif ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
 
-            $newColumn     = $columnDiff->getNewColumn();
             $newComment    = $this->getColumnComment($newColumn);
             $hasNewComment = ! empty($newComment) || is_numeric($newComment);
-
-            $oldColumn = $columnDiff->getOldColumn();
 
             if ($oldColumn instanceof Column) {
                 $oldComment    = $this->getColumnComment($oldColumn);
@@ -602,61 +623,40 @@ class SQLServerPlatform extends AbstractPlatform
                 }
             }
 
-            // Do not add query part if only comment has changed.
-            if ($columnDiff->hasCommentChanged() && count($columnDiff->changedProperties) === 1) {
+            $columnNameSQL = $newColumn->getQuotedName($this);
+
+            $newDeclarationSQL = $this->getColumnDeclarationSQL($columnNameSQL, $newColumn->toArray());
+            if ($oldColumn instanceof Column) {
+                $oldDeclarationSQL     = $this->getColumnDeclarationSQL($columnNameSQL, $oldColumn->toArray());
+                $declarationSQLChanged = $newDeclarationSQL !== $oldDeclarationSQL;
+            } else {
+                $maxChanged            = $columnDiff->hasCommentChanged() ? 1 : 0;
+                $declarationSQLChanged = count($columnDiff->changedProperties) > $maxChanged;
+            }
+
+            $defaultChanged = $columnDiff->hasDefaultChanged();
+
+            if (! $declarationSQLChanged && ! $defaultChanged && ! $nameChanged) {
                 continue;
             }
 
             $requireDropDefaultConstraint = $this->alterColumnRequiresDropDefaultConstraint($columnDiff);
 
             if ($requireDropDefaultConstraint) {
-                $oldColumn = $columnDiff->getOldColumn();
-
-                if ($oldColumn !== null) {
-                    $oldColumnName = $oldColumn->getName();
-                } else {
-                    $oldColumnName = $columnDiff->oldColumnName;
-                }
-
                 $queryParts[] = $this->getAlterTableDropDefaultConstraintClause($tableName, $oldColumnName);
             }
 
-            $columnProperties = $newColumn->toArray();
-
-            $queryParts[] = 'ALTER COLUMN ' .
-                    $this->getColumnDeclarationSQL($newColumn->getQuotedName($this), $columnProperties);
+            if ($declarationSQLChanged) {
+                $queryParts[] = 'ALTER COLUMN ' . $newDeclarationSQL;
+            }
 
             if (
-                ! isset($columnProperties['default'])
-                || (! $requireDropDefaultConstraint && ! $columnDiff->hasDefaultChanged())
+                $newColumn->getDefault() === null
+                || (! $requireDropDefaultConstraint && ! $defaultChanged)
             ) {
                 continue;
             }
 
-            $queryParts[] = $this->getAlterTableAddDefaultConstraintClause($tableName, $newColumn);
-        }
-
-        $tableNameSQL = $table->getQuotedName($this);
-
-        foreach ($diff->getRenamedColumns() as $oldColumnName => $newColumn) {
-            if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $newColumn, $diff, $columnSql)) {
-                continue;
-            }
-
-            $oldColumnName = new Identifier($oldColumnName);
-
-            $sql[] = "sp_rename '" . $tableNameSQL . '.' . $oldColumnName->getQuotedName($this) .
-                "', '" . $newColumn->getQuotedName($this) . "', 'COLUMN'";
-
-            // Recreate default constraint with new column name if necessary (for future reference).
-            if ($newColumn->getDefault() === null) {
-                continue;
-            }
-
-            $queryParts[] = $this->getAlterTableDropDefaultConstraintClause(
-                $tableName,
-                $oldColumnName->getQuotedName($this),
-            );
             $queryParts[] = $this->getAlterTableAddDefaultConstraintClause($tableName, $newColumn);
         }
 
@@ -700,7 +700,7 @@ class SQLServerPlatform extends AbstractPlatform
     public function getRenameTableSQL(string $oldName, string $newName): array
     {
         return [
-            sprintf('sp_rename %s, %s', $this->quoteStringLiteral($oldName), $this->quoteStringLiteral($newName)),
+            sprintf('EXEC sp_rename %s, %s', $this->quoteStringLiteral($oldName), $this->quoteStringLiteral($newName)),
 
             /* Rename table's default constraints names
              * to match the new table name.
@@ -783,7 +783,7 @@ class SQLServerPlatform extends AbstractPlatform
 
         // We need to drop an existing default constraint if the column was
         // defined with a default value before and the native column type has changed.
-        return $columnDiff->hasTypeChanged() || $columnDiff->hasFixedChanged();
+        return $columnDiff->hasTypeChanged() || $columnDiff->hasFixedChanged() || $columnDiff->hasNameChanged();
     }
 
     /**
@@ -874,6 +874,25 @@ class SQLServerPlatform extends AbstractPlatform
             $tableName,
             $oldIndexName,
             $index->getQuotedName($this),
+        ),
+        ];
+    }
+
+    /**
+     * Returns the SQL for renaming a column
+     *
+     * @param string $tableName     The table to rename the column on.
+     * @param string $oldColumnName The name of the column we want to rename.
+     * @param string $newColumnName The name we should rename it to.
+     *
+     * @return string[] The sequence of SQL statements for renaming the given column.
+     */
+    protected function getRenameColumnSQL(string $tableName, string $oldColumnName, string $newColumnName): array
+    {
+        return [sprintf(
+            "EXEC sp_rename %s, %s, 'COLUMN'",
+            $this->quoteStringLiteral($tableName . '.' . $oldColumnName),
+            $this->quoteStringLiteral($newColumnName),
         ),
         ];
     }

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -463,4 +463,13 @@ class Column extends AbstractAsset
             'comment' => $this->_comment,
         ], $this->_platformOptions, $this->_customSchemaOptions);
     }
+
+    /** @internal To be removed in 4.0 */
+    public function cloneWithName(string $name): Column
+    {
+        $clone = clone $this;
+        $clone->_setName($name);
+
+        return $clone;
+    }
 }

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\Deprecations\Deprecation;
 
 use function in_array;
+use function strcasecmp;
 
 /**
  * Represents the change of a column.
@@ -76,6 +77,14 @@ class ColumnDiff
     public function getNewColumn(): Column
     {
         return $this->column;
+    }
+
+    public function hasNameChanged(): bool
+    {
+        $oldColumn = $this->getOldColumn() ?? $this->getOldColumnName();
+
+        // Column names are case insensitive
+        return strcasecmp($oldColumn->getName(), $this->getNewColumn()->getName()) !== 0;
     }
 
     public function hasTypeChanged(): bool

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -7,12 +7,14 @@ use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
+use LogicException;
 
 use function array_filter;
 use function array_keys;
 use function array_merge;
 use function in_array;
 use function preg_match;
+use function sprintf;
 use function strlen;
 use function strtolower;
 
@@ -25,6 +27,9 @@ class Table extends AbstractAsset
 {
     /** @var Column[] */
     protected $_columns = [];
+
+    /** @var array<string, string> keys are new names, values are old names */
+    protected array $renamedColumns = [];
 
     /** @var Index[] */
     protected $_indexes = [];
@@ -342,6 +347,48 @@ class Table extends AbstractAsset
         $column = new Column($name, Type::getType($typeName), $options);
 
         $this->_addColumn($column);
+
+        return $column;
+    }
+
+    /** @return array<string, string> */
+    final public function getRenamedColumns(): array
+    {
+        return $this->renamedColumns;
+    }
+
+    /**
+     * @throws LogicException
+     * @throws SchemaException
+     */
+    final public function renameColumn(string $oldName, string $newName): Column
+    {
+        $oldName = $this->normalizeIdentifier($oldName);
+        $newName = $this->normalizeIdentifier($newName);
+
+        if ($oldName === $newName) {
+            throw new LogicException(sprintf(
+                'Attempt to rename column "%s.%s" to the same name.',
+                $this->getName(),
+                $oldName,
+            ));
+        }
+
+        $column = $this->getColumn($oldName);
+        $column->_setName($newName);
+        unset($this->_columns[$oldName]);
+        $this->_addColumn($column);
+
+        // If a column is renamed multiple times, we only want to know the original and last new name
+        if (isset($this->renamedColumns[$oldName])) {
+            $toRemove = $oldName;
+            $oldName  = $this->renamedColumns[$oldName];
+            unset($this->renamedColumns[$toRemove]);
+        }
+
+        if ($newName !== $oldName) {
+            $this->renamedColumns[$newName] = $oldName;
+        }
 
         return $column;
     }

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -8,6 +8,9 @@ use Doctrine\Deprecations\Deprecation;
 use function array_filter;
 use function array_values;
 use function count;
+use function current;
+use function func_get_arg;
+use function func_num_args;
 
 /**
  * Table Diff.
@@ -40,7 +43,7 @@ class TableDiff
     /**
      * All modified columns
      *
-     * @internal Use {@see getModifiedColumns()} instead.
+     * @internal Use {@see getChangedColumns()} instead.
      *
      * @var ColumnDiff[]
      */
@@ -54,15 +57,6 @@ class TableDiff
      * @var Column[]
      */
     public $removedColumns = [];
-
-    /**
-     * Columns that are only renamed from key to column instance name.
-     *
-     * @internal Use {@see getRenamedColumns()} instead.
-     *
-     * @var Column[]
-     */
-    public $renamedColumns = [];
 
     /**
      * All added indexes.
@@ -139,7 +133,6 @@ class TableDiff
      *
      * @internal The diff can be only instantiated by a {@see Comparator}.
      *
-     * @param string                            $tableName
      * @param array<Column>                     $addedColumns
      * @param array<ColumnDiff>                 $modifiedColumns
      * @param array<Column>                     $droppedColumns
@@ -149,28 +142,25 @@ class TableDiff
      * @param list<ForeignKeyConstraint>        $addedForeignKeys
      * @param list<ForeignKeyConstraint>        $changedForeignKeys
      * @param list<ForeignKeyConstraint|string> $removedForeignKeys
-     * @param array<string,Column>              $renamedColumns
      * @param array<string,Index>               $renamedIndexes
      */
     public function __construct(
-        $tableName,
-        $addedColumns = [],
-        $modifiedColumns = [],
-        $droppedColumns = [],
-        $addedIndexes = [],
-        $changedIndexes = [],
-        $removedIndexes = [],
+        string $tableName,
+        array $addedColumns = [],
+        array $modifiedColumns = [],
+        array $droppedColumns = [],
+        array $addedIndexes = [],
+        array $changedIndexes = [],
+        array $removedIndexes = [],
         ?Table $fromTable = null,
-        $addedForeignKeys = [],
-        $changedForeignKeys = [],
-        $removedForeignKeys = [],
-        $renamedColumns = [],
-        $renamedIndexes = []
+        array $addedForeignKeys = [],
+        array $changedForeignKeys = [],
+        array $removedForeignKeys = [],
+        array $renamedIndexes = []
     ) {
         $this->name               = $tableName;
         $this->addedColumns       = $addedColumns;
         $this->changedColumns     = $modifiedColumns;
-        $this->renamedColumns     = $renamedColumns;
         $this->removedColumns     = $droppedColumns;
         $this->addedIndexes       = $addedIndexes;
         $this->changedIndexes     = $changedIndexes;
@@ -189,7 +179,48 @@ class TableDiff
             );
         }
 
+        if (func_num_args() > 12 || (count($renamedIndexes) > 0 && current($renamedIndexes) instanceof Column)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6080',
+                'Passing $renamedColumns to %s is deprecated and will no longer be possible in the next major.',
+                __METHOD__,
+            );
+            /** @var array<string, Column> $renamedColumns */
+            $renamedColumns = $renamedIndexes;
+            $this->convertLegacyRenamedColumn($renamedColumns);
+            $this->renamedIndexes = func_num_args() > 12 ? func_get_arg(12) : [];
+        }
+
         $this->fromTable = $fromTable;
+    }
+
+    /** @param array<string, Column> $renamedColumns */
+    private function convertLegacyRenamedColumn(array $renamedColumns): void
+    {
+        $changedColumns = [];
+        foreach ($this->changedColumns as $key => $column) {
+            $oldName                  = isset($column->fromColumn)
+                ? $column->fromColumn->getName()
+                : $column->oldColumnName;
+            $changedColumns[$oldName] = $key;
+        }
+
+        foreach ($renamedColumns as $oldName => $column) {
+            if (isset($changedColumns[$oldName])) {
+                $i                        = $changedColumns[$oldName];
+                $existingCol              = $this->changedColumns[$changedColumns[$oldName]];
+                $column                   = $existingCol->getNewColumn()->cloneWithName($column->getName());
+                $this->changedColumns[$i] = new ColumnDiff(
+                    $oldName,
+                    $column,
+                    $existingCol->changedProperties,
+                    $existingCol->getOldColumn(),
+                );
+            } else {
+                $this->changedColumns[] = new ColumnDiff($oldName, $column, []);
+            }
+        }
     }
 
     /**
@@ -238,8 +269,27 @@ class TableDiff
         return array_values($this->addedColumns);
     }
 
-    /** @return list<ColumnDiff> */
+    /**
+     * @deprecated Use {@see getChangedColumns()} instead.
+     *
+     * @return list<ColumnDiff>
+     */
     public function getModifiedColumns(): array
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6080',
+            '%s is deprecated, use `getModifiedColumns()` instead.',
+            __METHOD__,
+        );
+
+        return array_values(array_filter($this->getChangedColumns(), static function (ColumnDiff $diff) {
+            return count($diff->changedProperties) > 0;
+        }));
+    }
+
+    /** @return array<ColumnDiff> */
+    public function getChangedColumns(): array
     {
         return array_values($this->changedColumns);
     }
@@ -250,10 +300,30 @@ class TableDiff
         return array_values($this->removedColumns);
     }
 
-    /** @return array<string,Column> */
+    /**
+     * @deprecated Use {@see getModifiedColumns()} instead.
+     *
+     * @return array<string,Column>
+     */
     public function getRenamedColumns(): array
     {
-        return $this->renamedColumns;
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6080',
+            '%s is deprecated, you should use `getModifiedColumns()` instead.',
+            __METHOD__,
+        );
+        $renamed = [];
+        foreach ($this->getChangedColumns() as $diff) {
+            if (! $diff->hasNameChanged()) {
+                continue;
+            }
+
+            $oldColumnName           = ($diff->getOldColumn() ?? $diff->getOldColumnName())->getName();
+            $renamed[$oldColumnName] = $diff->getNewColumn();
+        }
+
+        return $renamed;
     }
 
     /** @return list<Index> */
@@ -349,7 +419,6 @@ class TableDiff
         return count($this->addedColumns) === 0
             && count($this->changedColumns) === 0
             && count($this->removedColumns) === 0
-            && count($this->renamedColumns) === 0
             && count($this->addedIndexes) === 0
             && count($this->changedIndexes) === 0
             && count($this->removedIndexes) === 0
@@ -357,5 +426,47 @@ class TableDiff
             && count($this->addedForeignKeys) === 0
             && count($this->changedForeignKeys) === 0
             && count($this->removedForeignKeys) === 0;
+    }
+
+    /** Deprecation layer, to be removed in 4.0 */
+    public function __isset(string $name): bool
+    {
+        return $name === 'renamedColumns';
+    }
+
+    /** @param mixed $val */
+    public function __set(string $name, $val): void
+    {
+        if ($name === 'renamedColumns') {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6080',
+                'Modifying $renamedColumns is deprecated, this property will be removed in the next major. ' .
+                'Set $modifiedColumns in the constructor instead',
+                __METHOD__,
+            );
+            $this->convertLegacyRenamedColumn($val);
+        } else {
+            /** @phpstan-ignore-next-line */
+            $this->$name = $val;
+        }
+    }
+
+    /** @return mixed */
+    public function __get(string $name)
+    {
+        if ($name === 'renamedColumns') {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6080',
+                'Property %s is deprecated, you should use `getModifiedColumns()` instead.',
+                $name,
+            );
+
+            return $this->getRenamedColumns();
+        }
+
+        /** @phpstan-ignore-next-line */
+        return $this->$name;
     }
 }

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -5,15 +5,17 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_keys;
+use function array_values;
 use function strtolower;
 
 class RenameColumnTest extends FunctionalTestCase
 {
     /** @dataProvider columnNameProvider */
-    public function testColumnPositionRetainedAfterRenaming(string $columnName, string $newColumnName): void
+    public function testColumnPositionRetainedAfterImplicitRenaming(string $columnName, string $newColumnName): void
     {
         $table = new Table('test_rename');
         $table->addColumn($columnName, Types::STRING);
@@ -33,6 +35,34 @@ class RenameColumnTest extends FunctionalTestCase
 
         $table = $sm->introspectTable('test_rename');
         self::assertSame([strtolower($newColumnName), 'c2'], array_keys($table->getColumns()));
+        self::assertCount(1, $diff->getRenamedColumns());
+    }
+
+    /** @dataProvider columnNameProvider */
+    public function testColumnPositionRetainedAfterExplicitRenaming(string $columnName, string $newColumnName): void
+    {
+        $table = new Table('test_rename');
+        $table->addColumn($columnName, Types::INTEGER, ['length' => 16]);
+        $table->addColumn('c2', Types::INTEGER);
+
+        $this->dropAndCreateTable($table);
+
+        // Force a different type to make sure it's not being caught implicitly
+        $table->renameColumn($columnName, $newColumnName)->setType(Type::getType(Types::BIGINT))->setLength(32);
+
+        $sm   =  $this->connection->createSchemaManager();
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('test_rename'), $table);
+
+        $sm->alterTable($diff);
+
+        $table   = $sm->introspectTable('test_rename');
+        $columns = array_values($table->getColumns());
+
+        self::assertCount(1, $diff->getChangedColumns());
+        self::assertCount(2, $columns);
+        self::assertEqualsIgnoringCase($newColumnName, $columns[0]->getName());
+        self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
     }
 
     /** @return iterable<array{string}> */

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_merge;
@@ -50,6 +51,57 @@ class ComparatorTest extends FunctionalTestCase
         $onlineTable = $this->schemaManager->introspectTable('default_value');
 
         self::assertFalse($comparatorFactory($this->schemaManager)->diffTable($table, $onlineTable));
+    }
+
+    public function testRenameColumnComparison(): void
+    {
+        $comparator = new Comparator();
+
+        $table = new Table('rename_table');
+        $table->addColumn('test', Types::STRING, ['default' => 'baz', 'length' => 20]);
+        $table->addColumn('test2', Types::STRING, ['default' => 'baz', 'length' => 20]);
+        $table->addColumn('test3', Types::STRING, ['default' => 'foo', 'length' => 10]);
+
+        $onlineTable = clone $table;
+        $table->renameColumn('test', 'baz')
+            ->setLength(40)
+            ->setComment('Comment');
+
+        $table->renameColumn('test2', 'foo');
+
+        $table->getColumn('test3')
+            ->setAutoincrement(true)
+            ->setNotnull(false)
+            ->setType(Type::getType(Types::BIGINT));
+
+        $compareResult = $comparator->compareTables($onlineTable, $table);
+        self::assertCount(3, $compareResult->getChangedColumns());
+        self::assertCount(2, $compareResult->getRenamedColumns());
+        self::assertCount(2, $compareResult->getModifiedColumns());
+        self::assertArrayHasKey('test2', $compareResult->getRenamedColumns());
+
+        $renamedOnly        = $compareResult->changedColumns['test2'];
+        $renamedAndModified = $compareResult->changedColumns['test'];
+        $modifiedOnly       = $compareResult->changedColumns['test3'];
+
+        self::assertEquals('foo', $renamedOnly->getNewColumn()->getName());
+        self::assertTrue($renamedOnly->hasNameChanged());
+        self::assertCount(0, $renamedOnly->changedProperties);
+
+        self::assertEquals('baz', $renamedAndModified->getNewColumn()->getName());
+        self::assertTrue($renamedAndModified->hasNameChanged());
+        self::assertTrue($renamedAndModified->hasLengthChanged());
+        self::assertTrue($renamedAndModified->hasCommentChanged());
+        self::assertFalse($renamedAndModified->hasTypeChanged());
+        self::assertCount(2, $renamedAndModified->changedProperties);
+
+        self::assertTrue($modifiedOnly->hasAutoIncrementChanged());
+        self::assertTrue($modifiedOnly->hasNotNullChanged());
+        self::assertTrue($modifiedOnly->hasTypeChanged());
+        self::assertFalse($modifiedOnly->hasLengthChanged());
+        self::assertFalse($modifiedOnly->hasCommentChanged());
+        self::assertFalse($modifiedOnly->hasNameChanged());
+        self::assertCount(3, $modifiedOnly->changedProperties);
     }
 
     /** @return iterable<mixed[]> */

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -756,9 +756,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "CHANGE `create` reserved_keyword INT NOT NULL COMMENT 'Reserved keyword 1', " .
             "CHANGE `table` `from` INT NOT NULL COMMENT 'Reserved keyword 2', " .
             "CHANGE `select` `bar` INT NOT NULL COMMENT 'Reserved keyword 3', " .
-            "CHANGE quoted1 quoted INT NOT NULL COMMENT 'Quoted 1', " .
-            "CHANGE quoted2 `and` INT NOT NULL COMMENT 'Quoted 2', " .
-            "CHANGE quoted3 `baz` INT NOT NULL COMMENT 'Quoted 3'",
+            "CHANGE `quoted1` quoted INT NOT NULL COMMENT 'Quoted 1', " .
+            "CHANGE `quoted2` `and` INT NOT NULL COMMENT 'Quoted 2', " .
+            "CHANGE `quoted3` `baz` INT NOT NULL COMMENT 'Quoted 3'",
         ];
     }
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -128,7 +128,8 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return [
             'ALTER TABLE mytable ' .
-            'ADD COLUMN quota INTEGER NOT NULL WITH DEFAULT',
+            'ADD COLUMN quota INTEGER NOT NULL WITH DEFAULT ' .
+            'RENAME COLUMN bar TO baz',
             "CALL SYSPROC.ADMIN_CMD ('REORG TABLE mytable')",
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             "COMMENT ON COLUMN mytable.foo IS ''",
@@ -479,9 +480,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'RENAME COLUMN "create" TO reserved_keyword ' .
             'RENAME COLUMN "table" TO "from" ' .
             'RENAME COLUMN "select" TO "bar" ' .
-            'RENAME COLUMN quoted1 TO quoted ' .
-            'RENAME COLUMN quoted2 TO "and" ' .
-            'RENAME COLUMN quoted3 TO "baz"',
+            'RENAME COLUMN "quoted1" TO quoted ' .
+            'RENAME COLUMN "quoted2" TO "and" ' .
+            'RENAME COLUMN "quoted3" TO "baz"',
         ];
     }
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -398,6 +398,7 @@ SQL
     {
         return [
             'ALTER TABLE mytable ADD (quota NUMBER(10) NOT NULL)',
+            'ALTER TABLE mytable RENAME COLUMN bar TO baz',
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             "COMMENT ON COLUMN mytable.foo IS ''",
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
@@ -496,6 +497,7 @@ SQL
         );
 
         $expectedSql = [
+            'ALTER TABLE mytable RENAME COLUMN bar TO baz',
             "ALTER TABLE mytable MODIFY (foo VARCHAR2(255) DEFAULT 'bla', baz VARCHAR2(255) DEFAULT 'bla' NOT NULL, "
                 . 'metar VARCHAR2(2000) DEFAULT NULL NULL)',
         ];
@@ -615,9 +617,9 @@ SQL
             'ALTER TABLE mytable RENAME COLUMN "create" TO reserved_keyword',
             'ALTER TABLE mytable RENAME COLUMN "table" TO "from"',
             'ALTER TABLE mytable RENAME COLUMN "select" TO "bar"',
-            'ALTER TABLE mytable RENAME COLUMN quoted1 TO quoted',
-            'ALTER TABLE mytable RENAME COLUMN quoted2 TO "and"',
-            'ALTER TABLE mytable RENAME COLUMN quoted3 TO "baz"',
+            'ALTER TABLE mytable RENAME COLUMN "quoted1" TO quoted',
+            'ALTER TABLE mytable RENAME COLUMN "quoted2" TO "and"',
+            'ALTER TABLE mytable RENAME COLUMN "quoted3" TO "baz"',
         ];
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -361,6 +361,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         return [
             'ALTER TABLE mytable ADD quota INT NOT NULL',
+            'ALTER TABLE mytable RENAME COLUMN bar TO baz',
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             'COMMENT ON COLUMN mytable.foo IS NULL',
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
@@ -783,9 +784,9 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE mytable RENAME COLUMN "create" TO reserved_keyword',
             'ALTER TABLE mytable RENAME COLUMN "table" TO "from"',
             'ALTER TABLE mytable RENAME COLUMN "select" TO "bar"',
-            'ALTER TABLE mytable RENAME COLUMN quoted1 TO quoted',
-            'ALTER TABLE mytable RENAME COLUMN quoted2 TO "and"',
-            'ALTER TABLE mytable RENAME COLUMN quoted3 TO "baz"',
+            'ALTER TABLE mytable RENAME COLUMN "quoted1" TO quoted',
+            'ALTER TABLE mytable RENAME COLUMN "quoted2" TO "and"',
+            'ALTER TABLE mytable RENAME COLUMN "quoted3" TO "baz"',
         ];
     }
 

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -333,7 +334,8 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
         $tableDiff                          = new TableDiff('test');
         $tableDiff->fromTable               = $table;
-        $tableDiff->renamedColumns['value'] = new Column('data', Type::getType(Types::STRING));
+        $newCol                             = new Column('data', Type::getType(Types::STRING));
+        $tableDiff->changedColumns['value'] = new ColumnDiff('value', $newCol);
 
         $this->expectException(Exception::class);
         $this->platform->getAlterTableSQL($tableDiff);
@@ -405,8 +407,14 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff                           = new TableDiff('user');
         $diff->fromTable                = $table;
         $diff->newName                  = 'client';
-        $diff->renamedColumns['id']     = new Column('key', Type::getType(Types::INTEGER), []);
-        $diff->renamedColumns['post']   = new Column('comment', Type::getType(Types::INTEGER), []);
+        $diff->changedColumns['id']     = new ColumnDiff(
+            'id',
+            new Column('key', Type::getType(Types::INTEGER), []),
+        );
+        $diff->changedColumns['post']   = new ColumnDiff(
+            'post',
+            new Column('comment', Type::getType(Types::INTEGER), []),
+        );
         $diff->removedColumns['parent'] = new Column('parent', Type::getType(Types::INTEGER), []);
         $diff->removedIndexes['index1'] = $table->getIndex('index1');
 

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -261,12 +261,12 @@ class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
 
-        self::assertCount(1, $tableDiff->renamedColumns);
-        self::assertArrayHasKey('datecolumn1', $tableDiff->renamedColumns);
-        self::assertCount(1, $tableDiff->addedColumns);
+        self::assertCount(1, $tableDiff->getRenamedColumns());
+        self::assertArrayHasKey('datecolumn1', $tableDiff->getRenamedColumns());
+        self::assertCount(1, $tableDiff->getAddedColumns());
         self::assertArrayHasKey('new_datecolumn2', $tableDiff->addedColumns);
-        self::assertCount(0, $tableDiff->removedColumns);
-        self::assertCount(0, $tableDiff->changedColumns);
+        self::assertCount(0, $tableDiff->getDroppedColumns());
+        self::assertCount(0, $tableDiff->getModifiedColumns());
     }
 
     public function testCompareRemovedIndex(): void
@@ -714,10 +714,10 @@ class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
 
-        self::assertCount(0, $tableDiff->addedColumns);
-        self::assertCount(0, $tableDiff->removedColumns);
-        self::assertArrayHasKey('foo', $tableDiff->renamedColumns);
-        self::assertEquals('bar', $tableDiff->renamedColumns['foo']->getName());
+        self::assertCount(0, $tableDiff->getAddedColumns());
+        self::assertCount(0, $tableDiff->getDroppedColumns());
+        self::assertArrayHasKey('foo', $tableDiff->changedColumns);
+        self::assertEquals('bar', $tableDiff->changedColumns['foo']->getNewColumn()->getName());
     }
 
     /**
@@ -742,7 +742,7 @@ class AbstractComparatorTestCase extends TestCase
         self::assertCount(2, $tableDiff->removedColumns);
         self::assertArrayHasKey('foo', $tableDiff->removedColumns);
         self::assertArrayHasKey('bar', $tableDiff->removedColumns);
-        self::assertCount(0, $tableDiff->renamedColumns);
+        self::assertCount(0, $tableDiff->getRenamedColumns());
     }
 
     public function testDetectRenameIndex(): void
@@ -825,7 +825,7 @@ class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->diffTable($table, $newtable);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
-        self::assertEquals(['twitterId', 'displayName'], array_keys($tableDiff->renamedColumns));
+        self::assertEquals(['twitterId', 'displayName'], array_keys($tableDiff->getRenamedColumns()));
         self::assertEquals(['logged_in_at'], array_keys($tableDiff->addedColumns));
         self::assertCount(0, $tableDiff->removedColumns);
     }

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -3,9 +3,13 @@
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +31,65 @@ class TableDiffTest extends TestCase
         $tableDiff = new TableDiff('foo');
 
         self::assertEquals(new Identifier('foo'), $tableDiff->getName($this->platform));
+    }
+
+    public function testRenamedColumnDeprecationLayer(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6080');
+
+        /** @psalm-suppress InvalidArgument */
+        $diff = new TableDiff(
+            'foo',
+            [],
+            [
+                new ColumnDiff(
+                    'foo',
+                    new Column('foo', Type::getType(Types::INTEGER)),
+                    ['type'],
+                    new Column('foo', Type::getType(Types::BIGINT)),
+                ),
+                new ColumnDiff(
+                    'ba',
+                    new Column('ba', Type::getType(Types::INTEGER)),
+                    ['type'],
+                    new Column('ba', Type::getType(Types::BIGINT)),
+                ),
+            ],
+            [],
+            [],
+            [],
+            [],
+            new Table('foo'),
+            [],
+            [],
+            [],
+            [
+                'foo' => new Column('baz', Type::getType(Types::INTEGER)),
+                'bar' => new Column('renamed', Type::getType(Types::INTEGER)),
+            ],
+            [],
+        );
+
+        self::assertCount(3, $diff->getChangedColumns());
+        self::assertCount(2, $diff->getModifiedColumns());
+        self::assertEquals('foo', $diff->getChangedColumns()[0]->getOldColumnName()->getName());
+        self::assertEquals('baz', $diff->getChangedColumns()[0]->getNewColumn()->getName());
+        self::assertTrue($diff->getChangedColumns()[0]->hasTypeChanged());
+        self::assertEquals(Type::getType(Types::INTEGER), $diff->getChangedColumns()[0]->getNewColumn()->getType());
+        self::assertEquals('bar', $diff->getChangedColumns()[2]->getOldColumnName()->getName());
+        self::assertEquals('renamed', $diff->getChangedColumns()[2]->getNewColumn()->getName());
+
+        self::assertCount(2, $diff->renamedColumns);
+
+        $diff->renamedColumns = ['old_name' => new Column('new_name', Type::getType(Types::INTEGER))];
+        self::assertCount(4, $diff->getChangedColumns());
+        self::assertCount(3, $diff->renamedColumns);
+
+        // Test that __isset __set and __get have the default php behavior
+        @$diff->foo = 'baz';
+        self::assertTrue(isset($diff->renamedColumns));
+        self::assertTrue(isset($diff->foo));
+        self::assertEquals('baz', $diff->foo);
     }
 
     public function testPrefersNameFromTableObject(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | https://github.com/doctrine/migrations/issues/57

#### Summary

<!-- Provide a summary of your change. -->
Reopening #6078  on 3.7.x

Add a `renameColumn` in the `Table` class

This allow to create migration with schemas that rename columns explicitely, which is a missing feature

Right now only implicit detection is done (it looks for added columns with the same definition as a dropped column), and that means if you change an option or the type of the column, it will not consider it as a rename anymore and instead will drop and recreate, by being explicit, this is not a problem anymore


This PR allows the following migration, without losing the column data
```php

    public function up(Schema $schema): void
    {
        $schema->getTable('test')->renameColumn('foo', 'bar')->setType(Type::getType('text'));
    }
    
    public function down(Schema $schema): void
    {
        $schema->getTable('test')->renameColumn('bar', 'foo')->setType(Type::getType('string'));
    }
 ```
 
 Which before would have to drop the column and recreate it, as well as needing a full redefinition of the column, and losing the data in the process
 
```php

    public function up(Schema $schema): void
    {
        $schema->getTable('test')->dropColumn('foo')->addColumn('bar', 'text');
    }
    
    public function down(Schema $schema): void
    {
        $schema->getTable('test')->dropColumn('bar')->addColumn('foo', 'string');
    }
 ```
 
 PS: I'm building a feature for the `doctrine/migration` package to generate diffs of schema, directly using `Schema` instead of platform specific sql and without this `renameColumn` this would be impossible, it would also allow other frameworks which use schemas (Yes I'm thinking laravel) to rename columns [without using internals](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Schema/Grammars/RenameColumn.php#L65C21-L65C35)