### PR TITLE
PHPStan 1.10.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/coding-standard": "12.0.0",
         "fig/log-test": "^1",
         "jetbrains/phpstorm-stubs": "2023.1",
-        "phpstan/phpstan": "1.10.21",
+        "phpstan/phpstan": "1.10.26",
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpunit": "9.6.9",
         "psalm/plugin-phpunit": "0.18.4",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -136,5 +136,9 @@ parameters:
             message: '~^Strict comparison using === between array<int, array> and false will always evaluate to false\.$~'
             paths:
                 - src/Driver/PgSQL/Result.php
+
+        # Ignore the possible false return value of db2_num_rows().
+        - '~^Method Doctrine\\DBAL\\Driver\\IBMDB2\\Connection\:\:exec\(\) should return int but returns int<0, max>\|false\.$~'
+        - '~^Method Doctrine\\DBAL\\Driver\\IBMDB2\\Result\:\:rowCount\(\) should return int but returns int<0, max>\|false\.$~'
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Apparently, the stubs for `db2_num_rows()` were changed upstream. I'm ignoring the error for now, maybe we can fix it on 3.7.x if we feel like it's worth doing.
