### PR TITLE
Use 3.8.x as a target for dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    target-branch: "3.8.x"


### PR DESCRIPTION
By default, Dependabot checks the default branch, and raises pull requests against it. Since we are using a merge-up workflow, we should tell it to target 3.8.x. This is not great because it will mean we will have to maintain that setting for as long as we maintain the old patch branch, but I do not think there is a better solution.

Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch
