### PR TITLE
Add Oracle v23 to CI testing

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,13 +111,14 @@ jobs:
           - "8.3"
         oracle-version:
           - "21"
+          - "23"
         include:
           - php-version: "7.4"
             oracle-version: "11"
 
     services:
       oracle:
-        image: gvenzl/oracle-xe:${{ matrix.oracle-version }}
+        image: gvenzl/oracle-${{ matrix.oracle-version < 23 && 'xe' || 'free'  }}:${{ matrix.oracle-version }}
         env:
           ORACLE_PASSWORD: oracle
         ports:
@@ -148,7 +149,7 @@ jobs:
           composer-options: "--ignore-platform-req=php+"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/oci8.xml --coverage-clover=coverage.xml"
+        run: "vendor/bin/phpunit -c ci/github/phpunit/oci8${{ matrix.oracle-version < 23 && '-21' || ''  }}.xml --coverage-clover=coverage.xml"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v3"
@@ -169,13 +170,14 @@ jobs:
           - "8.3"
         oracle-version:
           - "21"
+          - "23"
         include:
           - php-version: "7.4"
             oracle-version: "11"
 
     services:
       oracle:
-        image: gvenzl/oracle-xe:${{ matrix.oracle-version }}
+        image: gvenzl/oracle-${{ matrix.oracle-version < 23 && 'xe' || 'free'  }}:${{ matrix.oracle-version }}
         env:
           ORACLE_PASSWORD: oracle
         ports:
@@ -206,7 +208,7 @@ jobs:
           composer-options: "--ignore-platform-req=php+"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/pdo_oci.xml --coverage-clover=coverage.xml"
+        run: "vendor/bin/phpunit -c ci/github/phpunit/pdo_oci${{ matrix.oracle-version < 23 && '-21' || ''  }}.xml --coverage-clover=coverage.xml"
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v3"

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -11,18 +11,18 @@
     <php>
         <ini name="error_reporting" value="-1" />
 
-        <var name="db_driver" value="pdo_oci"/>
+        <var name="db_driver" value="oci8"/>
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="FREE"/>
+        <var name="db_dbname" value="XE"/>
         <var name="db_charset" value="AL32UTF8" />
 
-        <var name="tmpdb_driver" value="pdo_oci"/>
+        <var name="tmpdb_driver" value="oci8"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="FREE"/>
+        <var name="tmpdb_dbname" value="XE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -15,14 +15,14 @@
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="XE"/>
+        <var name="db_dbname" value="FREE"/>
         <var name="db_charset" value="AL32UTF8" />
 
         <var name="tmpdb_driver" value="oci8"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="XE"/>
+        <var name="tmpdb_dbname" value="FREE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -15,14 +15,14 @@
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="FREE"/>
+        <var name="db_dbname" value="XE"/>
         <var name="db_charset" value="AL32UTF8" />
 
         <var name="tmpdb_driver" value="pdo_oci"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="FREE"/>
+        <var name="tmpdb_dbname" value="XE"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

Latest Oracle database compatibility should be tested.

Targetting lowest open branch to assert the compatibility for 3.7.x too for possible bugfixes.