### PR TITLE
Deprecate getting query parts from QueryBuilder

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 3.8
+
+## Deprecated getting query parts from `QueryBuilder`
+
+The usage of `QueryBuilder::getQueryPart()` and `::getQueryParts()` is deprecated. The query parts
+are implementation details and should not be relied upon.
+
 # Upgrade to 3.6
 
 ## Deprecated not setting a schema manager factory

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -499,6 +499,11 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Connection::getEventManager"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::setEventManager"/>
+                <!--
+                    TODO: remove in 4.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getQueryPart"/>
+                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getQueryParts"/>
 
                 <!-- TODO for PHPUnit 10 -->
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1297,22 +1297,38 @@ class QueryBuilder
     /**
      * Gets a query part by its name.
      *
+     * @deprecated The query parts are implementation details and should not be relied upon.
+     *
      * @param string $queryPartName
      *
      * @return mixed
      */
     public function getQueryPart($queryPartName)
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6179',
+            'Getting query parts is deprecated as they are implementation details.',
+        );
+
         return $this->sqlParts[$queryPartName];
     }
 
     /**
      * Gets all query parts.
      *
+     * @deprecated The query parts are implementation details and should not be relied upon.
+     *
      * @return mixed[]
      */
     public function getQueryParts()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6179',
+            'Getting query parts is deprecated as they are implementation details.',
+        );
+
         return $this->sqlParts;
     }
 

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Query\QueryException;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -19,6 +20,8 @@ use function hex2bin;
 
 class QueryBuilderTest extends TestCase
 {
+    use VerifyDeprecations;
+
     /** @var Connection&MockObject */
     protected Connection $conn;
 
@@ -791,6 +794,8 @@ class QueryBuilderTest extends TestCase
         self::assertEquals((string) $qb, (string) $qbClone);
 
         $qb->andWhere('u.id = 1');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6179');
 
         self::assertNotSame($qb->getQueryParts(), $qbClone->getQueryParts());
         self::assertNotSame($qb->getParameters(), $qbClone->getParameters());


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The methods were removed in https://github.com/doctrine/dbal/pull/3836.