### PR TITLE
Fix foreign key name change detection

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -371,6 +371,10 @@ class Comparator
 
     protected function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2): bool
     {
+        if (strtolower($key1->getName()) !== strtolower($key2->getName())) {
+            return true;
+        }
+
         if (
             array_map('strtolower', $key1->getUnquotedLocalColumns())
             !== array_map('strtolower', $key2->getUnquotedLocalColumns())

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -373,9 +373,14 @@ abstract class AbstractComparatorTestCase extends TestCase
         $tableB->addColumn('ID', Types::INTEGER);
         $tableB->addForeignKeyConstraint('bar', ['id'], ['id'], [], 'bar_constraint');
 
-        $tableDiff = $this->comparator->compareTables($tableA, $tableB);
-
-        self::assertTrue($tableDiff->isEmpty());
+        self::assertEquals(
+            new TableDiff($tableA, [], [], [], [], [], [], [], [], [
+                new ForeignKeyConstraint(['id'], 'bar', ['id'], 'bar_constraint'),
+            ], [], [
+                new ForeignKeyConstraint(['id'], 'bar', ['id'], 'foo_constraint'),
+            ]),
+            $this->comparator->compareTables($tableA, $tableB),
+        );
     }
 
     public function testDetectRenameColumn(): void

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -345,7 +345,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertTrue($tableDiff->isEmpty());
     }
 
-    public function testCompareIndexBasedOnPropertiesNotName(): void
+    public function testDetectIndexNameChange(): void
     {
         $tableA = new Table('foo');
         $tableA->addColumn('id', Types::INTEGER);
@@ -363,7 +363,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         );
     }
 
-    public function testCompareForeignKeyBasedOnPropertiesNotName(): void
+    public function testDetectForeignKeyNameChange(): void
     {
         $tableA = new Table('foo');
         $tableA->addColumn('id', Types::INTEGER);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6390

#### Summary

This changes how the schema comparator treats foreign key name changes.
The index renaming had the same behavior in the past, expecting a index name change to result in an empty table diff. This was changed some time ago but foreign key changes were still not picked up by the comparator. This pr will change that.
While at it, I've also changed the names of both tests to reflect the changes.

As it was discussed in #6413 the test code should be reworked to be as exact as possible. So essentially my changes got merged to 3.8.x and 3.9.x but got left out in the 4.0.x merge (#6417). This is the initial code with more precise testing as it tests for the added/removed foreign key constraints and not only the count for each of them.
