### PR TITLE
long-running processes: allow checking the database connection

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -36,6 +36,8 @@ class Configuration
 
     private ?SchemaManagerFactory $schemaManagerFactory = null;
 
+    private ?int $checkConnectionTiming = null;
+
     public function __construct()
     {
         $this->schemaAssetsFilter = static function (): bool {
@@ -152,5 +154,15 @@ class Configuration
         }
 
         return $this;
+    }
+
+    public function setCheckConnectionTiming(int $timing): void
+    {
+        $this->checkConnectionTiming = $timing;
+    }
+
+    public function getCheckConnectionTiming(): ?int
+    {
+        return $this->checkConnectionTiming;
     }
 }

--- a/tests/Functional/Connection/ConnectionReactivatedTest.php
+++ b/tests/Functional/Connection/ConnectionReactivatedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Connection;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+use function sleep;
+
+class ConnectionReactivatedTest extends FunctionalTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::markConnectionWithHeartBeat();
+    }
+
+    protected function setUp(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('Currently only supported with MySQL');
+    }
+
+    public function testConnectionReactivated(): void
+    {
+        $this->connection->executeStatement('SET SESSION wait_timeout=1');
+
+        sleep(2);
+
+        $query = $this->connection->getDatabasePlatform()
+            ->getDummySelectSQL();
+
+        $this->connection->executeQuery($query);
+
+        self::assertEquals(1, $this->connection->fetchOne($query));
+    }
+}

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -26,6 +26,8 @@ abstract class FunctionalTestCase extends TestCase
      */
     private bool $isConnectionReusable = true;
 
+    protected static bool $hasHeartBeat = false;
+
     /**
      * Mark shared connection not reusable for subsequent tests.
      *
@@ -37,11 +39,16 @@ abstract class FunctionalTestCase extends TestCase
         $this->isConnectionReusable = false;
     }
 
+    protected static function markConnectionWithHeartBeat(): void
+    {
+        self::$hasHeartBeat = true;
+    }
+
     #[Before]
     final protected function connect(): void
     {
         if (self::$sharedConnection === null) {
-            self::$sharedConnection = TestUtil::getConnection();
+            self::$sharedConnection = TestUtil::getConnection(self::$hasHeartBeat);
         }
 
         $this->connection = self::$sharedConnection;

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -62,7 +62,7 @@ class TestUtil
      *
      * @return Connection The database connection instance.
      */
-    public static function getConnection(): Connection
+    public static function getConnection(bool $hasHeartBeat = false): Connection
     {
         $params = self::getConnectionParams();
 
@@ -75,7 +75,7 @@ class TestUtil
 
         return DriverManager::getConnection(
             $params,
-            self::createConfiguration($params['driver']),
+            self::createConfiguration($params['driver'], $hasHeartBeat),
         );
     }
 
@@ -153,7 +153,7 @@ class TestUtil
         $privConn->close();
     }
 
-    private static function createConfiguration(string $driver): Configuration
+    private static function createConfiguration(string $driver, bool $hasHearBeat): Configuration
     {
         $configuration = new Configuration();
 
@@ -169,6 +169,10 @@ class TestUtil
         }
 
         $configuration->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+        if ($hasHearBeat) {
+            $configuration->setCheckConnectionTiming(1);
+        }
 
         return $configuration;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | new feature
| Fixed issues | https://github.com/symfony/symfony/issues/51661

#### Summary

DRAFT: 
In long-running processes, allows checking the database connection by pinging it, thus avoiding exceptions. Additionally, it provides the flexibility to configure the frequency of the check to be performed in the case of long-running processes.

As stated in this issue, there is a bug with long-running processes where Doctrine is left in a non-operable state, leading to the issuance of exceptions. 
While I acknowledge that this approach appears to resolve the problem, the current code has a strong dependency on Symfony. This is why the PR is kept in draft. If you have any suggestions for improvement and providing an extension point that Symfony can utilize, I am all ears! Or simply I move the code directly from the `ConnectionLossAwareHandler`(Symfony\Bridge) into the Doctrine bal.

linked to:
https://github.com/symfony/symfony/pull/53214
https://github.com/doctrine/DoctrineBundle/pull/1739
