### PR TITLE
Fix foreign key name change detection

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -555,6 +555,10 @@ class Comparator
      */
     public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2)
     {
+        if (strtolower($key1->getName()) !== strtolower($key2->getName())) {
+            return true;
+        }
+
         if (
             array_map('strtolower', $key1->getUnquotedLocalColumns())
             !== array_map('strtolower', $key2->getUnquotedLocalColumns())

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -652,7 +652,7 @@ class AbstractComparatorTestCase extends TestCase
         self::assertFalse($tableDiff);
     }
 
-    public function testCompareIndexBasedOnPropertiesNotName(): void
+    public function testDetectIndexNameChange(): void
     {
         $tableA = new Table('foo');
         $tableA->addColumn('id', Types::INTEGER);
@@ -672,7 +672,7 @@ class AbstractComparatorTestCase extends TestCase
         );
     }
 
-    public function testCompareForeignKeyBasedOnPropertiesNotName(): void
+    public function testDetectForeignKeyNameChange(): void
     {
         $tableA = new Table('foo');
         $tableA->addColumn('id', Types::INTEGER);

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -683,8 +683,9 @@ class AbstractComparatorTestCase extends TestCase
         $tableB->addForeignKeyConstraint('bar', ['id'], ['id'], [], 'bar_constraint');
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
-
-        self::assertFalse($tableDiff);
+        self::assertNotFalse($tableDiff);
+        self::assertCount(1, $tableDiff->addedForeignKeys);
+        self::assertCount(1, $tableDiff->removedForeignKeys);
     }
 
     public function testCompareForeignKeyRestrictNoActionAreTheSame(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6390 

#### Summary

This changes how the schema comparator treats foreign key name changes.
The index renaming had the same behavior in the past, expecting a index name change to result in an empty table diff. This was changed some time ago but foreign key changes were still not picked up by the comparator. This pr will change that.
While at it, I've also changed the names of both tests to reflect the changes.
