### PR TITLE
Sync MariaDB support strategy with upstream

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -293,33 +293,35 @@ jobs:
         php-version:
           - "7.4"
         mariadb-version:
-          - "10.0"
-          - "10.2"
-          - "10.5"
-          - "10.7"
-          - "10.9"
-          - "10.11"
+          - "10.0"  # Oldest version supported by DBAL
+          - "10.4"  # LTS (Jun 2024)
+          - "10.5"  # LTS (Jun 2025)
+          - "10.6"  # LTS (Jul 2026)
+          - "10.9"  # STS (Aug 2023)
+          - "10.10" # STS (Nov 2023)
+          - "10.11" # LTS (Feb 2028)
+          - "11.0"  # STS (Jun 2024)
         extension:
           - "mysqli"
           - "pdo_mysql"
         include:
           - php-version: "8.2"
-            mariadb-version: "10.7"
+            mariadb-version: "10.6"
             extension: "mysqli"
           - php-version: "8.2"
-            mariadb-version: "10.7"
+            mariadb-version: "10.6"
             extension: "pdo_mysql"
           - php-version: "8.2"
-            mariadb-version: "10.11"
+            mariadb-version: "11.0"
             extension: "mysqli"
           - php-version: "8.2"
-            mariadb-version: "10.11"
+            mariadb-version: "11.0"
             extension: "pdo_mysql"
           - php-version: "8.3"
-            mariadb-version: "10.11"
+            mariadb-version: "11.0"
             extension: "mysqli"
           - php-version: "8.3"
-            mariadb-version: "10.11"
+            mariadb-version: "11.0"
             extension: "pdo_mysql"
 
     services:
@@ -330,7 +332,7 @@ jobs:
           MYSQL_DATABASE: "doctrine_tests"
 
         options: >-
-          --health-cmd "mysqladmin ping --silent"
+          --health-cmd "mariadb-admin ping --silent || mysqladmin ping --silent"
 
         ports:
           - "3306:3306"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -62,6 +62,7 @@
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQL94Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLServer2012Keywords"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\MariaDb1027Platform"/>
+                <referencedClass name="Doctrine\DBAL\Platforms\MariaDb1043Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\MySQL57Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL100Platform"/>
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform"/>

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -47,6 +47,13 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
                 return new MariaDb1043Platform();
             }
 
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6110',
+                'Support for MariaDB < 10.4 is deprecated and will be removed in DBAL 4.'
+                . ' Consider upgrading to a more recent version of MariaDB.',
+            );
+
             if (version_compare($mariaDbVersion, '10.2.7', '>=')) {
                 return new MariaDb1027Platform();
             }
@@ -77,14 +84,14 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
                 return new MySQL57Platform();
             }
-        }
 
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5060',
-            'MySQL 5.6 support is deprecated and will be removed in DBAL 4.'
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/5060',
+                'MySQL 5.6 support is deprecated and will be removed in DBAL 4.'
                 . ' Consider upgrading to MySQL 5.7 or later.',
-        );
+            );
+        }
 
         return $this->getDatabasePlatform();
     }

--- a/src/Platforms/MariaDb1027Platform.php
+++ b/src/Platforms/MariaDb1027Platform.php
@@ -8,7 +8,7 @@ namespace Doctrine\DBAL\Platforms;
  * Note: Should not be used with versions prior to 10.2.7.
  *
  * @deprecated This class will be merged with {@see MariaDBPlatform} in 4.0 because support for MariaDB
- *             releases prior to 10.2.7 will be dropped.
+ *             releases prior to 10.4.3 will be dropped.
  */
 class MariaDb1027Platform extends MariaDBPlatform
 {

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -11,6 +11,9 @@ use function sprintf;
  *
  * Extend deprecated MariaDb1027Platform to ensure correct functions used in MySQLSchemaManager which
  * tests for MariaDb1027Platform not MariaDBPlatform.
+ *
+ * @deprecated This class will be merged with {@see MariaDBPlatform} in 4.0 because support for MariaDB
+ *             releases prior to 10.4.3 will be dropped.
  */
 class MariaDb1043Platform extends MariaDb1027Platform
 {

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -80,6 +80,12 @@ class VersionAwarePlatformDriverTest extends TestCase
                 'https://github.com/doctrine/dbal/pull/5779',
                 false,
             ],
+            [
+                '11.0.2-MariaDB-1:11.0.2+maria~ubu2204',
+                MariaDB1052Platform::class,
+                'https://github.com/doctrine/dbal/pull/5779',
+                false,
+            ],
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

I'd like to synchronize our CI with MariaDB's maintenance policy: https://mariadb.org/about/#maintenance-policy

The means that our CI would run tests against maintained the lowest supported version (currently 10.0) and all releases currently supported upstream. And because 10.2 and 10.3 have gone EOL, I'd like to deprecate support for those releases which would allow us to consolidate the platform classes a bit on the 4.0.x branch.
