### PR TITLE
Set fail_ci_if_error flag to true

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -655,7 +655,7 @@ jobs:
         working-directory: reports
 
       - name: "Upload to Codecov"
-        uses: "codecov/codecov-action@v3"
+        uses: "codecov/codecov-action@v4"
         with:
           directory: reports
           fail_ci_if_error: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -658,3 +658,4 @@ jobs:
         uses: "codecov/codecov-action@v3"
         with:
           directory: reports
+          fail_ci_if_error: true


### PR DESCRIPTION
In [a recent PR](https://github.com/doctrine/dbal/pull/6370), we got reports from CodeCov about several lines not being covered. After further inspection, I found [an error message in the coverage file upload saying we hit a rate limit](https://github.com/doctrine/dbal/pull/6370#issuecomment-2088548480).
This will make it more likely we spot such issues in the future.