### PR TITLE
Add missing schema name on drop index statement on psql

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 use function array_diff;

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -828,7 +828,28 @@ SQL
             return $this->getDropConstraintSQL($constraintName, $table);
         }
 
-        return parent::getDropIndexSQL($index, $table);
+        if ($index instanceof Index) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/issues/4798',
+                'Passing $index as an Index object to %s is deprecated. Pass it as a quoted name instead.',
+                __METHOD__,
+            );
+
+            $index = $index->getQuotedName($this);
+        } elseif (! is_string($index)) {
+            throw new InvalidArgumentException(
+                __METHOD__ . '() expects $index parameter to be string or ' . Index::class . '.',
+            );
+        }
+
+        if (strpos($table, '.') !== false) {
+            [$schema] = explode('.', $table);
+            $index    = $schema . '.' . $index;
+        }
+
+
+        return 'DROP INDEX ' . $index;
     }
 
     /**

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -849,7 +849,6 @@ SQL
             $index    = $schema . '.' . $index;
         }
 
-
         return 'DROP INDEX ' . $index;
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -1069,4 +1069,12 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('jsonb'));
         self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('jsonb'));
     }
+
+    public function testDropIndexSQLRequiresTable(): void
+    {
+        self::assertSame(
+            'DROP INDEX schema.idx_id',
+            $this->platform->getDropIndexSQL('idx_id', 'schema.table'),
+        );
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #2535

#### Summary

The generated SQL included a reference to an index (idx_8f16808653af4e34) without specifying the associated schema. This led to errors during execution, as the index was not found.

This pull request fixes the issue by adding the schema name for the Postgre SQL Platform
