### PR TITLE
Improve savepoint name

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1334,7 +1334,7 @@ class Connection
      */
     protected function _getNestedTransactionSavePointName()
     {
-        return 'DOCTRINE2_SAVEPOINT_' . $this->transactionNestingLevel;
+        return 'DOCTRINE_DBAL_SAVEPOINT_' . ($this->transactionNestingLevel - 1);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Previously the name started with `DOCTRINE2_`, newly it starts with `DOCTRINE_DBAL_` which is clearer.

Also the savepoint name is improved to start with 1, ie. `SAVEPOINT DOCTRINE2_SAVEPOINT_1`, `SAVEPOINT DOCTRINE2_SAVEPOINT_2`, ... The transaction nesting level is guaranteed to be always >=1 as savepoint cannot be saved when there is no transaction.

Improved naming is better for easier SQL logs understanding.