### PR TITLE
Check that providing CODECOV_TOKEN does not break the upload

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -659,3 +659,5 @@ jobs:
         with:
           directory: reports
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
This is the same as #6374 , except it's done from a fork. I don't plan on merging it, I just want to check both situations at once.