### PR TITLE
Fix SQL Server "extended property" SQL generation

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -909,8 +909,11 @@ class SQLServerPlatform extends AbstractPlatform
         return 'EXEC sp_addextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral($value ?? '') . ', ' .
             'N' . $this->quoteStringLiteral($level0Type ?? '') . ', ' . $level0Name . ', ' .
-            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name . ', ' .
-            'N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name;
+            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name .
+            ($level2Type !== null || $level2Name !== null
+                ? ', N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name
+                : ''
+            );
     }
 
     /**
@@ -942,8 +945,11 @@ class SQLServerPlatform extends AbstractPlatform
         return 'EXEC sp_dropextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', ' .
             'N' . $this->quoteStringLiteral($level0Type ?? '') . ', ' . $level0Name . ', ' .
-            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name . ', ' .
-            'N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name;
+            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name .
+            ($level2Type !== null || $level2Name !== null
+                ? ', N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name
+                : ''
+            );
     }
 
     /**
@@ -977,8 +983,11 @@ class SQLServerPlatform extends AbstractPlatform
         return 'EXEC sp_updateextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral($value ?? '') . ', ' .
             'N' . $this->quoteStringLiteral($level0Type ?? '') . ', ' . $level0Name . ', ' .
-            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name . ', ' .
-            'N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name;
+            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name .
+            ($level2Type !== null || $level2Name !== null
+                ? ', N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name
+                : ''
+            );
     }
 
     /**
@@ -1765,15 +1774,13 @@ class SQLServerPlatform extends AbstractPlatform
 
     protected function getCommentOnTableSQL(string $tableName, ?string $comment): string
     {
-        return sprintf(
-            <<<'SQL'
-                EXEC sys.sp_addextendedproperty @name=N'MS_Description',
-                  @value=N%s, @level0type=N'SCHEMA', @level0name=N'dbo',
-                  @level1type=N'TABLE', @level1name=N%s
-                SQL
-            ,
-            $this->quoteStringLiteral($comment ?? ''),
-            $this->quoteStringLiteral($tableName),
+        return $this->getAddExtendedPropertySQL(
+            'MS_Description',
+            $comment,
+            'SCHEMA',
+            "'dbo'",
+            'TABLE',
+            $tableSQL,
         );
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -907,10 +907,10 @@ class SQLServerPlatform extends AbstractPlatform
         $level2Name = null
     ) {
         return 'EXEC sp_addextendedproperty ' .
-            'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value) . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level1Type) . ', ' . $level1Name . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level2Type) . ', ' . $level2Name;
+            'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral($value ?? '') . ', ' .
+            'N' . $this->quoteStringLiteral($level0Type ?? '') . ', ' . $level0Name . ', ' .
+            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name . ', ' .
+            'N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name;
     }
 
     /**
@@ -941,9 +941,9 @@ class SQLServerPlatform extends AbstractPlatform
     ) {
         return 'EXEC sp_dropextendedproperty ' .
             'N' . $this->quoteStringLiteral($name) . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level1Type) . ', ' . $level1Name . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level2Type) . ', ' . $level2Name;
+            'N' . $this->quoteStringLiteral($level0Type ?? '') . ', ' . $level0Name . ', ' .
+            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name . ', ' .
+            'N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name;
     }
 
     /**
@@ -975,10 +975,10 @@ class SQLServerPlatform extends AbstractPlatform
         $level2Name = null
     ) {
         return 'EXEC sp_updateextendedproperty ' .
-            'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral((string) $value) . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level0Type) . ', ' . $level0Name . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level1Type) . ', ' . $level1Name . ', ' .
-            'N' . $this->quoteStringLiteral((string) $level2Type) . ', ' . $level2Name;
+            'N' . $this->quoteStringLiteral($name) . ', N' . $this->quoteStringLiteral($value ?? '') . ', ' .
+            'N' . $this->quoteStringLiteral($level0Type ?? '') . ', ' . $level0Name . ', ' .
+            'N' . $this->quoteStringLiteral($level1Type ?? '') . ', ' . $level1Name . ', ' .
+            'N' . $this->quoteStringLiteral($level2Type ?? '') . ', ' . $level2Name;
     }
 
     /**
@@ -1772,7 +1772,7 @@ class SQLServerPlatform extends AbstractPlatform
                   @level1type=N'TABLE', @level1name=N%s
                 SQL
             ,
-            $this->quoteStringLiteral((string) $comment),
+            $this->quoteStringLiteral($comment ?? ''),
             $this->quoteStringLiteral($tableName),
         );
     }

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -97,10 +97,13 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals(666, $columns['df_integer']->getDefault());
     }
 
-    /** @psalm-suppress DeprecatedConstant */
-    public function testColumnComments(): void
+    /**
+     * @dataProvider columnCommentsProvider
+     * @psalm-suppress DeprecatedConstant
+     */
+    public function testColumnComments(string $tableName): void
     {
-        $table = new Table('sqlsrv_column_comment');
+        $table = new Table($tableName);
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('comment_null', Types::INTEGER, ['comment' => null]);
         $table->addColumn('comment_false', Types::INTEGER, ['comment' => false]);
@@ -130,7 +133,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->createTable($table);
 
-        $columns = $this->schemaManager->listTableColumns('sqlsrv_column_comment');
+        $columns = $this->schemaManager->listTableColumns($tableName);
         self::assertCount(13, $columns);
         self::assertNull($columns['id']->getComment());
         self::assertNull($columns['comment_null']->getComment());
@@ -209,7 +212,7 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->alterTable($diff);
 
-        $columns = $this->schemaManager->listTableColumns('sqlsrv_column_comment');
+        $columns = $this->schemaManager->listTableColumns($tableName);
         self::assertCount(24, $columns);
         self::assertEquals('primary', $columns['id']->getComment());
         self::assertNull($columns['comment_null']->getComment());
@@ -235,6 +238,16 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNull($columns['added_commented_type']->getComment());
         self::assertEquals('666', $columns['added_commented_type_with_comment']->getComment());
         self::assertEquals('Some comment', $columns['commented_req_change_column']->getComment());
+    }
+
+    /** @return mixed[][] */
+    public static function columnCommentsProvider(): iterable
+    {
+        return [
+            'Simple table name' => ['sqlsrv_column_comment'],
+            'Quoted table name' => ['[sqlsrv_column_comment quoted]'],
+            'Quoted table name with schema' => ['[dbo].[sqlsrv_column_comment " with_schema]'],
+        ];
     }
 
     public function testPkOrdering(): void

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -663,7 +663,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $expectedSql = [
             'CREATE TABLE testschema.test (id INT NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'This is a comment', "
-                . "N'SCHEMA', 'testschema', N'TABLE', 'test', N'COLUMN', id",
+                . "N'SCHEMA', 'testschema', N'TABLE', 'test', N'COLUMN', 'id'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getCreateTableSQL($table));
@@ -681,7 +681,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         $expectedSql = [
             'ALTER TABLE testschema.mytable ADD quota INT NOT NULL',
             "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
-                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', quota",
+                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
@@ -699,7 +699,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
         $expectedSql = [
             "EXEC sp_dropextendedproperty N'MS_Description'"
-                . ", N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', quota",
+                . ", N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
@@ -716,7 +716,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         );
 
         $expectedSql = ["EXEC sp_updateextendedproperty N'MS_Description', N'B comment', "
-                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', quota",
+                . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
         self::assertEquals($expectedSql, $this->platform->getAlterTableSQL($tableDiff));
@@ -730,7 +730,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         return [
             'CREATE TABLE test (id INT NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'This is a comment', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', id",
+                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', 'id'",
         ];
     }
 
@@ -742,7 +742,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         return [
             'ALTER TABLE mytable ADD quota INT NOT NULL',
             "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', quota",
+                . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
     }
 
@@ -754,7 +754,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         return [
             'CREATE TABLE test (id INT NOT NULL, data VARCHAR(MAX) NOT NULL, PRIMARY KEY (id))',
             "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:array)', "
-                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', data",
+                . "N'SCHEMA', 'dbo', N'TABLE', 'test', N'COLUMN', 'data'",
         ];
     }
 
@@ -801,26 +801,26 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                     . 'comment_with_string_literal_char NVARCHAR(255) NOT NULL, '
                     . 'PRIMARY KEY (id))',
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_integer_0",
+                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_integer_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_float_0",
+                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_float_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_string_0",
+                    . "N'0', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_string_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'Doctrine 0wnz you!', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment",
+                    . "N'Doctrine 0wnz you!', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
                     . "N'Doctrine 0wnz comments for explicitly quoted columns!', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [comment_quoted]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_quoted'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
                     . "N'Doctrine 0wnz comments for reserved keyword columns!', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [create]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'create'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
-                    . "N'(DC2Type:object)', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type",
+                    . "N'(DC2Type:object)', N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type'",
                 "EXEC sp_addextendedproperty N'MS_Description', "
                     . "N'Doctrine array type.(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type_with_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type_with_comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'O''Reilly', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_with_string_literal_char",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_with_string_literal_char'",
             ],
             $this->platform->getCreateTableSQL($table),
         );
@@ -1025,45 +1025,45 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
                 // Added columns.
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_integer_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_integer_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_float_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_float_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'0', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_string_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_string_0'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'Doctrine', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'rulez', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [added_comment_quoted]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_quoted'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'666', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [select]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'select'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:object)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_commented_type",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_commented_type'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'666(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_commented_type_with_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_commented_type_with_comment'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'''''', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', added_comment_with_string_literal_char",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'added_comment_with_string_literal_char'",
 
                 // Changed columns.
                 "EXEC sp_addextendedproperty N'MS_Description', N'primary', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', id",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'id'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'false', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_false",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_false'",
                 "EXEC sp_addextendedproperty N'MS_Description', N'(DC2Type:object)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_empty_string",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_empty_string'",
                 "EXEC sp_dropextendedproperty N'MS_Description', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_string_0",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_string_0'",
                 "EXEC sp_dropextendedproperty N'MS_Description', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'Doctrine array.(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [comment_quoted]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_quoted'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'(DC2Type:object)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', [create]",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'create'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'foo', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'(DC2Type:array)', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', commented_type_with_comment",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'commented_type_with_comment'",
                 "EXEC sp_updateextendedproperty N'MS_Description', N'''', "
-                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', comment_with_string_literal_char",
+                    . "N'SCHEMA', 'dbo', N'TABLE', 'mytable', N'COLUMN', 'comment_with_string_literal_char'",
             ],
             $this->platform->getAlterTableSQL($tableDiff),
         );


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #4283, superseeded #4360, #4585

#### Summary

https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql?view=sql-server-ver15 shows the `sp_addextendedproperty` accepts `sysname` datatype which is subtype of string datatype and therefore the values must be escaped as string literal instead of escaped identifier. This is evident also in the [examples](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql?view=sql-server-ver15#examples).

As the DBAL method arguments accepts possibly escaped identifier, we unescape it before we escape the argument as string literal.