### PR TITLE
Deprecate MariaDB 10.4 and MySQL 5.7 support

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## Deprecated support for MariaDB 10.4 and MySQL 5.7
+
+* Upgrade to MariaDB 10.5 or later.
+* Upgrade to MySQL 8.0 or later.
+
+# Upgrade to 4.0
+
 ## BC BREAK: removed `AbstractMySQLPlatform` methods.
 
 1. `getColumnTypeSQLSnippets()`,

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -42,6 +42,17 @@
                 <file name="src/Driver/OCI8/ConvertPositionalToNamedPlaceholders.php"/>
             </errorLevel>
         </ConflictingReferenceConstraint>
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <!--
+                    See https://github.com/doctrine/dbal/pull/6343
+                    TODO: remove in 5.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\MariaDB1052Platform" />
+                <referencedClass name="Doctrine\DBAL\Platforms\MySQL80Platform" />
+            </errorLevel>
+        </DeprecatedClass>
         <DeprecatedMethod>
             <errorLevel type="suppress">
                 <!--

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\ServerVersionProvider;
+use Doctrine\Deprecations\Deprecation;
 
 use function preg_match;
 use function stripos;
@@ -43,12 +44,24 @@ abstract class AbstractMySQLDriver implements Driver
                 return new MariaDB1052Platform();
             }
 
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6343',
+                'Support for MariaDB < 10.5.2 is deprecated and will be removed in DBAL 5',
+            );
+
             return new MariaDBPlatform();
         }
 
         if (version_compare($version, '8.0.0', '>=')) {
             return new MySQL80Platform();
         }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6343',
+            'Support for MySQL < 8 is deprecated and will be removed in DBAL 5',
+        );
 
         return new MySQLPlatform();
     }

--- a/src/Platforms/Keywords/MySQL80Keywords.php
+++ b/src/Platforms/Keywords/MySQL80Keywords.php
@@ -8,6 +8,8 @@ use function array_merge;
 
 /**
  * MySQL 8.0 reserved keywords list.
+ *
+ * @deprecated This class will be removed once support for MySQL 5.7 is dropped.
  */
 class MySQL80Keywords extends MySQLKeywords
 {

--- a/src/Platforms/MariaDB1052Platform.php
+++ b/src/Platforms/MariaDB1052Platform.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 /**
  * Provides the behavior, features and SQL dialect of the MariaDB 10.5 (10.5.2 GA) database platform.
  *
- * Note: Should not be used with versions prior to 10.5.2.
+ * @deprecated This class will be removed once support for MariaDB 10.4 is dropped.
  */
 class MariaDB1052Platform extends MariaDBPlatform
 {

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 8.0 (8.0 GA) database platform.
+ *
+ * @deprecated This class will be removed once support for MySQL 5.7 is dropped.
  */
 class MySQL80Platform extends MySQLPlatform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Let's not carry support for the following old releases over into the next major.

* MariaDB 10.4 will be EOL three months from now.
* MySQL 5.7 is EOL [since October 2023](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-44.html).
