### PR TITLE
Restore reverse lookup determinism

### DIFF
--- a/src/Types/Exception/TypeAlreadyRegistered.php
+++ b/src/Types/Exception/TypeAlreadyRegistered.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types\Exception;
+
+use Doctrine\DBAL\Types\Type;
+use Exception;
+
+use function get_debug_type;
+use function spl_object_hash;
+use function sprintf;
+
+/** @psalm-immutable */
+final class TypeAlreadyRegistered extends Exception implements TypesException
+{
+    public static function new(Type $type): self
+    {
+        return new self(sprintf(
+            'Type of the class %s@%s is already registered.',
+            get_debug_type($type),
+            spl_object_hash($type),
+        ));
+    }
+}

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Types\Exception\TypeAlreadyRegistered;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
 use Doctrine\DBAL\Types\Exception\TypesAlreadyExists;
 use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 
 use function array_search;
+use function in_array;
 
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
@@ -71,6 +73,10 @@ final class TypeRegistry
             throw TypesAlreadyExists::new($name);
         }
 
+        if (array_search($type, $this->instances, true) !== false) {
+            throw TypeAlreadyRegistered::new($type);
+        }
+
         $this->instances[$name] = $type;
     }
 
@@ -83,6 +89,10 @@ final class TypeRegistry
     {
         if (! isset($this->instances[$name])) {
             throw TypeNotFound::new($name);
+        }
+
+        if (! in_array(array_search($type, $this->instances, true), [$name, false], true)) {
+            throw TypeAlreadyRegistered::new($type);
         }
 
         $this->instances[$name] = $type;

--- a/tests/Types/Exception/TypeAlreadyRegisteredTest.php
+++ b/tests/Types/Exception/TypeAlreadyRegisteredTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types\Exception;
+
+use Doctrine\DBAL\Types\Exception\TypeAlreadyRegistered;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+
+class TypeAlreadyRegisteredTest extends TestCase
+{
+    public function testNew(): void
+    {
+        $exception = TypeAlreadyRegistered::new(Type::getType('string'));
+
+        self::assertMatchesRegularExpression(
+            '/Type of the class Doctrine\\\DBAL\\\Types\\\StringType@([0-9a-zA-Z]+) is already registered./',
+            $exception->getMessage(),
+        );
+    }
+}

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -95,11 +95,8 @@ class TypeRegistryTest extends TestCase
         $newType = new TextType();
 
         $this->registry->register('type1', $newType);
+        $this->expectException(Exception::class);
         $this->registry->register('type2', $newType);
-        self::assertSame(
-            $this->registry->get('type1'),
-            $this->registry->get('type2'),
-        );
     }
 
     public function testOverride(): void
@@ -127,6 +124,17 @@ class TypeRegistryTest extends TestCase
     {
         $this->expectException(Exception::class);
         $this->registry->override('unknown', new TextType());
+    }
+
+    public function testOverrideWithAlreadyRegisteredInstance(): void
+    {
+        $newType = new TextType();
+
+        $this->registry->register('first', $newType);
+        $this->registry->register('second', new StringType());
+
+        $this->expectException(Exception::class);
+        $this->registry->override('second', $newType);
     }
 
     public function testGetMap(): void


### PR DESCRIPTION
In #5036, it looks like I wrongly assumed I wouldn't be able to allow having 2 classes of the same type in the type registry without also allowing having 2 objects of the same type. `array_search` can perfectly tell the difference between both situations, so let us continue forbidding that last part, it will allow us to make sure a given type matches exactly one name.