### PR TITLE
Fix bigint PHP_INT_MIN/PHP_INT_MAX string to int convert

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -131,6 +131,12 @@
                 <file name="tests/Types/DateIntervalTest.php"/>
             </errorLevel>
         </InaccessibleProperty>
+        <InvalidCast>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/vimeo/psalm/issues/10995 -->
+                <file name="src/Types/BigIntType.php"/>
+            </errorLevel>
+        </InvalidCast>
         <InvalidArgument>
             <errorLevel type="suppress">
                 <!-- We're testing with invalid input here. -->
@@ -185,6 +191,8 @@
         </MoreSpecificReturnType>
         <NoValue>
             <errorLevel type="suppress">
+                <!-- See https://github.com/vimeo/psalm/issues/10995 -->
+                <file name="src/Types/BigIntType.php"/>
                 <!--
                     This error looks bogus.
                 -->
@@ -291,6 +299,8 @@
                 <!-- Ignore isset() checks in destructors. -->
                 <file name="src/Driver/PgSQL/Connection.php"/>
                 <file name="src/Driver/PgSQL/Statement.php"/>
+                <!-- See https://github.com/vimeo/psalm/issues/10995 -->
+                <file name="src/Types/BigIntType.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
         <UndefinedClass>

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -10,8 +10,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use function assert;
 use function is_int;
 use function is_string;
-use function str_starts_with;
-use function substr;
 
 /**
  * Type that attempts to map a database BIGINT to a PHP int.
@@ -50,10 +48,6 @@ class BigIntType extends Type implements PhpIntegerMappingType
             is_string($value),
             'DBAL assumes values outside of the integer range to be returned as string by the database driver.',
         );
-
-        if (str_starts_with($value, '+') || $value === '-0') {
-            $value = substr($value, 1);
-        }
 
         if ($value === (string) (int) $value) {
             return (int) $value;

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -10,9 +10,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use function assert;
 use function is_int;
 use function is_string;
-use function rtrim;
 use function str_starts_with;
-use function strpos;
 use function substr;
 
 /**
@@ -52,11 +50,6 @@ class BigIntType extends Type implements PhpIntegerMappingType
             is_string($value),
             'DBAL assumes values outside of the integer range to be returned as string by the database driver.',
         );
-
-        $dotPos = strpos($value, '.');
-        if ($dotPos !== false && rtrim(substr($value, $dotPos + 1), '0') === '') {
-            $value = substr($value, 0, $dotPos);
-        }
 
         if (str_starts_with($value, '+') || $value === '-0') {
             $value = substr($value, 1);

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function assert;
-use function ctype_digit;
 use function is_int;
 use function is_string;
 use function rtrim;
@@ -54,24 +53,13 @@ class BigIntType extends Type implements PhpIntegerMappingType
             'DBAL assumes values outside of the integer range to be returned as string by the database driver.',
         );
 
-        if (str_starts_with($value, '-') || str_starts_with($value, '+')) {
-            $hasNegativeSign = str_starts_with($value, '-');
-            $value           = substr($value, 1);
-        } else {
-            $hasNegativeSign = false;
-        }
-
-        while (substr($value, 0, 1) === '0' && ctype_digit(substr($value, 1, 1))) {
-            $value = substr($value, 1);
-        }
-
         $dotPos = strpos($value, '.');
         if ($dotPos !== false && rtrim(substr($value, $dotPos + 1), '0') === '') {
             $value = substr($value, 0, $dotPos);
         }
 
-        if ($hasNegativeSign && $value !== '0') {
-            $value = '-' . $value;
+        if (str_starts_with($value, '+') || $value === '-0') {
+            $value = substr($value, 1);
         }
 
         if ($value === (string) (int) $value) {

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -8,10 +8,11 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function assert;
+use function ctype_digit;
 use function is_int;
 use function is_string;
-use function preg_replace;
 use function rtrim;
+use function str_starts_with;
 use function strpos;
 use function substr;
 
@@ -53,13 +54,27 @@ class BigIntType extends Type implements PhpIntegerMappingType
             'DBAL assumes values outside of the integer range to be returned as string by the database driver.',
         );
 
-        // workaround https://github.com/php/php-src/issues/14345
+        if (str_starts_with($value, '-') || str_starts_with($value, '+')) {
+            $hasNegativeSign = str_starts_with($value, '-');
+            $value           = substr($value, 1);
+        } else {
+            $hasNegativeSign = false;
+        }
+
+        while (substr($value, 0, 1) === '0' && ctype_digit(substr($value, 1, 1))) {
+            $value = substr($value, 1);
+        }
+
         $dotPos = strpos($value, '.');
         if ($dotPos !== false && rtrim(substr($value, $dotPos + 1), '0') === '') {
             $value = substr($value, 0, $dotPos);
         }
 
-        if (preg_replace('~^(\+|-(?=0+$))|(?<=^|^[+\-])0+(?=\d)~', '', $value) === (string) (int) $value) {
+        if ($hasNegativeSign && $value !== '0') {
+            $value = '-' . $value;
+        }
+
+        if ($value === (string) (int) $value) {
             return (int) $value;
         }
 

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -11,6 +11,9 @@ use function assert;
 use function is_int;
 use function is_string;
 
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
 /**
  * Type that attempts to map a database BIGINT to a PHP int.
  *
@@ -49,7 +52,10 @@ class BigIntType extends Type implements PhpIntegerMappingType
             'DBAL assumes values outside of the integer range to be returned as string by the database driver.',
         );
 
-        if ($value === (string) (int) $value) {
+        if (
+            ($value > PHP_INT_MIN && $value < PHP_INT_MAX)
+            || $value === (string) (int) $value
+        ) {
             return (int) $value;
         }
 

--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -47,7 +47,10 @@ class BigIntType extends Type implements PhpIntegerMappingType
             return $value;
         }
 
-        if ($value > PHP_INT_MIN && $value < PHP_INT_MAX) {
+        if (
+            ($value > PHP_INT_MIN && $value < PHP_INT_MAX)
+            || $value === (string) (int) $value
+        ) {
             return (int) $value;
         }
 

--- a/tests/Functional/Types/BigIntTypeTest.php
+++ b/tests/Functional/Types/BigIntTypeTest.php
@@ -38,18 +38,6 @@ class BigIntTypeTest extends FunctionalTestCase
                 Types::BIGINT,
             ),
         );
-
-        if ($expectedValue === null) {
-            return;
-        }
-
-        self::assertSame(
-            $expectedValue,
-            $this->connection->convertToPHPValue(
-                $sqlLiteral . '.00',
-                Types::BIGINT,
-            ),
-        );
     }
 
     /** @return Generator<string, array{string, int|string|null}> */

--- a/tests/Functional/Types/BigIntTypeTest.php
+++ b/tests/Functional/Types/BigIntTypeTest.php
@@ -11,9 +11,6 @@ use Doctrine\DBAL\Types\Types;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-use function str_starts_with;
-use function substr;
-
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 use const PHP_INT_SIZE;
@@ -50,18 +47,6 @@ class BigIntTypeTest extends FunctionalTestCase
             $expectedValue,
             $this->connection->convertToPHPValue(
                 $sqlLiteral . '.00',
-                Types::BIGINT,
-            ),
-        );
-
-        $startsWithSign = str_starts_with($sqlLiteral, '-') || str_starts_with($sqlLiteral, '+');
-
-        self::assertSame(
-            $expectedValue,
-            $this->connection->convertToPHPValue(
-                ($startsWithSign ? substr($sqlLiteral, 0, 1) : '')
-                . '00'
-                . ($startsWithSign ? substr($sqlLiteral, 1) : $sqlLiteral),
                 Types::BIGINT,
             ),
         );

--- a/tests/Functional/Types/BigIntTypeTest.php
+++ b/tests/Functional/Types/BigIntTypeTest.php
@@ -44,8 +44,6 @@ class BigIntTypeTest extends FunctionalTestCase
     public static function provideBigIntLiterals(): Generator
     {
         yield 'zero' => ['0', 0];
-        yield 'minus zero' => ['-0', 0];
-        yield 'plus zero' => ['+0', 0];
         yield 'null' => ['null', null];
         yield 'positive number' => ['42', 42];
         yield 'negative number' => ['-42', -42];
@@ -53,11 +51,6 @@ class BigIntTypeTest extends FunctionalTestCase
         yield 'large negative number' => [PHP_INT_SIZE === 4 ? '-2147483647' : '-9223372036854775807', PHP_INT_MIN + 1];
         yield 'largest positive number' => [PHP_INT_SIZE === 4 ? '2147483647' : '9223372036854775807', PHP_INT_MAX];
         yield 'largest negative number' => [PHP_INT_SIZE === 4 ? '-2147483648' : '-9223372036854775808', PHP_INT_MIN];
-
-        yield 'plus largest positive number' => [
-            PHP_INT_SIZE === 4 ? '+2147483647' : '+9223372036854775807',
-            PHP_INT_MAX,
-        ];
     }
 
     public function testUnsignedBigIntOnMySQL(): void

--- a/tests/Functional/Types/BigIntTypeTest.php
+++ b/tests/Functional/Types/BigIntTypeTest.php
@@ -28,13 +28,13 @@ class BigIntTypeTest extends FunctionalTestCase
 
         $this->connection->executeStatement(<<<SQL
             INSERT INTO bigint_type_test (id, my_integer)
-            VALUES (1, $sqlLiteral)
+            VALUES (42, $sqlLiteral)
             SQL);
 
         self::assertSame(
             $expectedValue,
             $this->connection->convertToPHPValue(
-                $this->connection->fetchOne('SELECT my_integer from bigint_type_test'),
+                $this->connection->fetchOne('SELECT my_integer from bigint_type_test WHERE id = 42'),
                 Types::BIGINT,
             ),
         );
@@ -68,13 +68,13 @@ class BigIntTypeTest extends FunctionalTestCase
         // Insert (2 ** 64) - 1
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO bigint_type_test (id, my_integer)
-            VALUES (1, 0xFFFFFFFFFFFFFFFF)
+            VALUES (42, 0xFFFFFFFFFFFFFFFF)
             SQL);
 
         self::assertSame(
             '18446744073709551615',
             $this->connection->convertToPHPValue(
-                $this->connection->fetchOne('SELECT my_integer from bigint_type_test'),
+                $this->connection->fetchOne('SELECT my_integer from bigint_type_test WHERE id = 42'),
                 Types::BIGINT,
             ),
         );

--- a/tests/Functional/Types/BigIntTypeTest.php
+++ b/tests/Functional/Types/BigIntTypeTest.php
@@ -10,8 +10,6 @@ use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Types;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Constraint\IsIdentical;
-use PHPUnit\Framework\Constraint\LogicalOr;
 
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
@@ -30,13 +28,13 @@ class BigIntTypeTest extends FunctionalTestCase
 
         $this->connection->executeStatement(<<<SQL
             INSERT INTO bigint_type_test (id, my_integer)
-            VALUES (42, $sqlLiteral)
+            VALUES (1, $sqlLiteral)
             SQL);
 
         self::assertSame(
             $expectedValue,
             $this->connection->convertToPHPValue(
-                $this->connection->fetchOne('SELECT my_integer from bigint_type_test WHERE id = 42'),
+                $this->connection->fetchOne('SELECT my_integer from bigint_type_test'),
                 Types::BIGINT,
             ),
         );
@@ -46,47 +44,15 @@ class BigIntTypeTest extends FunctionalTestCase
     public static function provideBigIntLiterals(): Generator
     {
         yield 'zero' => ['0', 0];
+        yield 'minus zero' => ['-0', 0];
+        yield 'plus zero' => ['+0', 0];
         yield 'null' => ['null', null];
         yield 'positive number' => ['42', 42];
         yield 'negative number' => ['-42', -42];
-
-        if (PHP_INT_SIZE < 8) {
-            // The following tests only work on 64bit systems.
-            return;
-        }
-
-        yield 'large positive number' => ['9223372036854775806', PHP_INT_MAX - 1];
-        yield 'large negative number' => ['-9223372036854775807', PHP_INT_MIN + 1];
-    }
-
-    #[DataProvider('provideBigIntEdgeLiterals')]
-    public function testSelectBigIntEdge(int $value): void
-    {
-        $table = new Table('bigint_type_test');
-        $table->addColumn('id', Types::SMALLINT, ['notnull' => true]);
-        $table->addColumn('my_integer', Types::BIGINT, ['notnull' => false]);
-        $table->setPrimaryKey(['id']);
-        $this->dropAndCreateTable($table);
-
-        $this->connection->executeStatement(<<<SQL
-            INSERT INTO bigint_type_test (id, my_integer)
-            VALUES (42, $value)
-            SQL);
-
-        self::assertThat(
-            $this->connection->convertToPHPValue(
-                $this->connection->fetchOne('SELECT my_integer from bigint_type_test WHERE id = 42'),
-                Types::BIGINT,
-            ),
-            LogicalOr::fromConstraints(new IsIdentical($value), new IsIdentical((string) $value)),
-        );
-    }
-
-    /** @return Generator<string, array{int}> */
-    public static function provideBigIntEdgeLiterals(): Generator
-    {
-        yield 'max int' => [PHP_INT_MAX];
-        yield 'min int' => [PHP_INT_MIN];
+        yield 'large positive number' => [PHP_INT_SIZE === 4 ? '2147483646' : '9223372036854775806', PHP_INT_MAX - 1];
+        yield 'large negative number' => [PHP_INT_SIZE === 4 ? '-2147483647' : '-9223372036854775807', PHP_INT_MIN + 1];
+        yield 'largest positive number' => [PHP_INT_SIZE === 4 ? '2147483647' : '9223372036854775807', PHP_INT_MAX];
+        yield 'largest negative number' => [PHP_INT_SIZE === 4 ? '-2147483648' : '-9223372036854775808', PHP_INT_MIN];
     }
 
     public function testUnsignedBigIntOnMySQL(): void
@@ -104,13 +70,13 @@ class BigIntTypeTest extends FunctionalTestCase
         // Insert (2 ** 64) - 1
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO bigint_type_test (id, my_integer)
-            VALUES (42, 0xFFFFFFFFFFFFFFFF)
+            VALUES (1, 0xFFFFFFFFFFFFFFFF)
             SQL);
 
         self::assertSame(
             '18446744073709551615',
             $this->connection->convertToPHPValue(
-                $this->connection->fetchOne('SELECT my_integer from bigint_type_test WHERE id = 42'),
+                $this->connection->fetchOne('SELECT my_integer from bigint_type_test'),
                 Types::BIGINT,
             ),
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

Resolve https://github.com/doctrine/dbal/pull/6177#discussion_r1613456751 discussion and related original #6177.

Whole native php `int` range is guaranteed to be supported per https://www.doctrine-project.org/projects/doctrine-dbal/en/4.0/reference/types.html#bigint docs.