### PR TITLE
Provide CODECOV_TOKEN

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -659,3 +659,5 @@ jobs:
         with:
           directory: reports
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
It is necessary for builds that run on branches that are not from a fork. Branches from a fork use the tokenless upload. See https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov
