### PR TITLE
Make AbstractSchemaManager covariant to its template argument

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -31,7 +31,7 @@ use function strtolower;
  * Base class for schema managers. Schema managers are used to inspect and/or
  * modify the database schema/structure.
  *
- * @template T of AbstractPlatform
+ * @template-covariant T of AbstractPlatform
  */
 abstract class AbstractSchemaManager
 {

--- a/static-analysis/abstract-schema-manager-covariant-template.php
+++ b/static-analysis/abstract-schema-manager-covariant-template.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\StaticAnalysis\DBAL;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
+use Exception;
+
+$smf = new DefaultSchemaManagerFactory();
+$schemaManager = $smf->createSchemaManager(new Connection([], new Driver()));
+
+if (!$schemaManager instanceof PostgreSQLSchemaManager) {
+    throw new Exception('should not happen');
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->

```php
<?php
declare(strict_types=1);

abstract class AbstractPlatform {}

class PostgreSQLPlatform extends AbstractPlatform {}

/**
 * @template T of AbstractPlatform
 */
abstract class AbstractSchemaManager {}

/**
 * @extends AbstractSchemaManager<PostgreSQLPlatform>
 */
class PostgreSQLSchemaManager extends AbstractSchemaManager {}

function createSchemaManager(): AbstractSchemaManager
{
    return new PostgreSQLSchemaManager();
}

$schemaManager = createSchemaManager();

if (!$schemaManager instanceof PostgreSQLSchemaManager) {}
```

```
ERROR: [RedundantCondition](https://psalm.dev/122) - 25:6 - AbstractSchemaManager<AbstractPlatform> cannot be identical to PostgreSQLSchemaManager
```

vs

```php
<?php
declare(strict_types=1);

abstract class AbstractPlatform {}

class PostgreSQLPlatform extends AbstractPlatform {}

/**
 * @template-covariant T of AbstractPlatform
 */
abstract class AbstractSchemaManager {}

/**
 * @extends AbstractSchemaManager<PostgreSQLPlatform>
 */
class PostgreSQLSchemaManager extends AbstractSchemaManager {}

function createSchemaManager(): AbstractSchemaManager
{
    return new PostgreSQLSchemaManager();
}

$schemaManager = createSchemaManager();

if (!$schemaManager instanceof PostgreSQLSchemaManager) {}
```
```
No issues!
```