### PR TITLE
Fix example for QB delete and update in doc block

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -580,8 +580,8 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->delete('users', 'u')
-     *         ->where('u.id = :user_id')
+     *         ->delete('users')
+     *         ->where('users.id = :user_id')
      *         ->setParameter(':user_id', 1);
      * </code>
      *
@@ -606,9 +606,9 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->update('counters', 'c')
-     *         ->set('c.value', 'c.value + 1')
-     *         ->where('c.id = ?');
+     *         ->update('counters')
+     *         ->set('counters.value', 'counters.value + 1')
+     *         ->where('counters.id = ?');
      * </code>
      *
      * @param string $table The table whose rows are subject to the update.


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | wrong documentation

#### Summary

$alias parameter in update() and delete() was removed in version 4 but the example still use the second parameter. Example was updated in this PR