### PR TITLE
Link to correct MR for mysql deprecation

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -69,7 +69,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         Deprecation::trigger(
             'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/5060',
+            'https://github.com/doctrine/dbal/pull/5072',
             'MySQL 5.6 support is deprecated and will be removed in DBAL 4.'
                 . ' Consider upgrading to MySQL 5.7 or later.',
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The link of the deprecation is to the postgress deprecation, rather than the mysql one.

This will however break the reference for people who ignore this wit  `ignoreDeprecations`, so i'm not sure if its worth fixing, or if we should instead add a comment with the correct MR above it.
