### PR TITLE
Add querybuilder from table hints

### DIFF
--- a/src/Query/From.php
+++ b/src/Query/From.php
@@ -10,6 +10,8 @@ final class From
     public function __construct(
         public readonly string $table,
         public readonly ?string $alias = null,
+        public readonly ?string $optimizerHints = null,
+        public readonly ?string $indexHints = null,
     ) {
     }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -666,15 +666,19 @@ class QueryBuilder
      *         ->from('users', 'u')
      * </code>
      *
-     * @param string      $table            The table.
-     * @param string|null $alias            The alias of the table.
-     * @param string|null $optimizerHints   Optimizer hints for table (eg `NO_MERGE(dt)`).
-     * @param string|null $indexHints       Index hints for table (eg `USE INDEX(col1)`).
+     * @param string      $table          The table.
+     * @param string|null $alias          The alias of the table.
+     * @param string|null $optimizerHints Optimizer hints for table (eg `NO_MERGE(dt)`).
+     * @param string|null $indexHints     Index hints for table (eg `USE INDEX(col1)`).
      *
      * @return $this This QueryBuilder instance.
      */
-    public function from(string $table, ?string $alias = null, ?string $optimizerHints = null, ?string $indexHints = null): self
-    {
+    public function from(
+        string $table,
+        ?string $alias = null,
+        ?string $optimizerHints = null,
+        ?string $indexHints = null,
+    ): self {
         $this->from[] = new From($table, $alias, $optimizerHints, $indexHints);
 
         $this->sql = null;

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -666,14 +666,16 @@ class QueryBuilder
      *         ->from('users', 'u')
      * </code>
      *
-     * @param string      $table The table.
-     * @param string|null $alias The alias of the table.
+     * @param string      $table            The table.
+     * @param string|null $alias            The alias of the table.
+     * @param string|null $optimizerHints   Optimizer hints for table (eg `NO_MERGE(dt)`).
+     * @param string|null $indexHints       Index hints for table (eg `USE INDEX(col1)`).
      *
      * @return $this This QueryBuilder instance.
      */
-    public function from(string $table, ?string $alias = null): self
+    public function from(string $table, ?string $alias = null, ?string $optimizerHints = null, ?string $indexHints = null): self
     {
-        $this->from[] = new From($table, $alias);
+        $this->from[] = new From($table, $alias, $optimizerHints, $indexHints);
 
         $this->sql = null;
 
@@ -1244,6 +1246,14 @@ class QueryBuilder
             } else {
                 $tableSql       = $from->table . ' ' . $from->alias;
                 $tableReference = $from->alias;
+            }
+
+            if ($from->optimizerHints !== null) {
+                $tableSql = '/*+ ' . $from->optimizerHints . ' */ ' . $tableSql;
+            }
+
+            if ($from->indexHints !== null) {
+                $tableSql .= ' ' . $from->indexHints;
             }
 
             $knownAliases[$tableReference] = true;

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -62,6 +62,36 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('SELECT u.id FROM users u', (string) $qb);
     }
 
+    public function testTableOptimizerHints(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('u.id')
+           ->from('users', 'u', 'MERGE(u)');
+
+        self::assertEquals('SELECT u.id FROM /*+ MERGE(u) */ users u', (string) $qb);
+    }
+
+    public function testTableIndexHints(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('u.id')
+           ->from('users', 'u', null, 'USE INDEX(u.name)');
+
+        self::assertEquals('SELECT u.id FROM users u USE INDEX(u.name)', (string) $qb);
+    }
+
+    public function testTableHints(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('u.id')
+           ->from('users', 'u', 'MERGE(u)', 'USE INDEX(u.name)');
+
+        self::assertEquals('SELECT u.id FROM /*+ MERGE(u) */ users u USE INDEX(u.name)', (string) $qb);
+    }
+
     public function testSimpleSelectWithDistinct(): void
     {
         $qb = new QueryBuilder($this->conn);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Working on Prestashop, I need to force some column index in order to improve mysql query time. `FORCE INDEX` did the trick, but this is impossible to configure.

This PR add the possibility to define content before and after table definition. I am aware this is only for mysql currently:

- https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
- https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
