### PR TITLE
TypeRegistry constructor must check for duplicate instances

### DIFF
--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -21,7 +21,10 @@ final class TypeRegistry
     /** @param array<string, Type> $instances */
     public function __construct(array $instances = [])
     {
-        $this->instances = $instances;
+        $this->instances = [];
+        foreach ($instances as $name => $type) {
+            $this->register($name, $type);
+        }
     }
 
     /**

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -99,6 +99,14 @@ class TypeRegistryTest extends TestCase
         $this->registry->register('other', $newType);
     }
 
+    public function testConstructorWithDuplicateInstance(): void
+    {
+        $newType = new TextType();
+
+        $this->expectException(Exception::class);
+        new TypeRegistry(['a' => $newType, 'b' => $newType]);
+    }
+
     public function testOverride(): void
     {
         $baseType     = new TextType();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

a) `TypeRegistry` methods like `TypeRegistry::register` checks if the type instance is not already registered.
b) `TypeRegistry::lookupName` method expects the instance to have only one name.

Thus I belive the type registry is expected to not hold duplicate type instances and this PR fixes/asserts that.

Also documented so - https://github.com/doctrine/dbal/blob/3.6.4/src/Types/TypeRegistry.php#L14