### PR TITLE
Add `QueryBuilder` support for `UNION` clause

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -315,6 +315,59 @@ user-input:
         ->setParameter(0, $userInputLastLogin)
     ;
 
+UNION-Clause
+~~~~~~~~~~~~
+
+To combine multiple ``SELECT`` queries into one result-set you can pass SQL Part strings
+or QueryBuilder instances to one of the following methods:
+
+* ``union(string|QueryBuilder $part)``
+* ``addUnion(string|QueryBuilder $part, UnionType $type)``
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->union('SELECT 1 AS field')
+        ->addUnion('SELECT 2 AS field', UnionType::DISTINCT)
+        ->addUnion('SELECT 3 AS field', UnionType::DISTINCT)
+        ->addUnion('SELECT 3 as field', UnionType::DISTINCT);
+
+    $queryBuilder
+        ->union('SELECT 1 AS field')
+        ->addUnion('SELECT 2 AS field', UnionType::ALL)
+        ->addUnion('SELECT 3 AS field', UnionType::ALL)
+        ->addUnion('SELECT 3 as field', UnionType::ALL);
+
+    $queryBuilder
+        ->union('SELECT 1 AS field')
+        ->addUnion('SELECT 2 AS field', UnionType::ALL)
+        ->addUnion('SELECT 3 AS field', UnionType::ALL)
+        ->addUnion('SELECT 3 as field', UnionType::DISTINCT);
+
+    $subQueryBuilder1
+        ->select('id AS field')
+        ->from('a_table');
+    $subQueryBuilder2
+        ->select('id AS field')
+        ->from('a_table');
+    $queryBuilder
+        ->union($subQueryBuilder1)
+        ->addUnion($subQueryBuilder2, UnionType::DISTINCT);
+
+    $subQueryBuilder1
+        ->select('id AS field')
+        ->from('a_table');
+    $subQueryBuilder2
+        ->select('id AS field')
+        ->from('a_table');
+    $queryBuilder
+        ->union($subQueryBuilder1)
+        ->addUnion($subQueryBuilder2,UnionType::ALL)
+        ->orderBy('field', 'DESC')
+        ->setMaxResults(100);
+
 Building Expressions
 --------------------
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -27,7 +27,9 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\DefaultUnionSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+use Doctrine\DBAL\SQL\Builder\UnionSQLBuilder;
 use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
@@ -768,6 +770,11 @@ abstract class AbstractPlatform
     public function createSelectSQLBuilder(): SelectSQLBuilder
     {
         return new DefaultSelectSQLBuilder($this, 'FOR UPDATE', 'SKIP LOCKED');
+    }
+
+    public function createUnionSQLBuilder(): UnionSQLBuilder
+    {
+        return new DefaultUnionSQLBuilder($this);
     }
 
     /**
@@ -2208,6 +2215,30 @@ abstract class AbstractPlatform
         }
 
         return $column1->getComment() === $column2->getComment();
+    }
+
+    /**
+     * Returns the union select query part surrounded by parenthesis if possible for platform.
+     */
+    public function getUnionSelectPartSQL(string $subQuery): string
+    {
+        return sprintf('(%s)', $subQuery);
+    }
+
+    /**
+     * Returns the `UNION ALL` keyword.
+     */
+    public function getUnionAllSQL(): string
+    {
+        return 'UNION ALL';
+    }
+
+    /**
+     * Returns the compatible `UNION DISTINCT` keyword.
+     */
+    public function getUnionDistinctSQL(): string
+    {
+        return 'UNION';
     }
 
     /**

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -991,4 +991,12 @@ class SQLitePlatform extends AbstractPlatform
     {
         return new SQLiteSchemaManager($connection, $this);
     }
+
+    /**
+     * Returns the union select query part surrounded by parenthesis if possible for platform.
+     */
+    public function getUnionSelectPartSQL(string $subQuery): string
+    {
+        return $subQuery;
+    }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -154,6 +154,13 @@ class QueryBuilder
     private array $values = [];
 
     /**
+     * The QueryBuilder for the union parts.
+     *
+     * @var Union[]
+     */
+    private array $unionParts = [];
+
+    /**
      * The query cache profile used for caching results.
      */
     private ?QueryCacheProfile $resultCacheProfile = null;
@@ -336,6 +343,7 @@ class QueryBuilder
             QueryType::DELETE => $this->getSQLForDelete(),
             QueryType::UPDATE => $this->getSQLForUpdate(),
             QueryType::SELECT => $this->getSQLForSelect(),
+            QueryType::UNION  => $this->getSQLForUnion(),
         };
     }
 
@@ -495,6 +503,54 @@ class QueryBuilder
     public function forUpdate(ConflictResolutionMode $conflictResolutionMode = ConflictResolutionMode::ORDINARY): self
     {
         $this->forUpdate = new ForUpdate($conflictResolutionMode);
+
+        $this->sql = null;
+
+        return $this;
+    }
+
+    /**
+     * Specifies union parts to be used to build a UNION query.
+     * Replaces any previously specified parts.
+     *
+     * <code>
+     *     $qb = $conn->createQueryBuilder()
+     *         ->union('SELECT 1 AS field1', 'SELECT 2 AS field1');
+     * </code>
+     *
+     * @return $this
+     */
+    public function union(string|QueryBuilder $part): self
+    {
+        $this->type = QueryType::UNION;
+
+        $this->unionParts = [new Union($part)];
+
+        $this->sql = null;
+
+        return $this;
+    }
+
+    /**
+     * Add parts to be used to build a UNION query.
+     *
+     * <code>
+     *     $qb = $conn->createQueryBuilder()
+     *         ->union('SELECT 1 AS field1')
+     *         ->addUnion('SELECT 2 AS field1', 'SELECT 3 AS field1')
+     * </code>
+     *
+     * @return $this
+     */
+    public function addUnion(string|QueryBuilder $part, UnionType $type): self
+    {
+        $this->type = QueryType::UNION;
+
+        if (count($this->unionParts) === 0) {
+            throw new QueryException('No initial UNION part set, use union() to set one first.');
+        }
+
+        $this->unionParts[] = new Union($part, $type);
 
         $this->sql = null;
 
@@ -1307,6 +1363,30 @@ class QueryBuilder
         }
 
         return $query;
+    }
+
+    /**
+     * Converts this instance into a UNION string in SQL.
+     */
+    private function getSQLForUnion(): string
+    {
+        $countUnions = count($this->unionParts);
+        if ($countUnions < 2) {
+            throw new QueryException(
+                'Insufficient UNION parts give, need at least 2.'
+                . ' Please use union() and addUnion() to set enough UNION parts.',
+            );
+        }
+
+        return $this->connection->getDatabasePlatform()
+            ->createUnionSQLBuilder()
+            ->buildSQL(
+                new UnionQuery(
+                    $this->unionParts,
+                    $this->orderBy,
+                    new Limit($this->maxResults, $this->firstResult),
+                ),
+            );
     }
 
     /**

--- a/src/Query/QueryType.php
+++ b/src/Query/QueryType.php
@@ -11,4 +11,5 @@ enum QueryType
     case DELETE;
     case UPDATE;
     case INSERT;
+    case UNION;
 }

--- a/src/Query/Union.php
+++ b/src/Query/Union.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+/** @internal */
+final class Union
+{
+    public function __construct(
+        public readonly string|QueryBuilder $query,
+        public readonly ?UnionType $type = null,
+    ) {
+    }
+}

--- a/src/Query/UnionQuery.php
+++ b/src/Query/UnionQuery.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+final class UnionQuery
+{
+    /**
+     * @internal This class should be instantiated only by {@link QueryBuilder}.
+     *
+     * @param Union[]  $unionParts
+     * @param string[] $orderBy
+     */
+    public function __construct(
+        private readonly array $unionParts,
+        private readonly array $orderBy,
+        private readonly Limit $limit,
+    ) {
+    }
+
+    /** @return Union[] */
+    public function getUnionParts(): array
+    {
+        return $this->unionParts;
+    }
+
+    /** @return string[] */
+    public function getOrderBy(): array
+    {
+        return $this->orderBy;
+    }
+
+    public function getLimit(): Limit
+    {
+        return $this->limit;
+    }
+}

--- a/src/Query/UnionType.php
+++ b/src/Query/UnionType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Query;
+
+enum UnionType
+{
+    case ALL;
+    case DISTINCT;
+}

--- a/src/SQL/Builder/DefaultUnionSQLBuilder.php
+++ b/src/SQL/Builder/DefaultUnionSQLBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\SQL\Builder;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Query\UnionQuery;
+use Doctrine\DBAL\Query\UnionType;
+
+use function count;
+use function implode;
+
+final class DefaultUnionSQLBuilder implements UnionSQLBuilder
+{
+    public function __construct(
+        private readonly AbstractPlatform $platform,
+    ) {
+    }
+
+    public function buildSQL(UnionQuery $query): string
+    {
+        $parts = [];
+        foreach ($query->getUnionParts() as $union) {
+            if ($union->type !== null) {
+                $parts[] = $union->type === UnionType::ALL
+                    ? $this->platform->getUnionAllSQL()
+                    : $this->platform->getUnionDistinctSQL();
+            }
+
+            $parts[] = $this->platform->getUnionSelectPartSQL((string) $union->query);
+        }
+
+        $orderBy = $query->getOrderBy();
+        if (count($orderBy) > 0) {
+            $parts[] = 'ORDER BY ' . implode(', ', $orderBy);
+        }
+
+        $sql   = implode(' ', $parts);
+        $limit = $query->getLimit();
+
+        if ($limit->isDefined()) {
+            $sql = $this->platform->modifyLimitQuery($sql, $limit->getMaxResults(), $limit->getFirstResult());
+        }
+
+        return $sql;
+    }
+}

--- a/src/SQL/Builder/UnionSQLBuilder.php
+++ b/src/SQL/Builder/UnionSQLBuilder.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\SQL\Builder;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Query\UnionQuery;
+
+interface UnionSQLBuilder
+{
+    /** @throws Exception */
+    public function buildSQL(UnionQuery $query): string;
+}

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Functional\Query;
 
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\MariaDB1060Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
@@ -13,10 +14,15 @@ use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
+use Doctrine\DBAL\Query\UnionType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Types;
+
+use function array_change_key_case;
+
+use const CASE_UPPER;
 
 final class QueryBuilderTest extends FunctionalTestCase
 {
@@ -103,6 +109,244 @@ final class QueryBuilderTest extends FunctionalTestCase
 
         self::expectException(Exception::class);
         $qb->executeQuery();
+    }
+
+    public function testUnionAllReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 1], ['field_one' => 1], ['field_one' => 2]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('2 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::ALL)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::ALL)
+            ->orderBy('field_one', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 1], ['field_one' => 2]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('2 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
+            ->orderBy('field_one', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionWithDescOrderByReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 2], ['field_one' => 1]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('1 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('2 as field_one'), UnionType::DISTINCT)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
+            ->orderBy('field_one', 'DESC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionAllWithLimitClauseReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 2]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('1 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('2 as field_one'), UnionType::ALL)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::ALL)
+            ->setMaxResults(1)
+            ->setFirstResult(0)
+            ->orderBy('field_one', 'DESC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionWithLimitClauseReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 2]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('1 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('2 as field_one'), UnionType::DISTINCT)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
+            ->setMaxResults(1)
+            ->setFirstResult(0)
+            ->orderBy('field_one', 'DESC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionAllWithLimitAndOffsetClauseReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 1]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('1 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('2 as field_one'), UnionType::ALL)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::ALL)
+            ->setMaxResults(1)
+            ->setFirstResult(1)
+            ->orderBy('field_one', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionWithLimitAndOffsetClauseReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 2]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $plainSelect1 = $platform->getDummySelectSQL('1 as field_one');
+        $plainSelect2 = $platform->getDummySelectSQL('2 as field_one');
+        $plainSelect3 = $platform->getDummySelectSQL('1 as field_one');
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('1 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('2 as field_one'), UnionType::DISTINCT)
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
+            ->setMaxResults(1)
+            ->setFirstResult(1)
+            ->orderBy('field_one', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionAllAndAddUnionAllWorksWithQueryBuilderPartsAndOrderByDescAndReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['id' => 2], ['id' => 1], ['id' => 1]]);
+        $qb           = $this->connection->createQueryBuilder();
+
+        $subQueryBuilder1 = $this->connection->createQueryBuilder();
+        $subQueryBuilder1->select('id')->from('for_update')->where($qb->expr()->eq('id', '1'));
+
+        $subQueryBuilder2 = $this->connection->createQueryBuilder();
+        $subQueryBuilder2->select('id')->from('for_update')->where($qb->expr()->eq('id', '2'));
+
+        $subQueryBuilder3 = $this->connection->createQueryBuilder();
+        $subQueryBuilder3->select('id')->from('for_update')->where($qb->expr()->eq('id', '1'));
+
+        $qb->union($subQueryBuilder1)
+            ->addUnion($subQueryBuilder2, UnionType::ALL)
+            ->addUnion($subQueryBuilder3, UnionType::ALL)
+            ->orderBy('id', 'DESC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionAndAddUnionWithNamedParameterOnOuterInstanceAndOrderByDescWorks(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['id' => 2], ['id' => 1]]);
+        $qb           = $this->connection->createQueryBuilder();
+
+        $subQueryBuilder1 = $this->connection->createQueryBuilder();
+        $subQueryBuilder1->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
+
+        $subQueryBuilder2 = $this->connection->createQueryBuilder();
+        $subQueryBuilder2->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(2, ParameterType::INTEGER)));
+
+        $subQueryBuilder3 = $this->connection->createQueryBuilder();
+        $subQueryBuilder3->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
+
+        $qb->union($subQueryBuilder1)
+            ->addUnion($subQueryBuilder2, UnionType::DISTINCT)
+            ->addUnion($subQueryBuilder3, UnionType::DISTINCT)
+            ->orderBy('id', 'DESC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionAllAndAddUnionAllWorksWithQueryBuilderPartsAndReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 1], ['id' => 2]]);
+        $qb           = $this->connection->createQueryBuilder();
+
+        $subQueryBuilder1 = $this->connection->createQueryBuilder();
+        $subQueryBuilder1->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
+
+        $subQueryBuilder2 = $this->connection->createQueryBuilder();
+        $subQueryBuilder2->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(2, ParameterType::INTEGER)));
+
+        $subQueryBuilder3 = $this->connection->createQueryBuilder();
+        $subQueryBuilder3->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
+
+        $qb->union($subQueryBuilder1)
+            ->addUnion($subQueryBuilder2, UnionType::ALL)
+            ->addUnion($subQueryBuilder3, UnionType::ALL)
+            ->orderBy('id', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionAndAddUnionWorksWithQueryBuilderPartsAndReturnsExpectedResult(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 2]]);
+        $qb           = $this->connection->createQueryBuilder();
+
+        $subQueryBuilder1 = $this->connection->createQueryBuilder();
+        $subQueryBuilder1->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
+
+        $subQueryBuilder2 = $this->connection->createQueryBuilder();
+        $subQueryBuilder2->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(2, ParameterType::INTEGER)));
+
+        $subQueryBuilder3 = $this->connection->createQueryBuilder();
+        $subQueryBuilder3->select('id')
+            ->from('for_update')
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
+
+        $qb->union($subQueryBuilder1)
+            ->addUnion($subQueryBuilder2, UnionType::DISTINCT)
+            ->addUnion($subQueryBuilder3, UnionType::DISTINCT)
+            ->orderBy('id', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    /**
+     * @param array<array<string, int>> $rows
+     *
+     * @return array<array<string, int|string>>
+     */
+    private function prepareExpectedRows(array $rows): array
+    {
+        if (! TestUtil::isDriverOneOf('ibm_db2', 'pdo_oci', 'pdo_sqlsrv', 'oci8')) {
+            return $rows;
+        }
+
+        if (! TestUtil::isDriverOneOf('ibm_db2')) {
+            foreach ($rows as &$row) {
+                foreach ($row as &$value) {
+                    $value = (string) $value;
+                }
+            }
+        }
+
+        if (! TestUtil::isDriverOneOf('ibm_db2', 'pdo_oci', 'oci8')) {
+            return $rows;
+        }
+
+        foreach ($rows as &$row) {
+            $row = array_change_key_case($row, CASE_UPPER);
+        }
+
+        return $rows;
     }
 
     private function platformSupportsSkipLocked(): bool


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #6368

### Summary

The `UNION` operator is used to combine the result-set
of two or more `SELECT` statements, which all database
vendors supports with usual specialities for each.

Still, there is a common shared subset which works for
all of them:

```
    SELECT column_name(s) FROM table1
    WHERE ...

    UNION <ALL | DISTINCT>

    SELECT column_name(s) FROM table2
    WHERE ...

    ORDER BY ...
    LIMIT x OFFSET y
```

with shared common requirements:

* Each `SELECT` must return the same fields
  in number, naming and order.

* Each `SELECT` **must not** have `ORDER BY`,
  expect MySQL allowing it to be used as sub
  query expression encapsulated in parenthesis.

It is now possible to build `UNION` queries using
following additional QueryBuilder API methods:

* `union(string|QueryBuilder $part)` to create a `UNION`
   query retrieving unique rows
* `addUnion(string|QueryBuilder $part, UnionType $type)`
   to add `UNION (ALL|DISTINCT)` query with the selected
   union query type.

This follows the generic logic of `select(...)` and
`addSelect(...)` along with introducing new UnionType
enum and internal QueryType::UNION enum case.

Technically, the SQL build process is dispatched to a
`DefaultUnionSQLBuilder` along with an `UnionSQLBuilder`
interface, which also allows application to implement
custom behaviour if required. Union SQL keyword and part
SQL generation is handled through added methods on the
Platforms to allow adjustment for furture versions if
needed - or throw a Exception if a Platform does not
support it anymore.

Example:

```php
$platform = $connection->getDatabasePlatform();
$qb       = $>connection->createQueryBuilder();
$select10 = $platform->getDummySelectSQL('2 as field_one');
$select20 = $platform->getDummySelectSQL('1 as field_one');
$qb->union($select10)
   ->addUnion($select20, UnionType::ALL)
   ->setMaxResults(1)
   ->setFirstResult(1)
   ->orderBy('field_one', 'ASC');
$rows = $qb->executeQuery()->fetchAllAssociative();
```

Unit and functional tests are added to demonstrate the
implementation and cover it for future changes.

Resolves: #6368
