### PR TITLE
Use different toctrees for different sections

### DIFF
--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -1,22 +1,33 @@
-.. toctree::
-    :depth: 3
+.. toc::
 
-    reference/introduction
-    reference/architecture
-    reference/configuration
-    reference/data-retrieval-and-manipulation
-    reference/query-builder
-    reference/transactions
-    reference/platforms
-    reference/types
-    reference/schema-manager
-    reference/schema-representation
-    reference/security
-    reference/supporting-other-databases
-    reference/portability
-    reference/caching
-    reference/known-vendor-issues
-    reference/testing
+   .. tocheader:: Reference
+
+   .. toctree::
+      :depth: 3
+
+      reference/introduction
+      reference/architecture
+      reference/configuration
+      reference/data-retrieval-and-manipulation
+      reference/query-builder
+      reference/transactions
+      reference/platforms
+      reference/types
+      reference/schema-manager
+      reference/schema-representation
+      reference/security
+      reference/supporting-other-databases
+      reference/portability
+      reference/caching
+      reference/known-vendor-issues
+      reference/testing
+
+.. toc::
+
+   .. tocheader:: Explanation
+
+   .. toctree::
+      :depth: 3
 
     explanation/dc2type-comments
     explanation/implicit-indexes


### PR DESCRIPTION
It will make clearer what category every article falls into. Also it addresses an issue that results in the second section disappearing whenever you click on any link.
It reveals classification issues in the existing docs. For instance, I think architecture should go in the "Explanation" section, and that there should probably be a tutorial and how-to section. If we decide to do such moves, we should probably set up redirects, and I do not know how to achieve that.

I reused syntax I saw in the ORM docs, I think it should do the trick.

Here is a gif showing the bug:

![Peek 2023-12-10 18-47](https://github.com/doctrine/dbal/assets/657779/95bfe973-686b-41fb-84d3-15677b5ef82a)
