### PR TITLE
Fix: #6146 - utf8/utf8mb3 alias causes redundant ALTER TABLE changes

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -856,4 +856,14 @@ SQL;
 
         return $sql . ' WHERE ' . implode(' AND ', $conditions);
     }
+
+    /**
+     * INFORMATION_SCHEMA.CHARACTER_SETS will contain either 'utf8' or 'utf8mb3' but not both.
+     */
+    public function informationSchemaUsesUtf8mb3(Connection $connection): bool
+    {
+        $sql = "SELECT character_set_name FROM INFORMATION_SCHEMA.CHARACTER_SETS WHERE character_set_name = 'utf8mb3'";
+
+        return $connection->fetchOne($sql) === 'utf8mb3';
+    }
 }

--- a/src/Platforms/MySQL/CharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider.php
@@ -7,5 +7,7 @@ namespace Doctrine\DBAL\Platforms\MySQL;
 /** @internal */
 interface CharsetMetadataProvider
 {
+    public function normalizeCharset(string $charset): string;
+
     public function getDefaultCharsetCollation(string $charset): ?string;
 }

--- a/src/Platforms/MySQL/CharsetMetadataProvider/CachingCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/CachingCharsetMetadataProvider.php
@@ -18,6 +18,11 @@ final class CachingCharsetMetadataProvider implements CharsetMetadataProvider
     {
     }
 
+    public function normalizeCharset(string $charset): string
+    {
+        return $this->charsetMetadataProvider->normalizeCharset($charset);
+    }
+
     public function getDefaultCharsetCollation(string $charset): ?string
     {
         if (array_key_exists($charset, $this->cache)) {

--- a/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
@@ -11,13 +11,28 @@ use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 /** @internal */
 final class ConnectionCharsetMetadataProvider implements CharsetMetadataProvider
 {
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private readonly Connection $connection, private bool $useUtf8mb3)
     {
+    }
+
+    public function normalizeCharset(string $charset): string
+    {
+        if ($this->useUtf8mb3 && $charset === 'utf8') {
+            return 'utf8mb3';
+        }
+
+        if (! $this->useUtf8mb3 && $charset === 'utf8mb3') {
+            return 'utf8';
+        }
+
+        return $charset;
     }
 
     /** @throws Exception */
     public function getDefaultCharsetCollation(string $charset): ?string
     {
+        $charset = $this->normalizeCharset($charset);
+
         $collation = $this->connection->fetchOne(
             <<<'SQL'
             SELECT DEFAULT_COLLATE_NAME

--- a/src/Platforms/MySQL/CollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider.php
@@ -7,5 +7,7 @@ namespace Doctrine\DBAL\Platforms\MySQL;
 /** @internal */
 interface CollationMetadataProvider
 {
+    public function normalizeCollation(string $collation): string;
+
     public function getCollationCharset(string $collation): ?string;
 }

--- a/src/Platforms/MySQL/CollationMetadataProvider/CachingCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/CachingCollationMetadataProvider.php
@@ -18,6 +18,11 @@ final class CachingCollationMetadataProvider implements CollationMetadataProvide
     {
     }
 
+    public function normalizeCollation(string $collation): string
+    {
+        return $this->collationMetadataProvider->normalizeCollation($collation);
+    }
+
     public function getCollationCharset(string $collation): ?string
     {
         if (array_key_exists($collation, $this->cache)) {

--- a/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
@@ -8,16 +8,34 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 
+use function str_starts_with;
+use function substr;
+
 /** @internal */
 final class ConnectionCollationMetadataProvider implements CollationMetadataProvider
 {
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private readonly Connection $connection, private bool $useUtf8mb3)
     {
+    }
+
+    public function normalizeCollation(string $collation): string
+    {
+        if ($this->useUtf8mb3 && str_starts_with($collation, 'utf8_')) {
+            return 'utf8mb3' . substr($collation, 4);
+        }
+
+        if (! $this->useUtf8mb3 && str_starts_with($collation, 'utf8mb3_')) {
+            return 'utf8' . substr($collation, 7);
+        }
+
+        return $collation;
     }
 
     /** @throws Exception */
     public function getCollationCharset(string $collation): ?string
     {
+        $collation = $this->normalizeCollation($collation);
+
         $charset = $this->connection->fetchOne(
             <<<'SQL'
 SELECT CHARACTER_SET_NAME

--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -82,10 +82,20 @@ class Comparator extends BaseComparator
      */
     private function normalizeOptions(array $options): array
     {
-        if (isset($options['charset']) && ! isset($options['collation'])) {
-            $options['collation'] = $this->charsetMetadataProvider->getDefaultCharsetCollation($options['charset']);
-        } elseif (isset($options['collation']) && ! isset($options['charset'])) {
-            $options['charset'] = $this->collationMetadataProvider->getCollationCharset($options['collation']);
+        if (isset($options['charset'])) {
+            $options['charset'] = $this->charsetMetadataProvider->normalizeCharset($options['charset']);
+
+            if (! isset($options['collation'])) {
+                $options['collation'] = $this->charsetMetadataProvider->getDefaultCharsetCollation($options['charset']);
+            }
+        }
+
+        if (isset($options['collation'])) {
+            $options['collation'] = $this->collationMetadataProvider->normalizeCollation($options['collation']);
+
+            if (! isset($options['charset'])) {
+                $options['charset'] = $this->collationMetadataProvider->getCollationCharset($options['collation']);
+            }
         }
 
         return $options;

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -316,13 +316,15 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /** @throws Exception */
     public function createComparator(): Comparator
     {
+        $useUtf8mb3 = $this->platform->informationSchemaUsesUtf8mb3($this->connection);
+
         return new MySQL\Comparator(
             $this->platform,
             new CachingCharsetMetadataProvider(
-                new ConnectionCharsetMetadataProvider($this->connection),
+                new ConnectionCharsetMetadataProvider($this->connection, $useUtf8mb3),
             ),
             new CachingCollationMetadataProvider(
-                new ConnectionCollationMetadataProvider($this->connection),
+                new ConnectionCollationMetadataProvider($this->connection, $useUtf8mb3),
             ),
             $this->getDefaultTableOptions(),
         );

--- a/tests/Functional/Driver/DBAL6146Test.php
+++ b/tests/Functional/Driver/DBAL6146Test.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\StringType;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class DBAL6146Test extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('pdo_mysql', 'mysqli')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the pdo_mysql or the mysqli driver.');
+    }
+
+    /** @return iterable<array{array<string,string>,array<string,string>}> */
+    public static function equivalentCharsetAndCollationProvider(): iterable
+    {
+        yield [[], []];
+        yield [['charset' => 'utf8'], ['charset' => 'utf8']];
+        yield [['charset' => 'utf8'], ['charset' => 'utf8mb3']];
+        yield [['charset' => 'utf8mb3'], ['charset' => 'utf8']];
+        yield [['charset' => 'utf8mb3'], ['charset' => 'utf8mb3']];
+        yield [['collation' => 'utf8_unicode_ci'], ['collation' => 'utf8_unicode_ci']];
+        yield [['collation' => 'utf8_unicode_ci'], ['collation' => 'utf8mb3_unicode_ci']];
+        yield [['collation' => 'utf8mb3_unicode_ci'], ['collation' => 'utf8mb3_unicode_ci']];
+        yield [['collation' => 'utf8mb3_unicode_ci'], ['collation' => 'utf8_unicode_ci']];
+        yield [
+            ['charset' => 'utf8', 'collation' => 'utf8_unicode_ci'],
+            ['charset' => 'utf8', 'collation' => 'utf8_unicode_ci'],
+        ];
+
+        yield [
+            ['charset' => 'utf8', 'collation' => 'utf8_unicode_ci'],
+            ['charset' => 'utf8mb3', 'collation' => 'utf8mb3_unicode_ci'],
+        ];
+
+        yield [
+            ['charset' => 'utf8mb3', 'collation' => 'utf8mb3_unicode_ci'],
+            ['charset' => 'utf8', 'collation' => 'utf8_unicode_ci'],
+        ];
+
+        yield [
+            ['charset' => 'utf8mb3', 'collation' => 'utf8mb3_unicode_ci'],
+            ['charset' => 'utf8mb3', 'collation' => 'utf8mb3_unicode_ci'],
+        ];
+    }
+
+    /**
+     * @param array<string,string> $options1
+     * @param array<string,string> $options2
+     */
+    #[DataProvider('equivalentCharsetAndCollationProvider')]
+    public function testThereAreNoRedundantAlterTableStatements(array $options1, array $options2): void
+    {
+        $column1 = new Column('bar', new StringType(), ['length' => 32, 'platformOptions' => $options1]);
+        $table1  = new Table(name: 'foo6146', columns: [$column1]);
+
+        $column2 = new Column('bar', new StringType(), ['length' => 32, 'platformOptions' => $options2]);
+        $table2  = new Table(name: 'foo6146', columns: [$column2]);
+
+        $this->dropAndCreateTable($table1);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $oldSchema     = $schemaManager->introspectSchema();
+        $newSchema     = new Schema([$table2]);
+        $comparator    = $schemaManager->createComparator();
+        $schemaDiff    = $comparator->compareSchemas($oldSchema, $newSchema);
+        $alteredTables = $schemaDiff->getAlteredTables();
+
+        self::assertEmpty($alteredTables);
+    }
+}

--- a/tests/Platforms/MySQL/CollationMetadataProvider/ConnectionCharsetMetadataProviderTest.php
+++ b/tests/Platforms/MySQL/CollationMetadataProvider/ConnectionCharsetMetadataProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms\MySQL\CollationMetadataProvider;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider\ConnectionCharsetMetadataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionCharsetMetadataProviderTest extends TestCase
+{
+    public function testNormalizeCharset(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $utf8Provider = new ConnectionCharsetMetadataProvider($connection, false);
+
+        self::assertSame('utf8', $utf8Provider->normalizeCharset('utf8'));
+        self::assertSame('utf8', $utf8Provider->normalizeCharset('utf8mb3'));
+        self::assertSame('foobar', $utf8Provider->normalizeCharset('foobar'));
+
+        $utf8mb3Provider = new ConnectionCharsetMetadataProvider($connection, true);
+
+        self::assertSame('utf8mb3', $utf8mb3Provider->normalizeCharset('utf8'));
+        self::assertSame('utf8mb3', $utf8mb3Provider->normalizeCharset('utf8mb3'));
+        self::assertSame('foobar', $utf8mb3Provider->normalizeCharset('foobar'));
+    }
+}

--- a/tests/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProviderTest.php
+++ b/tests/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms\MySQL\CollationMetadataProvider;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\ConnectionCollationMetadataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionCollationMetadataProviderTest extends TestCase
+{
+    public function testNormalizeCcollation(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $utf8Provider = new ConnectionCollationMetadataProvider($connection, false);
+
+        self::assertSame('utf8_unicode_ci', $utf8Provider->normalizeCollation('utf8_unicode_ci'));
+        self::assertSame('utf8_unicode_ci', $utf8Provider->normalizeCollation('utf8mb3_unicode_ci'));
+        self::assertSame('foobar_unicode_ci', $utf8Provider->normalizeCollation('foobar_unicode_ci'));
+
+        $utf8mb3Provider = new ConnectionCollationMetadataProvider($connection, true);
+
+        self::assertSame('utf8mb3_unicode_ci', $utf8mb3Provider->normalizeCollation('utf8_unicode_ci'));
+        self::assertSame('utf8mb3_unicode_ci', $utf8mb3Provider->normalizeCollation('utf8mb3_unicode_ci'));
+        self::assertSame('foobar_unicode_ci', $utf8mb3Provider->normalizeCollation('foobar_unicode_ci'));
+    }
+}

--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms\MySQL;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
+use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider\ConnectionCharsetMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
+use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\ConnectionCollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\Comparator;
 use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Schema\AbstractComparatorTestCase;
+use Doctrine\DBAL\Types\StringType;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ComparatorTest extends AbstractComparatorTestCase
 {
@@ -21,5 +28,82 @@ class ComparatorTest extends AbstractComparatorTestCase
             self::createStub(CollationMetadataProvider::class),
             new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci'),
         );
+    }
+
+    #[DataProvider('utf8AndUtf8mb3MismatchesProvider')]
+    public function testUtf8AndUtf8mb3Mismatches(bool $useUtf8mb3, string $defaultCharset): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $platform   = new MySQLPlatform();
+
+        $utf8Comparator = new Comparator(
+            $platform,
+            new ConnectionCharsetMetadataProvider($connection, $useUtf8mb3),
+            new ConnectionCollationMetadataProvider($connection, $useUtf8mb3),
+            new DefaultTableOptions($defaultCharset, $defaultCharset . '_unicode_ci'),
+        );
+
+        $table1 = new Table('t1', [
+            new Column('c', new StringType(), [
+                'length' => 8,
+                'platformOptions' => ['collation' => 'utf8_unicode_ci'],
+            ]),
+        ]);
+        $table2 = new Table('t2', [
+            new Column('c', new StringType(), [
+                'length' => 8,
+                'platformOptions' => ['collation' => 'utf8mb3_unicode_ci'],
+            ]),
+        ]);
+        $table3 = new Table('t3', [
+            new Column('c', new StringType(), [
+                'length' => 8,
+                'platformOptions' => ['collation' => 'utf8mb4_unicode_ci'],
+            ]),
+        ]);
+
+        self::assertEmpty($utf8Comparator->compareTables($table1, $table2)->getModifiedColumns());
+        self::assertEmpty($utf8Comparator->compareTables($table2, $table1)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table1, $table3)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table3, $table1)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table2, $table3)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table3, $table2)->getModifiedColumns());
+
+        $table4 = new Table('t4', [
+            new Column('c', new StringType(), [
+                'length' => 8,
+                'platformOptions' => ['charset' => 'utf8'],
+            ]),
+        ]);
+        $table5 = new Table('t5', [
+            new Column('c', new StringType(), [
+                'length' => 8,
+                'platformOptions' => ['charset' => 'utf8mb3'],
+            ]),
+        ]);
+        $table6 = new Table('t6', [
+            new Column('c', new StringType(), [
+                'length' => 8,
+                'platformOptions' => ['charset' => 'utf8mb4'],
+            ]),
+        ]);
+
+        self::assertEmpty($utf8Comparator->compareTables($table4, $table5)->getModifiedColumns());
+        self::assertEmpty($utf8Comparator->compareTables($table5, $table4)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table4, $table6)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table6, $table4)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table5, $table6)->getModifiedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table6, $table5)->getModifiedColumns());
+    }
+
+    /** @return iterable<array{bool,string}> */
+    public static function utf8AndUtf8mb3MismatchesProvider(): iterable
+    {
+        yield [false, 'utf8'];
+        yield [true, 'utf8'];
+        yield [false, 'utf8mb3'];
+        yield [true, 'utf8mb3'];
+        yield [false, 'utf8mb4'];
+        yield [true, 'utf8mb4'];
     }
 }

--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -62,12 +62,12 @@ class ComparatorTest extends AbstractComparatorTestCase
             ]),
         ]);
 
-        self::assertEmpty($utf8Comparator->compareTables($table1, $table2)->getModifiedColumns());
-        self::assertEmpty($utf8Comparator->compareTables($table2, $table1)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table1, $table3)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table3, $table1)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table2, $table3)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table3, $table2)->getModifiedColumns());
+        self::assertEmpty($utf8Comparator->compareTables($table1, $table2)->getChangedColumns());
+        self::assertEmpty($utf8Comparator->compareTables($table2, $table1)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table1, $table3)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table3, $table1)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table2, $table3)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table3, $table2)->getChangedColumns());
 
         $table4 = new Table('t4', [
             new Column('c', new StringType(), [
@@ -88,12 +88,12 @@ class ComparatorTest extends AbstractComparatorTestCase
             ]),
         ]);
 
-        self::assertEmpty($utf8Comparator->compareTables($table4, $table5)->getModifiedColumns());
-        self::assertEmpty($utf8Comparator->compareTables($table5, $table4)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table4, $table6)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table6, $table4)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table5, $table6)->getModifiedColumns());
-        self::assertNotEmpty($utf8Comparator->compareTables($table6, $table5)->getModifiedColumns());
+        self::assertEmpty($utf8Comparator->compareTables($table4, $table5)->getChangedColumns());
+        self::assertEmpty($utf8Comparator->compareTables($table5, $table4)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table4, $table6)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table6, $table4)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table5, $table6)->getChangedColumns());
+        self::assertNotEmpty($utf8Comparator->compareTables($table6, $table5)->getChangedColumns());
     }
 
     /** @return iterable<array{bool,string}> */

--- a/tests/Platforms/MySQL/MariaDBJsonComparatorTest.php
+++ b/tests/Platforms/MySQL/MariaDBJsonComparatorTest.php
@@ -28,12 +28,22 @@ class MariaDBJsonComparatorTest extends TestCase
         $this->comparator = new Comparator(
             new MariaDBPlatform(),
             new class implements CharsetMetadataProvider {
+                public function normalizeCharset(string $charset): string
+                {
+                    return $charset;
+                }
+
                 public function getDefaultCharsetCollation(string $charset): ?string
                 {
                     return null;
                 }
             },
             new class implements CollationMetadataProvider {
+                public function normalizeCollation(string $collation): string
+                {
+                    return $collation;
+                }
+
                 public function getCollationCharset(string $collation): ?string
                 {
                     return null;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6146

#### Summary

In MySQL (and MariaDB), `utf8` and `utf8mb3` are aliases.  Depending on the database server version, the information schema may contain one or the other.  Similarly, column definitions may contain one or the other.

When performing schema-comparisons, a mismatch between `utf8` and `utf8mb3` causes an `ALTER TABLE` statement to be generated - even when columns are identical.

The code already contains a function to normalize the charset/collation options:
https://github.com/doctrine/dbal/blob/61d79c6e379a39dc1fea6b4e50a23dfc3cd2076a/src/Platforms/MySQL/Comparator.php#L83

My solution is to extend this function so that it also replaces `utf8` with `utf8mb3` (or vice-versa), to match the current database connection.

To detect the prefered character set for the connection, I've added:
`AbstractMySQLPlatform::informationSchemaUsesUtf8mb3()`
`MariaDBPlatform::informationSchemaUsesUtf8mb3()`

The obvious place for the new normalization logic is the `CharsetMetadataProvider` and `CollationMetadataProvider` classes.  These are interfaces, so this is technically a BC break, however, they are marked `@internal`.

I've added tests which should cover all the new/modified code.  I've run it against MySQL.  I don't have MariaDB to hand.