### PR TITLE
MySQL 8.4 Platform

### DIFF
--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -36,6 +36,7 @@ MySQL
 -  ``MySQLPlatform`` for version 5.0 and above.
 -  ``MySQL57Platform`` for version 5.7 (5.7.9 GA) and above.
 -  ``MySQL80Platform`` for version 8.0 (8.0 GA) and above.
+-  ``MySQL84Platform`` for version 8.4 (8.4 GA) and above.
 
 MariaDB
 ^^^^^

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MariaDb1060Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Platforms\MySQL84Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
@@ -64,6 +65,20 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
             }
         } else {
             $oracleMysqlVersion = $this->getOracleMysqlVersionNumber($version);
+
+            if (version_compare($oracleMysqlVersion, '8.4.0', '>=')) {
+                if (! version_compare($version, '8.4.0', '>=')) {
+                    Deprecation::trigger(
+                        'doctrine/orm',
+                        'https://github.com/doctrine/dbal/pull/5779',
+                        'Version detection logic for MySQL will change in DBAL 4. '
+                            . 'Please specify the version as the server reports it, e.g. "8.4.0" instead of "8.4".',
+                    );
+                }
+
+                return new MySQL84Platform();
+            }
+
             if (version_compare($oracleMysqlVersion, '8', '>=')) {
                 if (! version_compare($version, '8.0.0', '>=')) {
                     Deprecation::trigger(
@@ -130,6 +145,8 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         if ($majorVersion === '5' && $minorVersion === '7') {
             $patchVersion ??= '9';
+        } else {
+            $patchVersion ??= '0';
         }
 
         return $majorVersion . '.' . $minorVersion . '.' . $patchVersion;

--- a/src/Platforms/Keywords/MySQL84Keywords.php
+++ b/src/Platforms/Keywords/MySQL84Keywords.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+use Doctrine\Deprecations\Deprecation;
+
+use function array_merge;
+
+/**
+ * MySQL 8.4 reserved keywords list.
+ */
+class MySQL84Keywords extends MySQL80Keywords
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated
+     */
+    public function getName()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MySQL84Keywords::getName() is deprecated.',
+        );
+
+        return 'MySQL84';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @link https://dev.mysql.com/doc/refman/8.4/en/keywords.html#keywords-new-in-current-series
+     */
+    protected function getKeywords()
+    {
+        $keywords = parent::getKeywords();
+
+        $keywords = array_merge($keywords, [
+            'AUTO',
+            'BERNOULLI',
+            'GTIDS',
+            'LOG',
+            'MANUAL',
+            'PARALLEL',
+            'PARSE_TREE',
+            'QUALIFY',
+            'S3',
+            'TABLESAMPLE',
+        ]);
+
+        return $keywords;
+    }
+}

--- a/src/Platforms/MySQL84Platform.php
+++ b/src/Platforms/MySQL84Platform.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\Deprecations\Deprecation;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MySQL 8.4 (8.4 GA) database platform.
+ */
+class MySQL84Platform extends MySQL80Platform
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated Implement {@see createReservedKeywordsList()} instead.
+     */
+    protected function getReservedKeywordsClass()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4510',
+            'MySQL84Platform::getReservedKeywordsClass() is deprecated,'
+                . ' use MySQL84Platform::createReservedKeywordsList() instead.',
+        );
+
+        return Keywords\MySQL84Keywords::class;
+    }
+}

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MariaDb102Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords;
+use Doctrine\DBAL\Platforms\Keywords\MySQL84Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Platforms\Keywords\OracleKeywords;
 use Doctrine\DBAL\Platforms\Keywords\PostgreSQL100Keywords;
@@ -59,6 +60,7 @@ class ReservedWordsCommand extends Command
             'mysql'      => new MySQLKeywords(),
             'mysql57'    => new MySQL57Keywords(),
             'mysql80'    => new MySQL80Keywords(),
+            'mysql84'    => new MySQL84Keywords(),
             'oracle'     => new OracleKeywords(),
             'pgsql'      => new PostgreSQL94Keywords(),
             'pgsql100'   => new PostgreSQL100Keywords(),
@@ -130,6 +132,7 @@ The following keyword lists are currently shipped with Doctrine:
     * mysql
     * mysql57
     * mysql80
+    * mysql84
     * oracle
     * pgsql
     * pgsql100

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MariaDb1060Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Platforms\MySQL84Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
@@ -51,6 +52,8 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['8', MySQL80Platform::class],
             ['8.0', MySQL80Platform::class],
             ['8.0.11', MySQL80Platform::class],
+            ['8.4', MySQL84Platform::class],
+            ['8.4.0', MySQL84Platform::class],
             ['6', MySQL57Platform::class],
             ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class],
             ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class],


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | none

#### Summary

MySQL 8.4 introduces a new set of reserved keywords ([link][8.4-reserved-keywords]). This PR adds a new platform definition for MySQL 8.4 and higher.

[8.4-reserved-keywords]: https://dev.mysql.com/doc/refman/8.4/en/keywords.html#keywords-new-in-current-series

#### Related
- #6386
