### PR TITLE
Make the type annotation for CompositeExpression::count more specific

### DIFF
--- a/src/Query/Expression/CompositeExpression.php
+++ b/src/Query/Expression/CompositeExpression.php
@@ -149,6 +149,7 @@ class CompositeExpression implements Countable
      * Retrieves the amount of expressions on composite expression.
      *
      * @return int
+     * @psalm-return int<0, max>
      */
     #[ReturnTypeWillChange]
     public function count()


### PR DESCRIPTION
This helps static analysis.

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | (none)

#### Summary

`count` cannot return a negative number. Add a PHPDoc annotation to make this clear for static analysis.
