### PR TITLE
Add the Result::getColumnName method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,11 @@ awareness about deprecated code.
 * Upgrade to MariaDB 10.5 or later.
 * Upgrade to MySQL 8.0 or later.
 
+## Add `Result::getColumnName()`
+
+Driver and middleware results need to implement a new method `getColumnName()` that gives access to the
+column name. Not doing so is deprecated.
+
 # Upgrade to 4.0
 
 ## BC BREAK: removed `AbstractMySQLPlatform` methods.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -109,6 +109,9 @@ parameters:
             message: '#^Parameter \#2 \$callback of function array_reduce expects callable\(\(callable&TIn\)\|Closure\(mixed \$value\)\: mixed\|null, callable\(T\)\: T\)\: \(\(callable&TIn\)\|Closure\(mixed \$value\)\: mixed\|null\), Closure\(callable\|null, callable\)\: \(callable\(T\)\: T\) given\.$#'
             path: src/Portability/Converter.php
 
+        # Type check for legacy implementations of the Result interface
+        # TODO: remove in 5.0.0
+        - '~^Call to function method_exists\(\) with Doctrine\\DBAL\\Driver\\Result and ''getColumnName'' will always evaluate to true\.$~'
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -282,6 +282,8 @@
         </TypeDoesNotContainNull>
         <TypeDoesNotContainType>
             <errorLevel type="suppress">
+                <!-- See https://github.com/vimeo/psalm/issues/11008 -->
+                <file name="src/Driver/SQLite3/Result.php"/>
                 <!-- Ignore isset() checks in destructors. -->
                 <file name="src/Driver/PgSQL/Connection.php"/>
                 <file name="src/Driver/PgSQL/Statement.php"/>

--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -6,7 +6,9 @@ namespace Doctrine\DBAL\Cache;
 
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 
+use function array_keys;
 use function array_values;
 use function count;
 use function reset;
@@ -82,6 +84,15 @@ final class ArrayResult implements Result
     public function columnCount(): int
     {
         return $this->columnCount;
+    }
+
+    public function getColumnName(int $index): string
+    {
+        if ($this->data === [] || $index > count($this->data[0])) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        return array_keys($this->data[0])[$index];
     }
 
     public function free(): void

--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 
 use function db2_fetch_array;
 use function db2_fetch_assoc;
@@ -97,6 +98,17 @@ final class Result implements ResultInterface
         }
 
         return 0;
+    }
+
+    public function getColumnName(int $index): string
+    {
+        $name = db2_field_name($this->statement, $index);
+
+        if ($name === false) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        return $name;
     }
 
     public function free(): void

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Middleware;
 
 use Doctrine\DBAL\Driver\Result;
+use LogicException;
+
+use function get_debug_type;
+use function method_exists;
+use function sprintf;
 
 abstract class AbstractResultMiddleware implements Result
 {
@@ -59,6 +64,18 @@ abstract class AbstractResultMiddleware implements Result
     public function columnCount(): int
     {
         return $this->wrappedResult->columnCount();
+    }
+
+    public function getColumnName(int $index): string
+    {
+        if (! method_exists($this->wrappedResult, 'getColumnName')) {
+            throw new LogicException(sprintf(
+                'The driver result %s does not support accessing the column name.',
+                get_debug_type($this->wrappedResult),
+            ));
+        }
+
+        return $this->wrappedResult->getColumnName($index);
     }
 
     public function free(): void

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Mysqli\Exception\StatementError;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 use mysqli_sql_exception;
 use mysqli_stmt;
 
@@ -155,6 +156,11 @@ final class Result implements ResultInterface
     public function columnCount(): int
     {
         return $this->statement->field_count;
+    }
+
+    public function getColumnName(int $index): string
+    {
+        return $this->columnNames[$index] ?? throw InvalidColumnIndex::new($index);
     }
 
     public function free(): void

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\OCI8\Exception\Error;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 
 use function oci_cancel;
 use function oci_error;
@@ -93,6 +94,18 @@ final class Result implements ResultInterface
         }
 
         return 0;
+    }
+
+    public function getColumnName(int $index): string
+    {
+        // OCI expects a 1-based index while DBAL works with a O-based index.
+        $name = @oci_field_name($this->statement, $index + 1);
+
+        if ($name === false) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        return $name;
     }
 
     public function free(): void

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDO;
 
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -68,6 +69,21 @@ final class Result implements ResultInterface
     {
         try {
             return $this->statement->columnCount();
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+    }
+
+    public function getColumnName(int $index): string
+    {
+        try {
+            $meta = $this->statement->getColumnMeta($index);
+
+            if ($meta === false) {
+                throw InvalidColumnIndex::new($index);
+            }
+
+            return $meta['name'];
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }

--- a/src/Driver/PgSQL/Result.php
+++ b/src/Driver/PgSQL/Result.php
@@ -7,7 +7,9 @@ namespace Doctrine\DBAL\Driver\PgSQL;
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\PgSQL\Exception\UnexpectedValue;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 use PgSql\Result as PgSqlResult;
+use ValueError;
 
 use function array_keys;
 use function array_map;
@@ -143,6 +145,19 @@ final class Result implements ResultInterface
         }
 
         return pg_num_fields($this->result);
+    }
+
+    public function getColumnName(int $index): string
+    {
+        if ($this->result === null) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        try {
+            return pg_field_name($this->result, $index);
+        } catch (ValueError) {
+            throw InvalidColumnIndex::new($index);
+        }
     }
 
     public function free(): void

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver;
 
 /**
  * Driver-level statement execution result.
+ *
+ * @method string getColumnName(int $index)
  */
 interface Result
 {

--- a/src/Driver/SQLSrv/Result.php
+++ b/src/Driver/SQLSrv/Result.php
@@ -6,9 +6,11 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 
 use function sqlsrv_fetch;
 use function sqlsrv_fetch_array;
+use function sqlsrv_field_metadata;
 use function sqlsrv_num_fields;
 use function sqlsrv_rows_affected;
 
@@ -85,6 +87,17 @@ final class Result implements ResultInterface
         }
 
         return 0;
+    }
+
+    public function getColumnName(int $index): string
+    {
+        $meta = sqlsrv_field_metadata($this->statement);
+
+        if ($meta === false || ! isset($meta[$index])) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        return $meta[$index]['Name'];
     }
 
     public function free(): void

--- a/src/Driver/SQLite3/Result.php
+++ b/src/Driver/SQLite3/Result.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Driver\SQLite3;
 
 use Doctrine\DBAL\Driver\FetchUtils;
 use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
 use SQLite3Result;
 
 use const SQLITE3_ASSOC;
@@ -74,6 +75,21 @@ final class Result implements ResultInterface
         }
 
         return $this->result->numColumns();
+    }
+
+    public function getColumnName(int $index): string
+    {
+        if ($this->result === null) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        $name = $this->result->columnName($index);
+
+        if ($name === false) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        return $name;
     }
 
     public function free(): void

--- a/src/Exception/InvalidColumnIndex.php
+++ b/src/Exception/InvalidColumnIndex.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+use LogicException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class InvalidColumnIndex extends LogicException implements Exception
+{
+    public static function new(int $index): self
+    {
+        return new self(sprintf('Invalid column index "%s".', $index));
+    }
+}

--- a/src/Portability/Converter.php
+++ b/src/Portability/Converter.php
@@ -11,6 +11,8 @@ use function array_map;
 use function array_reduce;
 use function is_string;
 use function rtrim;
+use function strtolower;
+use function strtoupper;
 
 use const CASE_LOWER;
 use const CASE_UPPER;
@@ -26,6 +28,7 @@ final class Converter
     private readonly Closure $convertAllNumeric;
     private readonly Closure $convertAllAssociative;
     private readonly Closure $convertFirstColumn;
+    private readonly Closure $convertColumnName;
 
     /**
      * @param bool                                   $convertEmptyStringToNull Whether each empty string should
@@ -48,6 +51,12 @@ final class Converter
         $this->convertAllNumeric     = $this->createConvertAll($convertNumeric);
         $this->convertAllAssociative = $this->createConvertAll($convertAssociative);
         $this->convertFirstColumn    = $this->createConvertAll($convertValue);
+
+        $this->convertColumnName = match ($case) {
+            null => static fn (string $name) => $name,
+            self::CASE_LOWER => strtolower(...),
+            self::CASE_UPPER => strtoupper(...),
+        };
     }
 
     /**
@@ -103,6 +112,11 @@ final class Converter
     public function convertFirstColumn(array $data): array
     {
         return ($this->convertFirstColumn)($data);
+    }
+
+    public function convertColumnName(string $name): string
+    {
+        return ($this->convertColumnName)($name);
     }
 
     /**

--- a/src/Portability/Result.php
+++ b/src/Portability/Result.php
@@ -65,4 +65,11 @@ final class Result extends AbstractResultMiddleware
             parent::fetchFirstColumn(),
         );
     }
+
+    public function getColumnName(int $index): string
+    {
+        return $this->converter->convertColumnName(
+            parent::getColumnName($index),
+        );
+    }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,11 +7,15 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Exception\NoKeyValue;
+use LogicException;
 use Traversable;
 
 use function array_shift;
 use function assert;
 use function count;
+use function get_debug_type;
+use function method_exists;
+use function sprintf;
 
 class Result
 {
@@ -248,6 +252,29 @@ class Result
     {
         try {
             return $this->result->columnCount();
+        } catch (DriverException $e) {
+            throw $this->connection->convertException($e);
+        }
+    }
+
+    /**
+     * Returns the name of the column in the result set for the given 0-based index.
+     *
+     * If the index is not a valid column index ({@see columnCount}), an exception will be thrown.
+     *
+     * @throws Exception
+     */
+    public function getColumnName(int $index): string
+    {
+        if (! method_exists($this->result, 'getColumnName')) {
+            throw new LogicException(sprintf(
+                'The driver result %s does not support accessing the column name.',
+                get_debug_type($this->result),
+            ));
+        }
+
+        try {
+            return $this->result->getColumnName($index);
         } catch (DriverException $e) {
             throw $this->connection->convertException($e);
         }

--- a/tests/Cache/ArrayStatementTest.php
+++ b/tests/Cache/ArrayStatementTest.php
@@ -41,6 +41,14 @@ class ArrayStatementTest extends TestCase
         self::assertSame(2, $statement->columnCount());
     }
 
+    public function testColumnNames(): void
+    {
+        $statement = $this->createTestArrayStatement();
+
+        self::assertSame('username', $statement->getColumnName(0));
+        self::assertSame('active', $statement->getColumnName(1));
+    }
+
     public function testRowCount(): void
     {
         $statement = $this->createTestArrayStatement();

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -62,6 +62,24 @@ class PortabilityTest extends FunctionalTestCase
         self::assertSame($expected, array_keys($row));
     }
 
+    /** @param list<string> $expected */
+    #[DataProvider('caseProvider')]
+    public function testCaseConversionColumnName(ColumnCase $case, array $expected): void
+    {
+        $this->connectWithPortability(Connection::PORTABILITY_FIX_CASE, $case);
+        $this->createTable();
+
+        $result = $this->connection->executeQuery('SELECT * FROM portability_table');
+
+        $actual = [];
+
+        foreach ($expected as $index => $name) {
+            $actual[$index] = $result->getColumnName($index);
+        }
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @return iterable<string, array{ColumnCase, list<string>}> */
     public static function caseProvider(): iterable
     {

--- a/tests/Functional/ResultMetadataTest.php
+++ b/tests/Functional/ResultMetadataTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+use function strtolower;
+
+class ResultMetadataTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $table = new Table('result_metadata_table');
+        $table->addColumn('test_int', 'integer');
+        $table->setPrimaryKey(['test_int']);
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('result_metadata_table', ['test_int' => 1]);
+    }
+
+    public function testColumnNameWithResults(): void
+    {
+        $sql = 'SELECT test_int, test_int AS alternate_name FROM result_metadata_table';
+
+        $result = $this->connection->executeQuery($sql);
+
+        self::assertEquals(2, $result->columnCount());
+        // Depending on the platform, field names might have different case than in the SQL
+        // query (for instance, Oracle turns unquoted identifiers into upper case).
+        self::assertEquals('test_int', strtolower($result->getColumnName(0)));
+        self::assertEquals('alternate_name', strtolower($result->getColumnName(1)));
+    }
+
+    public function testColumnNameWithInvalidIndex(): void
+    {
+        $sql = 'SELECT test_int, test_int AS alternate_name FROM result_metadata_table';
+
+        $result = $this->connection->executeQuery($sql);
+
+        // Consume the result set to avoid issues with unprocessed buffer between tests
+        $result->fetchAllAssociative();
+
+        $this->expectException(InvalidColumnIndex::class);
+
+        $result->getColumnName(2);
+    }
+
+    public function testColumnNameWithoutResults(): void
+    {
+        $sql = 'SELECT test_int, test_int AS alternate_name FROM result_metadata_table WHERE 1 = 0';
+
+        $result = $this->connection->executeQuery($sql);
+
+        self::assertEquals(2, $result->columnCount());
+        self::assertEquals('test_int', strtolower($result->getColumnName(0)));
+        self::assertEquals('alternate_name', strtolower($result->getColumnName(1)));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #5980

#### Summary

This method allows introspecting the shape of results by knowing the name of columns (combined with the `columnCount` which already exists).

