### PR TITLE
CI: Drop MariaDB 10.10, add MariaDB 11.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -300,10 +300,10 @@ jobs:
           - "10.4"  # LTS (Jun 2024)
           - "10.5"  # LTS (Jun 2025)
           - "10.6"  # LTS (Jul 2026)
-          - "10.10" # STS (Nov 2023)
           - "10.11" # LTS (Feb 2028)
           - "11.0"  # STS (Jun 2024)
           - "11.1"  # STS (Aug 2024)
+          - "11.2"  # STS (Nov 2024)
         extension:
           - "mysqli"
           - "pdo_mysql"
@@ -315,16 +315,16 @@ jobs:
             mariadb-version: "10.6"
             extension: "pdo_mysql"
           - php-version: "8.2"
-            mariadb-version: "11.1"
+            mariadb-version: "11.2"
             extension: "mysqli"
           - php-version: "8.2"
-            mariadb-version: "11.1"
+            mariadb-version: "11.2"
             extension: "pdo_mysql"
           - php-version: "8.3"
-            mariadb-version: "11.1"
+            mariadb-version: "11.2"
             extension: "mysqli"
           - php-version: "8.3"
-            mariadb-version: "11.1"
+            mariadb-version: "11.2"
             extension: "pdo_mysql"
 
     services:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

MariaDB 11.2 has been released, MariaDB 10.10 is EOL.
