### PR TITLE
Stricter `DateTime` types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,25 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## BC BREAK: Stricter `DateTime` types
+
+The following types don't accept or return `DateTimeImmutable` instances anymore:
+
+* `DateTimeType`
+* `DateTimeTzType`
+* `DateType`
+* `TimeType`
+* `VarDateTimeType`
+
+As a consequence, the following type classes don't extend their mutable
+counterparts anymore:
+
+* `DateTimeImmutableType`
+* `DateTimeTzImmutableType`
+* `DateImmutableType`
+* `TimeImmutableType`
+* `VarDateTimeImmutableType`
+
 ## BC BREAK: Remove legacy execute and fetch methods.
 
 The following methods have been removed:

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1463,11 +1463,11 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $this->getCurrentTimestampSQL();
         }
 
-        if ($type instanceof Types\TimeType && $default === $this->getCurrentTimeSQL()) {
+        if ($type instanceof Types\PhpTimeMappingType && $default === $this->getCurrentTimeSQL()) {
             return ' DEFAULT ' . $this->getCurrentTimeSQL();
         }
 
-        if ($type instanceof Types\DateType && $default === $this->getCurrentDateSQL()) {
+        if ($type instanceof Types\PhpDateMappingType && $default === $this->getCurrentDateSQL()) {
             return ' DEFAULT ' . $this->getCurrentDateSQL();
         }
 

--- a/src/Types/DateImmutableType.php
+++ b/src/Types/DateImmutableType.php
@@ -12,8 +12,16 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
 /**
  * Immutable type of {@see DateType}.
  */
-class DateImmutableType extends DateType
+class DateImmutableType extends Type implements PhpDateMappingType
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getDateTypeDeclarationSQL($column);
+    }
+
     /**
      * @param T $value
      *

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -13,8 +13,16 @@ use Exception;
 /**
  * Immutable type of {@see DateTimeType}.
  */
-class DateTimeImmutableType extends DateTimeType
+class DateTimeImmutableType extends Type implements PhpDateTimeMappingType
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getDateTimeTypeDeclarationSQL($column);
+    }
+
     /**
      * @param T $value
      *

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 use Exception;
 
 /**
@@ -39,49 +36,27 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                DateTimeImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value instanceof DateTimeInterface) {
+        if ($value instanceof DateTime) {
             return $value->format($platform->getDateTimeFormatString());
         }
 
         throw InvalidType::new(
             $value,
             static::class,
-            ['null', DateTime::class, DateTimeImmutable::class],
+            ['null', DateTime::class],
         );
     }
 
     /**
      * @param T $value
      *
-     * @return (T is null ? null : DateTimeInterface)
+     * @return (T is null ? null : DateTime)
      *
      * @template T
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTime
     {
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                DateTimeImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value === null || $value instanceof DateTimeInterface) {
+        if ($value === null || $value instanceof DateTime) {
             return $value;
         }
 

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -12,8 +12,16 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
 /**
  * Immutable type of {@see DateTimeTzType}.
  */
-class DateTimeTzImmutableType extends DateTimeTzType
+class DateTimeTzImmutableType extends Type implements PhpDateTimeMappingType
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getDateTimeTzTypeDeclarationSQL($column);
+    }
+
     /**
      * @psalm-param T $value
      *

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * DateTime type saving additional timezone information.
@@ -51,18 +48,7 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                DateTimeTzImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value instanceof DateTimeInterface) {
+        if ($value instanceof DateTime) {
             return $value->format($platform->getDateTimeTzFormatString());
         }
 
@@ -76,24 +62,13 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
     /**
      * @param T $value
      *
-     * @return (T is null ? null : DateTimeInterface)
+     * @return (T is null ? null : DateTime)
      *
      * @template T
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTime
     {
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                DateTimeTzImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value === null || $value instanceof DateTimeInterface) {
+        if ($value === null || $value instanceof DateTime) {
             return $value;
         }
 

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Type that maps an SQL DATE to a PHP Date object.
  */
-class DateType extends Type
+class DateType extends Type implements PhpDateMappingType
 {
     /**
      * {@inheritDoc}
@@ -38,18 +35,7 @@ class DateType extends Type
             return $value;
         }
 
-        if ($value instanceof DateTimeInterface) {
-            if ($value instanceof DateTimeImmutable) {
-                Deprecation::triggerIfCalledFromOutside(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/6017',
-                    'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                    $value::class,
-                    DateImmutableType::class,
-                    __FUNCTION__,
-                );
-            }
-
+        if ($value instanceof DateTime) {
             return $value->format($platform->getDateFormatString());
         }
 
@@ -59,24 +45,13 @@ class DateType extends Type
     /**
      * @param T $value
      *
-     * @return (T is null ? null : DateTimeInterface)
+     * @return (T is null ? null : DateTime)
      *
      * @template T
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTime
     {
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                DateImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value === null || $value instanceof DateTimeInterface) {
+        if ($value === null || $value instanceof DateTime) {
             return $value;
         }
 

--- a/src/Types/PhpDateMappingType.php
+++ b/src/Types/PhpDateMappingType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+/**
+ * Implementations should map a database type to a PHP DateTimeInterface instance.
+ *
+ * @internal
+ */
+interface PhpDateMappingType
+{
+}

--- a/src/Types/PhpTimeMappingType.php
+++ b/src/Types/PhpTimeMappingType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+/**
+ * Implementations should map a database type to a PHP DateTimeInterface instance.
+ *
+ * @internal
+ */
+interface PhpTimeMappingType
+{
+}

--- a/src/Types/TimeImmutableType.php
+++ b/src/Types/TimeImmutableType.php
@@ -12,8 +12,16 @@ use Doctrine\DBAL\Types\Exception\InvalidType;
 /**
  * Immutable type of {@see TimeType}.
  */
-class TimeImmutableType extends TimeType
+class TimeImmutableType extends Type implements PhpTimeMappingType
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getTimeTypeDeclarationSQL($column);
+    }
+
     /**
      * @param T $value
      *

--- a/src/Types/TimeType.php
+++ b/src/Types/TimeType.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Type that maps an SQL TIME to a PHP DateTime object.
  */
-class TimeType extends Type
+class TimeType extends Type implements PhpTimeMappingType
 {
     /**
      * {@inheritDoc}
@@ -38,18 +35,7 @@ class TimeType extends Type
             return $value;
         }
 
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                TimeImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value instanceof DateTimeInterface) {
+        if ($value instanceof DateTime) {
             return $value->format($platform->getTimeFormatString());
         }
 
@@ -59,24 +45,13 @@ class TimeType extends Type
     /**
      * @param T $value
      *
-     * @return (T is null ? null : DateTimeInterface)
+     * @return (T is null ? null : DateTime)
      *
      * @template T
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTime
     {
-        if ($value instanceof DateTimeImmutable) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6017',
-                'Passing an instance of %s is deprecated, use %s::%s() instead.',
-                $value::class,
-                TimeImmutableType::class,
-                __FUNCTION__,
-            );
-        }
-
-        if ($value === null || $value instanceof DateTimeInterface) {
+        if ($value === null || $value instanceof DateTime) {
             return $value;
         }
 

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -13,7 +13,7 @@ use Exception;
 /**
  * Immutable type of {@see VarDateTimeType}.
  */
-class VarDateTimeImmutableType extends VarDateTimeType
+class VarDateTimeImmutableType extends DateTimeImmutableType
 {
     /**
      * @param T $value

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use DateTime;
-use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use Exception;
@@ -22,11 +21,11 @@ class VarDateTimeType extends DateTimeType
     /**
      * @param T $value
      *
-     * @return (T is null ? null : DateTimeInterface)
+     * @return (T is null ? null : DateTime)
      *
      * @template T
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;

--- a/tests/Types/BaseDateTypeTestCase.php
+++ b/tests/Types/BaseDateTypeTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Types;
 
 use DateTime;
-use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
@@ -18,9 +17,7 @@ use function date_default_timezone_set;
 
 abstract class BaseDateTypeTestCase extends TestCase
 {
-    /** @var AbstractPlatform&MockObject */
-    protected AbstractPlatform $platform;
-
+    protected AbstractPlatform&MockObject $platform;
     protected Type $type;
     private string $currentTimezone;
 
@@ -58,28 +55,6 @@ abstract class BaseDateTypeTestCase extends TestCase
         $date = new DateTime('now');
 
         self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
-    }
-
-    /**
-     * Note that while \@see \DateTimeImmutable is supposed to be handled
-     * by @see \Doctrine\DBAL\Types\DateTimeImmutableType, previous DBAL versions handled it just fine.
-     * This test is just in place to prevent further regressions, even if the type is being misused
-     */
-    public function testConvertDateTimeImmutableToPHPValue(): void
-    {
-        $date = new DateTimeImmutable('now');
-
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
-    }
-
-    /**
-     * Note that while \@see \DateTimeImmutable is supposed to be handled
-     * by @see \Doctrine\DBAL\Types\DateTimeImmutableType, previous DBAL versions handled it just fine.
-     * This test is just in place to prevent further regressions, even if the type is being misused
-     */
-    public function testDateTimeImmutableConvertsToDatabaseValue(): void
-    {
-        self::assertIsString($this->type->convertToDatabaseValue(new DateTimeImmutable(), $this->platform));
     }
 
     /** @return mixed[][] */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6017 by @phansys

#### Summary

The following types don't accept or return `DateTimeImmutable` instances anymore:

* `DateTimeType`
* `DateTimeTzType`
* `DateType`
* `TimeType`
* `VarDateTimeType`

As a consequence, the following type classes don't extend their mutable
counterparts anymore:

* `DateTimeImmutableType`
* `DateTimeTzImmutableType`
* `DateImmutableType`
* `TimeImmutableType`
* `VarDateTimeImmutableType`