### PR TITLE
Add gssencmode option to connection string for PgSQL & PDO PgSQL driver

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -280,6 +280,8 @@ pdo_pgsql / pgsql
 -  ``sslcrl`` (string): specifies the filename of the SSL certificate
    revocation list (CRL).
    See `https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNECT-SSLCRL`
+-  ``gssencmode`` (string): Optional GSS-encrypted channel/GSSEncMode configuration.
+   See `https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE`
 -  ``application_name`` (string): Name of the application that is
    connecting to database. Optional. It will be displayed at ``pg_stat_activity``.
 

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -126,6 +126,10 @@ final class Driver extends AbstractPostgreSQLDriver
             $dsn .= 'application_name=' . $params['application_name'] . ';';
         }
 
+        if (isset($params['gssencmode'])) {
+            $dsn .= 'gssencmode=' . $params['gssencmode'] . ';';
+        }
+
         return $dsn;
     }
 }

--- a/src/Driver/PgSQL/Driver.php
+++ b/src/Driver/PgSQL/Driver.php
@@ -72,6 +72,7 @@ final class Driver extends AbstractPostgreSQLDriver
                 'user' => $params['user'] ?? null,
                 'password' => $params['password'] ?? null,
                 'sslmode' => $params['sslmode'] ?? null,
+                'gssencmode' => $params['gssencmode'] ?? null,
             ],
             static fn ($value) => $value !== '' && $value !== null,
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6319 

#### Summary

This adds the `gssencmode` option for PostgreSQL connections for both the PgSQL and PDO PgSQL driver.