### PR TITLE
Remove older versions from the docs

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -82,51 +82,6 @@
             "branchName": "3.0.x",
             "slug": "3.0",
             "maintained": false
-        },
-        {
-            "name": "2.13",
-            "slug": "2.13",
-            "maintained": false
-        },
-        {
-            "name": "2.12",
-            "slug": "2.12",
-            "maintained": false
-        },
-        {
-            "name": "2.11",
-            "slug": "2.11",
-            "maintained": false
-        },
-        {
-            "name": "2.10",
-            "slug": "2.10",
-            "maintained": false
-        },
-        {
-            "name": "2.9",
-            "slug": "2.9",
-            "maintained": false
-        },
-        {
-            "name": "2.8",
-            "slug": "2.8",
-            "maintained": false
-        },
-        {
-            "name": "2.7",
-            "slug": "2.7",
-            "maintained": false
-        },
-        {
-            "name": "2.6",
-            "slug": "2.6",
-            "maintained": false
-        },
-        {
-            "name": "2.5",
-            "slug": "2.5",
-            "maintained": false
         }
     ]
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

The Algolia indexes and records are currently above 90%. A quick way to reduce the amount is to drop older versions from the docs of DBAL that are unmaintained for a long time. This PR will drop all 2.x versions from the docs.
