### PR TITLE
Fixes duplicate quoting of table name when creating column comments

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -417,7 +417,7 @@ class SQLServerPlatform extends AbstractPlatform
             $tableSQL               = $this->quoteStringLiteral($tableSQL);
         } else {
             $schemaSQL = "'dbo'";
-            $tableSQL  = $this->quoteStringLiteral($tableName);
+            $tableSQL  = $tableName;
         }
 
         return $this->getAddExtendedPropertySQL(


### PR DESCRIPTION
Fix for: https://github.com/doctrine/dbal/issues/6169

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 6169

#### Summary

Prevents duplicate quoting of table name when creating column comments e.g. for JSON columns that are mapped to TEXT columns with `(DC2Type:json)` comment
