### PR TITLE
Revert the rename column feature

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -517,13 +517,6 @@
                 <!-- TODO for PHPUnit 10 -->
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive"/>
 
-                <!--
-                    TODO: remove in 4.0.0
-                    See https://github.com/doctrine/dbal/pull/6080
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getModifiedColumns"/>
-                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getRenamedColumns"/>
-
                 <!-- TODO: remove in 4.0.0 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\DB2Platform::getForUpdateSQL"/>
             </errorLevel>

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
@@ -683,26 +684,36 @@ SQL
             $queryParts[] =  'DROP ' . $column->getQuotedName($this);
         }
 
-        foreach ($diff->getChangedColumns() as $columnDiff) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
+            if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
+                continue;
+            }
+
             $newColumn = $columnDiff->getNewColumn();
 
             $newColumnProperties = array_merge($newColumn->toArray(), [
                 'comment' => $this->getColumnComment($newColumn),
             ]);
 
-            $oldColumn     = $columnDiff->getOldColumn() ?? $columnDiff->getOldColumnName();
-            $oldColumnName = $oldColumn->getName();
-
-            if ($columnDiff->hasNameChanged()) {
-                if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $newColumn, $diff, $columnSql)) {
-                    continue;
-                }
-            } elseif ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
-                continue;
-            }
+            $oldColumn = $columnDiff->getOldColumn() ?? $columnDiff->getOldColumnName();
 
             $queryParts[] =  'CHANGE ' . $oldColumn->getQuotedName($this) . ' '
                 . $this->getColumnDeclarationSQL($newColumn->getQuotedName($this), $newColumnProperties);
+        }
+
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
+            if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
+                continue;
+            }
+
+            $oldColumnName = new Identifier($oldColumnName);
+
+            $columnProperties = array_merge($column->toArray(), [
+                'comment' => $this->getColumnComment($column),
+            ]);
+
+            $queryParts[] = 'CHANGE ' . $oldColumnName->getQuotedName($this) . ' '
+                . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnProperties);
         }
 
         $addedIndexes    = $this->indexAssetsByLowerCaseName($diff->getAddedIndexes());
@@ -734,7 +745,7 @@ SQL
             $diff = new TableDiff(
                 $diff->name,
                 $diff->getAddedColumns(),
-                $diff->getChangedColumns(),
+                $diff->getModifiedColumns(),
                 $diff->getDroppedColumns(),
                 array_values($addedIndexes),
                 array_values($modifiedIndexes),
@@ -743,6 +754,7 @@ SQL
                 $diff->getAddedForeignKeys(),
                 $diff->getModifiedForeignKeys(),
                 $diff->getDroppedForeignKeys(),
+                $diff->getRenamedColumns(),
                 $diff->getRenamedIndexes(),
             );
         }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2941,20 +2941,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Returns the SQL for renaming a column
-     *
-     * @param string $tableName     The table to rename the column on.
-     * @param string $oldColumnName The name of the column we want to rename.
-     * @param string $newColumnName The name we should rename it to.
-     *
-     * @return string[] The sequence of SQL statements for renaming the given column.
-     */
-    protected function getRenameColumnSQL(string $tableName, string $oldColumnName, string $newColumnName): array
-    {
-        return [sprintf('ALTER TABLE %s RENAME COLUMN %s TO %s', $tableName, $oldColumnName, $newColumnName)];
-    }
-
-    /**
      * Gets declaration of a number of columns in bulk.
      *
      * @param mixed[][] $columns A multidimensional associative array.

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -897,26 +897,12 @@ SQL
         }
 
         $fields = [];
-        foreach ($diff->getChangedColumns() as $columnDiff) {
-            $newColumn     = $columnDiff->getNewColumn();
-            $newColumnName = $newColumn->getQuotedName($this);
-            $oldColumn     = $columnDiff->getOldColumn() ?? $columnDiff->getOldColumnName();
-
-            $oldColumnName = $oldColumn->getQuotedName($this);
-
-            // Column names in Oracle are case insensitive and automatically uppercased on the server.
-            if ($columnDiff->hasNameChanged()) {
-                if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $newColumn, $diff, $columnSql)) {
-                    continue;
-                }
-
-                $sql = array_merge(
-                    $sql,
-                    $this->getRenameColumnSQL($tableNameSQL, $oldColumnName, $newColumnName),
-                );
-            } elseif ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
+        foreach ($diff->getModifiedColumns() as $columnDiff) {
+            if ($this->onSchemaAlterTableChangeColumn($columnDiff, $diff, $columnSql)) {
                 continue;
             }
+
+            $newColumn = $columnDiff->getNewColumn();
 
             // Do not generate column alteration clause if type is binary and only fixed property has changed.
             // Oracle only supports binary type columns with variable length.
@@ -934,7 +920,7 @@ SQL
             /**
              * Do not add query part if only comment has changed
              */
-            if (count($columnDiff->changedProperties) > ($columnHasChangedComment ? 1 : 0)) {
+            if (! ($columnHasChangedComment && count($columnDiff->changedProperties) === 1)) {
                 $newColumnProperties = $newColumn->toArray();
 
                 if (! $columnDiff->hasNotNullChanged()) {
@@ -957,6 +943,17 @@ SQL
 
         if (count($fields) > 0) {
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY (' . implode(', ', $fields) . ')';
+        }
+
+        foreach ($diff->getRenamedColumns() as $oldColumnName => $column) {
+            if ($this->onSchemaAlterTableRenameColumn($oldColumnName, $column, $diff, $columnSql)) {
+                continue;
+            }
+
+            $oldColumnName = new Identifier($oldColumnName);
+
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' RENAME COLUMN ' . $oldColumnName->getQuotedName($this)
+                . ' TO ' . $column->getQuotedName($this);
         }
 
         $fields = [];

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -463,13 +463,4 @@ class Column extends AbstractAsset
             'comment' => $this->_comment,
         ], $this->_platformOptions, $this->_customSchemaOptions);
     }
-
-    /** @internal To be removed in 4.0 */
-    public function cloneWithName(string $name): Column
-    {
-        $clone = clone $this;
-        $clone->_setName($name);
-
-        return $clone;
-    }
 }

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\Deprecations\Deprecation;
 
 use function in_array;
-use function strcasecmp;
 
 /**
  * Represents the change of a column.
@@ -77,14 +76,6 @@ class ColumnDiff
     public function getNewColumn(): Column
     {
         return $this->column;
-    }
-
-    public function hasNameChanged(): bool
-    {
-        $oldColumn = $this->getOldColumn() ?? $this->getOldColumnName();
-
-        // Column names are case insensitive
-        return strcasecmp($oldColumn->getName(), $this->getNewColumn()->getName()) !== 0;
     }
 
     public function hasTypeChanged(): bool

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -7,14 +7,12 @@ use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Visitor\Visitor;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
-use LogicException;
 
 use function array_filter;
 use function array_keys;
 use function array_merge;
 use function in_array;
 use function preg_match;
-use function sprintf;
 use function strlen;
 use function strtolower;
 
@@ -27,9 +25,6 @@ class Table extends AbstractAsset
 {
     /** @var Column[] */
     protected $_columns = [];
-
-    /** @var array<string, string> keys are new names, values are old names */
-    protected array $renamedColumns = [];
 
     /** @var Index[] */
     protected $_indexes = [];
@@ -347,48 +342,6 @@ class Table extends AbstractAsset
         $column = new Column($name, Type::getType($typeName), $options);
 
         $this->_addColumn($column);
-
-        return $column;
-    }
-
-    /** @return array<string, string> */
-    final public function getRenamedColumns(): array
-    {
-        return $this->renamedColumns;
-    }
-
-    /**
-     * @throws LogicException
-     * @throws SchemaException
-     */
-    final public function renameColumn(string $oldName, string $newName): Column
-    {
-        $oldName = $this->normalizeIdentifier($oldName);
-        $newName = $this->normalizeIdentifier($newName);
-
-        if ($oldName === $newName) {
-            throw new LogicException(sprintf(
-                'Attempt to rename column "%s.%s" to the same name.',
-                $this->getName(),
-                $oldName,
-            ));
-        }
-
-        $column = $this->getColumn($oldName);
-        $column->_setName($newName);
-        unset($this->_columns[$oldName]);
-        $this->_addColumn($column);
-
-        // If a column is renamed multiple times, we only want to know the original and last new name
-        if (isset($this->renamedColumns[$oldName])) {
-            $toRemove = $oldName;
-            $oldName  = $this->renamedColumns[$oldName];
-            unset($this->renamedColumns[$toRemove]);
-        }
-
-        if ($newName !== $oldName) {
-            $this->renamedColumns[$newName] = $oldName;
-        }
 
         return $column;
     }

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -279,7 +279,7 @@ class TableDiff
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/6080',
-            '%s is deprecated, use `getChangedColumns()` instead.',
+            '%s is deprecated, use `getModifiedColumns()` instead.',
             __METHOD__,
         );
 
@@ -301,7 +301,7 @@ class TableDiff
     }
 
     /**
-     * @deprecated Use {@see getChangedColumns()} instead.
+     * @deprecated Use {@see getModifiedColumns()} instead.
      *
      * @return array<string,Column>
      */
@@ -310,7 +310,7 @@ class TableDiff
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/6080',
-            '%s is deprecated, you should use `getChangedColumns()` instead.',
+            '%s is deprecated, you should use `getModifiedColumns()` instead.',
             __METHOD__,
         );
         $renamed = [];

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -5,17 +5,15 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_keys;
-use function array_values;
 use function strtolower;
 
 class RenameColumnTest extends FunctionalTestCase
 {
     /** @dataProvider columnNameProvider */
-    public function testColumnPositionRetainedAfterImplicitRenaming(string $columnName, string $newColumnName): void
+    public function testColumnPositionRetainedAfterRenaming(string $columnName, string $newColumnName): void
     {
         $table = new Table('test_rename');
         $table->addColumn($columnName, Types::STRING);
@@ -35,34 +33,6 @@ class RenameColumnTest extends FunctionalTestCase
 
         $table = $sm->introspectTable('test_rename');
         self::assertSame([strtolower($newColumnName), 'c2'], array_keys($table->getColumns()));
-        self::assertCount(1, $diff->getRenamedColumns());
-    }
-
-    /** @dataProvider columnNameProvider */
-    public function testColumnPositionRetainedAfterExplicitRenaming(string $columnName, string $newColumnName): void
-    {
-        $table = new Table('test_rename');
-        $table->addColumn($columnName, Types::INTEGER, ['length' => 16]);
-        $table->addColumn('c2', Types::INTEGER);
-
-        $this->dropAndCreateTable($table);
-
-        // Force a different type to make sure it's not being caught implicitly
-        $table->renameColumn($columnName, $newColumnName)->setType(Type::getType(Types::BIGINT))->setLength(32);
-
-        $sm   =  $this->connection->createSchemaManager();
-        $diff = $sm->createComparator()
-            ->compareTables($sm->introspectTable('test_rename'), $table);
-
-        $sm->alterTable($diff);
-
-        $table   = $sm->introspectTable('test_rename');
-        $columns = array_values($table->getColumns());
-
-        self::assertCount(1, $diff->getChangedColumns());
-        self::assertCount(2, $columns);
-        self::assertEqualsIgnoringCase($newColumnName, $columns[0]->getName());
-        self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
     }
 
     /** @return iterable<array{string}> */

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_merge;
@@ -51,57 +50,6 @@ class ComparatorTest extends FunctionalTestCase
         $onlineTable = $this->schemaManager->introspectTable('default_value');
 
         self::assertFalse($comparatorFactory($this->schemaManager)->diffTable($table, $onlineTable));
-    }
-
-    public function testRenameColumnComparison(): void
-    {
-        $comparator = new Comparator();
-
-        $table = new Table('rename_table');
-        $table->addColumn('test', Types::STRING, ['default' => 'baz', 'length' => 20]);
-        $table->addColumn('test2', Types::STRING, ['default' => 'baz', 'length' => 20]);
-        $table->addColumn('test3', Types::STRING, ['default' => 'foo', 'length' => 10]);
-
-        $onlineTable = clone $table;
-        $table->renameColumn('test', 'baz')
-            ->setLength(40)
-            ->setComment('Comment');
-
-        $table->renameColumn('test2', 'foo');
-
-        $table->getColumn('test3')
-            ->setAutoincrement(true)
-            ->setNotnull(false)
-            ->setType(Type::getType(Types::BIGINT));
-
-        $compareResult = $comparator->compareTables($onlineTable, $table);
-        self::assertCount(3, $compareResult->getChangedColumns());
-        self::assertCount(2, $compareResult->getRenamedColumns());
-        self::assertCount(2, $compareResult->getModifiedColumns());
-        self::assertArrayHasKey('test2', $compareResult->getRenamedColumns());
-
-        $renamedOnly        = $compareResult->changedColumns['test2'];
-        $renamedAndModified = $compareResult->changedColumns['test'];
-        $modifiedOnly       = $compareResult->changedColumns['test3'];
-
-        self::assertEquals('foo', $renamedOnly->getNewColumn()->getName());
-        self::assertTrue($renamedOnly->hasNameChanged());
-        self::assertCount(0, $renamedOnly->changedProperties);
-
-        self::assertEquals('baz', $renamedAndModified->getNewColumn()->getName());
-        self::assertTrue($renamedAndModified->hasNameChanged());
-        self::assertTrue($renamedAndModified->hasLengthChanged());
-        self::assertTrue($renamedAndModified->hasCommentChanged());
-        self::assertFalse($renamedAndModified->hasTypeChanged());
-        self::assertCount(2, $renamedAndModified->changedProperties);
-
-        self::assertTrue($modifiedOnly->hasAutoIncrementChanged());
-        self::assertTrue($modifiedOnly->hasNotNullChanged());
-        self::assertTrue($modifiedOnly->hasTypeChanged());
-        self::assertFalse($modifiedOnly->hasLengthChanged());
-        self::assertFalse($modifiedOnly->hasCommentChanged());
-        self::assertFalse($modifiedOnly->hasNameChanged());
-        self::assertCount(3, $modifiedOnly->changedProperties);
     }
 
     /** @return iterable<mixed[]> */

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -756,9 +756,9 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             "CHANGE `create` reserved_keyword INT NOT NULL COMMENT 'Reserved keyword 1', " .
             "CHANGE `table` `from` INT NOT NULL COMMENT 'Reserved keyword 2', " .
             "CHANGE `select` `bar` INT NOT NULL COMMENT 'Reserved keyword 3', " .
-            "CHANGE `quoted1` quoted INT NOT NULL COMMENT 'Quoted 1', " .
-            "CHANGE `quoted2` `and` INT NOT NULL COMMENT 'Quoted 2', " .
-            "CHANGE `quoted3` `baz` INT NOT NULL COMMENT 'Quoted 3'",
+            "CHANGE quoted1 quoted INT NOT NULL COMMENT 'Quoted 1', " .
+            "CHANGE quoted2 `and` INT NOT NULL COMMENT 'Quoted 2', " .
+            "CHANGE quoted3 `baz` INT NOT NULL COMMENT 'Quoted 3'",
         ];
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -3,12 +3,6 @@
 namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\Event\SchemaAlterTableAddColumnEventArgs;
-use Doctrine\DBAL\Event\SchemaAlterTableChangeColumnEventArgs;
-use Doctrine\DBAL\Event\SchemaAlterTableEventArgs;
-use Doctrine\DBAL\Event\SchemaAlterTableRemoveColumnEventArgs;
-use Doctrine\DBAL\Event\SchemaAlterTableRenameColumnEventArgs;
-use Doctrine\DBAL\Event\SchemaEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidLockMode;
@@ -361,24 +355,19 @@ abstract class AbstractPlatformTestCase extends TestCase
         $listenerMock = $this->createMock(GetAlterTableSqlDispatchEventListener::class);
         $listenerMock
             ->expects(self::once())
-            ->method('onSchemaAlterTable')
-            ->willReturnCallback(static fn (SchemaEventArgs $args) => $args->preventDefault());
+            ->method('onSchemaAlterTable');
         $listenerMock
             ->expects(self::once())
-            ->method('onSchemaAlterTableAddColumn')
-            ->willReturnCallback(static fn (SchemaEventArgs $args) => $args->preventDefault());
+            ->method('onSchemaAlterTableAddColumn');
         $listenerMock
             ->expects(self::once())
-            ->method('onSchemaAlterTableRemoveColumn')
-            ->willReturnCallback(static fn (SchemaEventArgs $args) => $args->preventDefault());
+            ->method('onSchemaAlterTableRemoveColumn');
         $listenerMock
             ->expects(self::once())
-            ->method('onSchemaAlterTableChangeColumn')
-            ->willReturnCallback(static fn (SchemaEventArgs $args) => $args->preventDefault());
+            ->method('onSchemaAlterTableChangeColumn');
         $listenerMock
             ->expects(self::once())
-            ->method('onSchemaAlterTableRenameColumn')
-            ->willReturnCallback(static fn (SchemaEventArgs $args) => $args->preventDefault());
+            ->method('onSchemaAlterTableRenameColumn');
 
         $eventManager = new EventManager();
         $events       = [
@@ -404,16 +393,13 @@ abstract class AbstractPlatformTestCase extends TestCase
         $tableDiff->changedColumns['changed'] = new ColumnDiff(
             'changed',
             new Column(
-                'changed',
+                'changed2',
                 Type::getType(Types::STRING),
                 [],
             ),
             [],
         );
-        $tableDiff->changedColumns['renamed'] = new ColumnDiff(
-            'renamed',
-            new Column('renamed2', Type::getType(Types::INTEGER), []),
-        );
+        $tableDiff->renamedColumns['renamed'] = new Column('renamed2', Type::getType(Types::INTEGER), []);
 
         $this->platform->getAlterTableSQL($tableDiff);
     }
@@ -1210,8 +1196,8 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testGeneratesAlterTableRenameColumnSQL(): void
     {
-        $table     = new Table('foo');
-        $oldColumn = $table->addColumn(
+        $table = new Table('foo');
+        $table->addColumn(
             'bar',
             Types::INTEGER,
             ['notnull' => true, 'default' => 666, 'comment' => 'rename test'],
@@ -1219,12 +1205,11 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         $tableDiff                        = new TableDiff('foo');
         $tableDiff->fromTable             = $table;
-        $newColumn                        = new Column(
+        $tableDiff->renamedColumns['bar'] = new Column(
             'baz',
             Type::getType(Types::INTEGER),
             ['notnull' => true, 'default' => 666, 'comment' => 'rename test'],
         );
-        $tableDiff->changedColumns['bar'] = new ColumnDiff('bar', $newColumn, [], $oldColumn);
 
         self::assertSame($this->getAlterTableRenameColumnSQL(), $this->platform->getAlterTableSQL($tableDiff));
     }
@@ -1446,15 +1431,15 @@ interface GetCreateTableSqlDispatchEventListener
 
 interface GetAlterTableSqlDispatchEventListener
 {
-    public function onSchemaAlterTable(SchemaAlterTableEventArgs $args): void;
+    public function onSchemaAlterTable(): void;
 
-    public function onSchemaAlterTableAddColumn(SchemaAlterTableAddColumnEventArgs $args): void;
+    public function onSchemaAlterTableAddColumn(): void;
 
-    public function onSchemaAlterTableRemoveColumn(SchemaAlterTableRemoveColumnEventArgs $args): void;
+    public function onSchemaAlterTableRemoveColumn(): void;
 
-    public function onSchemaAlterTableChangeColumn(SchemaAlterTableChangeColumnEventArgs $args): void;
+    public function onSchemaAlterTableChangeColumn(): void;
 
-    public function onSchemaAlterTableRenameColumn(SchemaAlterTableRenameColumnEventArgs $args): void;
+    public function onSchemaAlterTableRenameColumn(): void;
 }
 
 interface GetDropTableSqlDispatchEventListener

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -128,8 +128,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     {
         return [
             'ALTER TABLE mytable ' .
-            'ADD COLUMN quota INTEGER NOT NULL WITH DEFAULT ' .
-            'RENAME COLUMN bar TO baz',
+            'ADD COLUMN quota INTEGER NOT NULL WITH DEFAULT',
             "CALL SYSPROC.ADMIN_CMD ('REORG TABLE mytable')",
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             "COMMENT ON COLUMN mytable.foo IS ''",
@@ -480,9 +479,9 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             'RENAME COLUMN "create" TO reserved_keyword ' .
             'RENAME COLUMN "table" TO "from" ' .
             'RENAME COLUMN "select" TO "bar" ' .
-            'RENAME COLUMN "quoted1" TO quoted ' .
-            'RENAME COLUMN "quoted2" TO "and" ' .
-            'RENAME COLUMN "quoted3" TO "baz"',
+            'RENAME COLUMN quoted1 TO quoted ' .
+            'RENAME COLUMN quoted2 TO "and" ' .
+            'RENAME COLUMN quoted3 TO "baz"',
         ];
     }
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -542,8 +542,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
     public function testGeneratesAlterColumnSQL(
         string $changedProperty,
         Column $column,
-        ?string $expectedSQLClause = null,
-        bool $shouldReorg = true
+        ?string $expectedSQLClause = null
     ): void {
         $tableDiff                        = new TableDiff('foo');
         $tableDiff->fromTable             = new Table('foo');
@@ -555,9 +554,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             $expectedSQL[] = 'ALTER TABLE foo ALTER COLUMN bar ' . $expectedSQLClause;
         }
 
-        if ($shouldReorg) {
-            $expectedSQL[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE foo')";
-        }
+        $expectedSQL[] = "CALL SYSPROC.ADMIN_CMD ('REORG TABLE foo')";
 
         self::assertSame($expectedSQL, $this->platform->getAlterTableSQL($tableDiff));
     }
@@ -615,7 +612,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
                 'default',
                 new Column('bar', Type::getType(Types::INTEGER), ['autoincrement' => true, 'default' => 666]),
                 null,
-                false,
             ],
             [
                 'default',

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -398,7 +398,6 @@ SQL
     {
         return [
             'ALTER TABLE mytable ADD (quota NUMBER(10) NOT NULL)',
-            'ALTER TABLE mytable RENAME COLUMN bar TO baz',
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             "COMMENT ON COLUMN mytable.foo IS ''",
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
@@ -497,7 +496,6 @@ SQL
         );
 
         $expectedSql = [
-            'ALTER TABLE mytable RENAME COLUMN bar TO baz',
             "ALTER TABLE mytable MODIFY (foo VARCHAR2(255) DEFAULT 'bla', baz VARCHAR2(255) DEFAULT 'bla' NOT NULL, "
                 . 'metar VARCHAR2(2000) DEFAULT NULL NULL)',
         ];
@@ -617,9 +615,9 @@ SQL
             'ALTER TABLE mytable RENAME COLUMN "create" TO reserved_keyword',
             'ALTER TABLE mytable RENAME COLUMN "table" TO "from"',
             'ALTER TABLE mytable RENAME COLUMN "select" TO "bar"',
-            'ALTER TABLE mytable RENAME COLUMN "quoted1" TO quoted',
-            'ALTER TABLE mytable RENAME COLUMN "quoted2" TO "and"',
-            'ALTER TABLE mytable RENAME COLUMN "quoted3" TO "baz"',
+            'ALTER TABLE mytable RENAME COLUMN quoted1 TO quoted',
+            'ALTER TABLE mytable RENAME COLUMN quoted2 TO "and"',
+            'ALTER TABLE mytable RENAME COLUMN quoted3 TO "baz"',
         ];
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -361,7 +361,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         return [
             'ALTER TABLE mytable ADD quota INT NOT NULL',
-            'ALTER TABLE mytable RENAME COLUMN bar TO baz',
             "COMMENT ON COLUMN mytable.quota IS 'A comment'",
             'COMMENT ON COLUMN mytable.foo IS NULL',
             "COMMENT ON COLUMN mytable.baz IS 'B comment'",
@@ -784,9 +783,9 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE mytable RENAME COLUMN "create" TO reserved_keyword',
             'ALTER TABLE mytable RENAME COLUMN "table" TO "from"',
             'ALTER TABLE mytable RENAME COLUMN "select" TO "bar"',
-            'ALTER TABLE mytable RENAME COLUMN "quoted1" TO quoted',
-            'ALTER TABLE mytable RENAME COLUMN "quoted2" TO "and"',
-            'ALTER TABLE mytable RENAME COLUMN "quoted3" TO "baz"',
+            'ALTER TABLE mytable RENAME COLUMN quoted1 TO quoted',
+            'ALTER TABLE mytable RENAME COLUMN quoted2 TO "and"',
+            'ALTER TABLE mytable RENAME COLUMN quoted3 TO "baz"',
         ];
     }
 

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -740,7 +740,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function getAlterTableColumnCommentsSQL(): array
     {
         return [
-            "EXEC sp_rename 'mytable.bar', 'baz', 'COLUMN'",
             'ALTER TABLE mytable ADD quota INT NOT NULL',
             "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
                 . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', quota",
@@ -896,10 +895,8 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $tableDiff->addedColumns['added_comment_with_string_literal_char']
             = new Column('added_comment_with_string_literal_char', Type::getType(Types::STRING), ['comment' => "''"]);
 
-        $tableDiff->changedColumns['comment_float_0'] = new ColumnDiff(
-            'comment_float_0',
-            new Column('comment_double_0', Type::getType(Types::DECIMAL), ['comment' => 'Double for real!']),
-        );
+        $tableDiff->renamedColumns['comment_float_0']
+            = new Column('comment_double_0', Type::getType(Types::DECIMAL), ['comment' => 'Double for real!']);
 
         // Add comment to non-commented column.
         $tableDiff->changedColumns['id'] = new ColumnDiff(
@@ -993,7 +990,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $tableDiff->changedColumns['comment_with_string_literal_char'] = new ColumnDiff(
             'comment_with_string_literal_char',
             new Column('comment_with_string_literal_char', Type::getType(Types::STRING), ['comment' => "'"]),
-            ['comment', 'type'],
+            ['comment'],
             new Column('comment_with_string_literal_char', Type::getType(Types::ARRAY), ['comment' => "O'Reilly"]),
         );
 
@@ -1003,7 +1000,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         self::assertEquals(
             [
                 // Renamed columns.
-                "EXEC sp_rename 'mytable.comment_float_0', 'comment_double_0', 'COLUMN'",
+                "sp_rename 'mytable.comment_float_0', 'comment_double_0', 'COLUMN'",
 
                 // Added columns.
                 'ALTER TABLE mytable ADD added_comment_none INT NOT NULL',
@@ -1025,7 +1022,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                 'ALTER TABLE mytable ALTER COLUMN [comment_quoted] VARCHAR(MAX) NOT NULL',
                 'ALTER TABLE mytable ALTER COLUMN [create] VARCHAR(MAX) NOT NULL',
                 'ALTER TABLE mytable ALTER COLUMN commented_type INT NOT NULL',
-                'ALTER TABLE mytable ALTER COLUMN comment_with_string_literal_char NVARCHAR(255) NOT NULL',
+
                 // Added columns.
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
                     . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_integer_0",
@@ -1242,15 +1239,15 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     protected function getQuotedAlterTableRenameColumnSQL(): array
     {
         return [
-            "EXEC sp_rename 'mytable.unquoted1', 'unquoted', 'COLUMN'",
-            "EXEC sp_rename 'mytable.unquoted2', '[where]', 'COLUMN'",
-            "EXEC sp_rename 'mytable.unquoted3', '[foo]', 'COLUMN'",
-            "EXEC sp_rename 'mytable.[create]', 'reserved_keyword', 'COLUMN'",
-            "EXEC sp_rename 'mytable.[table]', '[from]', 'COLUMN'",
-            "EXEC sp_rename 'mytable.[select]', '[bar]', 'COLUMN'",
-            "EXEC sp_rename 'mytable.[quoted1]', 'quoted', 'COLUMN'",
-            "EXEC sp_rename 'mytable.[quoted2]', '[and]', 'COLUMN'",
-            "EXEC sp_rename 'mytable.[quoted3]', '[baz]', 'COLUMN'",
+            "sp_rename 'mytable.unquoted1', 'unquoted', 'COLUMN'",
+            "sp_rename 'mytable.unquoted2', '[where]', 'COLUMN'",
+            "sp_rename 'mytable.unquoted3', '[foo]', 'COLUMN'",
+            "sp_rename 'mytable.[create]', 'reserved_keyword', 'COLUMN'",
+            "sp_rename 'mytable.[table]', '[from]', 'COLUMN'",
+            "sp_rename 'mytable.[select]', '[bar]', 'COLUMN'",
+            "sp_rename 'mytable.quoted1', 'quoted', 'COLUMN'",
+            "sp_rename 'mytable.quoted2', '[and]', 'COLUMN'",
+            "sp_rename 'mytable.quoted3', '[baz]', 'COLUMN'",
         ];
     }
 
@@ -1430,6 +1427,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                     "CONSTRAINT DF_6B2BD609_4AD86123 DEFAULT 'foo'",
                     'ALTER TABLE mytable DROP COLUMN removecolumn',
                     'ALTER TABLE mytable DROP CONSTRAINT DF_6B2BD609_9BADD926',
+                    'ALTER TABLE mytable ALTER COLUMN mycolumn NVARCHAR(255) NOT NULL',
                     "ALTER TABLE mytable ADD CONSTRAINT DF_6B2BD609_9BADD926 DEFAULT 'bar' FOR mycolumn",
                 ],
             ],
@@ -1453,6 +1451,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                     "CONSTRAINT DF_6B2BD609_4AD86123 DEFAULT 'foo'",
                     'ALTER TABLE [mytable] DROP COLUMN [removecolumn]',
                     'ALTER TABLE [mytable] DROP CONSTRAINT DF_6B2BD609_9BADD926',
+                    'ALTER TABLE [mytable] ALTER COLUMN [mycolumn] NVARCHAR(255) NOT NULL',
                     "ALTER TABLE [mytable] ADD CONSTRAINT DF_6B2BD609_9BADD926 DEFAULT 'bar' FOR [mycolumn]",
                 ],
             ],
@@ -1476,6 +1475,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                     "CONSTRAINT DF_F6298F46_FD1A73E7 DEFAULT 'foo'",
                     'ALTER TABLE [table] DROP COLUMN [drop]',
                     'ALTER TABLE [table] DROP CONSTRAINT DF_F6298F46_4BF2EAC0',
+                    'ALTER TABLE [table] ALTER COLUMN [select] NVARCHAR(255) NOT NULL',
                     "ALTER TABLE [table] ADD CONSTRAINT DF_F6298F46_4BF2EAC0 DEFAULT 'bar' FOR [select]",
                 ],
             ],
@@ -1499,6 +1499,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                     "CONSTRAINT DF_F6298F46_FD1A73E7 DEFAULT 'foo'",
                     'ALTER TABLE [table] DROP COLUMN [drop]',
                     'ALTER TABLE [table] DROP CONSTRAINT DF_F6298F46_4BF2EAC0',
+                    'ALTER TABLE [table] ALTER COLUMN [select] NVARCHAR(255) NOT NULL',
                     "ALTER TABLE [table] ADD CONSTRAINT DF_F6298F46_4BF2EAC0 DEFAULT 'bar' FOR [select]",
                 ],
             ],
@@ -1516,7 +1517,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function getAlterTableRenameColumnSQL(): array
     {
         return [
-            "EXEC sp_rename 'foo.bar', 'baz', 'COLUMN'",
+            "sp_rename 'foo.bar', 'baz', 'COLUMN'",
             'ALTER TABLE foo DROP CONSTRAINT DF_8C736521_76FF8CAA',
             'ALTER TABLE foo ADD CONSTRAINT DF_8C736521_78240498 DEFAULT 666 FOR baz',
         ];

--- a/tests/Platforms/SqlitePlatformTest.php
+++ b/tests/Platforms/SqlitePlatformTest.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -334,8 +333,7 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
 
         $tableDiff                          = new TableDiff('test');
         $tableDiff->fromTable               = $table;
-        $newCol                             = new Column('data', Type::getType(Types::STRING));
-        $tableDiff->changedColumns['value'] = new ColumnDiff('value', $newCol);
+        $tableDiff->renamedColumns['value'] = new Column('data', Type::getType(Types::STRING));
 
         $this->expectException(Exception::class);
         $this->platform->getAlterTableSQL($tableDiff);
@@ -407,14 +405,8 @@ class SqlitePlatformTest extends AbstractPlatformTestCase
         $diff                           = new TableDiff('user');
         $diff->fromTable                = $table;
         $diff->newName                  = 'client';
-        $diff->changedColumns['id']     = new ColumnDiff(
-            'id',
-            new Column('key', Type::getType(Types::INTEGER), []),
-        );
-        $diff->changedColumns['post']   = new ColumnDiff(
-            'post',
-            new Column('comment', Type::getType(Types::INTEGER), []),
-        );
+        $diff->renamedColumns['id']     = new Column('key', Type::getType(Types::INTEGER), []);
+        $diff->renamedColumns['post']   = new Column('comment', Type::getType(Types::INTEGER), []);
         $diff->removedColumns['parent'] = new Column('parent', Type::getType(Types::INTEGER), []);
         $diff->removedIndexes['index1'] = $table->getIndex('index1');
 

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -261,12 +261,12 @@ class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
 
-        self::assertCount(1, $tableDiff->getRenamedColumns());
-        self::assertArrayHasKey('datecolumn1', $tableDiff->getRenamedColumns());
-        self::assertCount(1, $tableDiff->getAddedColumns());
+        self::assertCount(1, $tableDiff->renamedColumns);
+        self::assertArrayHasKey('datecolumn1', $tableDiff->renamedColumns);
+        self::assertCount(1, $tableDiff->addedColumns);
         self::assertArrayHasKey('new_datecolumn2', $tableDiff->addedColumns);
-        self::assertCount(0, $tableDiff->getDroppedColumns());
-        self::assertCount(0, $tableDiff->getModifiedColumns());
+        self::assertCount(0, $tableDiff->removedColumns);
+        self::assertCount(0, $tableDiff->changedColumns);
     }
 
     public function testCompareRemovedIndex(): void
@@ -714,10 +714,10 @@ class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
         self::assertNotFalse($tableDiff);
 
-        self::assertCount(0, $tableDiff->getAddedColumns());
-        self::assertCount(0, $tableDiff->getDroppedColumns());
-        self::assertArrayHasKey('foo', $tableDiff->changedColumns);
-        self::assertEquals('bar', $tableDiff->changedColumns['foo']->getNewColumn()->getName());
+        self::assertCount(0, $tableDiff->addedColumns);
+        self::assertCount(0, $tableDiff->removedColumns);
+        self::assertArrayHasKey('foo', $tableDiff->renamedColumns);
+        self::assertEquals('bar', $tableDiff->renamedColumns['foo']->getName());
     }
 
     /**
@@ -742,7 +742,7 @@ class AbstractComparatorTestCase extends TestCase
         self::assertCount(2, $tableDiff->removedColumns);
         self::assertArrayHasKey('foo', $tableDiff->removedColumns);
         self::assertArrayHasKey('bar', $tableDiff->removedColumns);
-        self::assertCount(0, $tableDiff->getRenamedColumns());
+        self::assertCount(0, $tableDiff->renamedColumns);
     }
 
     public function testDetectRenameIndex(): void
@@ -825,7 +825,7 @@ class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->diffTable($table, $newtable);
 
         self::assertInstanceOf(TableDiff::class, $tableDiff);
-        self::assertEquals(['twitterId', 'displayName'], array_keys($tableDiff->getRenamedColumns()));
+        self::assertEquals(['twitterId', 'displayName'], array_keys($tableDiff->renamedColumns));
         self::assertEquals(['logged_in_at'], array_keys($tableDiff->addedColumns));
         self::assertCount(0, $tableDiff->removedColumns);
     }

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -3,13 +3,9 @@
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
-use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -31,65 +27,6 @@ class TableDiffTest extends TestCase
         $tableDiff = new TableDiff('foo');
 
         self::assertEquals(new Identifier('foo'), $tableDiff->getName($this->platform));
-    }
-
-    public function testRenamedColumnDeprecationLayer(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6080');
-
-        /** @psalm-suppress InvalidArgument */
-        $diff = new TableDiff(
-            'foo',
-            [],
-            [
-                new ColumnDiff(
-                    'foo',
-                    new Column('foo', Type::getType(Types::INTEGER)),
-                    ['type'],
-                    new Column('foo', Type::getType(Types::BIGINT)),
-                ),
-                new ColumnDiff(
-                    'ba',
-                    new Column('ba', Type::getType(Types::INTEGER)),
-                    ['type'],
-                    new Column('ba', Type::getType(Types::BIGINT)),
-                ),
-            ],
-            [],
-            [],
-            [],
-            [],
-            new Table('foo'),
-            [],
-            [],
-            [],
-            [
-                'foo' => new Column('baz', Type::getType(Types::INTEGER)),
-                'bar' => new Column('renamed', Type::getType(Types::INTEGER)),
-            ],
-            [],
-        );
-
-        self::assertCount(3, $diff->getChangedColumns());
-        self::assertCount(2, $diff->getModifiedColumns());
-        self::assertEquals('foo', $diff->getChangedColumns()[0]->getOldColumnName()->getName());
-        self::assertEquals('baz', $diff->getChangedColumns()[0]->getNewColumn()->getName());
-        self::assertTrue($diff->getChangedColumns()[0]->hasTypeChanged());
-        self::assertEquals(Type::getType(Types::INTEGER), $diff->getChangedColumns()[0]->getNewColumn()->getType());
-        self::assertEquals('bar', $diff->getChangedColumns()[2]->getOldColumnName()->getName());
-        self::assertEquals('renamed', $diff->getChangedColumns()[2]->getNewColumn()->getName());
-
-        self::assertCount(2, $diff->renamedColumns);
-
-        $diff->renamedColumns = ['old_name' => new Column('new_name', Type::getType(Types::INTEGER))];
-        self::assertCount(4, $diff->getChangedColumns());
-        self::assertCount(3, $diff->renamedColumns);
-
-        // Test that __isset __set and __get have the default php behavior
-        @$diff->foo = 'baz';
-        self::assertTrue(isset($diff->renamedColumns));
-        self::assertTrue(isset($diff->foo));
-        self::assertEquals('baz', $diff->foo);
     }
 
     public function testPrefersNameFromTableObject(): void

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use LogicException;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
@@ -49,52 +48,6 @@ class TableTest extends TestCase
         self::assertInstanceOf(Column::class, $table->getColumn('bar'));
 
         self::assertCount(2, $table->getColumns());
-    }
-
-    public function testRenameColumn(): void
-    {
-        $typeStr   = Type::getType(Types::STRING);
-        $typeTxt   = Type::getType(Types::TEXT);
-        $columns   = [];
-        $columns[] = new Column('foo', $typeStr);
-        $table     = new Table('foo', $columns, [], []);
-
-        self::assertFalse($table->hasColumn('bar'));
-        self::assertTrue($table->hasColumn('foo'));
-
-        $column = $table->renameColumn('foo', 'bar');
-        $column->setType($typeTxt);
-        self::assertTrue($table->hasColumn('bar'), 'Should now have bar column');
-        self::assertFalse($table->hasColumn('foo'), 'Should not have foo column anymore');
-        self::assertCount(1, $table->getColumns());
-
-        self::assertEquals(['bar' => 'foo'], $table->getRenamedColumns());
-        $table->renameColumn('bar', 'baz');
-
-        self::assertTrue($table->hasColumn('baz'), 'Should now have baz column');
-        self::assertFalse($table->hasColumn('bar'), 'Should not have bar column anymore');
-        self::assertEquals(['baz' => 'foo'], $table->getRenamedColumns());
-        self::assertCount(1, $table->getColumns());
-    }
-
-    public function testRenameColumnException(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Attempt to rename column "foo.baz" to the same name.');
-
-        $table = new Table('foo');
-        $table->renameColumn('baz', '`BaZ`');
-    }
-
-    public function testRenameColumnLoop(): void
-    {
-        $table = new Table('foo');
-        $table->addColumn('baz', Types::INTEGER);
-        $table->renameColumn('baz', '`foo`');
-        self::assertCount(1, $table->getRenamedColumns());
-        $table->renameColumn('foo', 'Baz');
-        self::assertCount(1, $table->getColumns());
-        self::assertCount(0, $table->getRenamedColumns());
     }
 
     public function testColumnsCaseInsensitive(): void


### PR DESCRIPTION
This PR reverts PR #6080 and its follow-up #6273. Merging this feature up to 4.0 is more difficult that I anticipated and I don't want to postpone the release of 3.8 and 4.0 any further.

@Tofandel: Please take all the time that you need to redo your PR on 4.x. As soon as you did that, I'd be more than happy to restore this change and do another 3.x feature release.