### PR TITLE
Bump Symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
         "psalm/plugin-phpunit": "0.18.4",
         "slevomat/coding-standard": "8.13.1",
         "squizlabs/php_codesniffer": "3.7.2",
-        "symfony/cache": "^5.4|^6.0",
-        "symfony/console": "^4.4.30|^5.4|^6.0",
+        "symfony/cache": "^6.3.8",
+        "symfony/console": "^5.4|^6.3",
         "vimeo/psalm": "5.15.0"
     },
     "suggest": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

This PR narrows down some dependencies from the `require-dev` section:

* Console 4.4 is EOL. We should stop testing against it.
* Cache can be bumped to 6.3. We don't depend on Symfony Cache specifically, we just need _a_ cache implementation for tests.