### PR TITLE
Enable skipping locked rows in QueryBuilder

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 3.8
 
+## Deprecated lock-related `AbstractPlatform` methods
+
+The usage of `AbstractPlatform::getReadLockSQL()`, `::getWriteLockSQL()` and `::getForUpdateSQL` is deprecated as this
+API is not portable. Use `QueryBuilder::forUpdate()` as a replacement for the latter.
+
 ## Deprecated `AbstractMySQLPlatform` methods
 
 * `AbstractMySQLPlatform::getColumnTypeSQLSnippets()` has been deprecated

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -515,6 +515,9 @@
 
                 <!-- TODO for PHPUnit 10 -->
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>
+
+                <!-- TODO: remove in 4.0.0 -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getForUpdateSQL"/>
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
+use Doctrine\DBAL\Platforms\MariaDb1060Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -39,6 +40,10 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '10.6.0', '>=')) {
+                return new MariaDb1060Platform();
+            }
+
             if (version_compare($mariaDbVersion, '10.5.2', '>=')) {
                 return new MariaDb1052Platform();
             }

--- a/src/Driver/OCI8/Driver.php
+++ b/src/Driver/OCI8/Driver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\OCI8\Exception\InvalidConfiguration;
 use SensitiveParameter;
 
 use function oci_connect;
+use function oci_new_connect;
 use function oci_pconnect;
 
 use const OCI_NO_AUTO_COMMIT;

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
@@ -539,6 +541,11 @@ SQL
         }
 
         return $sql;
+    }
+
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return new DefaultSelectSQLBuilder($this, 'FOR UPDATE', null);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -29,6 +29,8 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
@@ -1758,10 +1760,19 @@ abstract class AbstractPlatform
     /**
      * Returns the FOR UPDATE expression.
      *
+     * @deprecated This API is not portable. Use {@link QueryBuilder::forUpdate()}` instead.
+     *
      * @return string
      */
     public function getForUpdateSQL()
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6191',
+            '%s is deprecated as non-portable.',
+            __METHOD__,
+        );
+
         return 'FOR UPDATE';
     }
 
@@ -1793,10 +1804,19 @@ abstract class AbstractPlatform
      * This defaults to the ANSI SQL "FOR UPDATE", which is an exclusive lock (Write). Some database
      * vendors allow to lighten this constraint up to be a real read lock.
      *
+     * @deprecated This API is not portable.
+     *
      * @return string
      */
     public function getReadLockSQL()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6191',
+            '%s is deprecated as non-portable.',
+            __METHOD__,
+        );
+
         return $this->getForUpdateSQL();
     }
 
@@ -1805,10 +1825,19 @@ abstract class AbstractPlatform
      *
      * The semantics of this lock mode should equal the SELECT .. FOR UPDATE of the ANSI SQL standard.
      *
+     * @deprecated This API is not portable.
+     *
      * @return string
      */
     public function getWriteLockSQL()
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6191',
+            '%s is deprecated as non-portable.',
+            __METHOD__,
+        );
+
         return $this->getForUpdateSQL();
     }
 
@@ -2050,6 +2079,11 @@ abstract class AbstractPlatform
             ($createFlags & self::CREATE_INDEXES) > 0,
             ($createFlags & self::CREATE_FOREIGNKEYS) > 0,
         );
+    }
+
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return new DefaultSelectSQLBuilder($this, 'FOR UPDATE', 'SKIP LOCKED');
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
@@ -974,8 +976,15 @@ class DB2Platform extends AbstractPlatform
         return true;
     }
 
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return new DefaultSelectSQLBuilder($this, 'WITH RR USE AND KEEP UPDATE LOCKS', null);
+    }
+
     /**
      * {@inheritDoc}
+     *
+     * @deprecated This API is not portable.
      */
     public function getForUpdateSQL()
     {

--- a/src/Platforms/MariaDb1060Platform.php
+++ b/src/Platforms/MariaDb1060Platform.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.6 (10.6.0 GA) database platform.
+ */
+class MariaDb1060Platform extends MariaDb1052Platform
+{
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return AbstractPlatform::createSelectSQLBuilder();
+    }
+}

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\Deprecations\Deprecation;
 
 /**
@@ -24,5 +25,10 @@ class MySQL80Platform extends MySQL57Platform
         );
 
         return Keywords\MySQL80Keywords::class;
+    }
+
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return AbstractPlatform::createSelectSQLBuilder();
     }
 }

--- a/src/Platforms/PostgreSQL100Platform.php
+++ b/src/Platforms/PostgreSQL100Platform.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\Deprecations\Deprecation;
 
 /**
@@ -26,5 +27,10 @@ class PostgreSQL100Platform extends PostgreSQL94Platform
         );
 
         return PostgreSQL100Keywords::class;
+    }
+
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return AbstractPlatform::createSelectSQLBuilder();
     }
 }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Types;
@@ -264,6 +266,11 @@ class PostgreSQLPlatform extends AbstractPlatform
         );
 
         return true;
+    }
+
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return new DefaultSelectSQLBuilder($this, 'FOR UPDATE', null);
     }
 
     /**

--- a/src/Platforms/SQLServer/SQL/Builder/SQLServerSelectSQLBuilder.php
+++ b/src/Platforms/SQLServer/SQL/Builder/SQLServerSelectSQLBuilder.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\SQLServer\SQL\Builder;
+
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
+use Doctrine\DBAL\Query\SelectQuery;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+
+use function count;
+use function implode;
+
+final class SQLServerSelectSQLBuilder implements SelectSQLBuilder
+{
+    private SQLServerPlatform $platform;
+
+    /** @internal The SQL builder should be instantiated only by database platforms. */
+    public function __construct(SQLServerPlatform $platform)
+    {
+        $this->platform = $platform;
+    }
+
+    public function buildSQL(SelectQuery $query): string
+    {
+        $parts = ['SELECT'];
+
+        if ($query->isDistinct()) {
+            $parts[] = 'DISTINCT';
+        }
+
+        $parts[] = implode(', ', $query->getColumns());
+
+        $from = $query->getFrom();
+
+        if (count($from) > 0) {
+            $parts[] = 'FROM ' . implode(', ', $from);
+        }
+
+        $forUpdate = $query->getForUpdate();
+
+        if ($forUpdate !== null) {
+            $with = ['UPDLOCK', 'ROWLOCK'];
+
+            if ($forUpdate->getConflictResolutionMode() === ConflictResolutionMode::SKIP_LOCKED) {
+                $with[] = 'READPAST';
+            }
+
+            $parts[] = 'WITH (' . implode(', ', $with) . ')';
+        }
+
+        $where = $query->getWhere();
+
+        if ($where !== null) {
+            $parts[] = 'WHERE ' . $where;
+        }
+
+        $groupBy = $query->getGroupBy();
+
+        if (count($groupBy) > 0) {
+            $parts[] = 'GROUP BY ' . implode(', ', $groupBy);
+        }
+
+        $having = $query->getHaving();
+
+        if ($having !== null) {
+            $parts[] = 'HAVING ' . $having;
+        }
+
+        $orderBy = $query->getOrderBy();
+
+        if (count($orderBy) > 0) {
+            $parts[] = 'ORDER BY ' . implode(', ', $orderBy);
+        }
+
+        $sql   = implode(' ', $parts);
+        $limit = $query->getLimit();
+
+        if ($limit->isDefined()) {
+            $sql = $this->platform->modifyLimitQuery($sql, $limit->getMaxResults(), $limit->getFirstResult());
+        }
+
+        return $sql;
+    }
+}

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidLockMode;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Platforms\SQLServer\SQL\Builder\SQLServerSelectSQLBuilder;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -14,6 +15,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
@@ -49,6 +51,11 @@ use const PREG_OFFSET_CAPTURE;
  */
 class SQLServerPlatform extends AbstractPlatform
 {
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return new SQLServerSelectSQLBuilder($this);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -1610,6 +1617,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated This API is not portable.
      */
     public function getForUpdateSQL()
     {

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -14,6 +14,8 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\IntegerType;
@@ -191,6 +193,12 @@ class SqlitePlatform extends AbstractPlatform
     public function getCurrentDatabaseExpression(): string
     {
         return "'main'";
+    }
+
+    /** @link https://www2.sqlite.org/cvstrac/wiki?p=UnsupportedSql */
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return new DefaultSelectSQLBuilder($this, null, null);
     }
 
     /**
@@ -734,6 +742,8 @@ class SqlitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated This API is not portable.
      */
     public function getForUpdateSQL()
     {

--- a/src/Query/ForUpdate.php
+++ b/src/Query/ForUpdate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+/** @internal */
+final class ForUpdate
+{
+    private int $conflictResolutionMode;
+
+    public function __construct(int $conflictResolutionMode)
+    {
+        $this->conflictResolutionMode = $conflictResolutionMode;
+    }
+
+    public function getConflictResolutionMode(): int
+    {
+        return $this->conflictResolutionMode;
+    }
+}

--- a/src/Query/ForUpdate/ConflictResolutionMode.php
+++ b/src/Query/ForUpdate/ConflictResolutionMode.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query\ForUpdate;
+
+final class ConflictResolutionMode
+{
+    /**
+     * Wait for the row to be unlocked
+     */
+    public const ORDINARY = 0;
+
+    /**
+     * Skip the row if it is locked
+     */
+    public const SKIP_LOCKED = 1;
+
+    /**
+     * This class cannot be instantiated.
+     *
+     * @codeCoverageIgnore
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Query/Limit.php
+++ b/src/Query/Limit.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\DBAL\Query;
+
+final class Limit
+{
+    private ?int $maxResults;
+    private int $firstResult;
+
+    public function __construct(?int $maxResults, int $firstResult)
+    {
+        $this->maxResults  = $maxResults;
+        $this->firstResult = $firstResult;
+    }
+
+    public function isDefined(): bool
+    {
+        return $this->maxResults !== null || $this->firstResult !== 0;
+    }
+
+    public function getMaxResults(): ?int
+    {
+        return $this->maxResults;
+    }
+
+    public function getFirstResult(): int
+    {
+        return $this->firstResult;
+    }
+}

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Doctrine\DBAL\Query;
+
+final class SelectQuery
+{
+    private bool $distinct;
+
+    /** @var string[] */
+    private array $columns;
+
+    /** @var string[] */
+    private array $from;
+
+    private ?string $where;
+
+    /** @var string[] */
+    private array $groupBy;
+
+    private ?string $having;
+
+    /** @var string[] */
+    private array $orderBy;
+
+    private Limit $limit;
+
+    private ?ForUpdate $forUpdate;
+
+    /**
+     * @internal This class should be instantiated only by {@link QueryBuilder}.
+     *
+     * @param string[] $columns
+     * @param string[] $from
+     * @param string[] $groupBy
+     * @param string[] $orderBy
+     */
+    public function __construct(
+        bool $distinct,
+        array $columns,
+        array $from,
+        ?string $where,
+        array $groupBy,
+        ?string $having,
+        array $orderBy,
+        Limit $limit,
+        ?ForUpdate $forUpdate
+    ) {
+        $this->distinct  = $distinct;
+        $this->columns   = $columns;
+        $this->from      = $from;
+        $this->where     = $where;
+        $this->groupBy   = $groupBy;
+        $this->having    = $having;
+        $this->orderBy   = $orderBy;
+        $this->limit     = $limit;
+        $this->forUpdate = $forUpdate;
+    }
+
+    public function isDistinct(): bool
+    {
+        return $this->distinct;
+    }
+
+    /** @return string[] */
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    /** @return string[] */
+    public function getFrom(): array
+    {
+        return $this->from;
+    }
+
+    public function getWhere(): ?string
+    {
+        return $this->where;
+    }
+
+    /** @return string[] */
+    public function getGroupBy(): array
+    {
+        return $this->groupBy;
+    }
+
+    public function getHaving(): ?string
+    {
+        return $this->having;
+    }
+
+    /** @return string[] */
+    public function getOrderBy(): array
+    {
+        return $this->orderBy;
+    }
+
+    public function getLimit(): Limit
+    {
+        return $this->limit;
+    }
+
+    public function getForUpdate(): ?ForUpdate
+    {
+        return $this->forUpdate;
+    }
+}

--- a/src/SQL/Builder/DefaultSelectSQLBuilder.php
+++ b/src/SQL/Builder/DefaultSelectSQLBuilder.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Doctrine\DBAL\SQL\Builder;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
+use Doctrine\DBAL\Query\SelectQuery;
+
+use function count;
+use function implode;
+
+final class DefaultSelectSQLBuilder implements SelectSQLBuilder
+{
+    private AbstractPlatform $platform;
+    private ?string $forUpdateSQL;
+    private ?string $skipLockedSQL;
+
+    /** @internal The SQL builder should be instantiated only by database platforms. */
+    public function __construct(AbstractPlatform $platform, ?string $forUpdateSQL, ?string $skipLockedSQL)
+    {
+        $this->platform      = $platform;
+        $this->forUpdateSQL  = $forUpdateSQL;
+        $this->skipLockedSQL = $skipLockedSQL;
+    }
+
+    /** @throws Exception */
+    public function buildSQL(SelectQuery $query): string
+    {
+        $parts = ['SELECT'];
+
+        if ($query->isDistinct()) {
+            $parts[] = 'DISTINCT';
+        }
+
+        $parts[] = implode(', ', $query->getColumns());
+
+        $from = $query->getFrom();
+
+        if (count($from) > 0) {
+            $parts[] = 'FROM ' . implode(', ', $from);
+        }
+
+        $where = $query->getWhere();
+
+        if ($where !== null) {
+            $parts[] = 'WHERE ' . $where;
+        }
+
+        $groupBy = $query->getGroupBy();
+
+        if (count($groupBy) > 0) {
+            $parts[] = 'GROUP BY ' . implode(', ', $groupBy);
+        }
+
+        $having = $query->getHaving();
+
+        if ($having !== null) {
+            $parts[] = 'HAVING ' . $having;
+        }
+
+        $orderBy = $query->getOrderBy();
+
+        if (count($orderBy) > 0) {
+            $parts[] = 'ORDER BY ' . implode(', ', $orderBy);
+        }
+
+        $sql   = implode(' ', $parts);
+        $limit = $query->getLimit();
+
+        if ($limit->isDefined()) {
+            $sql = $this->platform->modifyLimitQuery($sql, $limit->getMaxResults(), $limit->getFirstResult());
+        }
+
+        $forUpdate = $query->getForUpdate();
+
+        if ($forUpdate !== null) {
+            if ($this->forUpdateSQL === null) {
+                throw Exception::notSupported('FOR UPDATE');
+            }
+
+            $sql .= ' ' . $this->forUpdateSQL;
+
+            if ($forUpdate->getConflictResolutionMode() === ConflictResolutionMode::SKIP_LOCKED) {
+                if ($this->skipLockedSQL === null) {
+                    throw Exception::notSupported('SKIP LOCKED');
+                }
+
+                $sql .= ' ' . $this->skipLockedSQL;
+            }
+        }
+
+        return $sql;
+    }
+}

--- a/src/SQL/Builder/SelectSQLBuilder.php
+++ b/src/SQL/Builder/SelectSQLBuilder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\DBAL\SQL\Builder;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Query\SelectQuery;
+
+interface SelectSQLBuilder
+{
+    /** @throws Exception */
+    public function buildSQL(SelectQuery $query): string;
+}

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -37,55 +37,29 @@ class VersionAwarePlatformDriverTest extends TestCase
         $this->assertDriverInstantiatesDatabasePlatform(new Driver\PDO\MySQL\Driver(), $version, $expectedClass);
     }
 
-    /** @return array<array{0: string, 1: class-string<AbstractPlatform>, 2?: string, 3?: bool}> */
+    /** @return array<array{string, class-string<AbstractPlatform>}> */
     public static function mySQLVersionProvider(): array
     {
         return [
-            ['5.6.9', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['5.7', MySQL57Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
-            ['5.7.0', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['5.7.8', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['5.7.9', MySQL57Platform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['5.7.10', MySQL57Platform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['8', MySQL80Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
-            ['8.0', MySQL80Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
-            ['8.0.11', MySQL80Platform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
+            ['5.6.9', MySQLPlatform::class],
+            ['5.7', MySQL57Platform::class],
+            ['5.7.0', MySQLPlatform::class],
+            ['5.7.8', MySQLPlatform::class],
+            ['5.7.9', MySQL57Platform::class],
+            ['5.7.10', MySQL57Platform::class],
+            ['8', MySQL80Platform::class],
+            ['8.0', MySQL80Platform::class],
+            ['8.0.11', MySQL80Platform::class],
             ['6', MySQL57Platform::class],
-            ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['10.1.2a-MariaDB-a1~lenny-log', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            ['5.5.40-MariaDB-1~wheezy', MySQLPlatform::class, 'https://github.com/doctrine/dbal/pull/5779', false],
-            [
-                '5.5.5-MariaDB-10.2.8+maria~xenial-log',
-                MariaDb1027Platform::class,
-                'https://github.com/doctrine/dbal/pull/5779',
-                false,
-            ],
-            [
-                '10.2.8-MariaDB-10.2.8+maria~xenial-log',
-                MariaDb1027Platform::class,
-                'https://github.com/doctrine/dbal/pull/5779',
-                false,
-            ],
-            [
-                '10.2.8-MariaDB-1~lenny-log',
-                MariaDb1027Platform::class,
-                'https://github.com/doctrine/dbal/pull/5779',
-                false,
-            ],
-            ['mariadb-10.9.3', MariaDB1052Platform::class, 'https://github.com/doctrine/dbal/pull/5779', true],
-            [
-                '10.5.2-MariaDB-1~lenny-log',
-                MariaDB1052Platform::class,
-                'https://github.com/doctrine/dbal/pull/5779',
-                false,
-            ],
-            [
-                '11.0.2-MariaDB-1:11.0.2+maria~ubu2204',
-                MariaDB1052Platform::class,
-                'https://github.com/doctrine/dbal/pull/5779',
-                false,
-            ],
+            ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class],
+            ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class],
+            ['10.1.2a-MariaDB-a1~lenny-log', MySQLPlatform::class],
+            ['5.5.40-MariaDB-1~wheezy', MySQLPlatform::class],
+            ['5.5.5-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
+            ['10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
+            ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],
+            ['10.5.2-MariaDB-1~lenny-log', MariaDB1052Platform::class],
+            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDB1052Platform::class],
         ];
     }
 
@@ -118,13 +92,13 @@ class VersionAwarePlatformDriverTest extends TestCase
         $this->assertDriverInstantiatesDatabasePlatform(new Driver\IBMDB2\Driver(), $version, $expectedClass);
     }
 
-    /** @return array<array{0: string, 1: class-string<AbstractPlatform>, 2?: string, 3?: bool}> */
+    /** @return array<array{string, class-string<AbstractPlatform>}> */
     public static function db2VersionProvider(): array
     {
         return [
-            ['10.1.0', DB2Platform::class, 'https://github.com/doctrine/dbal/pull/5156', true],
-            ['10.1.0.0', DB2Platform::class, 'https://github.com/doctrine/dbal/pull/5156', true],
-            ['DB2/LINUXX8664 10.1.0.0', DB2Platform::class, 'https://github.com/doctrine/dbal/pull/5156', true],
+            ['10.1.0', DB2Platform::class],
+            ['10.1.0.0', DB2Platform::class],
+            ['DB2/LINUXX8664 10.1.0.0', DB2Platform::class],
             ['11.1.0', DB2111Platform::class],
             ['11.1.0.0', DB2111Platform::class],
             ['DB2/LINUXX8664 11.1.0.0', DB2111Platform::class],

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\DB2111Platform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
+use Doctrine\DBAL\Platforms\MariaDb1060Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -59,7 +60,9 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['10.2.8-MariaDB-10.2.8+maria~xenial-log', MariaDb1027Platform::class],
             ['10.2.8-MariaDB-1~lenny-log', MariaDb1027Platform::class],
             ['10.5.2-MariaDB-1~lenny-log', MariaDB1052Platform::class],
-            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDB1052Platform::class],
+            ['mariadb-10.6.0', MariaDb1060Platform::class],
+            ['mariadb-10.9.3', MariaDb1060Platform::class],
+            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDb1060Platform::class],
         ];
     }
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Query;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MariaDb1060Platform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
+
+final class QueryBuilderTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $table = new Table('for_update');
+        $table->addColumn('id', Types::INTEGER);
+        $table->setPrimaryKey(['id']);
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('for_update', ['id' => 1]);
+        $this->connection->insert('for_update', ['id' => 2]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (! $this->connection->isTransactionActive()) {
+            return;
+        }
+
+        $this->connection->rollBack();
+    }
+
+    public function testForUpdateOrdinary(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SqlitePlatform) {
+            self::markTestSkipped('Skipping on SQLite');
+        }
+
+        $qb1 = $this->connection->createQueryBuilder();
+        $qb1->select('id')
+            ->from('for_update')
+            ->forUpdate();
+
+        self::assertEquals([1, 2], $qb1->fetchFirstColumn());
+    }
+
+    public function testForUpdateSkipLockedWhenSupported(): void
+    {
+        if (! $this->platformSupportsSkipLocked()) {
+            self::markTestSkipped('The database platform does not support SKIP LOCKED.');
+        }
+
+        $qb1 = $this->connection->createQueryBuilder();
+        $qb1->select('id')
+            ->from('for_update')
+            ->where('id = 1')
+            ->forUpdate();
+
+        $this->connection->beginTransaction();
+
+        self::assertEquals([1], $qb1->fetchFirstColumn());
+
+        $params = TestUtil::getConnectionParams();
+
+        if (TestUtil::isDriverOneOf('oci8')) {
+            $params['driverOptions']['exclusive'] = true;
+        }
+
+        $connection2 = DriverManager::getConnection($params);
+
+        $qb2 = $connection2->createQueryBuilder();
+        $qb2->select('id')
+            ->from('for_update')
+            ->orderBy('id')
+            ->forUpdate(ConflictResolutionMode::SKIP_LOCKED);
+
+        self::assertEquals([2], $qb2->fetchFirstColumn());
+    }
+
+    public function testForUpdateSkipLockedWhenNotSupported(): void
+    {
+        if ($this->platformSupportsSkipLocked()) {
+            self::markTestSkipped('The database platform supports SKIP LOCKED.');
+        }
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('id')
+            ->from('for_update')
+            ->forUpdate(ConflictResolutionMode::SKIP_LOCKED);
+
+        self::expectException(Exception::class);
+        $qb->executeQuery();
+    }
+
+    private function platformSupportsSkipLocked(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof DB2Platform) {
+            return false;
+        }
+
+        if ($platform instanceof MySQLPlatform) {
+            if ($platform instanceof MariaDBPlatform) {
+                if (! $platform instanceof MariaDb1060Platform) {
+                    return false;
+                }
+            } elseif (! $platform instanceof MySQL80Platform) {
+                return false;
+            }
+        }
+
+        if ($platform instanceof PostgreSQLPlatform && ! $platform instanceof PostgreSQL100Platform) {
+            return false;
+        }
+
+        return ! $platform instanceof SqlitePlatform;
+    }
+}

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -6,10 +6,12 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\QueryException;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -31,9 +33,15 @@ class QueryBuilderTest extends TestCase
 
         $expressionBuilder = new ExpressionBuilder($this->conn);
 
-        $this->conn->expects(self::any())
-                   ->method('getExpressionBuilder')
-                   ->willReturn($expressionBuilder);
+        $this->conn->method('getExpressionBuilder')
+           ->willReturn($expressionBuilder);
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->method('createSelectSQLBuilder')
+            ->willReturn(new DefaultSelectSQLBuilder($platform, null, null));
+
+        $this->conn->method('getDatabasePlatform')
+            ->willReturn($platform);
     }
 
     public function testSimpleSelectWithoutFrom(): void


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/doctrine/dbal/pull/6105.

There is quite some code duplication between the `SelectSQLBuilder` implementations but it should be acceptable. An alternative would be to compose platform-specific builders from a set of smaller ones (e.g. for `SELECT`, `FROM`, `FOR UPDATE`, etc). It would reduce code duplication but might impact the performance: for simple queries, building the builder might take longer than building the actual query. If/when necessary, we can decompose the builders without breaking the existing API. 

**TODO**:
- [x] Deprecate `getReadLockSQL()`, `getWriteLockSQL()` and `getForUpdateSQL()` as non-portable.
- [x] Add an integration test for `forUpdate()` without options. We cannot easily test the actual lock but we at least can test that the SQL syntax is valid across the platforms that provide the corresponding SQL snippets.
- [x] Make sure that the new API is extensible. We should be able to add the possibility build queries like `FOR UPDATE OF <columns>` or `FOR UPDATE NO WAIT` without breaking the API.
- [x] Mark new constructors as internal to avoid unnecessary BC breaks.

### Future scope

We may want to improve the UX of the new API and instead of throwing an "unsupported" exception at the SQL build time, throw it during the call to the corresponding method (e.g. `forUpdate()`) on SQLite. For that, we may replace the portable `SelectQuery` value object with a set of platform-specific ones. This way a call from the query builder to the value object that doesn't support a certain feature would fail right away.