### PR TITLE
fix: TableDiff deprecation points to wrong method

### DIFF
--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -279,7 +279,7 @@ class TableDiff
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/6080',
-            '%s is deprecated, use `getModifiedColumns()` instead.',
+            '%s is deprecated, use `getChangedColumns()` instead.',
             __METHOD__,
         );
 
@@ -301,7 +301,7 @@ class TableDiff
     }
 
     /**
-     * @deprecated Use {@see getModifiedColumns()} instead.
+     * @deprecated Use {@see getChangedColumns()} instead.
      *
      * @return array<string,Column>
      */
@@ -310,7 +310,7 @@ class TableDiff
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/6080',
-            '%s is deprecated, you should use `getModifiedColumns()` instead.',
+            '%s is deprecated, you should use `getChangedColumns()` instead.',
             __METHOD__,
         );
         $renamed = [];

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -542,7 +542,8 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     public function testGeneratesAlterColumnSQL(
         string $changedProperty,
         Column $column,
-        ?string $expectedSQLClause = null
+        ?string $expectedSQLClause = null,
+        bool $shouldReorg = true
     ): void {
         $tableDiff                        = new TableDiff('foo');
         $tableDiff->fromTable             = new Table('foo');
@@ -554,7 +555,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             $expectedSQL[] = 'ALTER TABLE foo ALTER COLUMN bar ' . $expectedSQLClause;
         }
 
-        $expectedSQL[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE foo')";
+        if ($shouldReorg) {
+            $expectedSQL[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE foo')";
+        }
 
         self::assertSame($expectedSQL, $this->platform->getAlterTableSQL($tableDiff));
     }
@@ -612,6 +615,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
                 'default',
                 new Column('bar', Type::getType(Types::INTEGER), ['autoincrement' => true, 'default' => 666]),
                 null,
+                false,
             ],
             [
                 'default',


### PR DESCRIPTION
Follow up of #6080 

While preparing the merge request to port to 4.0.x I found that some comments point to a deprecated method (one even points to itself)

I also found that in DB2 the reorg happens even if there is no query running which was a bit weird and adding column was not triggering a reorg which is wrong and was not picked up by tests (because other changed columns triggered it)