### PR TITLE
Move type coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |      [![GitHub Actions][GA 5.0 image]][GA 5.0]      |      [![GitHub Actions][GA 4.1 image]][GA 4.1]      |      [![GitHub Actions][GA 4.0 image]][GA 4.0]      |      [![GitHub Actions][GA 3.9 image]][GA 3.9]      |      [![GitHub Actions][GA 3.8 image]][GA 3.8]      |
 |   [![AppVeyor][AppVeyor 5.0 image]][AppVeyor 5.0]   |   [![AppVeyor][AppVeyor 4.1 image]][AppVeyor 4.1]   |   [![AppVeyor][AppVeyor 4.0 image]][AppVeyor 4.0]   |   [![AppVeyor][AppVeyor 3.9 image]][AppVeyor 3.9]   |   [![AppVeyor][AppVeyor 3.8 image]][AppVeyor 3.8]   |
 | [![Code Coverage][Coverage 5.0 image]][CodeCov 5.0] | [![Code Coverage][Coverage 4.1 image]][CodeCov 4.1] | [![Code Coverage][Coverage 4.0 image]][CodeCov 4.0] | [![Code Coverage][Coverage 3.9 image]][CodeCov 3.9] | [![Code Coverage][Coverage 3.8 image]][CodeCov 3.8] |
-|                         N/A                         |                         N/A                         |                         N/A                         |                         N/A                         | [![Type Coverage][TypeCov 3.8 image]][TypeCov 3.8]  |
+|                         N/A                         |                         N/A                         |  [![Type Coverage][TypeCov image]][TypeCov]         |                         N/A                         |                                                     |
 
 Powerful ***D***ata***B***ase ***A***bstraction ***L***ayer with many features for database schema introspection and schema management.
 
@@ -38,6 +38,8 @@ Powerful ***D***ata***B***ase ***A***bstraction ***L***ayer with many features f
   [AppVeyor 4.0 image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/4.0.x?svg=true
   [GA 4.0]: https://github.com/doctrine/dbal/actions?query=workflow%3A%22Continuous+Integration%22+branch%3A4.0.x
   [GA 4.0 image]: https://github.com/doctrine/dbal/workflows/Continuous%20Integration/badge.svg?branch=4.0.x
+  [TypeCov]: https://shepherd.dev/github/doctrine/dbal
+  [TypeCov image]: https://shepherd.dev/github/doctrine/dbal/coverage.svg
 
   [Coverage 3.9 image]: https://codecov.io/gh/doctrine/dbal/branch/3.9.x/graph/badge.svg
   [3.9]: https://github.com/doctrine/dbal/tree/3.9.x
@@ -54,5 +56,3 @@ Powerful ***D***ata***B***ase ***A***bstraction ***L***ayer with many features f
   [AppVeyor 3.8 image]: https://ci.appveyor.com/api/projects/status/i88kitq8qpbm0vie/branch/3.8.x?svg=true
   [GA 3.8]: https://github.com/doctrine/dbal/actions?query=workflow%3A%22Continuous+Integration%22+branch%3A3.8.x
   [GA 3.8 image]: https://github.com/doctrine/dbal/workflows/Continuous%20Integration/badge.svg?branch=3.8.x
-  [TypeCov 3.8]: https://shepherd.dev/github/doctrine/dbal
-  [TypeCov 3.8 image]: https://shepherd.dev/github/doctrine/dbal/coverage.svg


### PR DESCRIPTION
It describes the default branch, which is now 4.0. Also, since there is no support for several branches, let's remove the version number from the links.