### PR TITLE
fix(DB2): Instance of DateTimeType cannot be converted to string

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
@@ -855,7 +856,7 @@ class DB2Platform extends AbstractPlatform
         }
 
         if (! empty($column['version'])) {
-            if ((string) $column['type'] !== 'DateTime') {
+            if ($column['type'] instanceof DateTimeType) {
                 $column['default'] = '1';
             }
         }


### PR DESCRIPTION
Issue found in https://github.com/doctrine/dbal/pull/6280/files#r1467725285

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

`$column['type']` is an instance of a Dbal Type which cannot be converted to a string (because they do not have a __toString method

No idea when this should occur or how to write a test for it, but I just know this piece of code throws an error when it does run