### PR TITLE
Apply the connection filter to indexes

### DIFF
--- a/src/Schema/SchemaAssetFilter.php
+++ b/src/Schema/SchemaAssetFilter.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Doctrine\DBAL\Schema;
+
+interface SchemaAssetFilter
+{
+    /** @param AbstractAsset|string $asset */
+    public function __invoke($asset): bool;
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5420

#### Summary

When there are indexes that are not supported by doctrine present in a database, they will consistently create "DROP" migrations.  By applying the schema filter to the indexes one will be able to exclude these indexes from future migrations preventing the manual work of removing the DROP statement each time a migration is created.
