### PR TITLE
Add binary array type

### DIFF
--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -253,10 +253,12 @@ SQL injection possibilities if not handled carefully.
 Doctrine DBAL implements a very powerful parsing process that will make this kind of prepared
 statement possible natively in the binding type system.
 The parsing necessarily comes with a performance overhead, but only if you really use a list of parameters.
-There are two special binding types that describe a list of integers or strings:
+There are four special binding types that describe a list of integers, regular, ascii or binary strings:
 
 -   ``\Doctrine\DBAL\ArrayParameterType::INTEGER``
 -   ``\Doctrine\DBAL\ArrayParameterType::STRING``
+-   ``\Doctrine\DBAL\ArrayParameterType::ASCII``
+-   ``\Doctrine\DBAL\ArrayParameterType::BINARY``
 
 Using one of these constants as a type you can activate the SQLParser inside Doctrine that rewrites
 the SQL and flattens the specified values into the set of parameters. Consider our previous example:

--- a/src/ArrayParameterType.php
+++ b/src/ArrayParameterType.php
@@ -20,11 +20,16 @@ final class ArrayParameterType
     public const ASCII = ParameterType::ASCII + Connection::ARRAY_PARAM_OFFSET;
 
     /**
+     * Represents an array of ascii strings to be expanded by Doctrine SQL parsing.
+     */
+    public const BINARY = ParameterType::BINARY + Connection::ARRAY_PARAM_OFFSET;
+
+    /**
      * @internal
      *
      * @psalm-param self::* $type
      *
-     * @psalm-return ParameterType::INTEGER|ParameterType::STRING|ParameterType::ASCII
+     * @psalm-return ParameterType::INTEGER|ParameterType::STRING|ParameterType::ASCII|ParameterType::BINARY
      */
     public static function toElementParameterType(int $type): int
     {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1919,6 +1919,7 @@ class Connection
                 $type === ArrayParameterType::INTEGER
                 || $type === ArrayParameterType::STRING
                 || $type === ArrayParameterType::ASCII
+                || $type === ArrayParameterType::BINARY
             ) {
                 return true;
             }

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -108,10 +108,6 @@ final class Statement implements StatementInterface
                 $this->lobs[$param] = &$variable;
                 break;
 
-            case ParameterType::BINARY:
-                $this->bind($param, $variable, DB2_PARAM_IN, DB2_BINARY);
-                break;
-
             default:
                 $this->bind($param, $variable, DB2_PARAM_IN, DB2_CHAR);
                 break;

--- a/src/Driver/IBMDB2/Statement.php
+++ b/src/Driver/IBMDB2/Statement.php
@@ -108,6 +108,10 @@ final class Statement implements StatementInterface
                 $this->lobs[$param] = &$variable;
                 break;
 
+            case ParameterType::BINARY:
+                $this->bind($param, $variable, DB2_PARAM_IN, DB2_BINARY);
+                break;
+
             default:
                 $this->bind($param, $variable, DB2_PARAM_IN, DB2_CHAR);
                 break;

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -101,6 +101,7 @@ final class ExpandArrayParameters implements Visitor
             $type !== ArrayParameterType::INTEGER
             && $type !== ArrayParameterType::STRING
             && $type !== ArrayParameterType::ASCII
+            && $type !== ArrayParameterType::BINARY
         ) {
             $this->appendTypedParameter([$value], $type);
 

--- a/tests/Functional/BinaryDataAccessTest.php
+++ b/tests/Functional/BinaryDataAccessTest.php
@@ -16,7 +16,6 @@ use function array_keys;
 use function array_map;
 use function hex2bin;
 use function is_resource;
-use function pack;
 use function stream_get_contents;
 
 use const CASE_LOWER;
@@ -270,10 +269,23 @@ class BinaryDataAccessTest extends FunctionalTestCase
 
     public function testNativeArrayListSupport(): void
     {
+        $binaryValues = [
+            hex2bin('A0AEFA'),
+            hex2bin('1F43BA'),
+            hex2bin('8C9D2A'),
+            hex2bin('72E8AA'),
+            hex2bin('5B6F9A'),
+            hex2bin('DAB24A'),
+            hex2bin('3E71CA'),
+            hex2bin('F0D6EA'),
+            hex2bin('6A8B5A'),
+            hex2bin('C582FA'),
+        ];
+
         for ($i = 100; $i < 110; $i++) {
             $this->connection->insert('binary_fetch_table', [
                 'test_int' => $i,
-                'test_binary' => pack('L', $i),
+                'test_binary' => $binaryValues[$i - 100],
             ], [
                 'test_binary' => ParameterType::BINARY,
             ]);
@@ -293,11 +305,11 @@ class BinaryDataAccessTest extends FunctionalTestCase
             'SELECT test_int FROM binary_fetch_table WHERE test_binary IN (?)',
             [
                 [
-                    pack('L', 100),
-                    pack('L', 101),
-                    pack('L', 102),
-                    pack('L', 103),
-                    pack('L', 104),
+                    $binaryValues[0],
+                    $binaryValues[1],
+                    $binaryValues[2],
+                    $binaryValues[3],
+                    $binaryValues[4],
                 ],
             ],
             [ArrayParameterType::BINARY],
@@ -311,11 +323,11 @@ class BinaryDataAccessTest extends FunctionalTestCase
             'SELECT test_binary FROM binary_fetch_table WHERE test_binary IN (?)',
             [
                 [
-                    pack('L', 100),
-                    pack('L', 101),
-                    pack('L', 102),
-                    pack('L', 103),
-                    pack('L', 104),
+                    $binaryValues[0],
+                    $binaryValues[1],
+                    $binaryValues[2],
+                    $binaryValues[3],
+                    $binaryValues[4],
                 ],
             ],
             [ArrayParameterType::BINARY],
@@ -332,11 +344,11 @@ class BinaryDataAccessTest extends FunctionalTestCase
         );
 
         self::assertEquals([
-            pack('L', 100),
-            pack('L', 101),
-            pack('L', 102),
-            pack('L', 103),
-            pack('L', 104),
+            $binaryValues[0],
+            $binaryValues[1],
+            $binaryValues[2],
+            $binaryValues[3],
+            $binaryValues[4],
         ], $data);
     }
 }

--- a/tests/Functional/BinaryDataAccessTest.php
+++ b/tests/Functional/BinaryDataAccessTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
+
+use function array_change_key_case;
+use function array_keys;
+use function array_map;
+use function hex2bin;
+use function is_resource;
+use function pack;
+use function stream_get_contents;
+
+use const CASE_LOWER;
+
+class BinaryDataAccessTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        if (TestUtil::isDriverOneOf('pdo_oci')) {
+            self::markTestSkipped("PDO_OCI doesn't support binding binary values");
+        }
+
+        $table = new Table('binary_fetch_table');
+        $table->addColumn('test_int', 'integer');
+        $table->addColumn('test_binary', 'binary', ['notnull' => false, 'length' => 4]);
+        $table->setPrimaryKey(['test_int']);
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('binary_fetch_table', [
+            'test_int' => 1,
+            'test_binary' => hex2bin('C0DEF00D'),
+        ], [
+            'test_binary' => ParameterType::BINARY,
+        ]);
+    }
+
+    public function testPrepareWithBindValue(): void
+    {
+        $sql  = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $stmt = $this->connection->prepare($sql);
+
+        $stmt->bindValue(1, 1);
+        $stmt->bindValue(2, hex2bin('C0DEF00D'), ParameterType::BINARY);
+
+        $row = $stmt->executeQuery()->fetchAssociative();
+
+        self::assertIsArray($row);
+        $row = array_change_key_case($row, CASE_LOWER);
+        self::assertEquals(['test_int', 'test_binary'], array_keys($row));
+        self::assertEquals(1, $row['test_int']);
+
+        $binaryResult = $row['test_binary'];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testPrepareWithFetchAllAssociative(): void
+    {
+        $paramInt = 1;
+        $paramBin = hex2bin('C0DEF00D');
+
+        $sql  = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $stmt = $this->connection->prepare($sql);
+
+        $stmt->bindValue(1, $paramInt);
+        $stmt->bindValue(2, $paramBin, ParameterType::BINARY);
+
+        $rows    = $stmt->executeQuery()->fetchAllAssociative();
+        $rows[0] = array_change_key_case($rows[0], CASE_LOWER);
+
+        self::assertEquals(['test_int', 'test_binary'], array_keys($rows[0]));
+        self::assertEquals(1, $rows[0]['test_int']);
+
+        $binaryResult = $rows[0]['test_binary'];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testPrepareWithFetchOne(): void
+    {
+        $paramInt = 1;
+        $paramBin = hex2bin('C0DEF00D');
+
+        $sql  = 'SELECT test_int FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $stmt = $this->connection->prepare($sql);
+
+        $stmt->bindValue(1, $paramInt);
+        $stmt->bindValue(2, $paramBin, ParameterType::BINARY);
+
+        $column = $stmt->executeQuery()->fetchOne();
+        self::assertEquals(1, $column);
+    }
+
+    public function testFetchAllAssociative(): void
+    {
+        $sql  = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $data = $this->connection->fetchAllAssociative($sql, [1, hex2bin('C0DEF00D')], [1 => ParameterType::BINARY]);
+
+        self::assertCount(1, $data);
+
+        $row = $data[0];
+        self::assertCount(2, $row);
+
+        $row = array_change_key_case($row, CASE_LOWER);
+        self::assertEquals(1, $row['test_int']);
+
+        $binaryResult = $row['test_binary'];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testFetchAllWithTypes(): void
+    {
+        $sql  = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $data = $this->connection->fetchAllAssociative(
+            $sql,
+            [1, hex2bin('C0DEF00D')],
+            [ParameterType::STRING, Types::BINARY],
+        );
+
+        self::assertCount(1, $data);
+
+        $row = $data[0];
+        self::assertCount(2, $row);
+
+        $row = array_change_key_case($row, CASE_LOWER);
+        self::assertEquals(1, $row['test_int']);
+
+        $binaryResult = $row['test_binary'];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testFetchAssociative(): void
+    {
+        $sql = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $row = $this->connection->fetchAssociative($sql, [1, hex2bin('C0DEF00D')], [1 => ParameterType::BINARY]);
+
+        self::assertNotFalse($row);
+
+        $row = array_change_key_case($row, CASE_LOWER);
+
+        self::assertEquals(1, $row['test_int']);
+
+        $binaryResult = $row['test_binary'];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testFetchAssocWithTypes(): void
+    {
+        $sql = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $row = $this->connection->fetchAssociative(
+            $sql,
+            [1, hex2bin('C0DEF00D')],
+            [ParameterType::STRING, Types::BINARY],
+        );
+
+        self::assertNotFalse($row);
+
+        $row = array_change_key_case($row, CASE_LOWER);
+
+        self::assertEquals(1, $row['test_int']);
+
+        $binaryResult = $row['test_binary'];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testFetchArray(): void
+    {
+        $sql = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $row = $this->connection->fetchNumeric($sql, [1, hex2bin('C0DEF00D')], [1 => ParameterType::BINARY]);
+        self::assertNotFalse($row);
+
+        self::assertEquals(1, $row[0]);
+
+        $binaryResult = $row[1];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testFetchArrayWithTypes(): void
+    {
+        $sql = 'SELECT test_int, test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $row = $this->connection->fetchNumeric(
+            $sql,
+            [1, hex2bin('C0DEF00D')],
+            [ParameterType::STRING, Types::BINARY],
+        );
+
+        self::assertNotFalse($row);
+
+        $row = array_change_key_case($row, CASE_LOWER);
+
+        self::assertEquals(1, $row[0]);
+
+        $binaryResult = $row[1];
+        if (is_resource($binaryResult)) {
+            $binaryResult = stream_get_contents($binaryResult);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $binaryResult);
+    }
+
+    public function testFetchColumn(): void
+    {
+        $sql     = 'SELECT test_int FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $testInt = $this->connection->fetchOne($sql, [1, hex2bin('C0DEF00D')], [1 => ParameterType::BINARY]);
+
+        self::assertEquals(1, $testInt);
+
+        $sql        = 'SELECT test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $testBinary = $this->connection->fetchOne($sql, [1, hex2bin('C0DEF00D')], [1 => ParameterType::BINARY]);
+
+        if (is_resource($testBinary)) {
+            $testBinary = stream_get_contents($testBinary);
+        }
+
+        self::assertEquals(hex2bin('C0DEF00D'), $testBinary);
+    }
+
+    public function testFetchOneWithTypes(): void
+    {
+        $sql    = 'SELECT test_binary FROM binary_fetch_table WHERE test_int = ? AND test_binary = ?';
+        $column = $this->connection->fetchOne(
+            $sql,
+            [1, hex2bin('C0DEF00D')],
+            [ParameterType::STRING, Types::BINARY],
+        );
+
+        if (is_resource($column)) {
+            $column = stream_get_contents($column);
+        }
+
+        self::assertIsString($column);
+        self::assertEquals(hex2bin('C0DEF00D'), $column);
+    }
+
+    public function testNativeArrayListSupport(): void
+    {
+        for ($i = 100; $i < 110; $i++) {
+            $this->connection->insert('binary_fetch_table', [
+                'test_int' => $i,
+                'test_binary' => pack('L', $i),
+            ], [
+                'test_binary' => ParameterType::BINARY,
+            ]);
+        }
+
+        $result = $this->connection->executeQuery(
+            'SELECT test_int FROM binary_fetch_table WHERE test_int IN (?)',
+            [[100, 101, 102, 103, 104]],
+            [ArrayParameterType::INTEGER],
+        );
+
+        $data = $result->fetchAllNumeric();
+        self::assertCount(5, $data);
+        self::assertEquals([[100], [101], [102], [103], [104]], $data);
+
+        $result = $this->connection->executeQuery(
+            'SELECT test_int FROM binary_fetch_table WHERE test_binary IN (?)',
+            [
+                [
+                    pack('L', 100),
+                    pack('L', 101),
+                    pack('L', 102),
+                    pack('L', 103),
+                    pack('L', 104),
+                ],
+            ],
+            [ArrayParameterType::BINARY],
+        );
+
+        $data = $result->fetchAllNumeric();
+        self::assertCount(5, $data);
+        self::assertEquals([[100], [101], [102], [103], [104]], $data);
+
+        $result = $this->connection->executeQuery(
+            'SELECT test_binary FROM binary_fetch_table WHERE test_binary IN (?)',
+            [
+                [
+                    pack('L', 100),
+                    pack('L', 101),
+                    pack('L', 102),
+                    pack('L', 103),
+                    pack('L', 104),
+                ],
+            ],
+            [ArrayParameterType::BINARY],
+        );
+
+        $data = $result->fetchFirstColumn();
+        self::assertCount(5, $data);
+
+        $data = array_map(
+            static fn ($binaryField) => is_resource($binaryField)
+                ? stream_get_contents($binaryField)
+                : $binaryField,
+            $data,
+        );
+
+        self::assertEquals([
+            pack('L', 100),
+            pack('L', 101),
+            pack('L', 102),
+            pack('L', 103),
+            pack('L', 104),
+        ], $data);
+    }
+}

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -15,6 +15,8 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+use function hex2bin;
+
 class QueryBuilderTest extends TestCase
 {
     /** @var Connection&MockObject */
@@ -930,12 +932,17 @@ class QueryBuilderTest extends TestCase
         $qb->andWhere('name IN (:names)');
         $qb->setParameter('names', ['john', 'jane'], ArrayParameterType::STRING);
 
+        $qb->andWhere('hash IN (:hashes)');
+        $qb->setParameter('hashes', [hex2bin('DEADBEEF'), hex2bin('C0DEF00D')], ArrayParameterType::BINARY);
+
         self::assertSame(ArrayParameterType::INTEGER, $qb->getParameterType('ids'));
         self::assertSame(ArrayParameterType::STRING, $qb->getParameterType('names'));
+        self::assertSame(ArrayParameterType::BINARY, $qb->getParameterType('hashes'));
 
         self::assertSame([
             'ids'   => ArrayParameterType::INTEGER,
             'names' => ArrayParameterType::STRING,
+            'hashes' => ArrayParameterType::BINARY,
         ], $qb->getParameterTypes());
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | 

#### Summary

Superseeds #5994

Changes to his PR:

- Removed binding of BINARY in IBM DB2 as it makes no difference to the query.
- Fixed IBM DB2 test failures. It seems like DB2 Binary is just [VARCHAR with FOR BIT](https://www.ibm.com/docs/en/db2/11.5?topic=hvic-binary-storage-variable-values-using-bit-data-clause-in-cobol) and we passed characters (pack produced one character) to the Database and expected that it converts the character to binary. That seems not to happen with DB2, so I changed it to send always binary data.


(Never used DB2 before, why do people still use it? 🤣 )
