### PR TITLE
fix: truncate identity sequence name if necessary

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -31,8 +31,10 @@ use function is_bool;
 use function is_numeric;
 use function is_string;
 use function sprintf;
+use function strlen;
 use function strpos;
 use function strtolower;
+use function substr;
 use function trim;
 
 /**
@@ -236,7 +238,13 @@ class PostgreSQLPlatform extends AbstractPlatform
             __METHOD__,
         );
 
-        return $tableName . '_' . $columnName . '_seq';
+        $suffix = '_' . $columnName . '_seq';
+
+        if (strlen($tableName . $suffix) > $this->getMaxIdentifierLength()) {
+            $tableName = substr($tableName, 0, $this->getMaxIdentifierLength() - strlen($suffix));
+        }
+
+        return $tableName . $suffix;
     }
 
     /**

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -641,6 +641,17 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertSame('mytable_mycolumn_seq', $this->platform->getIdentitySequenceName('mytable', 'mycolumn'));
     }
 
+    public function testReturnsTruncatedIdentitySequenceName(): void
+    {
+        self::assertSame(
+            'mytable_to_test_that_the_identity_sequence_name_is_mycolumn_seq',
+            $this->platform->getIdentitySequenceName(
+                'mytable_to_test_that_the_identity_sequence_name_is_truncated',
+                'mycolumn',
+            ),
+        );
+    }
+
     /** @dataProvider dataCreateSequenceWithCache */
     public function testCreateSequenceWithCache(int $cacheSize, string $expectedSql): void
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6183

#### Summary

Hi,

generated identity sequence name will now be  truncated according to the PostgreSQL platform configuration. 


Regards, 

Sylvain