### PR TITLE
Fix DB name passing in SqliteSchemaManager::listTableForeignKeys()

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -202,7 +202,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     {
         $table = $this->normalizeName($table);
 
-        $columns = $this->selectForeignKeyColumns('', $table)
+        $columns = $this->selectForeignKeyColumns($database ?? 'main', $table)
             ->fetchAllAssociative();
 
         if (count($columns) > 0) {

--- a/tests/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Schema/SqliteSchemaManagerTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -339,5 +340,34 @@ class SqliteSchemaManagerTest extends TestCase
                 )',
             ],
         ];
+    }
+
+    /**
+     * TODO move to functional test once SqliteSchemaManager::selectForeignKeyColumns can honor database/schema name
+     * https://github.com/doctrine/dbal/blob/3.8.3/src/Schema/SqliteSchemaManager.php#L740
+     */
+    public function testListTableForeignKeysDefaultDatabasePassing(): void
+    {
+        $conn = $this->createMock(Connection::class);
+
+        $manager = new class ($conn, new SqlitePlatform()) extends SqliteSchemaManager {
+            public static string $passedDatabaseName;
+
+            protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+            {
+                self::$passedDatabaseName = $databaseName;
+
+                return parent::selectForeignKeyColumns($databaseName, $tableName);
+            }
+        };
+
+        $manager->listTableForeignKeys('t');
+        self::assertSame('main', $manager::$passedDatabaseName);
+
+        $manager->listTableForeignKeys('t', 'd');
+        self::assertSame('d', $manager::$passedDatabaseName);
+
+        $manager->listTableForeignKeys('t');
+        self::assertSame('main', $manager::$passedDatabaseName);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

Fix #5617, `''` was changed to `'main'`, but one occurence was missed.