### PR TITLE
Add a configuration setting to disable generating type comments

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -56,6 +56,14 @@ class Configuration
      */
     protected $autoCommit = true;
 
+    /**
+     * Whether type comments should be disabled to provide the same DB schema than
+     * will be obtained with DBAL 4.x. This is useful when relying only on the
+     * platform-aware schema comparison (which does not need those type comments)
+     * rather than the deprecated legacy tooling.
+     */
+    private bool $disableTypeComments = false;
+
     private ?SchemaManagerFactory $schemaManagerFactory = null;
 
     public function __construct()
@@ -238,6 +246,19 @@ class Configuration
     public function setSchemaManagerFactory(SchemaManagerFactory $schemaManagerFactory): self
     {
         $this->schemaManagerFactory = $schemaManagerFactory;
+
+        return $this;
+    }
+
+    public function getDisableTypeComments(): bool
+    {
+        return $this->disableTypeComments;
+    }
+
+    /** @return $this */
+    public function setDisableTypeComments(bool $disableTypeComments): self
+    {
+        $this->disableTypeComments = $disableTypeComments;
 
         return $this;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -209,6 +209,7 @@ class Connection
 
             $this->platform = $params['platform'];
             $this->platform->setEventManager($this->_eventManager);
+            $this->platform->setDisableTypeComments($config->getDisableTypeComments());
         }
 
         $this->_expr = $this->createExpressionBuilder();
@@ -315,6 +316,7 @@ class Connection
         if ($this->platform === null) {
             $this->platform = $this->detectDatabasePlatform();
             $this->platform->setEventManager($this->_eventManager);
+            $this->platform->setDisableTypeComments($this->_config->getDisableTypeComments());
         }
 
         return $this->platform;

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -103,6 +103,14 @@ abstract class AbstractPlatform
      */
     protected $_keywords;
 
+    private bool $disableTypeComments = false;
+
+    /** @internal */
+    final public function setDisableTypeComments(bool $value): void
+    {
+        $this->disableTypeComments = $value;
+    }
+
     /**
      * Sets the EventManager used by the Platform.
      *
@@ -578,7 +586,7 @@ abstract class AbstractPlatform
 
         $comment = $column->getComment();
 
-        if ($column->getType()->requiresSQLCommentHint($this)) {
+        if (! $this->disableTypeComments && $column->getType()->requiresSQLCommentHint($this)) {
             $comment .= $this->getDoctrineTypeComment($column->getType());
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | closes #6056

#### Summary

This allows to opt-in for a schema generated without type comments once the project is migrating to the new schema tooling that does not need them, allowing to have a clean DB schema without waiting for DBAL 4.0 and to decouple the schema migration from the DBAL upgrade itself.

I decided to name that field `disable*` so that the opt-in for the new behavior is done by setting it to `true`

