### PR TITLE
Fix blob binding overwrite on DB2

### DIFF
--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -182,6 +182,8 @@ final class Statement implements StatementInterface
             } else {
                 $this->bind($param, $value, DB2_PARAM_IN, DB2_CHAR);
             }
+
+            unset($value);
         }
 
         return $handles;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | -

#### Summary

On DB2 when binding more than 1 blob in the same statement each subsequent blob overwrites previous one. So instead of [1, 2, 3] we get [2, 3, 3]
This happens because of reference between the loop variable `$value` and the item in `$this->parameters[]`, which remains after iteration, see `bindLobs` and `bind` methods in `\Doctrine\DBAL\Driver\IBMDB2\Statement`