### PR TITLE
fix(PostgreSQL omit dropped columns in getListTableColumnsSQL (pg_att…

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -479,6 +479,7 @@ SQL
                         AND a.attrelid = c.oid
                         AND a.atttypid = t.oid
                         AND n.oid = c.relnamespace
+                        AND a.attisdropped = false
                     ORDER BY a.attnum';
     }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -657,6 +657,7 @@ SQL;
             'a.attnum > 0',
             "c.relkind = 'r'",
             'd.refobjid IS NULL',
+            'a.attisdropped = false',
         ], $this->buildQueryConditions($tableName));
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY a.attnum';

--- a/tests/Functional/TableDropColumnTest.php
+++ b/tests/Functional/TableDropColumnTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+use Throwable;
+
+use function count;
+
+class TableDropColumnTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $table = new Table('write_table');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('test_column1', Types::STRING);
+        $table->addColumn('test_column2', Types::INTEGER);
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['test_column1', 'test_column2']);
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->executeStatement('ALTER TABLE write_table DROP COLUMN test_column1');
+    }
+
+    public function testPgSqlPgAttributeTable(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (!$platform instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('Test does work on PostgreSQL only.');
+        }
+
+        try {
+            $this->connection->executeQuery('Select attisdropped from pg_attribute Limit 1')->fetchOne();
+        } catch (Throwable $e) {
+            self::fail("Column attisdropped not exists in pg_attribute table");
+        }
+    }
+
+    public function testColumnNumber(): void
+    {
+        $columns = $this->connection->createSchemaManager()->listTableColumns('write_table');
+
+        self::assertEquals(2, count($columns), 'listTableColumns() should return the number of exact number of columns');
+    }
+}

--- a/tests/Functional/TableDropColumnTest.php
+++ b/tests/Functional/TableDropColumnTest.php
@@ -22,17 +22,14 @@ class TableDropColumnTest extends FunctionalTestCase
 
         $platform = $this->connection->getDatabasePlatform();
 
-        $table->addIndex(['test_column1', 'test_column2'], 'test');
+        // some db engines dont allow drop column which belongs to index but on pgsql it leave pg_attribute with attisdropped=true so we can test it
+        if ($platform instanceof PostgreSQLPlatform) {
+            $table->addIndex(['test_column1', 'test_column2'], 'test');
+        }
 
         $this->dropAndCreateTable($table);
 
-        // some db engine dont allow drop column which belongs to index but on pgsql it leave pg_attribute with attisdropped=true so we can test it
-        try {
-            $this->connection->executeStatement('ALTER TABLE write_table DROP COLUMN test_column1');
-        } catch (Throwable $e) {
-            $table->dropIndex('test');
-            $this->connection->executeStatement('ALTER TABLE write_table DROP COLUMN test_column1');
-        }
+        $this->connection->executeStatement('ALTER TABLE write_table DROP COLUMN test_column1');
     }
 
     public function testPgSqlPgAttributeTable(): void


### PR DESCRIPTION
…ribute table) to avoid ........pg.dropped.x.......

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6248

#### Summary

Avoid fetching deleted columns for tables structure 
