### PR TITLE
Added support functional indexes for MySQL and Postgres

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
 use Doctrine\DBAL\Platforms\MariaDB1052Platform;
 use Doctrine\DBAL\Platforms\MariaDB1060Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQL8013Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQL84Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -58,7 +59,17 @@ abstract class AbstractMySQLDriver implements Driver
             return new MySQL84Platform();
         }
 
+        if (version_compare($version, '8.0.13', '>=')) {
+            return new MySQL8013Platform();
+        }
+
         if (version_compare($version, '8.0.0', '>=')) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6343',
+                'Support for MySQL <= 8.0.13 is deprecated and will be removed in DBAL 5',
+            );
+
             return new MySQL80Platform();
         }
 

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -48,7 +48,7 @@ abstract class AbstractMySQLDriver implements Driver
 
             Deprecation::trigger(
                 'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6343',
+                'https://github.com/doctrine/dbal/pull/6414',
                 'Support for MariaDB < 10.5.2 is deprecated and will be removed in DBAL 5',
             );
 
@@ -66,7 +66,7 @@ abstract class AbstractMySQLDriver implements Driver
         if (version_compare($version, '8.0.0', '>=')) {
             Deprecation::trigger(
                 'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6343',
+                'https://github.com/doctrine/dbal/pull/6414',
                 'Support for MySQL <= 8.0.13 is deprecated and will be removed in DBAL 5',
             );
 
@@ -75,7 +75,7 @@ abstract class AbstractMySQLDriver implements Driver
 
         Deprecation::trigger(
             'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6343',
+            'https://github.com/doctrine/dbal/pull/6414',
             'Support for MySQL < 8 is deprecated and will be removed in DBAL 5',
         );
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -43,6 +43,11 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     final public const LENGTH_LIMIT_BLOB       = 65535;
     final public const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
 
+    public function getColumnNameForIndexFetch(): string
+    {
+        return 'COLUMN_NAME';
+    }
+
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string
     {
         if ($limit !== null) {

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -43,7 +43,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     final public const LENGTH_LIMIT_BLOB       = 65535;
     final public const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
 
-    public function getColumnNameForIndexFetch(): string
+    public function getColumnOrExpressionNameForIndexFetching(): string
     {
         return 'COLUMN_NAME';
     }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2008,7 +2008,7 @@ abstract class AbstractPlatform
      */
     public function supportsFunctionalIndex(): bool
     {
-        return false;
+        return true;
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -42,6 +42,7 @@ use function array_values;
 use function assert;
 use function count;
 use function explode;
+use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
@@ -794,6 +795,16 @@ abstract class AbstractPlatform
         $options['primary']           = [];
 
         foreach ($table->getIndexes() as $index) {
+            if ($index->isFunctional() && ! $this->supportsFunctionalIndex()) {
+                throw new InvalidArgumentException(sprintf(
+                    'Index "%s" on table "%s" contains a functional part, ' .
+                    'but platform "%s" does not support functional indexes.',
+                    $index->getName(),
+                    $table->getName(),
+                    get_debug_type($this),
+                ));
+            }
+
             if (! $index->isPrimary()) {
                 $options['indexes'][$index->getQuotedName($this)] = $index;
 
@@ -1078,6 +1089,16 @@ abstract class AbstractPlatform
                 'Incomplete or invalid index definition %s on table %s',
                 $name,
                 $table,
+            ));
+        }
+
+        if ($index->isFunctional() && ! $this->supportsFunctionalIndex()) {
+            throw new InvalidArgumentException(sprintf(
+                'Index "%s" on table "%s" contains a functional part, ' .
+                'but platform "%s" does not support functional indexes.',
+                $name,
+                $table,
+                get_debug_type($this),
             ));
         }
 
@@ -1533,6 +1554,15 @@ abstract class AbstractPlatform
             throw new InvalidArgumentException('Incomplete definition. "columns" required.');
         }
 
+        if ($index->isFunctional() && ! $this->supportsFunctionalIndex()) {
+            throw new InvalidArgumentException(sprintf(
+                'Index "%s" contains a functional part, ' .
+                'but platform "%s" does not support functional indexes.',
+                $index->getName(),
+                get_debug_type($this),
+            ));
+        }
+
         return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this)
             . ' (' . implode(', ', $index->getQuotedColumns($this)) . ')' . $this->getPartialIndexSQL($index);
     }
@@ -1969,6 +1999,14 @@ abstract class AbstractPlatform
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
     public function supportsColumnCollation(): bool
+    {
+        return false;
+    }
+
+    /**
+     * A flag that indicates whether the platform supports functional indexes.
+     */
+    public function supportsFunctionalIndex(): bool
     {
         return false;
     }

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -162,4 +162,9 @@ class MariaDBPlatform extends AbstractMySQLPlatform
     {
         return new MariaDBKeywords();
     }
+
+    public function supportsFunctionalIndex(): bool
+    {
+        return false;
+    }
 }

--- a/src/Platforms/MySQL8013Platform.php
+++ b/src/Platforms/MySQL8013Platform.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+/**
+ * Provides features of the MySQL since 8.0.13 database platform.
+ *
+ * Note: Should not be used with versions prior to 8.0.13.
+ */
+class MySQL8013Platform extends MySQLPlatform
+{
+    public function getColumnNameForIndexFetch(): string
+    {
+        return "COALESCE(COLUMN_NAME, CONCAT('(', REPLACE(EXPRESSION, '\\\''', ''''), ')'))";
+    }
+
+    public function supportsFunctionalIndex(): bool
+    {
+        return true;
+    }
+}

--- a/src/Platforms/MySQL8013Platform.php
+++ b/src/Platforms/MySQL8013Platform.php
@@ -11,13 +11,16 @@ namespace Doctrine\DBAL\Platforms;
  */
 class MySQL8013Platform extends MySQLPlatform
 {
-    public function getColumnNameForIndexFetch(): string
+    public function getColumnOrExpressionNameForIndexFetching(): string
     {
-        return "COALESCE(COLUMN_NAME, CONCAT('(', REPLACE(EXPRESSION, '\\\''', ''''), ')'))";
-    }
-
-    public function supportsFunctionalIndex(): bool
-    {
-        return true;
+        return <<<'SQL'
+            COALESCE(
+                COLUMN_NAME,
+                (CASE WHEN SUBSTR(EXPRESSION, 1, 1) != '('
+                    THEN CONCAT('(', REPLACE(EXPRESSION, '\'', ''''), ')')
+                    ELSE REPLACE(EXPRESSION, '\'', '''')
+                END)
+            )
+        SQL;
     }
 }

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -24,4 +24,9 @@ class MySQL80Platform extends MySQLPlatform
     {
         return AbstractPlatform::createSelectSQLBuilder();
     }
+
+    public function supportsFunctionalIndex(): bool
+    {
+        return false;
+    }
 }

--- a/src/Platforms/MySQL84Platform.php
+++ b/src/Platforms/MySQL84Platform.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Platforms\Keywords\MySQL84Keywords;
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 8.4 database platform.
  */
-class MySQL84Platform extends MySQL80Platform
+class MySQL84Platform extends MySQL8013Platform
 {
     protected function createReservedKeywordsList(): KeywordList
     {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -781,4 +781,9 @@ class PostgreSQLPlatform extends AbstractPlatform
     {
         return new PostgreSQLSchemaManager($connection, $this);
     }
+
+    public function supportsFunctionalIndex(): bool
+    {
+        return true;
+    }
 }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -31,6 +31,7 @@ use function array_unique;
 use function array_values;
 use function count;
 use function explode;
+use function get_debug_type;
 use function implode;
 use function sprintf;
 use function str_replace;
@@ -558,6 +559,16 @@ class SQLitePlatform extends AbstractPlatform
                 'Incomplete or invalid index definition %s on table %s',
                 $name,
                 $table,
+            ));
+        }
+
+        if ($index->isFunctional() && ! $this->supportsFunctionalIndex()) {
+            throw new InvalidArgumentException(sprintf(
+                'Index "%s" on table "%s" contains a functional part, ' .
+                'but platform "%s" does not support functional indexes.',
+                $name,
+                $table,
+                get_debug_type($this),
             ));
         }
 

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -63,9 +63,11 @@ class Index extends AbstractAsset
         foreach ($columns as $column) {
             $this->_addColumn($column);
 
-            $this->_isFunctional = $this->_isFunctional === true
-                ? $this->_isFunctional
-                : self::isFunctionalIndex($column);
+            if ($this->_isFunctional === true) {
+                continue;
+            }
+
+            $this->_isFunctional = self::isColumnNameAnExpression($column);
         }
 
         foreach ($flags as $flag) {
@@ -300,9 +302,9 @@ class Index extends AbstractAsset
         return $this->options;
     }
 
-    public static function isFunctionalIndex(string $name): bool
+    public static function isColumnNameAnExpression(string $columnName): bool
     {
-        return str_starts_with($name, '(') && str_ends_with($name, ')');
+        return str_starts_with($columnName, '(') && str_ends_with($columnName, ')');
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -552,6 +552,6 @@ SQL;
      */
     private function getColumnNameForIndexFetch(): string
     {
-        return $this->platform->getColumnNameForIndexFetch() . ' as Column_Name';
+        return $this->platform->getColumnOrExpressionNameForIndexFetching() . ' as Column_Name';
     }
 }

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -390,10 +390,12 @@ SQL;
             $sql .= ' TABLE_NAME,';
         }
 
-        $sql .= <<<'SQL'
+        $columnName = $this->getColumnNameForIndexFetch();
+
+        $sql .= <<<SQL
         NON_UNIQUE  AS Non_Unique,
         INDEX_NAME  AS Key_name,
-        COLUMN_NAME AS Column_Name,
+        {$columnName},
         SUB_PART    AS Sub_Part,
         INDEX_TYPE  AS Index_Type
 FROM information_schema.STATISTICS
@@ -538,5 +540,18 @@ SQL;
         }
 
         return $this->defaultTableOptions;
+    }
+
+    /**
+     * EXPRESSION
+     *
+     * MySQL 8.0.13 and higher supports functional key parts (see Functional Key Parts), which affects both
+     * the COLUMN_NAME and EXPRESSION columns:
+     * For a nonfunctional key part, COLUMN_NAME indicates the column indexed by the key part and EXPRESSION is NULL.
+     * For a functional key part, COLUMN_NAME column is NULL and EXPRESSION indicates the expression for the key part.
+     */
+    private function getColumnNameForIndexFetch(): string
+    {
+        return $this->platform->getColumnNameForIndexFetch() . ' as Column_Name';
     }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -743,7 +743,7 @@ class Table extends AbstractAsset
         }
 
         foreach ($columns as $columnName) {
-            if (! $this->hasColumn($columnName)) {
+            if (! $this->hasColumn($columnName) && ! Index::isFunctionalIndex($columnName)) {
                 throw ColumnDoesNotExist::new($columnName, $this->_name);
             }
         }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -743,7 +743,7 @@ class Table extends AbstractAsset
         }
 
         foreach ($columns as $columnName) {
-            if (! $this->hasColumn($columnName) && ! Index::isFunctionalIndex($columnName)) {
+            if (! $this->hasColumn($columnName) && ! Index::isColumnNameAnExpression($columnName)) {
                 throw ColumnDoesNotExist::new($columnName, $this->_name);
             }
         }

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDB1052Platform;
 use Doctrine\DBAL\Platforms\MariaDB1060Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQL8013Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQL84Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -37,6 +38,8 @@ class VersionAwarePlatformDriverTest extends TestCase
         return [
             ['5.7.0', MySQLPlatform::class],
             ['8.0.11', MySQL80Platform::class],
+            ['8.0.13', MySQL8013Platform::class],
+            ['8.0.14', MySQL8013Platform::class],
             ['8.4.0', MySQL84Platform::class],
             ['5.5.40-MariaDB-1~wheezy', MariaDBPlatform::class],
             ['5.5.5-MariaDB-10.2.8+maria~xenial-log', MariaDBPlatform::class],

--- a/tests/Functional/Platform/FunctionalIndexTest.php
+++ b/tests/Functional/Platform/FunctionalIndexTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Exception\InvalidArgumentException;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Doctrine\DBAL\Types\Types;
+
+use function array_filter;
+use function array_pop;
+
+class FunctionalIndexTest extends FunctionalTestCase
+{
+    public function testGetIndex(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (! $platform->supportsFunctionalIndex()) {
+            self::markTestSkipped('Platform does not support functional indexes.');
+        }
+
+        $tableName = 'some_table';
+
+        $table = new Table($tableName);
+        $table->addColumn('column1', Types::INTEGER, ['notnull' => false]);
+        $table->addColumn('column2', Types::INTEGER, ['notnull' => false]);
+        $table->addIndex(['column1', 'column2', '(column2 IS NOT NULL)'], 'func_idx');
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert($tableName, ['column1' => 1]);
+
+        $tablesFromList = $this->connection->createSchemaManager()->listTables();
+
+        $tables    = array_filter($tablesFromList, static fn (Table $table): bool => $table->getName() === $tableName);
+        $someTable = array_pop($tables);
+
+        self::assertInstanceOf(Table::class, $someTable);
+        self::assertEquals($tableName, $someTable->getName());
+
+        $index = $someTable->getIndex('func_idx');
+
+        self::assertTrue($index->isFunctional());
+
+        if (TestUtil::isDriverOneOf('pdo_pgsql', 'pgsql')) {
+            self::assertEquals(['column1', 'column2', '(column2 IS NOT NULL)'], $index->getColumns());
+        } else {
+            self::assertEquals(['column1', 'column2', '((`column2` is not null))'], $index->getColumns());
+        }
+    }
+
+    public function testPlatformException(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform->supportsFunctionalIndex()) {
+            self::markTestSkipped('Skipping, platform supports functional indexes.');
+        }
+
+        $table = new Table('some_table');
+        $table->addColumn('column1', Types::INTEGER, ['notnull' => false]);
+        $table->addColumn('column2', Types::INTEGER, ['notnull' => false]);
+        $table->addIndex(['column1', 'column2', '(column2 IS NOT NULL)'], 'func_idx');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->dropAndCreateTable($table);
+    }
+}

--- a/tests/Schema/Platforms/MySQL8013SchemaTest.php
+++ b/tests/Schema/Platforms/MySQL8013SchemaTest.php
@@ -12,26 +12,19 @@ use PHPUnit\Framework\TestCase;
 
 class MySQL8013SchemaTest extends TestCase
 {
-    private MySQL80Platform $platformMysql;
-    private MySQL8013Platform $platformMysql8013;
-
-    protected function setUp(): void
-    {
-        $this->platformMysql8013 = new MySQL8013Platform();
-        $this->platformMysql     = new MySQL80Platform();
-    }
-
     public function testGenerateFunctionalIndex(): void
     {
         $table = new Table('test');
         $table->addColumn('foo_id', 'integer');
         $table->addIndex(['foo_id', '(CAST(bar AS CHAR(10)))'], 'idx_foo_id');
 
+        $platform = new MySQL8013Platform();
+
         $sqls = [];
         foreach ($table->getIndexes() as $index) {
-            $sqls[] = $this->platformMysql8013->getCreateIndexSQL(
+            $sqls[] = $platform->getCreateIndexSQL(
                 $index,
-                $table->getQuotedName($this->platformMysql8013),
+                $table->getQuotedName($platform),
             );
         }
 
@@ -47,12 +40,14 @@ class MySQL8013SchemaTest extends TestCase
         $table->addColumn('foo_id', 'integer');
         $table->addIndex(['foo_id', '(CAST(bar AS CHAR(10)))'], 'idx_foo_id');
 
+        $platform = new MySQL80Platform();
+
         foreach ($table->getIndexes() as $index) {
             $this->expectException(Exception::class);
 
-            $this->platformMysql->getCreateIndexSQL(
+            $platform->getCreateIndexSQL(
                 $index,
-                $table->getQuotedName($this->platformMysql),
+                $table->getQuotedName($platform),
             );
         }
     }

--- a/tests/Schema/Platforms/MySQL8013SchemaTest.php
+++ b/tests/Schema/Platforms/MySQL8013SchemaTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Platforms;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQL8013Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Schema\Table;
+use PHPUnit\Framework\TestCase;
+
+class MySQL8013SchemaTest extends TestCase
+{
+    private MySQL80Platform $platformMysql;
+    private MySQL8013Platform $platformMysql8013;
+
+    protected function setUp(): void
+    {
+        $this->platformMysql8013 = new MySQL8013Platform();
+        $this->platformMysql     = new MySQL80Platform();
+    }
+
+    public function testGenerateFunctionalIndex(): void
+    {
+        $table = new Table('test');
+        $table->addColumn('foo_id', 'integer');
+        $table->addIndex(['foo_id', '(CAST(bar AS CHAR(10)))'], 'idx_foo_id');
+
+        $sqls = [];
+        foreach ($table->getIndexes() as $index) {
+            $sqls[] = $this->platformMysql8013->getCreateIndexSQL(
+                $index,
+                $table->getQuotedName($this->platformMysql8013),
+            );
+        }
+
+        self::assertEquals(
+            ['CREATE INDEX idx_foo_id ON test (foo_id, (CAST(bar AS CHAR(10))))'],
+            $sqls,
+        );
+    }
+
+    public function testGenerateFunctionalIndexWithError(): void
+    {
+        $table = new Table('test');
+        $table->addColumn('foo_id', 'integer');
+        $table->addIndex(['foo_id', '(CAST(bar AS CHAR(10)))'], 'idx_foo_id');
+
+        foreach ($table->getIndexes() as $index) {
+            $this->expectException(Exception::class);
+
+            $this->platformMysql->getCreateIndexSQL(
+                $index,
+                $table->getQuotedName($this->platformMysql),
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature

#### Summary

This feature allows the DBAL to create and work with functional indexes.

Documentation:
PostgreSQL (version 7 and higher) - [https://www.postgresql.org/docs/7.3/indexes-functional.html](https://www.postgresql.org/docs/7.3/indexes-functional.html)
MySQL (version 8.0.13 and higher) - [https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-functional-key-parts](https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-functional-key-parts)