### PR TITLE
Add deprecation layer and upgrade path for QueryBuilder::reset*() methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,23 @@ awareness about deprecated code.
 
 # Upgrade to 3.8
 
+## Deprecated reset methods from `QueryBuilder`
+
+`QueryBuilder::resetQueryParts()` has been deprecated.
+
+Resetting individual query parts through the generic `resetQueryPart()` method has been deprecated as well.
+However, several replacements have been put in place depending on the `$queryPartName` parameter:
+
+| `$queryPartName` | suggested replacement                      |
+|------------------|--------------------------------------------|
+| `'select'`       | Call `select()` with a new set of columns. |
+| `'distinct'`     | `distinct(false)`                          |
+| `'where'`        | `resetWhere()`                             |
+| `'groupBy'`      | `resetGroupBy()`                           |
+| `'having'`       | `resetHaving()`                            |
+| `'orderBy'`      | `resetOrderBy()`                           |
+| `'values'`       | Call `values()` with a new set of values.  |
+
 ## Deprecated getting query parts from `QueryBuilder`
 
 The usage of `QueryBuilder::getQueryPart()` and `::getQueryParts()` is deprecated. The query parts

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -112,6 +112,12 @@ parameters:
             paths:
                 - src/Platforms/AbstractPlatform.php
 
+        # Deprecated method, will be removed in 4.0.0
+        -
+            message: '~^Variable method call on \$this\(Doctrine\\DBAL\\Query\\QueryBuilder\)\.$~'
+            paths:
+                - src/Query/QueryBuilder.php
+
         # There is no way to make this assertion in the code,
         # and the API doesn't support parametrization of returned column types.
         -

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -504,6 +504,8 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getQueryPart"/>
                 <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::getQueryParts"/>
+                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::resetQueryPart"/>
+                <referencedMethod name="Doctrine\DBAL\Query\QueryBuilder::resetQueryParts"/>
 
                 <!-- TODO for PHPUnit 10 -->
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>
@@ -658,6 +660,12 @@
                 <file name="src/Schema/PostgreSQLSchemaManager.php"/>
             </errorLevel>
         </NullableReturnStatement>
+        <ParadoxicalCondition>
+            <errorLevel type="suppress">
+                <!-- False positive in deprecation layer. Can be removed in 4.0.x -->
+                <file name="src/Query/QueryBuilder.php" />
+            </errorLevel>
+        </ParadoxicalCondition>
         <PossiblyInvalidArgument>
             <errorLevel type="suppress">
                 <!-- PgSql objects are represented as resources in PHP 7.4 -->

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -609,37 +609,167 @@ class QueryBuilderTest extends TestCase
         self::assertEquals(10, $qb->getFirstResult());
     }
 
-    public function testResetQueryPart(): void
+    private function prepareQueryBuilderToReset(): QueryBuilder
     {
-        $qb = new QueryBuilder($this->conn);
+        $qb = (new QueryBuilder($this->conn))
+            ->select('u.*')
+            ->distinct()
+            ->from('users', 'u')
+            ->where('u.name = ?')
+            ->orderBy('u.name', 'ASC');
 
-        $qb->select('u.*')->from('users', 'u')->where('u.name = ?');
+        self::assertEquals('SELECT DISTINCT u.* FROM users u WHERE u.name = ? ORDER BY u.name ASC', (string) $qb);
 
-        self::assertEquals('SELECT u.* FROM users u WHERE u.name = ?', (string) $qb);
-        $qb->resetQueryPart('where');
-        self::assertEquals('SELECT u.* FROM users u', (string) $qb);
+        return $qb;
     }
 
     public function testResetQueryParts(): void
     {
-        $qb = new QueryBuilder($this->conn);
+        $qb = $this->prepareQueryBuilderToReset();
 
-        $qb->select('u.*')->from('users', 'u')->where('u.name = ?')->orderBy('u.name');
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryParts(['distinct', 'where', 'orderBy']);
+
+        self::assertEquals('SELECT u.* FROM users u', (string) $qb);
+    }
+
+    public function testLegacyResetSelect(): void
+    {
+        $qb = $this->prepareQueryBuilderToReset();
+
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryPart('select')->addSelect('u.name');
+
+        self::assertEquals('SELECT DISTINCT u.name FROM users u WHERE u.name = ? ORDER BY u.name ASC', (string) $qb);
+    }
+
+    public function testLegacyResetDistinct(): void
+    {
+        $qb = $this->prepareQueryBuilderToReset();
+
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryPart('distinct');
 
         self::assertEquals('SELECT u.* FROM users u WHERE u.name = ? ORDER BY u.name ASC', (string) $qb);
-        $qb->resetQueryParts(['where', 'orderBy']);
-        self::assertEquals('SELECT u.* FROM users u', (string) $qb);
+    }
+
+    public function testResetDistinct(): void
+    {
+        $qb = $this->prepareQueryBuilderToReset();
+
+        $this->expectNoDeprecationWithIdentifier('TODO');
+        $qb->distinct(false);
+
+        self::assertEquals('SELECT u.* FROM users u WHERE u.name = ? ORDER BY u.name ASC', (string) $qb);
+    }
+
+    public function testLegacyResetWhere(): void
+    {
+        $qb = $this->prepareQueryBuilderToReset();
+
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryPart('where');
+
+        self::assertEquals('SELECT DISTINCT u.* FROM users u ORDER BY u.name ASC', (string) $qb);
+    }
+
+    public function testResetWhere(): void
+    {
+        $qb = $this->prepareQueryBuilderToReset();
+
+        $this->expectNoDeprecationWithIdentifier('TODO');
+        $qb->resetWhere();
+
+        self::assertEquals('SELECT DISTINCT u.* FROM users u ORDER BY u.name ASC', (string) $qb);
+    }
+
+    public function testLegacyResetOrderBy(): void
+    {
+        $qb = $this->prepareQueryBuilderToReset();
+
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryPart('orderBy');
+
+        self::assertEquals('SELECT DISTINCT u.* FROM users u WHERE u.name = ?', (string) $qb);
     }
 
     public function testResetOrderBy(): void
     {
-        $qb = new QueryBuilder($this->conn);
+        $qb = $this->prepareQueryBuilderToReset();
 
-        $qb->select('u.*')->from('users', 'u')->orderBy('u.name');
-
-        self::assertEquals('SELECT u.* FROM users u ORDER BY u.name ASC', (string) $qb);
+        $this->expectNoDeprecationWithIdentifier('TODO');
         $qb->resetOrderBy();
-        self::assertEquals('SELECT u.* FROM users u', (string) $qb);
+
+        self::assertEquals('SELECT DISTINCT u.* FROM users u WHERE u.name = ?', (string) $qb);
+    }
+
+    private function prepareGroupedQueryBuilderToReset(): QueryBuilder
+    {
+        $qb = (new QueryBuilder($this->conn))
+            ->select('u.country', 'COUNT(*)')
+            ->from('users', 'u')
+            ->groupBy('u.country')
+            ->having('COUNT(*) > ?')
+            ->orderBy('COUNT(*)', 'DESC');
+
+        self::assertEquals(
+            'SELECT u.country, COUNT(*) FROM users u GROUP BY u.country HAVING COUNT(*) > ? ORDER BY COUNT(*) DESC',
+            (string) $qb,
+        );
+
+        return $qb;
+    }
+
+    public function testLegacyResetHaving(): void
+    {
+        $qb = $this->prepareGroupedQueryBuilderToReset();
+
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryPart('having');
+
+        self::assertEquals(
+            'SELECT u.country, COUNT(*) FROM users u GROUP BY u.country ORDER BY COUNT(*) DESC',
+            (string) $qb,
+        );
+    }
+
+    public function testResetHaving(): void
+    {
+        $qb = $this->prepareGroupedQueryBuilderToReset();
+
+        $this->expectNoDeprecationWithIdentifier('TODO');
+        $qb->resetHaving();
+
+        self::assertEquals(
+            'SELECT u.country, COUNT(*) FROM users u GROUP BY u.country ORDER BY COUNT(*) DESC',
+            (string) $qb,
+        );
+    }
+
+    public function testLegacyResetGroupBy(): void
+    {
+        $qb = $this->prepareGroupedQueryBuilderToReset();
+
+        $this->expectDeprecationWithIdentifier('TODO');
+        $qb->resetQueryPart('groupBy');
+
+        self::assertEquals(
+            'SELECT u.country, COUNT(*) FROM users u HAVING COUNT(*) > ? ORDER BY COUNT(*) DESC',
+            (string) $qb,
+        );
+    }
+
+    public function testGroupBy(): void
+    {
+        $qb = $this->prepareGroupedQueryBuilderToReset();
+
+        $this->expectNoDeprecationWithIdentifier('TODO');
+        $qb->resetGroupBy();
+
+        self::assertEquals(
+            'SELECT u.country, COUNT(*) FROM users u HAVING COUNT(*) > ? ORDER BY COUNT(*) DESC',
+            (string) $qb,
+        );
     }
 
     public function testCreateNamedParameter(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6186

#### Summary

This PR adds the missing deprecation layer for the `QueryBuilder::resetQueryParts()` and `QueryBuilder::resetQueryPart()` methods that had been removed from the 4.0.x branch already. Following the discussion in #6186 and the work done in #6190, some replacements have been put in place.