### PR TITLE
Added native UUID field type for MariaDB1070+

### DIFF
--- a/src/Platforms/MariaDB1070Platform.php
+++ b/src/Platforms/MariaDB1070Platform.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.7 (10.7.0 GA) database platform.
+ */
+class MariaDB1070Platform extends MariaDB1060Platform
+{
+    protected function initializeDoctrineTypeMappings(): void
+    {
+        parent::initializeDoctrineTypeMappings();
+
+        $this->doctrineTypeMapping['uuid'] = Types::GUID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGuidTypeDeclarationSQL(array $column): string
+    {
+        return 'UUID';
+    }
+}


### PR DESCRIPTION
#### Summary

MariaDB 10.7.0+ implements a native UUID field type (Guid) that works in similar way of Postgres UUID.

+Info: https://mariadb.com/kb/en/uuid-data-type/