### PR TITLE
Connection::setNestTransactionsWithSavepoints() should not break lazy connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1317,10 +1317,6 @@ class Connection
             throw ConnectionException::mayNotAlterNestedTransactionWithSavepointsInTransaction();
         }
 
-        if (! $this->getDatabasePlatform()->supportsSavepoints()) {
-            throw ConnectionException::savepointsNotSupported();
-        }
-
         $this->nestTransactionsWithSavepoints = (bool) $nestTransactionsWithSavepoints;
     }
 

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -195,18 +195,6 @@ class ConnectionTest extends FunctionalTestCase
         self::assertFalse($this->connection->isTransactionActive());
     }
 
-    public function testSetNestedTransactionsThroughSavepointsNotSupportedThrowsException(): void
-    {
-        if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {
-            self::markTestSkipped('This test requires the platform not to support savepoints.');
-        }
-
-        $this->expectException(ConnectionException::class);
-        $this->expectExceptionMessage('Savepoints are not supported by this driver.');
-
-        $this->connection->setNestTransactionsWithSavepoints(true);
-    }
-
     public function testCreateSavepointsNotSupportedThrowsException(): void
     {
         if ($this->connection->getDatabasePlatform()->supportsSavepoints()) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

When calling `Connection::setNestTransactionsWithSavepoints()`, the platform is fetched to check if savepoints are actually supported. This is a problem because it might cause the connection to be opened.

I've removed the check which will postpone the exception to the first time we attempt to create a savepoint.
