### PR TITLE
Add fallback compatibility for detecting autoincrement in serial-created fields

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -237,7 +237,10 @@ SQL,
         assert(array_key_exists('complete_type', $tableColumn));
 
         if ($tableColumn['default'] !== null) {
-            if (preg_match("/^['(](.*)[')]::/", $tableColumn['default'], $matches) === 1) {
+            if (preg_match("/^nextval\('(.*)'(::.*)?\)$/", $tableColumn['default'], $matches) === 1) {
+                $tableColumn['default'] = null;
+                $autoincrement          = true;
+            } elseif (preg_match("/^['(](.*)[')]::/", $tableColumn['default'], $matches) === 1) {
                 $tableColumn['default'] = $matches[1];
             } elseif (preg_match('/^NULL::/', $tableColumn['default']) === 1) {
                 $tableColumn['default'] = null;

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -555,6 +555,17 @@ SQL;
             'bigint->int' => ['bigint', 'integer', 'INT'],
         ];
     }
+
+    public function testIdentifySerialAsAutoincrement(): void
+    {
+        $sql = 'CREATE TABLE test_serial (id SERIAL PRIMARY KEY)';
+        $this->connection->executeStatement($sql);
+
+        $table = $this->schemaManager->introspectTable('test_serial');
+
+        self::assertTrue($table->getColumn('id')->getAutoincrement());
+        self::assertNull($table->getColumn('id')->getDefault());
+    }
 }
 
 class MoneyType extends Type


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Thanks for implementing the identity autoincrement at #5396, with the [how-to guide](https://github.com/doctrine/dbal/blob/4.0.x/docs/en/how-to/postgresql-identity-migration.rst).

This PR aims to enhance `introspectTable` by adding fallback compatibility. It will allow columns created with serial to be recognized as autoincrement.

This feature benefit projects utilizing `dbal` for table introspection that not ready to `upgrade_serial_to_identity` yet.

I am sorry if I brought back an intended-to-remove feature, it is possible I might not have been fully aware of the core's team direction in this area.

Feel free to close this PR if it doesn't align with the project's current strategy.