### PR TITLE
Remove API to disable column comments

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -77,6 +77,8 @@
                 <file name="src/Schema/Column.php"/>
                 <!-- See https://github.com/vimeo/psalm/issues/5472 -->
                 <file name="src/Portability/Converter.php"/>
+                <!-- We're checking for invalid input -->
+                <file name="src/Configuration.php"/>
             </errorLevel>
         </DocblockTypeContradiction>
         <FalsableReturnStatement>

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver\Middleware;
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -32,14 +33,6 @@ class Configuration
      * The default auto-commit mode for connections.
      */
     protected bool $autoCommit = true;
-
-    /**
-     * Whether type comments should be disabled to provide the same DB schema than
-     * will be obtained with DBAL 4.x. This is useful when relying only on the
-     * platform-aware schema comparison (which does not need those type comments)
-     * rather than the deprecated legacy tooling.
-     */
-    private bool $disableTypeComments = false;
 
     private ?SchemaManagerFactory $schemaManagerFactory = null;
 
@@ -141,15 +134,22 @@ class Configuration
         return $this;
     }
 
+    /** @return true */
     public function getDisableTypeComments(): bool
     {
-        return $this->disableTypeComments;
+        return true;
     }
 
-    /** @return $this */
+    /**
+     * @param true $disableTypeComments
+     *
+     * @return $this
+     */
     public function setDisableTypeComments(bool $disableTypeComments): self
     {
-        $this->disableTypeComments = $disableTypeComments;
+        if (! $disableTypeComments) {
+            throw new InvalidArgumentException('Column comments cannot be enabled anymore.');
+        }
 
         return $this;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -188,7 +188,6 @@ class Connection implements ServerVersionProvider
             }
 
             $this->platform = $this->driver->getDatabasePlatform($versionProvider);
-            $this->platform->setDisableTypeComments($this->_config->getDisableTypeComments());
         }
 
         return $this->platform;

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -81,14 +81,6 @@ abstract class AbstractPlatform
      */
     protected ?KeywordList $_keywords = null;
 
-    private bool $disableTypeComments = false;
-
-    /** @internal */
-    final public function setDisableTypeComments(bool $value): void
-    {
-        $this->disableTypeComments = $value;
-    }
-
     /**
      * Returns the SQL snippet that declares a boolean column.
      *


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6150
#### Summary

#6150 introduced a forward-compatibility layer for disabling DBAL's column comments. Since not disabling them has no effect on 4.0, we should remove as much of that API as possible.

`Configuration::getDisableTypeComments()` and `setDisableTypeComments()` are kept to allow a smooth transition from 3.7 to 4.0, but `true` is the only valid setting now.