### PR TITLE
Move schema part to the index 

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -326,6 +326,7 @@
                 <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableForeignKeysSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableIndexesSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SQLServerPlatform::getListTableMetadataSQL"/>
+                <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::disableSchemaEmulation"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableColumnsSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableForeignKeysSQL"/>
                 <referencedMethod name="Doctrine\DBAL\Platforms\SqlitePlatform::getListTableIndexesSQL"/>

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\Deprecations\Deprecation;
+use InvalidArgumentException;
 
 use function array_combine;
 use function array_keys;
@@ -26,12 +27,14 @@ use function array_search;
 use function array_unique;
 use function array_values;
 use function count;
+use function explode;
 use function implode;
 use function is_numeric;
 use function sprintf;
 use function sqrt;
 use function str_replace;
 use function strlen;
+use function strpos;
 use function strtolower;
 use function trim;
 
@@ -916,6 +919,48 @@ class SqlitePlatform extends AbstractPlatform
         }
 
         return $sql;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCreateIndexSQL(Index $index, $table)
+    {
+        if ($table instanceof Table) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $table as a Table object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__,
+            );
+
+            $table = $table->getQuotedName($this);
+        }
+
+        $name    = $index->getQuotedName($this);
+        $columns = $index->getColumns();
+
+        if (strpos($table, '.') !== false) {
+            [$schema, $table] = explode('.', $table);
+            $name             = $schema . '.' . $name;
+        }
+
+        if (count($columns) === 0) {
+            throw new InvalidArgumentException(sprintf(
+                'Incomplete or invalid index definition %s on table %s',
+                $name,
+                $table,
+            ));
+        }
+
+        if ($index->isPrimary()) {
+            return $this->getCreatePrimaryKeySQL($index, $table);
+        }
+
+        $query  = 'CREATE ' . $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name . ' ON ' . $table;
+        $query .= ' (' . $this->getIndexFieldDeclarationListSQL($index) . ')' . $this->getPartialIndexSQL($index);
+
+        return $query;
     }
 
     /**

--- a/tests/Functional/Platform/OtherSchemaTest.php
+++ b/tests/Functional/Platform/OtherSchemaTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+class OtherSchemaTest extends FunctionalTestCase
+{
+    public function testATableCanBeCreatedInAnotherSchema(): void
+    {
+        $databasePlatform = $this->connection->getDatabasePlatform();
+        if (! ($databasePlatform instanceof SqlitePlatform)) {
+            self::markTestSkipped('This test requires SQLite');
+        }
+
+        $this->connection->executeStatement("ATTACH DATABASE '/tmp/test_other_schema.sqlite' AS other");
+        $databasePlatform->disableSchemaEmulation();
+
+        $table = new Table('other.test_other_schema');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addIndex(['id']);
+
+        $this->dropAndCreateTable($table);
+        $this->connection->insert('other.test_other_schema', ['id' => 1]);
+
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(*) FROM other.test_other_schema'));
+        $connection  = DriverManager::getConnection(
+            ['url' => 'sqlite:////tmp/test_other_schema.sqlite'],
+        );
+        $onlineTable = $connection->createSchemaManager()->introspectTable('test_other_schema');
+        self::assertCount(1, $onlineTable->getIndexes());
+    }
+}


### PR DESCRIPTION
In SQLite, creating an index in another schema is done by prepending the
index name with the schema, while the table name must be unprefixed.

See https://www.sqlite.org/lang_createindex.html