### PR TITLE
Optimize TypeRegistry::lookupName() from O(N) to O(1)

### DIFF
--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -21,7 +21,10 @@ final class TypeRegistry
     /** @param array<string, Type> $instances */
     public function __construct(array $instances = [])
     {
-        $this->instances = $instances;
+        $this->instances = [];
+        foreach ($instances as $name => $type) {
+            $this->register($name, $type);
+        }
     }
 
     /**

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -6,8 +6,7 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Exception;
 
-use function array_search;
-use function in_array;
+use function spl_object_id;
 
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
@@ -17,11 +16,14 @@ final class TypeRegistry
 {
     /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
     private array $instances;
+    /** @var array<int, string> */
+    private array $instancesReverseIndex;
 
     /** @param array<string, Type> $instances */
     public function __construct(array $instances = [])
     {
-        $this->instances = [];
+        $this->instances             = [];
+        $this->instancesReverseIndex = [];
         foreach ($instances as $name => $type) {
             $this->register($name, $type);
         }
@@ -34,11 +36,12 @@ final class TypeRegistry
      */
     public function get(string $name): Type
     {
-        if (! isset($this->instances[$name])) {
+        $type = $this->instances[$name] ?? null;
+        if ($type === null) {
             throw Exception::unknownColumnType($name);
         }
 
-        return $this->instances[$name];
+        return $type;
     }
 
     /**
@@ -80,7 +83,8 @@ final class TypeRegistry
             throw Exception::typeAlreadyRegistered($type);
         }
 
-        $this->instances[$name] = $type;
+        $this->instances[$name]                            = $type;
+        $this->instancesReverseIndex[spl_object_id($type)] = $name;
     }
 
     /**
@@ -90,15 +94,18 @@ final class TypeRegistry
      */
     public function override(string $name, Type $type): void
     {
-        if (! isset($this->instances[$name])) {
+        $origType = $this->instances[$name] ?? null;
+        if ($origType === null) {
             throw Exception::typeNotFound($name);
         }
 
-        if (! in_array($this->findTypeName($type), [$name, null], true)) {
+        if (($this->findTypeName($type) ?? $name) !== $name) {
             throw Exception::typeAlreadyRegistered($type);
         }
 
-        $this->instances[$name] = $type;
+        unset($this->instancesReverseIndex[spl_object_id($origType)]);
+        $this->instances[$name]                            = $type;
+        $this->instancesReverseIndex[spl_object_id($type)] = $name;
     }
 
     /**
@@ -115,12 +122,6 @@ final class TypeRegistry
 
     private function findTypeName(Type $type): ?string
     {
-        $name = array_search($type, $this->instances, true);
-
-        if ($name === false) {
-            return null;
-        }
-
-        return $name;
+        return $this->instancesReverseIndex[spl_object_id($type)] ?? null;
     }
 }

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -99,6 +99,14 @@ class TypeRegistryTest extends TestCase
         $this->registry->register('other', $newType);
     }
 
+    public function testConstructorWithDuplicateInstance(): void
+    {
+        $newType = new TextType();
+
+        $this->expectException(Exception::class);
+        new TypeRegistry(['a' => $newType, 'b' => $newType]);
+    }
+
     public function testOverride(): void
     {
         $baseType     = new TextType();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | performance issue
| Fixed issues | n/a

#### Summary

We use a lot of custom types and migration from `Type::getName()` to `TypeRegistry->lookupName()` discovered us the reverse lookup was very slow (O(N)). This PR makes it O(1).

~Index is initialized lazily on the 1st reverse lookup.~ The type registry is expected to not hold duplicate type instances and this PR fixes it, in https://github.com/doctrine/dbal/pull/6083#discussion_r1261812593 I was requested to fix it in this PR instead of a separate one.