### PR TITLE
Add precision to MSSQL datetime2

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1390,7 +1390,10 @@ class SQLServerPlatform extends AbstractPlatform
     {
         // 3 - microseconds precision length
         // https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-ver16
-        $precision = $column['precision'] ?? 6;
+        $precision = $column['precision'] ?? null;
+        if (is_null($precision) || !is_int($precision) || $precision < 0 || $precision > 7) {
+            $precision = 6;
+        }
         return 'DATETIME2(' + $precision + ')';
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1389,8 +1389,9 @@ class SQLServerPlatform extends AbstractPlatform
     public function getDateTimeTypeDeclarationSQL(array $column)
     {
         // 3 - microseconds precision length
-        // http://msdn.microsoft.com/en-us/library/ms187819.aspx
-        return 'DATETIME2(6)';
+        // https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-ver16
+        $precision = $column['precision'] ?? 6;
+        return 'DATETIME2(' + $precision + ')';
     }
 
     /**

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1826,7 +1826,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         self::assertEquals(
             'DATETIME2(6)',
-            $this->platform->getStringTypeDeclarationSQL([]),
+            $this->platform->getDateTimeTypeDeclarationSQL([]),
         );
         self::assertEquals(
             'DATETIME2(0)',
@@ -1838,11 +1838,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         );
         self::assertEquals(
             'DATETIME2(6)',
-            $this->platform->getStringTypeDeclarationSQL(['precision' => -1]),
+            $this->platform->getDateTimeTypeDeclarationSQL(['precision' => -1]),
         );
         self::assertEquals(
             'DATETIME2(6)',
-            $this->platform->getStringTypeDeclarationSQL(['precision' => 255]),
+            $this->platform->getDateTimeTypeDeclarationSQL(['precision' => 255]),
         );
     }
 

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1822,6 +1822,18 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         self::assertEquals('DATETIMEOFFSET(6)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
     }
 
+    public function testGeneratesTypeDeclarationsForDateTime(): void
+    {
+        self::assertEquals(
+            'DATETIME2(7)',
+            $this->platform->getDateTimeTypeDeclarationSQL([]),
+        );
+        self::assertEquals(
+            'DATETIME2(6)',
+            $this->platform->getStringTypeDeclarationSQL(['precision' => 6]),
+        );
+    }
+
     public function testDropIndexSQLRequiresTable(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1825,12 +1825,24 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     public function testGeneratesTypeDeclarationsForDateTime(): void
     {
         self::assertEquals(
+            'DATETIME2(6)',
+            $this->platform->getStringTypeDeclarationSQL([]),
+        );
+        self::assertEquals(
+            'DATETIME2(0)',
+            $this->platform->getDateTimeTypeDeclarationSQL(['precision' => 0]),
+        );
+        self::assertEquals(
             'DATETIME2(7)',
-            $this->platform->getDateTimeTypeDeclarationSQL([]),
+            $this->platform->getDateTimeTypeDeclarationSQL(['precision' => 7]),
         );
         self::assertEquals(
             'DATETIME2(6)',
-            $this->platform->getStringTypeDeclarationSQL(['precision' => 6]),
+            $this->platform->getStringTypeDeclarationSQL(['precision' => -1]),
+        );
+        self::assertEquals(
+            'DATETIME2(6)',
+            $this->platform->getStringTypeDeclarationSQL(['precision' => 255]),
         );
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | N/A

#### Summary

We sometimes don't need to be accurate to the microsecond on certain tables. (i.e. tables with 'enumType'). This MR saves space on very large data processing operations.

I don't know if the precision check is relevant, let me know!