### PR TITLE
Switch to absolute paths 

### DIFF
--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -29,5 +29,5 @@
    .. toctree::
       :depth: 3
 
-    explanation/dc2type-comments
-    explanation/implicit-indexes
+      explanation/dc2type-comments
+      explanation/implicit-indexes

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -5,22 +5,22 @@
    .. toctree::
       :depth: 3
 
-      reference/introduction
-      reference/architecture
-      reference/configuration
-      reference/data-retrieval-and-manipulation
-      reference/query-builder
-      reference/transactions
-      reference/platforms
-      reference/types
-      reference/schema-manager
-      reference/schema-representation
-      reference/security
-      reference/supporting-other-databases
-      reference/portability
-      reference/caching
-      reference/known-vendor-issues
-      reference/testing
+      /reference/introduction
+      /reference/architecture
+      /reference/configuration
+      /reference/data-retrieval-and-manipulation
+      /reference/query-builder
+      /reference/transactions
+      /reference/platforms
+      /reference/types
+      /reference/schema-manager
+      /reference/schema-representation
+      /reference/security
+      /reference/supporting-other-databases
+      /reference/portability
+      /reference/caching
+      /reference/known-vendor-issues
+      /reference/testing
 
 .. toc::
 
@@ -29,5 +29,5 @@
    .. toctree::
       :depth: 3
 
-      explanation/dc2type-comments
-      explanation/implicit-indexes
+      /explanation/dc2type-comments
+      /explanation/implicit-indexes


### PR DESCRIPTION
There is a piece of code in doctrine-website that adds leading slash,
and comes with a comment saying to remove that piece of code once all
sidebar files are fixed. It does so only for directories named
"reference", "tutorials" or "cookbook", which might explain why items
under explanation disappear once you navigate deeper in the tree.

See https://github.com/doctrine/doctrine-website/blob/6277d81a78c0d0688012e66f3c2ffd6933e6f63f/lib/Docs/RST/RSTCopier.php#L159-L160