### PR TITLE
Solve listTableColumn deprecation

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -482,7 +482,7 @@ abstract class AbstractSchemaManager
 
         return new Table(
             $name,
-            $this->listTableColumns($name, $database),
+            $this->listTableColumns($name),
             $this->listTableIndexes($name),
             [],
             $foreignKeys,


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Passing $database to AbstractSchemaManager::listTableColumns() is deprecated.
