### PR TITLE
Fix MariaDB fetching of default table character-set

### DIFF
--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -557,6 +557,11 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
+        // MariaDB-10.10.1 added FULL_COLLATION_NAME to the information_schema.COLLATION_CHARACTER_SET_APPLICABILITY.
+        // A base collation like uca1400_ai_ci can refer to multiple character sets. The value in the
+        // information_schema.TABLES.TABLE_COLLATION corresponds to the full collation name.
+        // The MariaDB executable comment syntax with version, /*M!101001, is exclusively executed on
+        // MariaDB-10.10.1+ servers for backwards compatibility, and compatiblity to MySQL servers.
         $sql = <<<'SQL'
     SELECT t.TABLE_NAME,
            t.ENGINE,
@@ -567,7 +572,8 @@ SQL;
            ccsa.CHARACTER_SET_NAME
       FROM information_schema.TABLES t
         INNER JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ccsa
-            ON ccsa.COLLATION_NAME = t.TABLE_COLLATION
+	     ON /*M!101001 ccsa.FULL_COLLATION_NAME = t.TABLE_COLLATION OR */
+               ccsa.COLLATION_NAME = t.TABLE_COLLATION
 SQL;
 
         $conditions = ['t.TABLE_SCHEMA = ?'];


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6361

#### Summary

From MariaDB-10.10.1, where uca1400 was added, the information_schema.COLLATION_CHARACTER_SET_APPLICABILITY was extended to have FULL_COLLATION_NAME which corresponds to the information_schema.TABLES.TABLE_COLLATION value.

Executable comment syntax is used to limited to the applicable versions.

To preserve compatibility with older MariaDB versions, and MySQL versions where the previous COLLATION_NAME was the match is left as a JOIN criteria. In new MariaDB versions this won't result in an extra row match.

Closes: #6361


The lack of this fix did case the CI test to fail with a MariaDB-11.0+ container:


```
1) Doctrine\DBAL\Tests\Functional\Schema\MySQLSchemaManagerTest::testEnsureTableWithoutOptionsAreReflectedInMetadata
Undefined array key "engine"

/home/runner/work/dbal/dbal/src/Schema/Table.php:927
/home/runner/work/dbal/dbal/tests/Functional/Schema/MySQLSchemaManagerTest.php:550
```


With this fix all version of MySQL and MariaDB (even those new ones soon to be in a different PR) will pass like: https://github.com/grooverdan/dbal/actions/runs/9412110648/job/25926481038