### PR TITLE
Stop considering generated column definition as being its default value

### DIFF
--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\PostgreSQL;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
@@ -39,6 +40,10 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
         $minorVersion = $versionParts['minor'] ?? 0;
         $patchVersion = $versionParts['patch'] ?? 0;
         $version      = $majorVersion . '.' . $minorVersion . '.' . $patchVersion;
+
+        if (version_compare($version, '12.0', '>=')) {
+            return new PostgreSQL120Platform();
+        }
 
         if (version_compare($version, '10.0', '>=')) {
             return new PostgreSQL100Platform();

--- a/src/Platforms/PostgreSQL120Platform.php
+++ b/src/Platforms/PostgreSQL120Platform.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Provides the behavior, features and SQL dialect of the PostgreSQL 12.0 database platform.
+ */
+class PostgreSQL120Platform extends PostgreSQL100Platform
+{
+    public function getDefaultColumnValueSQLSnippet(): string
+    {
+        // in case of GENERATED ALWAYS AS (foobar) STORED column (added in PostgreSQL 12.0)
+        // PostgreSQL's pg_get_expr(adbin, adrelid) will return the 'foobar' part
+        // which is not the 'default' value of the column but its 'definition'
+        // so in that case we force it to NULL as DBAL will use that column only for the
+        // 'default' value
+        return <<<'SQL'
+            SELECT
+                CASE
+                    WHEN a.attgenerated = 's' THEN NULL
+                    ELSE pg_get_expr(adbin, adrelid)
+                END
+             FROM pg_attrdef
+             WHERE c.oid = pg_attrdef.adrelid
+                AND pg_attrdef.adnum=a.attnum
+        SQL;
+    }
+}

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -1194,6 +1194,19 @@ SQL
     }
 
     /**
+     * Get the snippet used to retrieve the default value for a given column
+     */
+    public function getDefaultColumnValueSQLSnippet(): string
+    {
+        return <<<'SQL'
+             SELECT pg_get_expr(adbin, adrelid)
+             FROM pg_attrdef
+             WHERE c.oid = pg_attrdef.adrelid
+                AND pg_attrdef.adnum=a.attnum
+        SQL;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getReadLockSQL()

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -616,7 +616,7 @@ SQL;
             $sql .= ' c.relname AS table_name, n.nspname AS schema_name,';
         }
 
-        $sql .= <<<'SQL'
+        $sql .= sprintf(<<<'SQL'
             a.attnum,
             quote_ident(a.attname) AS field,
             t.typname AS type,
@@ -632,11 +632,7 @@ SQL;
                 AND pg_index.indkey[0] = a.attnum
                 AND pg_index.indisprimary = 't'
             ) AS pri,
-            (SELECT pg_get_expr(adbin, adrelid)
-             FROM pg_attrdef
-             WHERE c.oid = pg_attrdef.adrelid
-                AND pg_attrdef.adnum=a.attnum
-            ) AS default,
+            (%s) AS default,
             (SELECT pg_description.description
                 FROM pg_description WHERE pg_description.objoid = c.oid AND a.attnum = pg_description.objsubid
             ) AS comment
@@ -651,7 +647,7 @@ SQL;
                     ON d.objid = c.oid
                         AND d.deptype = 'e'
                         AND d.classid = (SELECT oid FROM pg_class WHERE relname = 'pg_class')
-SQL;
+SQL, $this->_platform->getDefaultColumnValueSQLSnippet());
 
         $conditions = array_merge([
             'a.attnum > 0',

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -86,6 +87,7 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['9.4.0', PostgreSQL94Platform::class],
             ['9.4.1', PostgreSQL94Platform::class],
             ['10', PostgreSQL100Platform::class],
+            ['12', PostgreSQL120Platform::class],
         ];
     }
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
@@ -310,6 +311,35 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table = new Table('ddc2843_bools');
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('checked', Types::BOOLEAN, ['default' => false]);
+
+        $this->dropAndCreateTable($table);
+
+        $databaseTable = $this->schemaManager->introspectTable($table->getName());
+
+        $diff = $comparatorFactory($this->schemaManager)->diffTable($table, $databaseTable);
+
+        self::assertFalse($diff);
+    }
+
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider \Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils::comparatorProvider
+     */
+    public function testGeneratedColumn(callable $comparatorFactory): void
+    {
+        $wrappedConnection = $this->connection->getWrappedConnection();
+        if (! $this->connection->getDatabasePlatform() instanceof PostgreSQL120Platform) {
+             self::markTestSkipped('Generated columns are not supported in Postgres 11 and earlier');
+        }
+
+        $table = new Table('ddc6198_generated_always_as');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn(
+            'idIsOdd',
+            Types::BOOLEAN,
+            ['columnDefinition' => 'boolean GENERATED ALWAYS AS (id % 2 = 1) STORED', 'notNull' => false],
+        );
 
         $this->dropAndCreateTable($table);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | #6198 




#### Summary

The `pg_get_expr(adbin, adrelid)` expression in Postgresql's internal table `pg_attrdef` is used to know a column definition

for most column, if this returns something, it means this column's default value. So DBAL has been considering has ALWAYS meaning it contains its default.

However for generated columns, it contains the value definition and not its default value, so we change the selectTableColumns' query to correctly set the 'default' column to `null` for generated columns 

It will help setting correctly the column's attributes which in turn will help generate correct schema diff.

<!-- Fill in the relevant information below to help triage your pull request. -->
