### PR TITLE
Remove Type::canRequireSQLConversion from docs

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -848,19 +848,8 @@ Now we implement our ``Doctrine\DBAL\Types\Type`` instance:
 
 The job of Doctrine-DBAL is to transform your type into an SQL
 declaration. You can modify the SQL declaration Doctrine will produce.
-At first, to enable this feature, you must override the
-``canRequireSQLConversion`` method:
-
-::
-
-    <?php
-    public function canRequireSQLConversion()
-    {
-        return true;
-    }
-
-Then you override the ``convertToPhpValueSQL`` and
-``convertToDatabaseValueSQL`` methods :
+At first, you override the ``convertToPhpValueSQL`` and
+``convertToDatabaseValueSQL`` methods:
 
 ::
 
@@ -875,7 +864,7 @@ Then you override the ``convertToPhpValueSQL`` and
         return 'MyFunction('.$sqlExpr.')';
     }
 
-Now we have to register this type with the Doctrine Type system and
+Then you have to register this type with the Doctrine Type system and
 hook it into the database platform:
 
 ::


### PR DESCRIPTION

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

removed Type::canRequireSQLConversion() from documentation after it 
was deprecated in 3.3.x #5136 and removed in 4.4.0 #5143
