### PR TITLE
Fix deprecation message Parameter::STRING -> ParameterType::STRING

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -420,7 +420,7 @@ The `Connection::ARRAY_PARAM_OFFSET` constant has been marked as internal. It wi
 
 ## Deprecated using NULL as prepared statement parameter type.
 
-Omit the type or use `Parameter::STRING` instead.
+Omit the type or use `ParameterType::STRING` instead.
 
 ## Deprecated passing asset names as assets in `AbstractPlatform` and `AbstractSchemaManager` methods.
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1794,7 +1794,7 @@ class Connection
                             'doctrine/dbal',
                             'https://github.com/doctrine/dbal/pull/5550',
                             'Using NULL as prepared statement parameter type is deprecated.'
-                                . 'Omit or use Parameter::STRING instead',
+                                . 'Omit or use ParameterType::STRING instead',
                         );
                     }
 
@@ -1817,7 +1817,7 @@ class Connection
                             'doctrine/dbal',
                             'https://github.com/doctrine/dbal/pull/5550',
                             'Using NULL as prepared statement parameter type is deprecated.'
-                                . 'Omit or use Parameter::STRING instead',
+                                . 'Omit or use ParameterType::STRING instead',
                         );
                     }
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -454,7 +454,7 @@ class QueryBuilder
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/pull/5550',
                 'Using NULL as prepared statement parameter type is deprecated.'
-                    . 'Omit or use Parameter::STRING instead',
+                    . 'Omit or use ParameterType::STRING instead',
             );
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | docs improvement
| Fixed issues | /

#### Summary

#5550 introduced a typo in the deprecation message. This PR fixes it.
