### PR TITLE
Avoid ambigous TABLE_NAME in query

### DIFF
--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Types\JsonType;
 use Doctrine\Deprecations\Deprecation;
 
@@ -92,6 +93,11 @@ class MariaDb1043Platform extends MariaDb1027Platform
             );
         }
 
+        // 't' alias is already in use for following query
+        if ($tableAlias === 't') {
+            throw new InvalidArgumentException('Table alias "t" is not allowed, please choose another one.');
+        }
+
         $databaseName = $this->getDatabaseNameSQL($databaseName);
 
         // The check for `CONSTRAINT_SCHEMA = $databaseName` is mandatory here to prevent performance issues
@@ -102,7 +108,7 @@ class MariaDb1043Platform extends MariaDb1027Platform
                     SELECT * from information_schema.CHECK_CONSTRAINTS t
                     WHERE t.CONSTRAINT_SCHEMA = $databaseName
                     AND t.TABLE_NAME = $tableAlias.TABLE_NAME
-                    AND CHECK_CLAUSE = CONCAT(
+                    AND t.CHECK_CLAUSE = CONCAT(
                         'json_valid(`',
                             $tableAlias.COLUMN_NAME,
                         '`)'

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -92,8 +92,7 @@ class MariaDb1043Platform extends MariaDb1027Platform
             );
         }
 
-        // do not collide with $tableAlias
-        $subQueryAlias = $tableAlias === '_t' ? 't' : '_t';
+        $subQueryAlias = 'i_' . $tableAlias;
 
         $databaseName = $this->getDatabaseNameSQL($databaseName);
 

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Types\JsonType;
 use Doctrine\Deprecations\Deprecation;
 

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -103,7 +103,7 @@ class MariaDb1043Platform extends MariaDb1027Platform
             IF(
                 $tableAlias.COLUMN_TYPE = 'longtext'
                 AND EXISTS(
-                    SELECT * from information_schema.CHECK_CONSTRAINTS t
+                    SELECT * from information_schema.CHECK_CONSTRAINTS $subQueryAlias
                     WHERE $subQueryAlias.CONSTRAINT_SCHEMA = $databaseName
                     AND $subQueryAlias.TABLE_NAME = $tableAlias.TABLE_NAME
                     AND $subQueryAlias.CHECK_CLAUSE = CONCAT(

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -93,10 +93,8 @@ class MariaDb1043Platform extends MariaDb1027Platform
             );
         }
 
-        // 't' alias is already in use for following query
-        if ($tableAlias === 't') {
-            throw new InvalidArgumentException('Table alias "t" is not allowed, please choose another one.');
-        }
+        // do not collide with $tableAlias
+        $subQueryAlias = $tableAlias === '_t' ? 't' : '_t';
 
         $databaseName = $this->getDatabaseNameSQL($databaseName);
 
@@ -106,9 +104,9 @@ class MariaDb1043Platform extends MariaDb1027Platform
                 $tableAlias.COLUMN_TYPE = 'longtext'
                 AND EXISTS(
                     SELECT * from information_schema.CHECK_CONSTRAINTS t
-                    WHERE t.CONSTRAINT_SCHEMA = $databaseName
-                    AND t.TABLE_NAME = $tableAlias.TABLE_NAME
-                    AND t.CHECK_CLAUSE = CONCAT(
+                    WHERE $subQueryAlias.CONSTRAINT_SCHEMA = $databaseName
+                    AND $subQueryAlias.TABLE_NAME = $tableAlias.TABLE_NAME
+                    AND $subQueryAlias.CHECK_CLAUSE = CONCAT(
                         'json_valid(`',
                             $tableAlias.COLUMN_NAME,
                         '`)'

--- a/src/Platforms/MariaDb1043Platform.php
+++ b/src/Platforms/MariaDb1043Platform.php
@@ -99,9 +99,9 @@ class MariaDb1043Platform extends MariaDb1027Platform
             IF(
                 $tableAlias.COLUMN_TYPE = 'longtext'
                 AND EXISTS(
-                    SELECT * from information_schema.CHECK_CONSTRAINTS 
-                    WHERE CONSTRAINT_SCHEMA = $databaseName
-                    AND TABLE_NAME = $tableAlias.TABLE_NAME
+                    SELECT * from information_schema.CHECK_CONSTRAINTS t
+                    WHERE t.CONSTRAINT_SCHEMA = $databaseName
+                    AND t.TABLE_NAME = $tableAlias.TABLE_NAME
                     AND CHECK_CLAUSE = CONCAT(
                         'json_valid(`',
                             $tableAlias.COLUMN_NAME,


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6274 

#### Summary

The current produced query leads to an ambigous column reference as described in the linked issue.
