### PR TITLE
Reset nested transaction level on deadlock exceptions

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1277,6 +1277,8 @@ class Connection
             $this->commit();
 
             return $res;
+        } catch (DeadlockException $e) {
+            throw $e;
         } catch (Throwable $e) {
             $this->rollBack();
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Event\TransactionBeginEventArgs;
 use Doctrine\DBAL\Event\TransactionCommitEventArgs;
 use Doctrine\DBAL\Event\TransactionRollBackEventArgs;
 use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -1936,6 +1937,11 @@ class Connection
 
         if ($exception instanceof ConnectionLost) {
             $this->close();
+        }
+
+        if ($exception instanceof DeadlockException) {
+            //Reset transaction nesting level since deadlocks always rollback.
+            $this->transactionNestingLevel = 0;
         }
 
         return $exception;

--- a/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
+++ b/tests/Functional/Driver/PDO/MySQL/DeadlockTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PDO\MySQL;
+
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+
+use function implode;
+use function pcntl_fork;
+use function sleep;
+use function sprintf;
+
+/** @require extension pcntl */
+class DeadlockTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $supportedDrivers = ['pdo_mysql', 'mysqli', 'pdo_pgsql'];
+        if (! TestUtil::isDriverOneOf(...$supportedDrivers)) {
+            self::markTestSkipped(sprintf('This supports one of %s drivers', implode(', ', $supportedDrivers)));
+        }
+
+        $table = new Table('test1');
+        $table->addColumn('id', 'integer');
+        $this->dropAndCreateTable($table);
+
+        $table = new Table('test2');
+        $table->addColumn('id', 'integer');
+        $this->dropAndCreateTable($table);
+
+        $this->connection->executeStatement('INSERT INTO test1 VALUES(1)');
+        $this->connection->executeStatement('INSERT INTO test2 VALUES(1)');
+    }
+
+    public function testNestedTransactionsDeadlockExceptionHandling(): void
+    {
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement('DELETE FROM test1');
+
+        $pid = pcntl_fork();
+        if ($pid) {
+            $connection = TestUtil::getConnection();
+            $connection->beginTransaction();
+            $connection->executeStatement('DELETE FROM test2');
+            $connection->executeStatement('DELETE FROM test1');
+            $connection->commit();
+            $connection->close();
+
+            $this->markTestSkipped('Gracefully skip child process in deadlock test');
+        }
+
+        try {
+            $this->waitForTableLock();
+            $this->connection->executeStatement('DELETE FROM test2');
+            $this->connection->commit();
+            $this->connection->commit();
+        } catch (DeadlockException $ex) {
+            self::assertFalse($this->connection->isTransactionActive());
+
+            return;
+        }
+
+        $this->fail('Expected deadlock exception did not happen.');
+    }
+
+    private function waitForTableLock(): void
+    {
+        sleep(5);
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #4279.

#### Summary
All mysql flavors on deadlock exception rollback all transactions, thus making the internal counter in DBAL invalid.

This pull request fixes that behaviour by reseting the dbal nested transactions counter on such exceptions.


