### PR TITLE
Move `getJsonTypeDeclarationSQL()` to `AbstractMySQLPlatform`

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -120,6 +120,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getJsonTypeDeclarationSQL(array $column): string
+    {
+        return 'JSON';
+    }
+
+    /**
      * Gets the SQL snippet used to declare a CLOB column type.
      *     TINYTEXT   : 2 ^  8 - 1 = 255
      *     TEXT       : 2 ^ 16 - 1 = 65535

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -21,19 +21,6 @@ use function in_array;
 class MariaDBPlatform extends AbstractMySQLPlatform
 {
     /**
-     * Use JSON rather than LONGTEXT for json columns. Since it is not a true native type, do not override
-     * hasNativeJsonType() so the DC2Type comment will still be set.
-     *
-     * @link https://mariadb.com/kb/en/library/json-data-type/
-     *
-     * {@inheritDoc}
-     */
-    public function getJsonTypeDeclarationSQL(array $column): string
-    {
-        return 'JSON';
-    }
-
-    /**
      * Generate SQL snippets to reverse the aliasing of JSON to LONGTEXT.
      *
      * MariaDb aliases columns specified as JSON to LONGTEXT and sets a CHECK constraint to ensure the column
@@ -46,10 +33,6 @@ class MariaDBPlatform extends AbstractMySQLPlatform
      */
     public function getColumnTypeSQLSnippets(string $tableAlias = 'c'): array
     {
-        if ($this->getJsonTypeDeclarationSQL([]) !== 'JSON') {
-            return parent::getColumnTypeSQLSnippets($tableAlias);
-        }
-
         $columnTypeSQL = <<<SQL
             IF(
                 x.CHECK_CLAUSE IS NOT NULL AND $tableAlias.COLUMN_TYPE = 'longtext',

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -37,14 +37,6 @@ class MySQLPlatform extends AbstractMySQLPlatform
     /**
      * {@inheritDoc}
      */
-    public function getJsonTypeDeclarationSQL(array $column): string
-    {
-        return 'JSON';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
     {
         return ['ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)];


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Both MySQL dialects support the `JSON` column type, so let's move this method up to `AbstractMySQLPlatform`.
