### PR TITLE
Psalm 5.16.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "squizlabs/php_codesniffer": "3.7.2",
         "symfony/cache": "^6.3.8",
         "symfony/console": "^5.4|^6.3",
-        "vimeo/psalm": "5.15.0"
+        "vimeo/psalm": "5.16.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -101,10 +101,8 @@ parameters:
         - '~^Method Doctrine\\DBAL\\Driver\\IBMDB2\\Connection\:\:exec\(\) should return int but returns int<0, max>\|false\.$~'
         - '~^Method Doctrine\\DBAL\\Driver\\IBMDB2\\Result\:\:rowCount\(\) should return int but returns int<0, max>\|false\.$~'
 
-        # TODO
-        -
-            message: '~^Property Doctrine\\DBAL\\Platforms\\AbstractPlatform\:\:\$disableTypeComments is never read, only written\.$~'
-            path: src/Platforms/AbstractPlatform.php
+        # Required for Psalm compatibility
+        - '~^Property Doctrine\\DBAL\\Tests\\Types\\BaseDateTypeTestCase\:\:\$currentTimezone \(non-empty-string\) does not accept string\.$~'
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/tests/Types/BaseDateTypeTestCase.php
+++ b/tests/Types/BaseDateTypeTestCase.php
@@ -19,6 +19,8 @@ abstract class BaseDateTypeTestCase extends TestCase
 {
     protected AbstractPlatform&MockObject $platform;
     protected Type $type;
+
+    /** @var non-empty-string */
     private string $currentTimezone;
 
     protected function setUp(): void


### PR DESCRIPTION
Apparently, Psalm's made the stubs of `date_default_timezone_get()` and `date_default_timezone_set()` a bit stricter. 🤷🏻 