### PR TITLE
Extend `AbstractMySQLPlatform::getColumnTypeSQLSnippets()` deprecation layer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,10 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 3.8
 
-## Deprecated `AbstractMySQLPlatform::getColumnTypeSQLSnippets()`
+## Deprecated `AbstractMySQLPlatform` methods
 
-`AbstractMySQLPlatform::getColumnTypeSQLSnippets()` has been deprecated.
-Use `AbstractMySQLPlatform::getColumnTypeSQLSnippet()` instead.
+* `AbstractMySQLPlatform::getColumnTypeSQLSnippets()` has been deprecated
+  in favor of `AbstractMySQLPlatform::getColumnTypeSQLSnippet()`.
+* `AbstractMySQLPlatform::getDatabaseNameSQL()` has been deprecated without replacement.
+* Not passing a database name to `AbstractMySQLPlatform::getColumnTypeSQLSnippet()` has been deprecated.
 
 ## Deprecated reset methods from `QueryBuilder`
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -511,6 +511,7 @@
                     TODO: remove in 4.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getColumnTypeSQLSnippets" />
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getDatabaseNameSQL" />
 
                 <!-- TODO for PHPUnit 10 -->
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -1422,8 +1422,16 @@ SQL
         return true;
     }
 
+    /** @deprecated Will be removed without replacement. */
     protected function getDatabaseNameSQL(?string $databaseName): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6215',
+            '%s is deprecated without replacement.',
+            __METHOD__,
+        );
+
         if ($databaseName !== null) {
             return $this->quoteStringLiteral($databaseName);
         }

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -3,6 +3,7 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Types\JsonType;
+use Doctrine\Deprecations\Deprecation;
 
 use function sprintf;
 
@@ -79,6 +80,16 @@ class MariaDb1043Platform extends MariaDb1027Platform
     {
         if ($this->getJsonTypeDeclarationSQL([]) !== 'JSON') {
             return parent::getColumnTypeSQLSnippet($tableAlias, $databaseName);
+        }
+
+        if ($databaseName === null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6215',
+                'Not passing a database name to methods "getColumnTypeSQLSnippet()", '
+                    . '"getColumnTypeSQLSnippets()", and "getListTableColumnsSQL()" of "%s" is deprecated.',
+                self::class,
+            );
         }
 
         $databaseName = $this->getDatabaseNameSQL($databaseName);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6213

#### Summary

We want to stop guessing the current database.

cc @ausi 
