### PR TITLE
Properly handle MySQL error code 4031 from PHP 8.4

### DIFF
--- a/src/Driver/API/MySQL/ExceptionConverter.php
+++ b/src/Driver/API/MySQL/ExceptionConverter.php
@@ -101,6 +101,7 @@ final class ExceptionConverter implements ExceptionConverterInterface
                 return new ConnectionException($exception, $query);
 
             case 2006:
+            case 4031:
                 return new ConnectionLost($exception, $query);
 
             case 1048:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Prevents future issues ;-)

#### Summary

PHP 8.4 will support a new error code 4031 in mysqlnd when the connection is dropped due to timeouts.

It has been introduced in:
https://github.com/mysql/mysql-server/commit/14508bbb1790697c28659dd051fbc855cd3b5da9

And PHP 8.4 will support it:
https://github.com/php/php-src/pull/13618

The PR gets the test suite green again (mysqli + pdo_mysql). I have used 4.0.x as base, but feel free to change according to your preferences.