### PR TITLE
Correct Column->getDefault() annotation

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -36,7 +36,7 @@ class Column extends AbstractAsset
     /** @var bool */
     protected $_notnull = true;
 
-    /** @var string|null */
+    /** @var mixed */
     protected $_default;
 
     /** @var bool */
@@ -278,7 +278,7 @@ class Column extends AbstractAsset
         return $this->_notnull;
     }
 
-    /** @return string|null */
+    /** @return mixed */
     public function getDefault()
     {
         return $this->_default;


### PR DESCRIPTION
The value can be mixed, not string|null.
4.0.x reflects this already using PHP types,
3.x now follows in its annotations.
