### PR TITLE
fix: sort query parameters by default

### DIFF
--- a/tests/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Functional/Driver/OCI8/StatementTest.php
@@ -43,6 +43,11 @@ class StatementTest extends FunctionalTestCase
                 [1],
                 ['COL1' => 1],
             ],
+            'positional_not_sorted' => [
+                'SELECT ? COL1, ? COL2 FROM DUAL',
+                [2, 1],
+                ['COL1' => 1, 'COL2' => 2],
+            ],
             'named' => [
                 'SELECT :COL COL1 FROM DUAL',
                 ['COL' => 1],


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | Related to https://github.com/symfony/symfony/pull/54172

#### Summary

Fixing the file `//OCI8//ConvertPositionalToNamedParameters.php` was enough for our use case, and I confirm that our query is correctly executed now. I also confirm that the initial PR is now optional (https://github.com/symfony/symfony/pull/54172), however I think it's a nice to have. Dealing with named parameters is safer and easier to reason about when reading the code.
I took the liberty to also sort other methods, let me know if I did well or not. 

Last question, what's the policy to backport this fix in older versions?