### PR TITLE
Remove duplicate alias and slug

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -20,9 +20,8 @@
         {
             "name": "3.6",
             "branchName": "3.6.x",
-            "slug": "current",
-            "current": true,
-            "aliases": ["stable"]
+            "slug": "3.6",
+            "current": true
         },
         {
             "name": "3.5",


### PR DESCRIPTION
Marking a branch as current is equivalent to creating "current" and "stable" aliases for it.