### PR TITLE
Fix double quote used wrongly for literal value in SqliteSchemaManager

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -744,7 +744,7 @@ SQL;
                    p.*
               FROM sqlite_master t
               JOIN pragma_foreign_key_list(t.name) p
-                ON p."seq" != "-1"
+                ON p."seq" != '-1'
 SQL;
 
         $conditions = [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 

#### Summary

It seems PHP SQLite drivers allows `"` to be used to escape literal values, but natively such syntax produces an sqlite parse error [1].

I have discovered this when analysing SQLite log, it is otherwise tested.

I checked all other `"` in SQLite platform and manager and all of them seems correct otherwise.

[1] https://dbfiddle.uk/KQAGp9Ea (notice the 2nd query is the same, but uses `"` instead of `'`)