### PR TITLE
Add Type::lookupName() shortcut method

### DIFF
--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -139,6 +139,16 @@ abstract class Type
     }
 
     /**
+     * Finds a name for the given type.
+     *
+     * @throws Exception
+     */
+    public static function lookupName(self $type): string
+    {
+        return self::getTypeRegistry()->lookupName($type);
+    }
+
+    /**
      * Adds a custom type to the type map.
      *
      * @param string             $name      The name of the type. This should correspond to what getName() returns.

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -17,6 +17,13 @@ class TypeTest extends TestCase
         self::assertTrue(Type::hasType($name));
     }
 
+    /** @dataProvider defaultTypesProvider() */
+    public function testDefaultTypesReverseLookup(string $name): void
+    {
+        $type = Type::getType($name);
+        self::assertSame($name, Type::lookupName($type));
+    }
+
     /** @return iterable<string[]> */
     public static function defaultTypesProvider(): iterable
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | n/a

#### Summary

`Type` class has static methods for global `TypeRegistry` instance shorter access like `Type::getType`.

This feature adds a static method for `TypeRegistry::lookupName`.

Thanks to https://github.com/doctrine/dbal/pull/6082, the reverse lookup is O(1) thus fine to be used massively - for ex. schema introspection returns type as object, and this method is needed to obtain a string name.

In DBAL 4.0, the method can be renamed to `Type::getName(Type $type): string` to be more consistent with `Type::getType(string $name): Type`.