### PR TITLE
Fix: Skip type comparison if disableTypeComments is true

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4693,6 +4693,11 @@ abstract class AbstractPlatform
             return false;
         }
 
+        // If disableTypeComments is true, we do not need to check types, all comparison is already done above
+        if ($this->disableTypeComments) {
+            return true;
+        }
+
         return $column1->getType() === $column2->getType();
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1445,6 +1445,18 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertSame([], $this->platform->getAlterSchemaSQL($diff));
     }
 
+    public function testColumnComparisonWithDisabledTypeComments(): void
+    {
+        //Since DATETIME_MUTABLE is a "parent" of DATETIME_IMMUTABLE, they will have the same SQL type declaration.
+        $column1 = new Column('foo', Type::getType(Types::DATETIME_MUTABLE));
+        $column2 = new Column('foo', Type::getType(Types::DATETIME_IMMUTABLE));
+
+        $this->platform->setDisableTypeComments(true);
+        $result = (new Comparator($this->platform))->columnsEqual($column1, $column2);
+
+        self::assertTrue($result);
+    }
+
     public function tearDown(): void
     {
         if (! isset($this->backedUpType)) {

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1451,10 +1451,10 @@ abstract class AbstractPlatformTestCase extends TestCase
         $column1 = new Column('foo', Type::getType(Types::DATETIME_MUTABLE));
         $column2 = new Column('foo', Type::getType(Types::DATETIME_IMMUTABLE));
 
-        $this->platform->setDisableTypeComments(true);
-        $result = (new Comparator($this->platform))->columnsEqual($column1, $column2);
+        self::assertFalse($this->platform->columnsEqual($column1, $column2));
 
-        self::assertTrue($result);
+        $this->platform->setDisableTypeComments(true);
+        self::assertTrue($this->platform->columnsEqual($column1, $column2));
     }
 
     public function tearDown(): void

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1445,7 +1445,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertSame([], $this->platform->getAlterSchemaSQL($diff));
     }
 
-    public function testColumnComparisonWithDisabledTypeComments(): void
+    public function testColumnComparison(): void
     {
         //Since DATETIME_MUTABLE is a "parent" of DATETIME_IMMUTABLE, they will have the same SQL type declaration.
         $column1 = new Column('foo', Type::getType(Types::DATETIME_MUTABLE));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6422

#### Summary

In the https://github.com/doctrine/dbal/pull/6150, a check was missed when we were validating the database schema.
