### PR TITLE
Fix self deprecation from getCustomSchemaOptions

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -436,7 +436,7 @@ class Column extends AbstractAsset
      */
     public function getCustomSchemaOptions()
     {
-        Deprecation::trigger(
+        Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5476',
             'Column::getCustomSchemaOptions() is deprecated. Use getPlatformOptions() instead.',


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

`getCustomSchemaOptions` is used here: https://github.com/doctrine/dbal/blob/62cce0a4486ce8757fa43a3f72d95a81b89da9e7/src/Schema/Comparator.php#L677-L678

And `diffColumn` is used inside `Comparator::compareTables`, I asume that's why the deprecation was only "if call outside".
https://github.com/doctrine/dbal/blob/62cce0a4486ce8757fa43a3f72d95a81b89da9e7/src/Schema/Comparator.php#L609-L616