### PR TITLE
Add safety check about cache value

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -37,6 +37,7 @@ use function assert;
 use function count;
 use function get_class;
 use function implode;
+use function is_array;
 use function is_int;
 use function is_string;
 use function key;
@@ -1137,6 +1138,10 @@ class Connection
 
         if ($item->isHit()) {
             $value = $item->get();
+            if (! is_array($value)) {
+                $value = [];
+            }
+
             if (isset($value[$realKey])) {
                 return new Result(new ArrayResult($value[$realKey]), $this);
             }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

I recently got an exception:
```
Uncaught PHP Exception TypeError: "Cannot access offset of type string on string" at Connection.php line 1149
```
Connection.php:1149

I'm not sure how I get this error (certainly an issue with my cache), but I think doctrine/dbal shouldn't trust 
```
$value = $item->get();
```
to be an array and add a safety check, just in case the cache is corrupt.
