### PR TITLE
Ensure correct json default value normalization

### DIFF
--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -463,6 +463,7 @@ SQL,
                 $length = null;
                 break;
 
+            case 'json':
             case 'text':
             case '_varchar':
             case 'varchar':

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -300,6 +300,20 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('foo', $databaseTable->getColumn('def')->getDefault());
     }
 
+    public function testJsonDefaultValue(): void
+    {
+        $testTable = new Table('test_json');
+        $testTable
+            ->addColumn('foo', Types::JSON)
+            ->setDefault('{"key": "value with a single quote \' in string value"}');
+        $this->dropAndCreateTable($testTable);
+
+        $columns = $this->schemaManager->listTableColumns('test_json');
+
+        self::assertSame(Types::JSON, $columns['foo']->getType()->getName());
+        self::assertSame('{"key": "value with a single quote \' in string value"}', $columns['foo']->getDefault());
+    }
+
     /**
      * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
      *


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6357

#### Summary

`PostgreSQLSchemaManager::_getPortableTableColumnDefinition()` is modified to call the private method `parseDefaultExpression()` on default values for `JSON` field to correctly normalize doubled single-quotes in json string value.

A test to cover this case is added.
