### PR TITLE
Log "disconnecting" only in debug mode

### DIFF
--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -20,7 +20,7 @@ final class Connection extends AbstractConnectionMiddleware
 
     public function __destruct()
     {
-        $this->logger->info('Disconnecting');
+        $this->logger->debug('Disconnecting');
     }
 
     public function prepare(string $sql): DriverStatement


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Fix info log pollution in Symfony when using doctrine dbal. 
