### PR TITLE
Avoid calling deprecated Type::getName()

### DIFF
--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -310,7 +310,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('test_json');
 
-        self::assertSame(Types::JSON, $columns['foo']->getType()->getName());
+        self::assertSame(Type::getType(Types::JSON), $columns['foo']->getType());
         self::assertSame('{"key": "value with a single quote \' in string value"}', $columns['foo']->getDefault());
     }
 


### PR DESCRIPTION
Follow-up to #6358 (@sbuerk): `getName()` is gone on 4.0.x. This change will make merging this test up easier for us.