### PR TITLE
Remove irrelevant details from the savepoint name

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1336,7 +1336,7 @@ class Connection
      */
     protected function _getNestedTransactionSavePointName()
     {
-        return 'DOCTRINE2_SAVEPOINT_' . $this->transactionNestingLevel;
+        return 'DOCTRINE_' . $this->transactionNestingLevel;
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

The "2" in the savepoint name is obsolete. The "savepoint" is redundant.