### PR TITLE
Fix comparator type detection

### DIFF
--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -191,12 +191,6 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $tableColumn['comment'] = $this->removeDoctrineTypeFromComment($tableColumn['comment'], $type);
         }
 
-        // Check underlying database type where doctrine type is inferred from DC2Type comment
-        // and set a flag if it is not as expected.
-        if ($origType !== $type && $this->expectedDbType($type, $tableColumn) !== $dbType) {
-            $tableColumn['declarationMismatch'] = true;
-        }
-
         switch ($dbType) {
             case 'char':
             case 'binary':
@@ -294,6 +288,12 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
         if (isset($tableColumn['declarationMismatch'])) {
             $column->setPlatformOption('declarationMismatch', $tableColumn['declarationMismatch']);
+        }
+
+        // Check underlying database type where doctrine type is inferred from DC2Type comment
+        // and set a flag if it is not as expected.
+        if ($origType !== $type && $this->expectedDbType($type, $options) !== $dbType) {
+            $column->setPlatformOption('declarationMismatch', true);
         }
 
         return $column;

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1043Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Comparator;
@@ -148,9 +149,29 @@ final class ComparatorTest extends FunctionalTestCase
         ));
     }
 
+    public function testSimpleArrayTypeNonChangeNotDetected(): void
+    {
+        $table = new Table('comparator_test');
+
+        $table->addColumn('simple_array_col', Types::SIMPLE_ARRAY, ['length' => 255]);
+        $this->dropAndCreateTable($table);
+
+        self::assertFalse(ComparatorTestUtils::diffFromActualToDesiredTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table,
+        ));
+
+        self::assertFalse(ComparatorTestUtils::diffFromDesiredToActualTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table,
+        ));
+    }
+
     public function testMariaDb1043NativeJsonUpgradeDetected(): void
     {
-        if (! $this->platform instanceof MariaDb1043Platform) {
+        if (! $this->platform instanceof MariaDb1043Platform && ! $this->platform instanceof MySQL80Platform) {
             self::markTestSkipped();
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | https://github.com/contao/contao/issues/6409

#### Summary

Since https://github.com/doctrine/dbal/pull/5916 some column configurations always show up as changed in the Comparator. For example a `Types::SIMPLE_ARRAY, ['length' => 255]` column.

This pull request moves the `->expectedDbType()` check to the correct position to fix this issue
and adds a test that verifies the fix.