### PR TITLE
:bug: bugfix/#6261 - Allow (also for DATETIME) dynamic intervals in DATE_ADD & DATE_SUB for SQLite

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -843,6 +843,7 @@
                 <file name="tests/Platforms/DB2PlatformTest.php"/>
                 <file name="tests/Platforms/OraclePlatformTest.php"/>
                 <file name="tests/Platforms/SqlitePlatformTest.php"/>
+                <file name="tests/Functional/Ticket/DBAL6261Test.php"/>
 
                 <!-- See https://github.com/doctrine/dbal/pull/3574 -->
                 <file name="tests/Query/Expression/ExpressionBuilderTest.php"/>

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -152,6 +152,10 @@ class SqlitePlatform extends AbstractPlatform
             case DateIntervalUnit::SECOND:
             case DateIntervalUnit::MINUTE:
             case DateIntervalUnit::HOUR:
+                if (! is_numeric($interval)) {
+                    $interval = "' || " . $interval . " || '";
+                }
+
                 return 'DATETIME(' . $date . ",'" . $operator . $interval . ' ' . $unit . "')";
         }
 

--- a/tests/Functional/Ticket/DBAL6261Test.php
+++ b/tests/Functional/Ticket/DBAL6261Test.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Doctrine\DBAL\Tests\Functional\Ticket;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+class DBAL6261Test extends FunctionalTestCase
+{
+    /** @throws Exception */
+    protected function setUp(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
+            return;
+        }
+
+        self::markTestSkipped('Related to SQLite only');
+    }
+
+    /**
+     * @throws SchemaException
+     * @throws Exception
+     */
+    public function testUnsignedIntegerDetection(): void
+    {
+        $testTable        = 'dbal6261tbl';
+        $testTableService = $testTable . '_service';
+        $testTableAgency  = $testTable . '_agency';
+
+        $tableService = new Table($testTableService);
+        $tableService->addColumn('id', Types::INTEGER);
+        $tableService->addColumn('end_at', Types::DATETIME_MUTABLE);
+        $tableService->addColumn('agency_id', Types::INTEGER);
+        $tableService->setPrimaryKey(['id']);
+
+        $tableAgency = new Table($testTableAgency);
+        $tableAgency->addColumn('id', Types::INTEGER);
+        $tableAgency->addColumn('utc_offset', Types::INTEGER);
+        $tableAgency->setPrimaryKey(['id']);
+
+        $this->dropAndCreateTable($tableService);
+        $this->dropAndCreateTable($tableAgency);
+
+        $this->connection->insert($testTableAgency, [
+            'id' => 1,
+            'utc_offset' => 120,
+        ]);
+
+        $match1     = [
+            'id' => 1,
+            'end_at' => '2023-01-05 16:59:59',
+            'agency_id' => 1,
+        ];
+        $match2     = [
+            'id' => 2,
+            'end_at' => '2023-01-05 17:00:00',
+            'agency_id' => 1,
+        ];
+        $wontMatch1 = [
+            'id' => 3,
+            'end_at' => '2023-01-05 17:00:01',
+            'agency_id' => 1,
+        ];
+
+        $this->connection->insert($testTableService, $match1);
+        $this->connection->insert($testTableService, $match2);
+        $this->connection->insert($testTableService, $wontMatch1);
+
+        $platfom = $this->connection->getDatabasePlatform();
+        $qb      = $this->connection->createQueryBuilder()
+            ->select('s.*')
+            ->from($testTableService, 's')
+            ->leftJoin('s', $testTableAgency, 'a', 's.agency_id = a.id')
+            ->where(
+                's.end_at <= ' . $platfom->getDateAddMinutesExpression(
+                    "DATETIME('2023-01-05 15:00:00')",
+                    'a.utc_offset',
+                ),
+            );
+        $sql     = $qb
+            ->getSQL();
+        self::assertEquals(
+            'SELECT s.* FROM dbal6261tbl_service s '
+            . 'LEFT JOIN dbal6261tbl_agency a ON s.agency_id = a.id '
+            . "WHERE s.end_at <= DATETIME(DATETIME('2023-01-05 15:00:00'),'+' || a.utc_offset || ' MINUTE')",
+            $sql,
+        );
+
+        $result = $qb->fetchAllAssociative();
+
+        self::assertEquals(
+            [
+                $match1,
+                $match2,
+            ],
+            $result,
+        );
+    }
+}

--- a/tests/Functional/Ticket/DBAL6261Test.php
+++ b/tests/Functional/Ticket/DBAL6261Test.php
@@ -2,16 +2,13 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
 
 class DBAL6261Test extends FunctionalTestCase
 {
-    /** @throws Exception */
     protected function setUp(): void
     {
         if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
@@ -21,10 +18,6 @@ class DBAL6261Test extends FunctionalTestCase
         self::markTestSkipped('Related to SQLite only');
     }
 
-    /**
-     * @throws SchemaException
-     * @throws Exception
-     */
     public function testUnsignedIntegerDetection(): void
     {
         $testTable        = 'dbal6261tbl';
@@ -71,7 +64,7 @@ class DBAL6261Test extends FunctionalTestCase
         $this->connection->insert($testTableService, $wontMatch1);
 
         $platfom = $this->connection->getDatabasePlatform();
-        $qb      = $this->connection->createQueryBuilder()
+        $result  = $this->connection->createQueryBuilder()
             ->select('s.*')
             ->from($testTableService, 's')
             ->leftJoin('s', $testTableAgency, 'a', 's.agency_id = a.id')
@@ -80,17 +73,8 @@ class DBAL6261Test extends FunctionalTestCase
                     "DATETIME('2023-01-05 15:00:00')",
                     'a.utc_offset',
                 ),
-            );
-        $sql     = $qb
-            ->getSQL();
-        self::assertEquals(
-            'SELECT s.* FROM dbal6261tbl_service s '
-            . 'LEFT JOIN dbal6261tbl_agency a ON s.agency_id = a.id '
-            . "WHERE s.end_at <= DATETIME(DATETIME('2023-01-05 15:00:00'),'+' || a.utc_offset || ' MINUTE')",
-            $sql,
-        );
-
-        $result = $qb->fetchAllAssociative();
+            )
+            ->fetchAllAssociative();
 
         self::assertEquals(
             [

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -733,6 +733,22 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $this->markTestSkipped('SQLite does not support altering foreign key constraints.');
     }
 
+    public function testDateAddStaticNumberOfMinutes(): void
+    {
+        self::assertSame(
+            "DATETIME(endAt,'+12 MINUTE')",
+            $this->platform->getDateAddMinutesExpression('endAt', 12),
+        );
+    }
+
+    public function testDateAddNumberOfMinutesFromColumn(): void
+    {
+        self::assertSame(
+            "DATETIME(endAt,'+' || duration || ' MINUTE')",
+            $this->platform->getDateAddMinutesExpression('endAt', 'duration'),
+        );
+    }
+
     public function testDateAddStaticNumberOfDays(): void
     {
         self::assertSame(


### PR DESCRIPTION
- :bug: Fix code divergence
- :white_check_mark: Add related tests

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6261

#### Summary
Code inspired from a sibling Pull Request

#### Question
1. Documentation currently **don't** match :
```php
<?php
/**
* [...]
* @param int|numeric-string $interval The interval [...]
*/
```
May i update documentation ?

2. Note that the existing code **don't** work and will produce a warning with `WEEK` and `QUARTER` with a `$interval` as non-numeric value. Probably an unknown issue, so maybe the code **would** throw an error for these specific cases.
https://github.com/doctrine/dbal/blob/6a793fb72948c9dec844de57de8cdbc16ff75bec/src/Platforms/SqlitePlatform.php#L160C3-L160C3
```
TypeError : Unsupported operand types: string * int
```
 In doctrine 4.x.x, `getDateArithmeticIntervalExpression` is redesigned and : 
- use `DATETIME()` in all cases;
- use the dedicated `getConcatExpression` and `quoteStringLiteral` ;

For `WEEK` and `QUARTER`, a method called `multiplyInterval` is called and may prevent this issue.