### PR TITLE
Allow to disable SQLite schema emulation in SqliteSchemaManager

### DIFF
--- a/src/Platforms/SqlitePlatform.php
+++ b/src/Platforms/SqlitePlatform.php
@@ -908,7 +908,7 @@ class SqlitePlatform extends AbstractPlatform
      */
     public function canEmulateSchemas()
     {
-        Deprecation::trigger(
+        Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/4805',
             'SqlitePlatform::canEmulateSchemas() is deprecated.',

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -715,7 +715,9 @@ SQL;
 
         if ($tableName !== null) {
             $conditions[] = 't.name = ?';
-            $params[]     = str_replace('.', '__', $tableName);
+            $params[]     = $this->_platform->canEmulateSchemas()
+                ? str_replace('.', '__', $tableName)
+                : $tableName;
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, c.cid';
@@ -740,7 +742,9 @@ SQL;
 
         if ($tableName !== null) {
             $conditions[] = 't.name = ?';
-            $params[]     = str_replace('.', '__', $tableName);
+            $params[]     = $this->_platform->canEmulateSchemas()
+                ? str_replace('.', '__', $tableName)
+                : $tableName;
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, i.seq';
@@ -766,7 +770,9 @@ SQL;
 
         if ($tableName !== null) {
             $conditions[] = 't.name = ?';
-            $params[]     = str_replace('.', '__', $tableName);
+            $params[]     = $this->_platform->canEmulateSchemas()
+                ? str_replace('.', '__', $tableName)
+                : $tableName;
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, p.id DESC, p.seq';

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BlobType;
@@ -14,6 +15,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_keys;
+use function array_map;
 use function array_shift;
 use function assert;
 use function dirname;
@@ -395,6 +397,82 @@ SQL;
                 'CREATE INDEX IDX_D6E3F8A6FB96D8BC ON track (trackartist)',
             ],
             $createTableTrackSql,
+        );
+    }
+
+    public function testListTableNoSchemaEmulation(): void
+    {
+        $databasePlatform = $this->connection->getDatabasePlatform();
+        assert($databasePlatform instanceof SqlitePlatform);
+        $databasePlatform->disableSchemaEmulation();
+
+        $this->dropTableIfExists('`list_table_no_schema_emulation.test`');
+
+        $this->connection->executeStatement(<<<'DDL'
+            CREATE TABLE `list_table_no_schema_emulation.test` (
+                id INTEGER,
+                parent_id INTEGER,
+                PRIMARY KEY (id),
+                FOREIGN KEY (parent_id) REFERENCES `list_table_no_schema_emulation.test` (id)
+            );
+            DDL);
+
+        $this->connection->executeStatement(<<<'DDL'
+            CREATE INDEX i ON `list_table_no_schema_emulation.test` (parent_id);
+            DDL);
+
+        $customSqliteSchemaManager = new class ($this->connection, $databasePlatform) extends SqliteSchemaManager {
+            /** @return list<array<string, mixed>> */
+            public function selectTableColumnsWithSchema(): array
+            {
+                return $this->selectTableColumns('main', 'list_table_no_schema_emulation.test')
+                    ->fetchAllAssociative();
+            }
+
+            /** @return list<array<string, mixed>> */
+            public function selectIndexColumnsWithSchema(): array
+            {
+                return $this->selectIndexColumns('main', 'list_table_no_schema_emulation.test')
+                    ->fetchAllAssociative();
+            }
+
+            /** @return list<array<string, mixed>> */
+            public function selectForeignKeyColumnsWithSchema(): array
+            {
+                return $this->selectForeignKeyColumns('main', 'list_table_no_schema_emulation.test')
+                    ->fetchAllAssociative();
+            }
+        };
+
+        self::assertSame(
+            [
+                ['list_table_no_schema_emulation.test', 'id'],
+                ['list_table_no_schema_emulation.test', 'parent_id'],
+            ],
+            array_map(
+                static fn (array $row) => [$row['table_name'], $row['name']],
+                $customSqliteSchemaManager->selectTableColumnsWithSchema(),
+            ),
+        );
+
+        self::assertSame(
+            [
+                ['list_table_no_schema_emulation.test', 'i'],
+            ],
+            array_map(
+                static fn (array $row) => [$row['table_name'], $row['name']],
+                $customSqliteSchemaManager->selectIndexColumnsWithSchema(),
+            ),
+        );
+
+        self::assertSame(
+            [
+                ['list_table_no_schema_emulation.test', 'parent_id', 'id'],
+            ],
+            array_map(
+                static fn (array $row) => [$row['table_name'], $row['from'], $row['to']],
+                $customSqliteSchemaManager->selectForeignKeyColumnsWithSchema(),
+            ),
         );
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6314

#### Summary

Missed in https://github.com/doctrine/dbal/pull/4804 and fix related https://github.com/doctrine/dbal/pull/5517.

When merging up (into 4.x), simply remove the `str_replace`.