### PR TITLE
MySQL 8.4 removed keywords

### DIFF
--- a/src/Platforms/Keywords/MySQL84Keywords.php
+++ b/src/Platforms/Keywords/MySQL84Keywords.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\DBAL\Platforms\Keywords;
 
 use Doctrine\Deprecations\Deprecation;
 
+use function array_diff;
 use function array_merge;
 
 /**
@@ -30,12 +33,19 @@ class MySQL84Keywords extends MySQL80Keywords
     /**
      * {@inheritDoc}
      *
-     * @link https://dev.mysql.com/doc/refman/8.4/en/keywords.html#keywords-new-in-current-series
+     * @link https://dev.mysql.com/doc/refman/8.4/en/keywords.html
      */
     protected function getKeywords()
     {
         $keywords = parent::getKeywords();
 
+        // Removed Keywords and Reserved Words
+        $keywords = array_diff($keywords, [
+            'MASTER_BIND',
+            'MASTER_SSL_VERIFY_SERVER_CERT',
+        ]);
+
+        // New Keywords and Reserved Words
         $keywords = array_merge($keywords, [
             'AUTO',
             'BERNOULLI',

--- a/tests/Platforms/MySQL84PlatformTest.php
+++ b/tests/Platforms/MySQL84PlatformTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Keywords\KeywordList;
+use Doctrine\DBAL\Platforms\MySQL84Platform;
+
+class MySQL84PlatformTest extends MySQL57PlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MySQL84Platform();
+    }
+
+    public function testMySQL84KeywordList(): void
+    {
+        $keywordList = $this->platform->getReservedKeywordsList();
+        self::assertInstanceOf(KeywordList::class, $keywordList);
+
+        self::assertTrue($keywordList->isKeyword('persist'));
+        self::assertTrue($keywordList->isKeyword('manual'));
+        self::assertFalse($keywordList->isKeyword('master_bind'));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | none

#### Summary

PR doctrine/dbal#6385 added MySQL 8.4 support by extending the list of reserved keywords. MySQL 8.4 freed up several keywords as well.

https://dev.mysql.com/doc/refman/8.4/en/keywords.html#keywords-removed-in-current-series

This PR removes the freed keywords from the list.

Branch 3.9.x was targeted to stay in line with doctrine/dbal#6385 given that there hasn't been a new release yet either.
