### PR TITLE
Added native UUID field type for MariaDB1070+

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
 use Doctrine\DBAL\Platforms\MariaDB1052Platform;
 use Doctrine\DBAL\Platforms\MariaDB1060Platform;
+use Doctrine\DBAL\Platforms\MariaDB1070Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -35,6 +36,10 @@ abstract class AbstractMySQLDriver implements Driver
         $version = $versionProvider->getServerVersion();
         if (stripos($version, 'mariadb') !== false) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '10.7.0', '>=')) {
+                return new MariaDB1070Platform();
+            }
+
             if (version_compare($mariaDbVersion, '10.6.0', '>=')) {
                 return new MariaDB1060Platform();
             }

--- a/src/Platforms/MariaDB1070Platform.php
+++ b/src/Platforms/MariaDB1070Platform.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.7 (10.7.0 GA) database platform.
+ */
+class MariaDB1070Platform extends MariaDB1060Platform
+{
+    protected function initializeDoctrineTypeMappings(): void
+    {
+        parent::initializeDoctrineTypeMappings();
+
+        $this->doctrineTypeMapping['uuid'] = Types::GUID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGuidTypeDeclarationSQL(array $column): string
+    {
+        return 'UUID';
+    }
+}

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDB1052Platform;
 use Doctrine\DBAL\Platforms\MariaDB1060Platform;
+use Doctrine\DBAL\Platforms\MariaDB1070Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -41,7 +42,9 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['10.2.8-MariaDB-1~lenny-log', MariaDBPlatform::class],
             ['10.5.2-MariaDB-1~lenny-log', MariaDB1052Platform::class],
             ['10.6.0-MariaDB-1~lenny-log', MariaDB1060Platform::class],
-            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDB1060Platform::class],
+            ['10.7.0-MariaDB-1~lenny-log', MariaDB1070Platform::class],
+            ['10.11.7-MariaDB-1:10.11.7+maria~ubu2204', MariaDB1070Platform::class],
+            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDB1070Platform::class],
         ];
     }
 

--- a/tests/Functional/Platform/AlterUuidColumnTest.php
+++ b/tests/Functional/Platform/AlterUuidColumnTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\GuidType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+use function sprintf;
+
+class AlterUuidColumnTest extends FunctionalTestCase
+{
+    public const DEFAULT_UUID4 = '85626c2f-2f63-4120-b814-ecc085eaaba0';
+
+    public function testAlterToUuidColumn(): void
+    {
+        $table = static::prepareLegacyUuidTable('simple_uuid_table', 'id');
+        $table->setPrimaryKey(['id']);
+        $this->dropAndCreateTable($table);
+
+        $this->connection->executeStatement(
+            sprintf(
+                'INSERT INTO simple_uuid_table VALUES (%s)',
+                static::DEFAULT_UUID4,
+            ),
+        );
+
+        $table->getColumn('id')
+            ->setType(Type::getType(Types::GUID));
+
+        $sm   = $this->connection->createSchemaManager();
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('simple_uuid_table'), $table);
+
+        $sm->alterTable($diff);
+
+        $table = $sm->introspectTable('simple_uuid_table');
+
+        self::assertInstanceOf(GuidType::class, $table->getColumn('id')->getType());
+
+        // Verify data integrity
+        $resultUuid = $this->connection
+            ->executeQuery('SELECT id from simple_uuid_table')
+            ->fetchOne();
+
+        static::assertEquals(static::DEFAULT_UUID4, $resultUuid);
+    }
+
+    public function testAlterUuidInForeignRelation(): void
+    {
+        $parentTable = static::prepareLegacyUuidTable('parent_uuid_table', 'id');
+        $parentTable->setPrimaryKey(['id']);
+        $this->dropAndCreateTable($parentTable);
+
+        $this->connection->executeStatement(
+            sprintf(
+                'INSERT INTO parent_uuid_table VALUES (%s)',
+                static::DEFAULT_UUID4,
+            ),
+        );
+
+        $childTable = static::prepareLegacyUuidTable('child_uuid_table', 'parent_uuid_id');
+        $childTable->addColumn('id', Types::INTEGER)->setAutoincrement(true);
+        $childTable->setPrimaryKey(['id']);
+
+        $childTable = static::prepareForeignKey($childTable, 'parent_uuid');
+        $this->dropAndCreateTable($childTable);
+
+        $this->connection->executeStatement(
+            sprintf(
+                'INSERT INTO child_uuid_table VALUE(`parent_uuid_id`) VALUES (%s)',
+                static::DEFAULT_UUID4,
+            ),
+        );
+
+        $childTable->dropIndex('fk_parent_uuid_id');
+
+        $parentTable->getColumn('id')
+            ->setType(Type::getType(Types::GUID));
+
+        $sm   = $this->connection->createSchemaManager();
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('parent_uuid_table'), $parentTable);
+
+        $sm->alterTable($diff);
+
+        $childTable->getColumn('parent_uuid_id')
+            ->setType(Type::getType(Types::GUID));
+
+        $childTable = static::prepareForeignKey($childTable, 'parent_uuid');
+
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('child_uuid_table'), $childTable);
+
+        $sm->alterTable($diff);
+
+        self::assertInstanceOf(GuidType::class, $parentTable->getColumn('id')->getType());
+        self::assertInstanceOf(GuidType::class, $childTable->getColumn('parent_uuid_id')->getType());
+
+        // Verify data integrity
+        $resultUuid = $this->connection
+            ->executeQuery('SELECT id from parent_uuid_table')
+            ->fetchOne();
+
+        static::assertEquals(static::DEFAULT_UUID4, $resultUuid);
+
+        $resultUuid = $this->connection
+            ->executeQuery('SELECT id from child_uuid_table')
+            ->fetchOne();
+
+        static::assertEquals(static::DEFAULT_UUID4, $resultUuid);
+    }
+
+    /**
+     * Create legacy Uuid table.
+     */
+    protected static function prepareLegacyUuidTable(string $tableName, string $uuidField): Table
+    {
+        $table = new Table($tableName);
+        $table->addColumn($uuidField, 'char', [
+            'length' => 36,
+            'notnull' => false,
+        ]);
+
+        return $table;
+    }
+
+    protected static function prepareForeignKey(Table $table, string $foreign): Table
+    {
+        $table->addForeignKeyConstraint(
+            $foreign . '_table',
+            [$foreign . '_id'],
+            ['id'],
+            [],
+            'fk_' . $foreign . '_id',
+        );
+
+        return $table;
+    }
+}

--- a/tests/Functional/Platform/AlterUuidColumnTest.php
+++ b/tests/Functional/Platform/AlterUuidColumnTest.php
@@ -16,6 +16,15 @@ class AlterUuidColumnTest extends FunctionalTestCase
 {
     public const DEFAULT_UUID4 = '85626c2f-2f63-4120-b814-ecc085eaaba0';
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!$this->connection->getDatabasePlatform()->hasDoctrineTypeMappingFor('uuid')) {
+            self::markTestSkipped("This test requires a platform that support native uuid");
+        }
+    }
+
     public function testAlterToUuidColumn(): void
     {
         $table = static::prepareLegacyUuidTable('simple_uuid_table', 'id');

--- a/tests/Functional/Platform/AlterUuidColumnTest.php
+++ b/tests/Functional/Platform/AlterUuidColumnTest.php
@@ -28,7 +28,6 @@ class AlterUuidColumnTest extends FunctionalTestCase
         self::markTestSkipped('This test requires MariDB 10.7 or newer');
     }
 
-
     public function testAlterToUuidColumn(): void
     {
         $table = static::prepareLegacyUuidTable('simple_uuid_table', 'id');

--- a/tests/Functional/Platform/AlterUuidColumnTest.php
+++ b/tests/Functional/Platform/AlterUuidColumnTest.php
@@ -89,7 +89,9 @@ class AlterUuidColumnTest extends FunctionalTestCase
             ),
         );
 
-        $childTable->removeForeignKey('fk_parent_uuid_id');
+        // Comparator should automatically remove the foreign key.
+        // $childTable->removeForeignKey('fk_parent_uuid_id');
+
         $diff = $sm->createComparator()
             ->compareTables($sm->introspectTable('child_uuid_table'), $childTable);
 

--- a/tests/Functional/Platform/AlterUuidColumnTest.php
+++ b/tests/Functional/Platform/AlterUuidColumnTest.php
@@ -21,9 +21,11 @@ class AlterUuidColumnTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        if (! $this->connection->getDatabasePlatform() instanceof MariaDB1070Platform) {
-            self::markTestSkipped('This test requires MariDB 10.7 or newer');
+        if ($this->connection->getDatabasePlatform() instanceof MariaDB1070Platform) {
+            return;
         }
+
+        self::markTestSkipped('This test requires MariDB 10.7 or newer');
     }
 
     public function testAlterToUuidColumn(): void
@@ -90,12 +92,14 @@ class AlterUuidColumnTest extends FunctionalTestCase
         );
 
         // Comparator should automatically remove the foreign key.
-        // $childTable->removeForeignKey('fk_parent_uuid_id');
+        /*
+        $childTable->removeForeignKey('fk_parent_uuid_id');
 
         $diff = $sm->createComparator()
             ->compareTables($sm->introspectTable('child_uuid_table'), $childTable);
 
         $sm->alterTable($diff);
+        */
 
         $parentTable->getColumn('id')
             ->setType(Type::getType(Types::GUID));
@@ -105,6 +109,7 @@ class AlterUuidColumnTest extends FunctionalTestCase
 
         $sm->alterTable($diff);
 
+        /*
         $childTable->getColumn('parent_uuid_id')
             ->setType(Type::getType(Types::GUID));
 
@@ -114,6 +119,7 @@ class AlterUuidColumnTest extends FunctionalTestCase
             ->compareTables($sm->introspectTable('child_uuid_table'), $childTable);
 
         $sm->alterTable($diff);
+        */
 
         self::assertInstanceOf(GuidType::class, $parentTable->getColumn('id')->getType());
         self::assertInstanceOf(GuidType::class, $childTable->getColumn('parent_uuid_id')->getType());
@@ -142,8 +148,8 @@ class AlterUuidColumnTest extends FunctionalTestCase
                 sprintf(
                     'CREATE TABLE `%s` (`%s` CHAR(36) NOT NULL)',
                     $tableName,
-                    $uuidField
-                )
+                    $uuidField,
+                ),
             );
 
         return $this->connection

--- a/tests/Functional/Platform/AlterUuidColumnTest.php
+++ b/tests/Functional/Platform/AlterUuidColumnTest.php
@@ -28,6 +28,7 @@ class AlterUuidColumnTest extends FunctionalTestCase
         self::markTestSkipped('This test requires MariDB 10.7 or newer');
     }
 
+
     public function testAlterToUuidColumn(): void
     {
         $table = static::prepareLegacyUuidTable('simple_uuid_table', 'id');
@@ -91,15 +92,12 @@ class AlterUuidColumnTest extends FunctionalTestCase
             ),
         );
 
-        // Comparator should automatically remove the foreign key.
-        /*
         $childTable->removeForeignKey('fk_parent_uuid_id');
 
         $diff = $sm->createComparator()
             ->compareTables($sm->introspectTable('child_uuid_table'), $childTable);
 
         $sm->alterTable($diff);
-        */
 
         $parentTable->getColumn('id')
             ->setType(Type::getType(Types::GUID));
@@ -109,7 +107,6 @@ class AlterUuidColumnTest extends FunctionalTestCase
 
         $sm->alterTable($diff);
 
-        /*
         $childTable->getColumn('parent_uuid_id')
             ->setType(Type::getType(Types::GUID));
 
@@ -119,7 +116,6 @@ class AlterUuidColumnTest extends FunctionalTestCase
             ->compareTables($sm->introspectTable('child_uuid_table'), $childTable);
 
         $sm->alterTable($diff);
-        */
 
         self::assertInstanceOf(GuidType::class, $parentTable->getColumn('id')->getType());
         self::assertInstanceOf(GuidType::class, $childTable->getColumn('parent_uuid_id')->getType());

--- a/tests/Platforms/MariaDB1070PlatformTest.php
+++ b/tests/Platforms/MariaDB1070PlatformTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDB1070Platform;
+
+class MariaDB1070PlatformTest extends MariaDB1052PlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MariaDB1070Platform();
+    }
+
+    public function testReturnsGuidTypeDeclarationSQL(): void
+    {
+        self::assertSame('UUID', $this->platform->getGuidTypeDeclarationSQL([]));
+    }
+}


### PR DESCRIPTION
I added the native UUID field type for MariaDB1070+ into the branch 4.1.x.

I also provided the following tests:
- Test that check column modification from char(36) (Legacy UUID) to native UUID.
- Test that check column modification using foreign key constraint (It requires drop foreign key).

The tests also check for data integrity after the column modification.
