### PR TITLE
SQLServer - fix unicode support for text type - nvarchar(max) instead of varchar(max)

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -899,7 +899,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     public function getClobTypeDeclarationSQL(array $column): string
     {
-        return 'VARCHAR(MAX)';
+        return 'NVARCHAR(MAX)';
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -99,6 +99,16 @@ SQL,
                 $length /= 2;
                 break;
 
+            case 'varchar':
+                // keep for backward compatibility
+                // as some fields might come back as VARCHAR(MAX) with a length of -1
+                // and we want them to be mapped to the 'text' type
+                if ($length === -1) {
+                    $dbType = 'text';
+                }
+
+                break;
+
             case 'varbinary':
                 if ($length === -1) {
                     $dbType = 'blob';

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -89,20 +89,14 @@ SQL,
                 break;
 
             case 'nvarchar':
+                // TEXT type is returned as NVARCHAR(MAX) with a length of -1
                 if ($length === -1) {
+                    $dbType = 'text';
                     break;
                 }
 
                 // Unicode data requires 2 bytes per character
                 $length /= 2;
-                break;
-
-            case 'varchar':
-                // TEXT type is returned as VARCHAR(MAX) with a length of -1
-                if ($length === -1) {
-                    $dbType = 'text';
-                }
-
                 break;
 
             case 'varbinary':

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -120,9 +120,9 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
     public function testGeneratesTypeDeclarationsForStrings(): void
     {
-        self::assertSame('VARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
+        self::assertSame('NVARCHAR(MAX)', $this->platform->getClobTypeDeclarationSQL([]));
         self::assertSame(
-            'VARCHAR(MAX)',
+            'NVARCHAR(MAX)',
             $this->platform->getClobTypeDeclarationSQL(['length' => 5, 'fixed' => true]),
         );
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #2323

#### Summary

Very old bug for SQLServer platform preventing usage unicode characters with "text" type.

#### Background

Here are previously reported issues and attempts to fix it:
- #1182
- #1351
- #2323
- #5237

Before it was unfortunately not classified as a bug - see https://github.com/doctrine/dbal/pull/5237#issuecomment-1029294556
but let me provide here a bit more light, why actually IT IS a bug.



First of all in SQLServer we have types like:
- `varchar` (variable length)
- `char` (fixed length)
- `text` (deprecated in favour of `varchar(max)`)

But these types does not accept support UTF-8, so therefore there are the following types:
- `nvarchar` (variable length)
- `nchar` (fixed length)
- `ntext` (deprecated in favour of `nvarchar(max)`)


At some point, when doctrine evolved SQLServer platform from MSSQL the change has been made, but not in all places - see https://github.com/doctrine/dbal/commit/8b29ffe5a53e4b823615e2ffc2b39a04aab549e9:

![image](https://github.com/doctrine/dbal/assets/7423207/aa35b44e-a91d-4023-8d44-93f011fbe38c)

So it was recognised that we suppose to use `nvarchar` in some places, but not `ntext` in the other.
And since then it is just there.

Later it was just updated to use `varchar(max)` instead of `text` (as `text` become deprecated): https://github.com/doctrine/dbal/pull/451

#### Current situation

Now, on version 4.0.x, we still have no ability to use text field with SQLServer for UTF-8 characters.

The other fields:
- fixed length:
https://github.com/doctrine/dbal/blob/cbd0e9adb46ec66f22c163e7003d0f4b2e38c8c7/src/Platforms/SQLServerPlatform.php#L875
- variable length:
https://github.com/doctrine/dbal/blob/cbd0e9adb46ec66f22c163e7003d0f4b2e38c8c7/src/Platforms/SQLServerPlatform.php#L890
do use `n` version of the columns by, but not the text one:
https://github.com/doctrine/dbal/blob/cbd0e9adb46ec66f22c163e7003d0f4b2e38c8c7/src/Platforms/SQLServerPlatform.php#L910-L913

and there is no easy option to use it, but overriding the type to provide support of length=-1 on the type level (so migrations is not trying to create nvarchar(-1) but uses nvarchar(max); -1 is reported back from the schema when we use max length, and this is also the same behaviour for varchar field).


#### Additional considerations

As it would solve the current issue, it's not a perfect solution.
It might be even considered as a BC break for some, especially when taking into account [storage differences](https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver16#storage_differences) between `varchar` and `nvarchar` types.

Not everyone has a need to store unicode characters, but I haven't seen any issues reported that "`(var)char` should be used instead of `n(var)char`".

If we want to provide full flexibility we should be able to choose the exact type we want - either unicode or non-unicode, BUT the default solution should be at least consistent and not mix of these two.



<!-- Provide a summary of your change. -->
