### PR TITLE
Remove composer-runtime-api dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "composer-runtime-api": "^2",
         "doctrine/deprecations": "^0.5.3|^1",
         "psr/cache": "^1|^2|^3",
         "psr/log": "^1|^2|^3"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Since the removal of the `ConsoleRunner` class, we don't access Composer's runtime API anymore.