### PR TITLE
Remove redundant variable

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -944,7 +944,7 @@ abstract class AbstractPlatform
      * @param mixed[][] $columns
      * @param mixed[]   $options
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     protected function _getCreateTableSQL(string $name, array $columns, array $options = []): array
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -816,8 +816,7 @@ abstract class AbstractPlatform
             }
         }
 
-        $columnSql = [];
-        $columns   = [];
+        $columns = [];
 
         foreach ($table->getColumns() as $column) {
             $columnData = $this->columnToArray($column);
@@ -847,7 +846,7 @@ abstract class AbstractPlatform
             }
         }
 
-        return array_merge($sql, $columnSql);
+        return $sql;
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Just removing unused variable and redundant `array_merge`. <strike>As I see Psalm fails here, and not really sure how to fix it, adding `array_values` probably would solve the issue, but I guess this is not what we want there?</strike>

Also updated return type on `_getCreateTableSQL` method, to fix the Psalm issue.

<!-- Provide a summary of your change. -->
