### PR TITLE
Fix IBM i Db2 DSN parameters for local

### DIFF
--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -57,9 +57,14 @@ final class DataSourceName
         }
 
         $dsnParams = [];
+        $serverIsIBMi = str_contains(php_uname(), 'OS400');
 
         foreach (
-            [
+            $serverIsIBMi ? [
+                'dbname'   => 'DSN',
+                'user'     => 'UID',
+                'password' => 'PWD',
+            ] : [
                 'host'     => 'HOSTNAME',
                 'port'     => 'PORT',
                 'protocol' => 'PROTOCOL',


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues |n/a

#### Summary

This fixes a bug, for lack of a better term, that arises when trying to use Doctrine locally on an IBM i system. There is a workaround, but that workaround isn't consistent with other database configurations. The IBMDB2/Driver.php uses IBMDB2/DataSourceName to translate any config into a connection string to pass to the db2_connect() and db2_pconnect() functions. When using this behavior remotely, the Db2 connect functions call the underlying non-IBM-i-system driver which takes the typical DSN parameters of DATABASE, HOSTNAME, PORT, PROTOCOL, UID, and PWD. However, on an IBM i, the Db2 connect functions call IBM i's very own [SQLDriverConnect](https://tinyurl.com/sdc-usage), which only takes DSN, UID, and PWD as arguments.

In summary, this checks if the IBMDB2/DataSourceName.php is running on an IBM i or not. If it is, it will build a connection string including DSN, UID, and PWD. Otherwise, it builds a typical connection string with DATABASE, HOSTNAME, PORT, PROTOCOL, UID, and PWD.
