### PR TITLE
Fix SQLite temp table name must not contain dot

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -1150,7 +1150,12 @@ class SqlitePlatform extends AbstractPlatform
         $sql      = [];
         $tableSql = [];
         if (! $this->onSchemaAlterTable($diff, $tableSql)) {
-            $dataTable = new Table('__temp__' . $table->getName());
+            $tableName = $table->getName();
+            if (strpos($tableName, '.') !== false) {
+                [, $tableName] = explode('.', $tableName, 2);
+            }
+
+            $dataTable = new Table('__temp__' . $tableName);
 
             $newTable = new Table(
                 $table->getQuotedName($this),


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 

#### Summary

Fix invalid SQL generated when table with schema is given. As it was invalid, this PR is fully BC in sense of the exact generated SQL.