### PR TITLE
Keep NVARCHAR(MAX) length as -1

### DIFF
--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -133,8 +133,16 @@ SQL,
 
         switch ($dbType) {
             case 'nchar':
-            case 'nvarchar':
             case 'ntext':
+                // Unicode data requires 2 bytes per character
+                $length /= 2;
+                break;
+
+            case 'nvarchar':
+                if ($length === -1) {
+                    break;
+                }
+
                 // Unicode data requires 2 bytes per character
                 $length /= 2;
                 break;

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -262,4 +262,19 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('colB', $columns[0]);
         self::assertEquals('colA', $columns[1]);
     }
+
+    public function testNvarcharMaxIsLengthMinus1(): void
+    {
+        $sql = 'CREATE TABLE test_nvarchar_max (
+            col_nvarchar_max NVARCHAR(MAX),
+            col_nvarchar NVARCHAR(128)
+        )';
+
+        $this->connection->executeStatement($sql);
+
+        $table = $this->schemaManager->introspectTable('test_nvarchar_max');
+
+        self::assertSame(-1, $table->getColumn('col_nvarchar_max')->getLength());
+        self::assertSame(128, $table->getColumn('col_nvarchar')->getLength());
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6038

#### Summary

As described in the mentioned issue, `-0.5` from `-1 / 2` will raise type error when trying to `setLength`

```
Argument #1 ($length) must be of type ?int, float given
```
https://github.com/doctrine/dbal/blob/8bc0d9ae42f20af54120396ef7a1b3248479c2b5/src/Schema/Column.php#L78

This PR check if length is `-1` and keep it as is before perform division.
