### PR TITLE
Fix condition on Ascii String for SQL Server

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1306,7 +1306,7 @@ class SQLServerPlatform extends AbstractPlatform
     {
         $length = $column['length'] ?? null;
 
-        if (! isset($column['fixed'])) {
+        if (empty($column['fixed'])) {
             return sprintf('VARCHAR(%d)', $length ?? 255);
         }
 

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -124,13 +124,51 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             $this->platform->getStringTypeDeclarationSQL(['length' => 50]),
         );
         self::assertEquals(
+            'NVARCHAR(50)',
+            $this->platform->getStringTypeDeclarationSQL(
+                ['length' => 50, 'fixed' => false],
+            ),
+        );
+        self::assertEquals(
             'NVARCHAR(255)',
             $this->platform->getStringTypeDeclarationSQL([]),
+        );
+        self::assertEquals(
+            'NVARCHAR(255)',
+            $this->platform->getStringTypeDeclarationSQL(['fixed' => false]),
         );
         self::assertSame('VARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
         self::assertSame(
             'VARCHAR(MAX)',
             $this->platform->getClobTypeDeclarationSQL(['length' => 5, 'fixed' => true]),
+        );
+    }
+
+    public function testGeneratesTypeDeclarationsForAsciiStrings(): void
+    {
+        self::assertEquals(
+            'CHAR(10)',
+            $this->platform->getAsciiStringTypeDeclarationSQL(
+                ['length' => 10, 'fixed' => true],
+            ),
+        );
+        self::assertEquals(
+            'VARCHAR(50)',
+            $this->platform->getAsciiStringTypeDeclarationSQL(['length' => 50]),
+        );
+        self::assertEquals(
+            'VARCHAR(50)',
+            $this->platform->getAsciiStringTypeDeclarationSQL(
+                ['length' => 50, 'fixed' => false],
+            ),
+        );
+        self::assertEquals(
+            'VARCHAR(255)',
+            $this->platform->getAsciiStringTypeDeclarationSQL([]),
+        );
+        self::assertEquals(
+            'VARCHAR(255)',
+            $this->platform->getAsciiStringTypeDeclarationSQL(['fixed' => false]),
         );
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6245

#### Summary

This MR fixes a condition on SQL Server where `fixed` is always defined as `true` or `false` so `return sprintf('VARCHAR(%d)', $length ?? 255);` is always ignored.
