### PR TITLE
Fix collisions caused by spl_object_id return

### DIFF
--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -6,7 +6,8 @@ namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Exception;
 
-use function spl_object_id;
+use function crc32;
+use function get_class;
 
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
@@ -84,7 +85,7 @@ final class TypeRegistry
         }
 
         $this->instances[$name]                            = $type;
-        $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        $this->instancesReverseIndex[self::getObjectKey($type)] = $name;
     }
 
     /**
@@ -103,9 +104,9 @@ final class TypeRegistry
             throw Exception::typeAlreadyRegistered($type);
         }
 
-        unset($this->instancesReverseIndex[spl_object_id($origType)]);
+        unset($this->instancesReverseIndex[self::getObjectKey($origType)]);
         $this->instances[$name]                            = $type;
-        $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        $this->instancesReverseIndex[self::getObjectKey($type)] = $name;
     }
 
     /**
@@ -122,6 +123,11 @@ final class TypeRegistry
 
     private function findTypeName(Type $type): ?string
     {
-        return $this->instancesReverseIndex[spl_object_id($type)] ?? null;
+        return $this->instancesReverseIndex[self::getObjectKey($type)] ?? null;
+    }
+
+    private static function getObjectKey(object $object): int
+    {
+        return crc32(get_class($object));
     }
 }

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 
 use function crc32;
 use function get_class;
+use function spl_object_id;
 
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
@@ -128,6 +129,6 @@ final class TypeRegistry
 
     private static function getObjectKey(object $object): int
     {
-        return crc32(get_class($object));
+        return crc32(get_class($object) . spl_object_id($object));
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | no issue created

#### Summary

Here I debugged a case: `spl_object_id($type)` returns "6922" for already registered "decimal" mapping type, when tried to add custom mapping type, but `$type` is not decimal! This solution will work until `\Doctrine\DBAL\Types\Type::overrideType` instantiates `new $className()` and no need to register different mappings instances (but if it's needed in future, usage of WeakMap may be more elegant approach).
 Unfortunately I could not write test that reproduces it because it's a transient bug.

<img width="1436" alt="Screenshot 2023-12-05 at 22 56 30" src="https://github.com/doctrine/dbal/assets/3006342/851bf947-c377-487e-adab-8639566bfccb">

