### PR TITLE
Add `QueryBuilder::resetOrderBy()`

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1366,6 +1366,20 @@ class QueryBuilder
         return $this;
     }
 
+    /**
+     * Resets the ordering for the query.
+     *
+     * @return $this This QueryBuilder instance.
+     */
+    public function resetOrderBy(): self
+    {
+        $this->sqlParts['orderBy'] = self::SQL_PARTS_DEFAULTS['orderBy'];
+
+        $this->state = self::STATE_DIRTY;
+
+        return $this;
+    }
+
     /** @throws QueryException */
     private function getSQLForSelect(): string
     {

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -631,6 +631,17 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('SELECT u.* FROM users u', (string) $qb);
     }
 
+    public function testResetOrderBy(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('u.*')->from('users', 'u')->orderBy('u.name');
+
+        self::assertEquals('SELECT u.* FROM users u ORDER BY u.name ASC', (string) $qb);
+        $qb->resetOrderBy();
+        self::assertEquals('SELECT u.* FROM users u', (string) $qb);
+    }
+
     public function testCreateNamedParameter(): void
     {
         $qb = new QueryBuilder($this->conn);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #6186

#### Summary

Based on the discussion in #6186, this adds `QueryBuilder::resetOrderBy()` to allow resetting the `ORDER BY` part of a query in 4.0, even after the removal of other API methods for accessing and resetting query parts.