### PR TITLE
Enum support

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -19,6 +19,8 @@ class Column extends AbstractAsset
 
     protected ?int $_length = null;
 
+    protected array $_members = [];
+
     protected ?int $_precision = null;
 
     protected int $_scale = 0;
@@ -219,6 +221,16 @@ class Column extends AbstractAsset
         return $this;
     }
 
+    public function getMembers(): array
+    {
+        return $this->_members;
+    }
+
+    public function setMembers(array $members): void
+    {
+        $this->_members = $members;
+    }
+
     public function setComment(string $comment): self
     {
         $this->_comment = $comment;
@@ -240,6 +252,7 @@ class Column extends AbstractAsset
             'default'       => $this->_default,
             'notnull'       => $this->_notnull,
             'length'        => $this->_length,
+            'members'       => $this->_members,
             'precision'     => $this->_precision,
             'scale'         => $this->_scale,
             'fixed'         => $this->_fixed,

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -19,6 +19,7 @@ class Column extends AbstractAsset
 
     protected ?int $_length = null;
 
+    /** @var string[] */
     protected array $_members = [];
 
     protected ?int $_precision = null;
@@ -221,11 +222,13 @@ class Column extends AbstractAsset
         return $this;
     }
 
+    /** @return string[] */
     public function getMembers(): array
     {
         return $this->_members;
     }
 
+    /** @param string[] $members */
     public function setMembers(array $members): void
     {
         $this->_members = $members;

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-use Infrastructure\Persistence\Doctrine\Types\EnumType;
 use function array_map;
 use function assert;
 use function count;

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
+use Infrastructure\Persistence\Doctrine\Types\EnumType;
 use function array_map;
 use function assert;
 use function count;

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -212,7 +212,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
             'autoincrement' => str_contains($tableColumn['extra'], 'auto_increment'),
         ];
 
-        if ($dbType === 'enum' && false !== preg_match_all("/'([^']+)'/", $tableColumn['type'], $members)) {
+        if ($dbType === 'enum' && preg_match_all("/'([^']+)'/", $tableColumn['type'], $members) !== false) {
             $options['members'] = $members[1];
         }
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -211,6 +211,10 @@ class MySQLSchemaManager extends AbstractSchemaManager
             'autoincrement' => str_contains($tableColumn['extra'], 'auto_increment'),
         ];
 
+        if ($dbType === 'enum' && false !== preg_match_all("/'([^']+)'/", $tableColumn['type'], $members)) {
+            $options['members'] = $members[1];
+        }
+
         if (isset($tableColumn['comment'])) {
             $options['comment'] = $tableColumn['comment'];
         }

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -22,6 +22,7 @@ use function explode;
 use function implode;
 use function is_string;
 use function preg_match;
+use function preg_match_all;
 use function str_contains;
 use function strtok;
 use function strtolower;

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
 use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use ReflectionClass;
-use StringBackedEnum;
 use Throwable;
 use UnitEnum;
 

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
+
+final class EnumType extends Type
+{
+    public string $name = 'enum';
+
+    public ?string $enumClassname = null;
+
+    public array $members = [];
+
+    /**
+     * Gets an array of database types that map to this Doctrine type.
+     *
+     * @return string[]
+     */
+    public function getMappedDatabaseTypes(AbstractPlatform $platform): array
+    {
+        return [$this->name];
+    }
+
+    /**
+     * Gets the SQL declaration snippet for a field of this type.
+     *
+     * @param mixed[]          $column   The field declaration
+     * @param AbstractPlatform $platform The currently used database platform
+     */
+    public function getSqlDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        assert($column['type'] instanceof self::class);
+
+        $values = implode(
+            ', ',
+            array_map(
+                static fn (string $value) => "'{$value}'",
+                $column['members'] ?: $column['type']->members
+            )
+        );
+
+        $sqlDeclaration = match (true) {
+            $platform instanceof SqlitePlatform => sprintf('TEXT CHECK(%s IN (%s))', $column['name'], $values),
+            $platform instanceof PostgreSqlPlatform, $platform instanceof SQLServerPlatform => sprintf('VARCHAR(255) CHECK(%s IN (%s))', $column['name'], $values),
+            default => sprintf('ENUM(%s)', $values),
+        };
+
+        return $sqlDeclaration;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed the database representation of the value
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed the PHP representation of the value
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!\is_string($value)) {
+            throw InvalidType::new($value, $this->name, ['null', 'string']);
+        }
+
+        $refl = new \ReflectionClass($this->enumClassname);
+
+        try {
+            return $refl->newInstance($value);
+        } catch (\Throwable $e) {
+            throw ValueNotConvertible::new($value, $this->name, $e->getMessage(), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function addType(string $name, string $enumClassname): void
+    {
+        self::getTypeRegistry()->register($name, $me = new self());
+        $me->name = $name;
+        $me->enumClassname = $enumClassname;
+        $me->members = $enumClassname::getAllowedValues();
+    }
+}

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -109,7 +109,7 @@ final class EnumType extends Type
         }
 
         if (! is_string($value)) {
-            throw InvalidFormat::new($value, $this->name, ['null', 'string']);
+            throw InvalidFormat::new($value, $this->name, 'string');
         }
 
         if ($this->enumClassname === null) {

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
+use Infrastructure\Persistence\Doctrine\Types\EnumType;
 use function array_map;
 
 /**
@@ -42,6 +43,7 @@ abstract class Type
         Types::SMALLINT             => SmallIntType::class,
         Types::STRING               => StringType::class,
         Types::TEXT                 => TextType::class,
+        Types::ENUM                 => EnumType::class,
         Types::TIME_MUTABLE         => TimeType::class,
         Types::TIME_IMMUTABLE       => TimeImmutableType::class,
     ];

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-use Infrastructure\Persistence\Doctrine\Types\EnumType;
 use function array_map;
 
 /**
@@ -35,6 +34,7 @@ abstract class Type
         Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
         Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
         Types::DECIMAL              => DecimalType::class,
+        Types::ENUM                 => EnumType::class,
         Types::FLOAT                => FloatType::class,
         Types::GUID                 => GuidType::class,
         Types::INTEGER              => IntegerType::class,
@@ -43,7 +43,6 @@ abstract class Type
         Types::SMALLINT             => SmallIntType::class,
         Types::STRING               => StringType::class,
         Types::TEXT                 => TextType::class,
-        Types::ENUM                 => EnumType::class,
         Types::TIME_MUTABLE         => TimeType::class,
         Types::TIME_IMMUTABLE       => TimeImmutableType::class,
     ];

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -22,6 +22,7 @@ final class Types
     public const DATETIMETZ_MUTABLE   = 'datetimetz';
     public const DATETIMETZ_IMMUTABLE = 'datetimetz_immutable';
     public const DECIMAL              = 'decimal';
+    public const ENUM                 = 'enum';
     public const FLOAT                = 'float';
     public const GUID                 = 'guid';
     public const INTEGER              = 'integer';

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -38,6 +38,15 @@ final class ComparatorTestUtils
         );
     }
 
+    public static function assertNoDiffDetected(Connection $connection, Comparator $comparator, Table $table): void
+    {
+        $schemaManager = $connection->createSchemaManager();
+
+        $diff = self::diffFromActualToDesiredTable($schemaManager, $comparator, $table);
+
+        TestCase::assertTrue($diff->isEmpty());
+    }
+
     public static function assertDiffNotEmpty(Connection $connection, Comparator $comparator, Table $table): void
     {
         $schemaManager = $connection->createSchemaManager();

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -43,6 +43,7 @@ final class ComparatorTestUtils
         $schemaManager = $connection->createSchemaManager();
 
         $diff = self::diffFromActualToDesiredTable($schemaManager, $comparator, $table);
+        var_dump($diff->getModifiedColumns()[0]);
 
         TestCase::assertTrue($diff->isEmpty());
     }

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -16,11 +16,6 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use Doctrine\DBAL\Tests\Types\EnumObject;
-use Doctrine\DBAL\Tests\Types\EnumNative;
-use Doctrine\DBAL\Tests\Types\EnumNativeBacked;
-use Doctrine\DBAL\Types\EnumType;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -220,36 +215,16 @@ final class ComparatorTest extends FunctionalTestCase
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
 
-    public function testEnumDiffEmpty(): void
-    {
-        if (! $this->platform instanceof MySQLPlatform) {
-            self::markTestSkipped();
-        }
-
-        $table = new Table('enum_test_table');
-
-        $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
-        $this->dropAndCreateTable($table);
-
-        // Revert column to previous ENUM declaration
-        $sql = 'ALTER TABLE enum_test_table CHANGE enum_col enum_col ENUM(\'a\', \'b\') NOT NULL';
-        $this->connection->executeStatement($sql);
-
-        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
-    }
-
     public function testEnumDiffDetected(): void
     {
-        if (! $this->platform instanceof MySQLPlatform) {
-            self::markTestSkipped();
-        }
-
         $table = new Table('enum_test_table');
 
         $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
         $this->dropAndCreateTable($table);
 
-        // Revert column to previous ENUM declaration
+        ComparatorTestUtils::assertNoDiffDetected($this->connection, $this->comparator, $table);
+
+        // Alter column to previous state and check diff
         $sql = 'ALTER TABLE enum_test_table CHANGE enum_col enum_col ENUM(\'NOT_A_MEMBER_ANYMORE\') NOT NULL';
         $this->connection->executeStatement($sql);
 

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -16,6 +16,11 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Schema\ComparatorTestUtils;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\Types\EnumObject;
+use Doctrine\DBAL\Tests\Types\EnumNative;
+use Doctrine\DBAL\Tests\Types\EnumNativeBacked;
+use Doctrine\DBAL\Types\EnumType;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -215,19 +220,37 @@ final class ComparatorTest extends FunctionalTestCase
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
 
-    public function testNativeEnumUpgradeDetected(): void
+    public function testEnumDiffEmpty(): void
     {
         if (! $this->platform instanceof MySQLPlatform) {
             self::markTestSkipped();
         }
 
-        $table = new Table('mariadb_enum_upgrade');
+        $table = new Table('enum_test_table');
 
         $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
         $this->dropAndCreateTable($table);
 
-        // Revert column to old LONGTEXT declaration
-        $sql = 'ALTER TABLE mariadb_json_upgrade CHANGE json_col json_col LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'';
+        // Revert column to previous ENUM declaration
+        $sql = 'ALTER TABLE enum_test_table CHANGE enum_col enum_col ENUM(\'a\', \'b\') NOT NULL';
+        $this->connection->executeStatement($sql);
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
+
+    public function testEnumDiffDetected(): void
+    {
+        if (! $this->platform instanceof MySQLPlatform) {
+            self::markTestSkipped();
+        }
+
+        $table = new Table('enum_test_table');
+
+        $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
+        $this->dropAndCreateTable($table);
+
+        // Revert column to previous ENUM declaration
+        $sql = 'ALTER TABLE enum_test_table CHANGE enum_col enum_col ENUM(\'NOT_A_MEMBER_ANYMORE\') NOT NULL';
         $this->connection->executeStatement($sql);
 
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);

--- a/tests/Functional/Schema/Oracle/ComparatorTest.php
+++ b/tests/Functional/Schema/Oracle/ComparatorTest.php
@@ -60,4 +60,20 @@ final class ComparatorTest extends FunctionalTestCase
             $table,
         )->isEmpty());
     }
+
+    public function testEnumDiffDetected(): void
+    {
+        $table = new Table('enum_test_table');
+
+        $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
+        $this->dropAndCreateTable($table);
+
+        ComparatorTestUtils::assertNoDiffDetected($this->connection, $this->comparator, $table);
+
+        // Alter column to previous state and check diff
+        $sql = 'ALTER TABLE enum_test_table CHANGE enum_col enum_col ENUM(\'NOT_A_MEMBER_ANYMORE\') NOT NULL';
+        $this->connection->executeStatement($sql);
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
 }

--- a/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
+++ b/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
@@ -92,4 +92,20 @@ final class ComparatorTest extends FunctionalTestCase
             $table,
         )->isEmpty());
     }
+
+    public function testEnumDiffDetected(): void
+    {
+        $table = new Table('enum_test_table');
+
+        $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
+        $this->dropAndCreateTable($table);
+
+        ComparatorTestUtils::assertNoDiffDetected($this->connection, $this->comparator, $table);
+
+        // Alter column to previous state and check diff
+        $sql = 'ALTER TABLE enum_test_table CHANGE enum_col enum_col ENUM(\'NOT_A_MEMBER_ANYMORE\') NOT NULL';
+        $this->connection->executeStatement($sql);
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
 }

--- a/tests/Functional/Schema/SQLite/ComparatorTest.php
+++ b/tests/Functional/Schema/SQLite/ComparatorTest.php
@@ -43,7 +43,7 @@ final class ComparatorTest extends FunctionalTestCase
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
 
-    public function testEnumDiffDetected(): void
+    public function testEnumColumnIsCreated(): void
     {
         $table = new Table('enum_test_table');
 
@@ -51,11 +51,5 @@ final class ComparatorTest extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         ComparatorTestUtils::assertNoDiffDetected($this->connection, $this->comparator, $table);
-
-        // Alter column to previous state and check diff
-        $sql = 'ALTER TABLE enum_test_table ALTER COLUMN enum_col enum_col ENUM(\'NOT_A_MEMBER_ANYMORE\') NOT NULL';
-        $this->connection->executeStatement($sql);
-
-        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
 }

--- a/tests/Functional/Schema/SQLite/ComparatorTest.php
+++ b/tests/Functional/Schema/SQLite/ComparatorTest.php
@@ -42,4 +42,20 @@ final class ComparatorTest extends FunctionalTestCase
         $column->setPlatformOption('collation', 'NOCASE');
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
+
+    public function testEnumDiffDetected(): void
+    {
+        $table = new Table('enum_test_table');
+
+        $table->addColumn('enum_col', Types::ENUM, ['members' => ['a', 'b']]);
+        $this->dropAndCreateTable($table);
+
+        ComparatorTestUtils::assertNoDiffDetected($this->connection, $this->comparator, $table);
+
+        // Alter column to previous state and check diff
+        $sql = 'ALTER TABLE enum_test_table ALTER COLUMN enum_col enum_col ENUM(\'NOT_A_MEMBER_ANYMORE\') NOT NULL';
+        $this->connection->executeStatement($sql);
+
+        ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
+    }
 }

--- a/tests/Functional/Types/EnumTest.php
+++ b/tests/Functional/Types/EnumTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+class EnumTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $table = new Table('enum_table');
+        $table->addColumn('val', Types::ENUM, ['members' => ['a', 'b']]);
+
+        $this->dropAndCreateTable($table);
+    }
+
+    public function testInsertAndSelect(): void
+    {
+        $val = 'b';
+
+        $result = $this->connection->insert('enum_table', ['val' => $val]);
+        self::assertSame(1, $result);
+
+        $value = $this->connection->fetchOne('SELECT val FROM enum_table');
+
+        self::assertEquals($val, $value);
+    }
+}

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -45,6 +45,7 @@ class ColumnTest extends TestCase
             'default' => 'baz',
             'notnull' => false,
             'length' => 200,
+            'members' => [],
             'precision' => 5,
             'scale' => 2,
             'fixed' => true,
@@ -147,5 +148,18 @@ class ColumnTest extends TestCase
         $columnArray = $column->toArray();
         self::assertArrayHasKey('comment', $columnArray);
         self::assertEquals('foo', $columnArray['comment']);
+    }
+
+    public function testEnumMembers(): void
+    {
+        $column = new Column('bar', Type::getType(Types::ENUM));
+        self::assertSame([], $column->getMembers());
+
+        $column->setMembers(['a', 'b']);
+        self::assertEquals(['a', 'b'], $column->getMembers());
+
+        $columnArray = $column->toArray();
+        self::assertArrayHasKey('members', $columnArray);
+        self::assertEquals(['a', 'b'], $columnArray['members']);
     }
 }

--- a/tests/Types/EnumTest.php
+++ b/tests/Types/EnumTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\EnumType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Stringable;
+
+class EnumTest extends TestCase
+{
+    private AbstractPlatform&MockObject $platform;
+    private EnumType $type;
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->type     = new EnumType();
+    }
+
+    public function testReturnsSQLDeclaration(): void
+    {
+        self::assertSame('ENUM(\'a\', \'b\')', $this->type->getSQLDeclaration(['members' => ['a', 'b']], $this->platform));
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        self::assertIsString($this->type->convertToPHPValue('foo', $this->platform));
+        self::assertIsString($this->type->convertToPHPValue('', $this->platform));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testConvertToPHPEnum(): void
+    {
+        $this->type->enumClassname = EnumPhp::class;
+
+        self::assertInstanceOf($this->type->enumClassname, $this->type->convertToPHPValue('A', $this->platform));
+        self::assertSame(EnumPhp::A, $this->type->convertToPHPValue('A', $this->platform));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testConvertToPHPEnumBacked(): void
+    {
+        $this->type->enumClassname = EnumPhpBacked::class;
+
+        self::assertInstanceOf($this->type->enumClassname, $this->type->convertToPHPValue('a', $this->platform));
+        self::assertSame(EnumPhpBacked::A, $this->type->convertToPHPValue('a', $this->platform));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testConvertToPHPObject(): void
+    {
+        $this->type->enumClassname = EnumClass::class;
+
+        self::assertInstanceOf($this->type->enumClassname, $this->type->convertToPHPValue('a', $this->platform));
+        self::assertEquals(new EnumClass('a'), $this->type->convertToPHPValue('a', $this->platform));
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testConvertStringToDatabaseValue(): void
+    {
+        self::assertSame('a', $this->type->convertToDatabaseValue('a', $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertEnumToDatabaseValue(): void
+    {
+        $this->type->enumClassname = EnumPhp::class;
+
+        self::assertSame('A', $this->type->convertToDatabaseValue(EnumPhp::A, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertEnumBackedToDatabaseValue(): void
+    {
+        $this->type->enumClassname = EnumPhpBacked::class;
+
+        self::assertSame('a', $this->type->convertToDatabaseValue(EnumPhpBacked::A, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertObjectToDatabaseValue(): void
+    {
+        $this->type->enumClassname = EnumClass::class;
+
+        self::assertSame('a', $this->type->convertToDatabaseValue(new EnumClass('a'), $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+}
+
+enum EnumPhp
+{
+    case A;
+    case B;
+}
+
+
+enum EnumPhpBacked: string
+{
+    case A = 'a';
+    case B = 'b';
+}
+
+final class EnumClass implements Stringable
+{
+    public function __construct(
+        private string $value,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Types/EnumTest.php
+++ b/tests/Types/EnumTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\EnumType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -28,8 +30,9 @@ class EnumTest extends TestCase
 
     public function testConvertToPHPValue(): void
     {
-        self::assertIsString($this->type->convertToPHPValue('foo', $this->platform));
-        self::assertIsString($this->type->convertToPHPValue('', $this->platform));
+        $this->type->members = ['a', 'b'];
+
+        self::assertIsString($this->type->convertToPHPValue('b', $this->platform));
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
@@ -62,6 +65,8 @@ class EnumTest extends TestCase
 
     public function testConvertStringToDatabaseValue(): void
     {
+        $this->type->members = ['a', 'b'];
+
         self::assertSame('a', $this->type->convertToDatabaseValue('a', $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
@@ -89,6 +94,107 @@ class EnumTest extends TestCase
         self::assertSame('a', $this->type->convertToDatabaseValue(new EnumClass('a'), $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
+
+    #[DataProvider('provideInvalidDataForEnumStringToDatabaseValueConversion')]
+    public function testEnumStringDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue($value, $this->platform);
+    }
+
+    public static function provideInvalidDataForEnumStringToDatabaseValueConversion()
+    {
+        return [
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'integer' => [17],
+            'string' => ['not_in_members'],
+            'array' => [['']],
+            'enum' => [EnumPhp::A],
+            'enum backed' => [EnumPhpBacked::A],
+            'object' => [new \stdClass()],
+            'stringable' => [new class() { function __toString() { return 'a'; }}],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDataForEnumPhpToDatabaseValueConversion')]
+    public function testEnumPhpDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue($value, $this->platform);
+    }
+
+    public static function provideInvalidDataForEnumPhpToDatabaseValueConversion()
+    {
+        return [
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'integer' => [17],
+            'string' => ['a'],
+            'array' => [['']],
+            'enum' => [WrongEnumPhp::WRONG],
+            'enum backed' => [EnumPhpBacked::A],
+            'object' => [new \stdClass()],
+            'stringable' => [new class() { function __toString() { return 'a'; }}],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDataForEnumPhpBackedToDatabaseValueConversion')]
+    public function testEnumPhpBackedDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue($value, $this->platform);
+    }
+
+    public static function provideInvalidDataForEnumPhpBackedToDatabaseValueConversion()
+    {
+        return [
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'integer' => [17],
+            'string' => ['a'],
+            'array' => [['']],
+            'enum' => [EnumPhp::A],
+            'enum backed' => [WrongEnumPhpBacked::WRONG],
+            'object' => [new \stdClass()],
+            'stringable' => [new class() { function __toString() { return 'a'; }}],
+        ];
+    }
+
+    #[DataProvider('provideInvalidDataForEnumObjectToDatabaseValueConversion')]
+    public function testEnumObjectDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue($value, $this->platform);
+    }
+
+    public static function provideInvalidDataForEnumObjectToDatabaseValueConversion()
+    {
+        return [
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'integer' => [17],
+            'string' => ['a'],
+            'array' => [['']],
+            'enum' => [EnumPhp::A],
+            'enum backed' => [EnumPhpBacked::A],
+            'object' => [new \stdClass()],
+            'stringable' => [new class() { function __toString() { return 'a'; }}],
+        ];
+    }
+
+    public function testInvalidValueForDatabaseValueToEnumStringConversion(): void
+    {
+        $this->type->members = ['a', 'b'];
+
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToPHPValue('not_in_members', $this->platform);
+    }
 }
 
 enum EnumPhp
@@ -97,11 +203,20 @@ enum EnumPhp
     case B;
 }
 
+enum WrongEnumPhp
+{
+    case WRONG;
+}
 
 enum EnumPhpBacked: string
 {
     case A = 'a';
     case B = 'b';
+}
+
+enum WrongEnumPhpBacked: string
+{
+    case WRONG = 'wrong';
 }
 
 final class EnumClass implements Stringable

--- a/tests/Types/EnumTest.php
+++ b/tests/Types/EnumTest.php
@@ -38,28 +38,28 @@ class EnumTest extends TestCase
 
     public function testConvertToPHPEnum(): void
     {
-        $this->type->enumClassname = EnumPhp::class;
+        $this->type->enumClassname = EnumNative::class;
 
         self::assertInstanceOf($this->type->enumClassname, $this->type->convertToPHPValue('A', $this->platform));
-        self::assertSame(EnumPhp::A, $this->type->convertToPHPValue('A', $this->platform));
+        self::assertSame(EnumNative::A, $this->type->convertToPHPValue('A', $this->platform));
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertToPHPEnumBacked(): void
     {
-        $this->type->enumClassname = EnumPhpBacked::class;
+        $this->type->enumClassname = EnumNativeBacked::class;
 
         self::assertInstanceOf($this->type->enumClassname, $this->type->convertToPHPValue('a', $this->platform));
-        self::assertSame(EnumPhpBacked::A, $this->type->convertToPHPValue('a', $this->platform));
+        self::assertSame(EnumNativeBacked::A, $this->type->convertToPHPValue('a', $this->platform));
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
     public function testConvertToPHPObject(): void
     {
-        $this->type->enumClassname = EnumClass::class;
+        $this->type->enumClassname = EnumObject::class;
 
         self::assertInstanceOf($this->type->enumClassname, $this->type->convertToPHPValue('a', $this->platform));
-        self::assertEquals(new EnumClass('a'), $this->type->convertToPHPValue('a', $this->platform));
+        self::assertEquals(new EnumObject('a'), $this->type->convertToPHPValue('a', $this->platform));
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
@@ -73,25 +73,25 @@ class EnumTest extends TestCase
 
     public function testConvertEnumToDatabaseValue(): void
     {
-        $this->type->enumClassname = EnumPhp::class;
+        $this->type->enumClassname = EnumNative::class;
 
-        self::assertSame('A', $this->type->convertToDatabaseValue(EnumPhp::A, $this->platform));
+        self::assertSame('A', $this->type->convertToDatabaseValue(EnumNative::A, $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testConvertEnumBackedToDatabaseValue(): void
     {
-        $this->type->enumClassname = EnumPhpBacked::class;
+        $this->type->enumClassname = EnumNativeBacked::class;
 
-        self::assertSame('a', $this->type->convertToDatabaseValue(EnumPhpBacked::A, $this->platform));
+        self::assertSame('a', $this->type->convertToDatabaseValue(EnumNativeBacked::A, $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
     public function testConvertObjectToDatabaseValue(): void
     {
-        $this->type->enumClassname = EnumClass::class;
+        $this->type->enumClassname = EnumObject::class;
 
-        self::assertSame('a', $this->type->convertToDatabaseValue(new EnumClass('a'), $this->platform));
+        self::assertSame('a', $this->type->convertToDatabaseValue(new EnumObject('a'), $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
     }
 
@@ -111,22 +111,22 @@ class EnumTest extends TestCase
             'integer' => [17],
             'string' => ['not_in_members'],
             'array' => [['']],
-            'enum' => [EnumPhp::A],
-            'enum backed' => [EnumPhpBacked::A],
+            'enum' => [EnumNative::A],
+            'enum backed' => [EnumNativeBacked::A],
             'object' => [new \stdClass()],
             'stringable' => [new class() { function __toString() { return 'a'; }}],
         ];
     }
 
-    #[DataProvider('provideInvalidDataForEnumPhpToDatabaseValueConversion')]
-    public function testEnumPhpDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
+    #[DataProvider('provideInvalidDataForEnumNativeToDatabaseValueConversion')]
+    public function testEnumNativeDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
     {
         $this->expectException(ConversionException::class);
 
         $this->type->convertToDatabaseValue($value, $this->platform);
     }
 
-    public static function provideInvalidDataForEnumPhpToDatabaseValueConversion()
+    public static function provideInvalidDataForEnumNativeToDatabaseValueConversion()
     {
         return [
             'boolean true' => [true],
@@ -134,22 +134,22 @@ class EnumTest extends TestCase
             'integer' => [17],
             'string' => ['a'],
             'array' => [['']],
-            'enum' => [WrongEnumPhp::WRONG],
-            'enum backed' => [EnumPhpBacked::A],
+            'enum' => [WrongEnumNative::WRONG],
+            'enum backed' => [EnumNativeBacked::A],
             'object' => [new \stdClass()],
             'stringable' => [new class() { function __toString() { return 'a'; }}],
         ];
     }
 
-    #[DataProvider('provideInvalidDataForEnumPhpBackedToDatabaseValueConversion')]
-    public function testEnumPhpBackedDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
+    #[DataProvider('provideInvalidDataForEnumNativeBackedToDatabaseValueConversion')]
+    public function testEnumNativeBackedDoesNotSupportInvalidValuesToDatabaseValueConversion($value): void
     {
         $this->expectException(ConversionException::class);
 
         $this->type->convertToDatabaseValue($value, $this->platform);
     }
 
-    public static function provideInvalidDataForEnumPhpBackedToDatabaseValueConversion()
+    public static function provideInvalidDataForEnumNativeBackedToDatabaseValueConversion()
     {
         return [
             'boolean true' => [true],
@@ -157,8 +157,8 @@ class EnumTest extends TestCase
             'integer' => [17],
             'string' => ['a'],
             'array' => [['']],
-            'enum' => [EnumPhp::A],
-            'enum backed' => [WrongEnumPhpBacked::WRONG],
+            'enum' => [EnumNative::A],
+            'enum backed' => [WrongEnumNativeBacked::WRONG],
             'object' => [new \stdClass()],
             'stringable' => [new class() { function __toString() { return 'a'; }}],
         ];
@@ -180,8 +180,8 @@ class EnumTest extends TestCase
             'integer' => [17],
             'string' => ['a'],
             'array' => [['']],
-            'enum' => [EnumPhp::A],
-            'enum backed' => [EnumPhpBacked::A],
+            'enum' => [EnumNative::A],
+            'enum backed' => [EnumNativeBacked::A],
             'object' => [new \stdClass()],
             'stringable' => [new class() { function __toString() { return 'a'; }}],
         ];
@@ -197,29 +197,29 @@ class EnumTest extends TestCase
     }
 }
 
-enum EnumPhp
+enum EnumNative
 {
     case A;
     case B;
 }
 
-enum WrongEnumPhp
+enum WrongEnumNative
 {
     case WRONG;
 }
 
-enum EnumPhpBacked: string
+enum EnumNativeBacked: string
 {
     case A = 'a';
     case B = 'b';
 }
 
-enum WrongEnumPhpBacked: string
+enum WrongEnumNativeBacked: string
 {
     case WRONG = 'wrong';
 }
 
-final class EnumClass implements Stringable
+final class EnumObject implements Stringable
 {
     public function __construct(
         private string $value,


### PR DESCRIPTION
I'm migrating a project to DBAL 4.
This is initial support for native ENUM type.
A custom mapping type is used in the ORM side.

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | --

#### Summary

This change allows to track ENUM members in order to be able to generate right migration.

If this is welcome and you like it, I can continue to work on this feature adding some tests