### PR TITLE
AbstractPlatform: allow any string in interval for date interval expression

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1727,6 +1727,17 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Generates the SQL expression which represents the given date interval multiplied by a number
+     *
+     * @param string $interval   SQL expression describing the interval value
+     * @param int    $multiplier Interval multiplier
+     */
+    protected function multiplyInterval(string $interval, int $multiplier): string
+    {
+        return sprintf('(%s * %d)', $interval, $multiplier);
+    }
+
+    /**
      * Returns the SQL bit AND comparison expression.
      *
      * @param string $value1

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1342,8 +1342,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given seconds to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $seconds
+     * @param string     $date
+     * @param int|string $seconds
      *
      * @return string
      *
@@ -1365,8 +1365,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given seconds from a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $seconds
+     * @param string     $date
+     * @param int|string $seconds
      *
      * @return string
      *
@@ -1388,8 +1388,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given minutes to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $minutes
+     * @param string     $date
+     * @param int|string $minutes
      *
      * @return string
      *
@@ -1411,8 +1411,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given minutes from a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $minutes
+     * @param string     $date
+     * @param int|string $minutes
      *
      * @return string
      *
@@ -1434,8 +1434,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given hours to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $hours
+     * @param string     $date
+     * @param int|string $hours
      *
      * @return string
      *
@@ -1457,8 +1457,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given hours to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $hours
+     * @param string     $date
+     * @param int|string $hours
      *
      * @return string
      *
@@ -1480,8 +1480,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given days to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $days
+     * @param string     $date
+     * @param int|string $days
      *
      * @return string
      *
@@ -1503,8 +1503,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given days to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $days
+     * @param string     $date
+     * @param int|string $days
      *
      * @return string
      *
@@ -1526,8 +1526,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given weeks to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $weeks
+     * @param string     $date
+     * @param int|string $weeks
      *
      * @return string
      *
@@ -1549,8 +1549,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given weeks from a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $weeks
+     * @param string     $date
+     * @param int|string $weeks
      *
      * @return string
      *
@@ -1572,8 +1572,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given months to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $months
+     * @param string     $date
+     * @param int|string $months
      *
      * @return string
      *
@@ -1595,8 +1595,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given months to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $months
+     * @param string     $date
+     * @param int|string $months
      *
      * @return string
      *
@@ -1618,8 +1618,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given quarters to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $quarters
+     * @param string     $date
+     * @param int|string $quarters
      *
      * @return string
      *
@@ -1641,8 +1641,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given quarters from a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $quarters
+     * @param string     $date
+     * @param int|string $quarters
      *
      * @return string
      *
@@ -1664,8 +1664,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to add the number of given years to a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $years
+     * @param string     $date
+     * @param int|string $years
      *
      * @return string
      *
@@ -1687,8 +1687,8 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL to subtract the number of given years from a date.
      *
-     * @param string             $date
-     * @param int|numeric-string $years
+     * @param string     $date
+     * @param int|string $years
      *
      * @return string
      *
@@ -1710,11 +1710,11 @@ abstract class AbstractPlatform
     /**
      * Returns the SQL for a date arithmetic expression.
      *
-     * @param string             $date     The column or literal representing a date
+     * @param string     $date     The column or literal representing a date
      *                                     to perform the arithmetic operation on.
-     * @param string             $operator The arithmetic operator (+ or -).
-     * @param int|numeric-string $interval The interval that shall be calculated into the date.
-     * @param string             $unit     The unit of the interval that shall be calculated into the date.
+     * @param string     $operator The arithmetic operator (+ or -).
+     * @param int|string $interval The interval that shall be calculated into the date.
+     * @param string     $unit     The unit of the interval that shall be calculated into the date.
      *                                     One of the {@see DateIntervalUnit} constants.
      *
      * @return string

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -293,13 +293,13 @@ class DB2Platform extends AbstractPlatform
     {
         switch ($unit) {
             case DateIntervalUnit::WEEK:
-                $interval *= 7;
-                $unit      = DateIntervalUnit::DAY;
+                $interval = $this->multiplyInterval((string) $interval, 7);
+                $unit     = DateIntervalUnit::DAY;
                 break;
 
             case DateIntervalUnit::QUARTER:
-                $interval *= 3;
-                $unit      = DateIntervalUnit::MONTH;
+                $interval = $this->multiplyInterval((string) $interval, 3);
+                $unit     = DateIntervalUnit::MONTH;
                 break;
         }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -114,11 +114,11 @@ class OraclePlatform extends AbstractPlatform
             case DateIntervalUnit::YEAR:
                 switch ($unit) {
                     case DateIntervalUnit::QUARTER:
-                        $interval *= 3;
+                        $interval = $this->multiplyInterval((string) $interval, 3);
                         break;
 
                     case DateIntervalUnit::YEAR:
-                        $interval *= 12;
+                        $interval = $this->multiplyInterval((string) $interval, 12);
                         break;
                 }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -136,8 +136,8 @@ class PostgreSQLPlatform extends AbstractPlatform
     protected function getDateArithmeticIntervalExpression($date, $operator, $interval, $unit)
     {
         if ($unit === DateIntervalUnit::QUARTER) {
-            $interval *= 3;
-            $unit      = DateIntervalUnit::MONTH;
+            $interval = $this->multiplyInterval((string) $interval, 3);
+            $unit     = DateIntervalUnit::MONTH;
         }
 
         return '(' . $date . ' ' . $operator . ' (' . $interval . " || ' " . $unit . "')::interval)";

--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -159,13 +159,13 @@ class SqlitePlatform extends AbstractPlatform
 
         switch ($unit) {
             case DateIntervalUnit::WEEK:
-                $interval *= 7;
-                $unit      = DateIntervalUnit::DAY;
+                $interval = $this->multiplyInterval((string) $interval, 7);
+                $unit     = DateIntervalUnit::DAY;
                 break;
 
             case DateIntervalUnit::QUARTER:
-                $interval *= 3;
-                $unit      = DateIntervalUnit::MONTH;
+                $interval = $this->multiplyInterval((string) $interval, 3);
+                $unit     = DateIntervalUnit::MONTH;
                 break;
         }
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -321,9 +321,12 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertEquals("'1987/05/02' + 12 HOUR", $this->platform->getDateAddHourExpression("'1987/05/02'", 12));
         self::assertEquals("'1987/05/02' + 2 MINUTE", $this->platform->getDateAddMinutesExpression("'1987/05/02'", 2));
         self::assertEquals("'1987/05/02' + 102 MONTH", $this->platform->getDateAddMonthExpression("'1987/05/02'", 102));
-        self::assertEquals("'1987/05/02' + 15 MONTH", $this->platform->getDateAddQuartersExpression("'1987/05/02'", 5));
+        self::assertEquals(
+            "'1987/05/02' + (5 * 3) MONTH",
+            $this->platform->getDateAddQuartersExpression("'1987/05/02'", 5),
+        );
         self::assertEquals("'1987/05/02' + 1 SECOND", $this->platform->getDateAddSecondsExpression("'1987/05/02'", 1));
-        self::assertEquals("'1987/05/02' + 21 DAY", $this->platform->getDateAddWeeksExpression("'1987/05/02'", 3));
+        self::assertEquals("'1987/05/02' + (3 * 7) DAY", $this->platform->getDateAddWeeksExpression("'1987/05/02'", 3));
         self::assertEquals("'1987/05/02' + 10 YEAR", $this->platform->getDateAddYearsExpression("'1987/05/02'", 10));
 
         self::assertEquals(
@@ -335,9 +338,12 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertEquals("'1987/05/02' - 12 HOUR", $this->platform->getDateSubHourExpression("'1987/05/02'", 12));
         self::assertEquals("'1987/05/02' - 2 MINUTE", $this->platform->getDateSubMinutesExpression("'1987/05/02'", 2));
         self::assertEquals("'1987/05/02' - 102 MONTH", $this->platform->getDateSubMonthExpression("'1987/05/02'", 102));
-        self::assertEquals("'1987/05/02' - 15 MONTH", $this->platform->getDateSubQuartersExpression("'1987/05/02'", 5));
+        self::assertEquals(
+            "'1987/05/02' - (5 * 3) MONTH",
+            $this->platform->getDateSubQuartersExpression("'1987/05/02'", 5),
+        );
         self::assertEquals("'1987/05/02' - 1 SECOND", $this->platform->getDateSubSecondsExpression("'1987/05/02'", 1));
-        self::assertEquals("'1987/05/02' - 21 DAY", $this->platform->getDateSubWeeksExpression("'1987/05/02'", 3));
+        self::assertEquals("'1987/05/02' - (3 * 7) DAY", $this->platform->getDateSubWeeksExpression("'1987/05/02'", 3));
         self::assertEquals("'1987/05/02' - 10 YEAR", $this->platform->getDateSubYearsExpression("'1987/05/02'", 10));
         self::assertEquals(' WITH RR USE AND KEEP UPDATE LOCKS', $this->platform->getForUpdateSQL());
 


### PR DESCRIPTION


<!-- Fill in the relevant information below to help triage your pull request. -->
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

This change allows these methods to be called with just a `string` in ORM 3.0.x. See https://github.com/doctrine/orm/pull/11243#issuecomment-1936232509

DBAL 4.0.x already has `string` there.

Also I'd like to note that I noticed that methods `getDateAddQuartersExpression` and `getDateSubQuartersExpression` aren't called from ORM. Shouldn't support for them be added?


