### PR TITLE
Changed `Connection::executeStatement` annotation to always return int

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1176,11 +1176,11 @@ class Connection
      * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
      * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
      *
-     * @return int|string The number of affected rows.
+     * @return int The number of affected rows.
      *
      * @throws Exception
      */
-    public function executeStatement($sql, array $params = [], array $types = [])
+    public function executeStatement($sql, array $params = [], array $types = []): int
     {
         $connection = $this->getWrappedConnection();
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

<!-- Provide a summary of your change. -->

The function has two return points:

`\Doctrine\DBAL\Driver\Result::rowCount`

and 

`\Doctrine\DBAL\Driver\Connection::exec`

Both are annotated with `function ....(): int`

Or am I missing something?