### PR TITLE
Add array of patterns and replacements in parser to reformat SQL prior to parsing as needed

### DIFF
--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -111,8 +111,6 @@ final class Parser
             $sql = implode('', $parts);
         }
 
-        assert(is_string($sql));
-
         /** @var array<string,callable> $patterns */
         $patterns = [
             self::NAMED_PARAMETER => static function (string $sql) use ($visitor): void {

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -6,12 +6,13 @@ use Doctrine\DBAL\SQL\Parser\Exception;
 use Doctrine\DBAL\SQL\Parser\Exception\RegularExpressionError;
 use Doctrine\DBAL\SQL\Parser\Visitor;
 
-use function array_merge;
 use function array_keys;
+use function array_merge;
 use function array_values;
 use function assert;
 use function current;
 use function implode;
+use function is_string;
 use function key;
 use function next;
 use function preg_last_error;
@@ -84,8 +85,8 @@ final class Parser
      */
     public function parse(string $sql, Visitor $visitor): void
     {
-        /** @var string $sql */
         $sql = preg_replace(array_keys(self::REPLACE_PATTERNS), array_values(self::REPLACE_PATTERNS), $sql);
+        assert(is_string($sql));
 
         /** @var array<string,callable> $patterns */
         $patterns = [

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -84,6 +84,7 @@ final class Parser
      */
     public function parse(string $sql, Visitor $visitor): void
     {
+        /** @var string $sql */
         $sql = preg_replace(array_keys(self::REPLACE_PATTERNS), array_values(self::REPLACE_PATTERNS), $sql);
 
         /** @var array<string,callable> $patterns */

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -7,6 +7,8 @@ use Doctrine\DBAL\SQL\Parser\Exception\RegularExpressionError;
 use Doctrine\DBAL\SQL\Parser\Visitor;
 
 use function array_merge;
+use function array_keys;
+use function array_values;
 use function assert;
 use function current;
 use function implode;
@@ -14,6 +16,7 @@ use function key;
 use function next;
 use function preg_last_error;
 use function preg_match;
+use function preg_replace;
 use function reset;
 use function sprintf;
 use function strlen;
@@ -43,6 +46,8 @@ final class Parser
     private const MULTI_LINE_COMMENT   = '/\*([^*]+|\*+[^/*])*\**\*/';
     private const SPECIAL              = '[' . self::SPECIAL_CHARS . ']';
     private const OTHER                = '[^' . self::SPECIAL_CHARS . ']+';
+
+    private const REPLACE_PATTERNS = ['/\bARRAY\s*\[/' => 'ARRAY['];
 
     private string $sqlPattern;
 
@@ -79,6 +84,8 @@ final class Parser
      */
     public function parse(string $sql, Visitor $visitor): void
     {
+        $sql = preg_replace(array_keys(self::REPLACE_PATTERNS), array_values(self::REPLACE_PATTERNS), $sql);
+
         /** @var array<string,callable> $patterns */
         $patterns = [
             self::NAMED_PARAMETER => static function (string $sql) use ($visitor): void {

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -47,7 +47,7 @@ final class Parser
     private const SPECIAL              = '[' . self::SPECIAL_CHARS . ']';
     private const OTHER                = '[^' . self::SPECIAL_CHARS . ']+';
 
-    private const REPLACE_PATTERNS = ['/\bARRAY\s*\[/' => 'ARRAY['];
+    private const REPLACE_PATTERNS = ['/\b([Aa][Rr][Rr][Aa][Yy])\s*\[/' => '\1['];
 
     private string $sqlPattern;
 

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -24,7 +24,8 @@ class ParserTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the pgsql or pdo_pgsql driver.');
         }
 
-        $sql = 'SELECT * FROM (SELECT CAST(\'xyz\' AS text) AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
+        $sql = 'SELECT * FROM (SELECT CAST(\'xyz\' AS text) AS x, ' .
+               '\'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
                'dummy WHERE x = :x AND json_value @> ANY (ARRAY    [:value]::jsonb[]);';
 
         $params = [

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -24,7 +24,7 @@ class ParserTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the pgsql or pdo_pgsql driver.');
         }
 
-        $sql = 'SELECT * FROM (SELECT \'xyz\' AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
+        $sql = 'SELECT * FROM (SELECT CAST(\'xyz\' AS text) AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
                'dummy WHERE x = :x AND json_value @> ANY (ARRAY    [:value]::jsonb[]);';
 
         $params = [

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -7,8 +7,6 @@ namespace Doctrine\DBAL\Tests\Functional\SQL;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
-use function assert;
-
 class ParserTest extends FunctionalTestCase
 {
     public function testPostgreSQLJSONBQuestionOperator(): void
@@ -27,18 +25,16 @@ class ParserTest extends FunctionalTestCase
             self::markTestSkipped('This test requires the pdo_pgsql driver.');
         }
 
-        $sql    = 'SELECT * FROM (SELECT \'xyz\' AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
-                  'dummy WHERE x = :x AND json_value @> ANY (ARRAY    [:value]::jsonb[]);';
-        $stmt   = $this->connection->prepare($sql);
+        $sql = 'SELECT * FROM (SELECT \'xyz\' AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
+               'dummy WHERE x = :x AND json_value @> ANY (ARRAY    [:value]::jsonb[]);';
+
         $params = [
             'x' => 'xyz',
             'value' => '{"foo":[3]}',
         ];
 
-        $row = $stmt->execute($params)->fetchAssociative();
+        $results = $this->connection->fetchAllAssociative($sql, $params);
 
-        assert($row !== false);
-
-        self::assertCount(2, $row);
+        self::assertCount(1, $results);
     }
 }

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional\SQL;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
+use function assert;
+
 class ParserTest extends FunctionalTestCase
 {
     public function testPostgreSQLJSONBQuestionOperator(): void
@@ -16,5 +18,27 @@ class ParserTest extends FunctionalTestCase
         }
 
         self::assertTrue($this->connection->fetchOne('SELECT \'{"a":null}\'::jsonb ?? :key', ['key' => 'a']));
+    }
+
+    /** test the REPLACE_PATTERNS change for ARRAY [ to ARRAY[ does not cause the mixed positional and named parameters error found prior to the fix */
+    public function testParametersInArrayConstructWithWhitespace(): void
+    {
+        if (! TestUtil::isDriverOneOf('pdo_pgsql')) {
+            self::markTestSkipped('This test requires the pdo_pgsql driver.');
+        }
+
+        $sql    = 'SELECT * FROM (SELECT \'xyz\' AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .
+                  'dummy WHERE x = :x AND json_value @> ANY (ARRAY    [:value]::jsonb[]);';
+        $stmt   = $this->connection->prepare($sql);
+        $params = [
+            'x' => 'xyz',
+            'value' => '{"foo":[3]}',
+        ];
+
+        $row = $stmt->execute($params)->fetchAssociative();
+
+        assert($row !== false);
+
+        self::assertCount(2, $row);
     }
 }

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -18,11 +18,10 @@ class ParserTest extends FunctionalTestCase
         self::assertTrue($this->connection->fetchOne('SELECT \'{"a":null}\'::jsonb ?? :key', ['key' => 'a']));
     }
 
-    /** test the REPLACE_PATTERNS change for ARRAY [ to ARRAY[ does not cause the mixed positional and named parameters error found prior to the fix */
     public function testParametersInArrayConstructWithWhitespace(): void
     {
-        if (! TestUtil::isDriverOneOf('pdo_pgsql')) {
-            self::markTestSkipped('This test requires the pdo_pgsql driver.');
+        if (! TestUtil::isDriverOneOf('pdo_pgsql', 'pgsql')) {
+            self::markTestSkipped('This test requires the pgsql or pdo_pgsql driver.');
         }
 
         $sql = 'SELECT * FROM (SELECT \'xyz\' AS x, \'{"foo":[1,2,3,4,5],"bar":true}\'::jsonb AS json_value) AS ' .

--- a/tests/SQL/ParserTest.php
+++ b/tests/SQL/ParserTest.php
@@ -78,6 +78,11 @@ class ParserTest extends TestCase implements Visitor
         ];
 
         yield [
+            'SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, ARRAY   [?])',
+            'SELECT * FROM foo WHERE jsonb_exists_any(foo.bar, ARRAY[{?}])',
+        ];
+
+        yield [
             "SELECT 'Doctrine\DBAL?' FROM foo WHERE bar = ?",
             "SELECT 'Doctrine\DBAL?' FROM foo WHERE bar = {?}",
         ];


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6081 

#### Summary

I originally tried to fix this issue in line with the regex pattern parsing approach already used, however the fact that specific checks exist for square brackets not immediately preceded by `ARRAY` _without_ any whitespace as part of the general pattern which won't match positional or named parameters makes this too impractical.

So the alternative approach and the only one I've been able to make work without significant rewrite of the parser's regex-based approach is to simply allow `parse()` to sanitize the input SQL string for specific patterns we wish to match and replace; in this case, the only one for now is (case-insensitive) `<word boundary>ARRAY<zero or more whitespace chars>[` with `ARRAY[`.

The same technique in place here can be expanded for any similar issues to #6081 which may arise in future just by adding new patterns to replace.