### PR TITLE
Fix "bigint" type introspection for PK column with AI for SQLite

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -379,6 +379,12 @@ class SqliteSchemaManager extends AbstractSchemaManager
             $default = null;
         }
 
+        // https://github.com/doctrine/dbal/blob/3.8.4/src/Platforms/SqlitePlatform.php#L271-L274
+        // https://dbfiddle.uk/yyXvHV-6
+        if (strtolower($type) === 'integer' && ($tableColumn['pk'] !== 0 && $tableColumn['pk'] !== '0')) {
+            $type = 'bigint';
+        }
+
         if ($default !== null) {
             // SQLite returns the default value as a literal expression, so we need to parse it
             if (preg_match('/^\'(.*)\'$/s', $default, $matches) === 1) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6396

#### Summary

Because SQLite does not support `AUTOINCREMENT` keyword on any other type than `INTEGER` [1] [2], `bigint` type is mapped to `INTEGER` SQLite database column by DBAL already [3].

As we remap the type on table creation, we need to remap the type also on table introspection. The reason, we remap `integer` to `bigint`, is `bigint` is subtype of `integer` - PK defined/created originally as `bigint` must be always introspected as `bigint`.

[1] https://www.sqlite.org/autoinc.html
[2] https://dbfiddle.uk/yyXvHV-6
[3] https://github.com/doctrine/dbal/blob/3.8.4/src/Platforms/SqlitePlatform.php#L271-L274