### PR TITLE
Unset statement resource in bindValue

### DIFF
--- a/src/Driver/SQLSrv/Statement.php
+++ b/src/Driver/SQLSrv/Statement.php
@@ -99,6 +99,8 @@ final class Statement implements StatementInterface
 
         $this->variables[$param] = $value;
         $this->types[$param]     = $type;
+        // unset the statement resource if it exists as the new one will need to be bound to the new variable
+        $this->stmt = null;
 
         return true;
     }

--- a/tests/Functional/Ticket/DBAL6088Test.php
+++ b/tests/Functional/Ticket/DBAL6088Test.php
@@ -25,7 +25,7 @@ CREATE TABLE bug (id int identity primary key, content varchar(max))
 SQL);
 
         $stmt = $this->connection->prepare(<<<'SQL'
-INSERT INTO bug (content) VALUES (?);')
+INSERT INTO bug (content) VALUES (?)
 SQL);
 
         $stmt->bindValue(1, implode(array_fill(0, 4000, 'x')));

--- a/tests/Functional/Ticket/DBAL6088Test.php
+++ b/tests/Functional/Ticket/DBAL6088Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+use function array_fill;
+use function implode;
+
+class DBAL6088Test extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('Related to SQL Server only');
+    }
+
+    public function testOdbcStringDataRightTruncationExceptionIsNotThrown() {
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE bug (id int identity primary key, content varchar(max))
+SQL);
+
+        $stmt = $this->connection->prepare(<<<'SQL'
+INSERT INTO bug (content) VALUES (?);')
+SQL);
+
+        $stmt->bindValue(1, implode(array_fill(0, 4000, 'x')));
+        $stmt->executeStatement();
+
+        $stmt->bindValue(1, implode(array_fill(0, 4001, 'x')));
+        $stmt->executeStatement();
+
+        $result = $this->connection->executeQuery('SELECT content from bug');
+
+        self::assertEquals(implode(array_fill(0, 4000, 'x')), $result->fetchOne());
+        self::assertEquals(implode(array_fill(0, 4001, 'x')), $result->fetchOne());
+    }
+}


### PR DESCRIPTION
Fix odbc issue #6088


|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | #6088

#### Summary

Reset statement resource after call to bindValue
