### PR TITLE
fix(PgSQL): Allow to pass IPv6 address in URI notation for postgres

### DIFF
--- a/src/Driver/PgSQL/Driver.php
+++ b/src/Driver/PgSQL/Driver.php
@@ -15,6 +15,7 @@ use function array_values;
 use function func_get_args;
 use function implode;
 use function pg_connect;
+use function preg_match;
 use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
@@ -64,9 +65,18 @@ final class Driver extends AbstractPostgreSQLDriver
         #[SensitiveParameter]
         array $params
     ): string {
+        // pg_connect used by Doctrine DBAL does not support [...] notation,
+        // but requires the host address in plain form like `aa:bb:99...`
+        $matches = [];
+        if (isset($params['host']) && preg_match('/^\[(.+)\]$/', $params['host'], $matches) === 1) {
+            $params['hostaddr'] = $matches[1];
+            unset($params['host']);
+        }
+
         $components = array_filter(
             [
                 'host' => $params['host'] ?? null,
+                'hostaddr' => $params['hostaddr'] ?? null,
                 'port' => $params['port'] ?? null,
                 'dbname' => $params['dbname'] ?? 'postgres',
                 'user' => $params['user'] ?? null,

--- a/tests/Driver/PgSQL/DriverTest.php
+++ b/tests/Driver/PgSQL/DriverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Driver\PgSQL;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\PgSQL\Driver;
+use Doctrine\DBAL\Tests\Driver\AbstractPostgreSQLDriverTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+
+use function in_array;
+
+class DriverTest extends AbstractPostgreSQLDriverTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (isset($GLOBALS['db_driver']) && $GLOBALS['db_driver'] === 'pgsql') {
+            return;
+        }
+
+        self::markTestSkipped('Test enabled only when using pgsql specific phpunit.xml');
+    }
+
+    /**
+     * Ensure we can handle URI notation for IPv6 addresses
+     */
+    public function testConnectionIPv6(): void
+    {
+        if (! in_array($GLOBALS['db_host'], ['localhost', '127.0.0.1', '[::1]'], true)) {
+            // We cannot assume that every contributor runs the same setup as our CI
+            self::markTestSkipped('This test only works if there is a Postgres server listening on localhost.');
+        }
+
+        self::expectNotToPerformAssertions();
+
+        $params         = TestUtil::getConnectionParams();
+        $params['host'] = '[::1]';
+
+        $this->driver->connect($params);
+    }
+
+    protected function createDriver(): DriverInterface
+    {
+        return new Driver();
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Allow to pass IPv6 address of postgres server in URI notation (`[ff:aa:...]`).
When the host is passed in URI format to `host` parameter of `pg_connect` it will fail because it then tries to resolve it as when it was a real host name.
Instead just pass the IP address to the `hostaddr` parameter.
