### PR TITLE
SQLite generated columns

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -230,7 +230,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
         $indexBuffer = [];
 
         // fetch primary
-        $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_TABLE_INFO (?)', [$tableName]);
+        $indexArray = $this->_conn->fetchAllAssociative('SELECT * FROM PRAGMA_TABLE_XINFO (?)', [$tableName]);
 
         usort(
             $indexArray,
@@ -684,7 +684,7 @@ SQL;
             SELECT t.name AS table_name,
                    c.*
               FROM sqlite_master t
-              JOIN pragma_table_info(t.name) c
+              JOIN pragma_table_xinfo(t.name) c
 SQL;
 
         $conditions = [

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -291,4 +291,27 @@ SQL;
         self::assertSame('users', $foreignKey->getForeignTableName());
         self::assertSame(['id'], $foreignKey->getForeignColumns());
     }
+
+    public function testGeneratedColumnsGetListed(): void
+    {
+        $this->dropTableIfExists('users');
+
+        $ddl = <<<'DDL'
+        CREATE TABLE "users" (
+            "id" INTEGER,
+            "a" INTEGER,
+            "b" INTEGER AS (a*2),
+            "c" INT GENERATED ALWAYS AS (a*2) VIRTUAL,
+            "d" INT GENERATED ALWAYS AS (a*2) STORED
+        );
+        DDL;
+
+        $this->connection->executeStatement($ddl);
+        $users = $this->schemaManager->introspectTable('users');
+
+        $this->assertTrue($users->hasColumn('a'));
+        $this->assertTrue($users->hasColumn('b'));
+        $this->assertTrue($users->hasColumn('c'));
+        $this->assertTrue($users->hasColumn('d'));
+    }
 }


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The current implementation for SQLite will not list any generated columns due to them being retrieved through the `table_info` pragma statement. This causes problems for situations where DBAL is used for schema changes (for example Laravel) where a generated field will get dropped whenever a column gets changed (Laravel uses DBAL for this specific case). 

`table_xinfo` returns data the same way but does include the generated columns.