### PR TITLE
Make all mapped database types case insensitive

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -213,6 +213,7 @@ abstract class AbstractPlatform
 
         foreach (Type::getTypesMap() as $typeName => $className) {
             foreach (Type::getType($typeName)->getMappedDatabaseTypes($this) as $dbType) {
+                $dbType                             = strtolower($dbType);
                 $this->doctrineTypeMapping[$dbType] = $typeName;
             }
         }

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -106,6 +106,40 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertEquals(Types::INTEGER, $this->platform->getDoctrineTypeMapping('foo'));
     }
 
+    public function testCaseInsensitiveDoctrineTypeMappingFromType(): void
+    {
+        $type = new class () extends Type {
+            /**
+             * {@inheritDoc}
+             */
+            public function getMappedDatabaseTypes(AbstractPlatform $platform): array
+            {
+                return ['TESTTYPE'];
+            }
+
+            public function getName(): string
+            {
+                return 'testtype';
+            }
+
+            /**
+             * {@inheritDoc}
+             */
+            public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+            {
+                return $platform->getDecimalTypeDeclarationSQL($column);
+            }
+        };
+
+        if (Type::hasType($type->getName())) {
+            Type::overrideType($type->getName(), get_class($type));
+        } else {
+            Type::addType($type->getName(), get_class($type));
+        }
+
+        self::assertSame($type->getName(), $this->platform->getDoctrineTypeMapping('TeStTyPe'));
+    }
+
     public function testRegisterUnknownDoctrineMappingType(): void
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
Currently, a custom mapping type has to return an array of lowercase strings in `getMappedDatabaseTypes` or else Doctrine fails to retrieve the added type as both `AbstractPlatform::getDoctrineTypeMapping` and `AbstractPlatform::hasDoctrineTypeMappingFor` do a lowercase conversion before the look-up. A devolper should not depend on internal representation.

This PR addresses this by storing the mapped type in lowercase to `AbstractPlatform#doctrineTypeMapping`. This is in line with `AbstractPlatform::registerDoctrineTypeMapping`, which does a lowercase conversion as well.