### PR TITLE
Unseal array in return type to make wrapperClass work correctly

### DIFF
--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -155,7 +155,7 @@ final class DriverManager
      * @param EventManager|null  $eventManager The event manager to use.
      * @psalm-param Params $params
      *
-     * @psalm-return ($params is array{wrapperClass: class-string<T>} ? T : Connection)
+     * @psalm-return ($params is array{wrapperClass: class-string<T>, ...} ? T : Connection)
      *
      * @throws Exception
      *


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Since psalm ~5 arrays are sealed by default, so an array with extra properties does not satisfy a type. You can unseal an array using the `...` syntax.
See: https://psalm.dev/docs/annotating_code/type_syntax/array_types/#unsealed-array-and-list-shapes

Demo:
https://psalm.dev/r/66a1f8620b
