### PR TITLE
Fix return type of iterateKeyValue()

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -184,7 +184,7 @@ class Result
     }
 
     /**
-     * @return Traversable<int,list<mixed>>
+     * @return Traversable<mixed, mixed>
      *
      * @throws Exception
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

I messed this up in #6399. We cannot make any assumptions regarding key and value here.
