### PR TITLE
Remove internal flag on DriverException

### DIFF
--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -18,8 +18,6 @@ use function assert;
 class DriverException extends \Exception implements Exception, Driver\Exception
 {
     /**
-     * @internal
-     *
      * @param Driver\Exception $driverException The DBAL driver exception to chain.
      * @param Query|null       $query           The SQL query that triggered the exception, if any.
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6317

#### Summary

Removing @internal flag on DriverException prevents warnings while implementing ExceptionConverter for a custom driver.

