### PR TITLE
Fix the portability documentation

### DIFF
--- a/docs/en/reference/portability.rst
+++ b/docs/en/reference/portability.rst
@@ -51,15 +51,16 @@ Using the following code block in your initialization will:
     <?php
 
     use Doctrine\DBAL\ColumnCase;
+    use Doctrine\DBAL\Configuration;
     use Doctrine\DBAL\Portability\Connection as PortableConnection;
+    use Doctrine\DBAL\Portability\Middleware as PotableMiddleware;
 
-    $params = [
-        // vendor specific configuration
+    $configuration = new Configuration();
+    $configuration->setMiddlewares([
+        // Other middlewares
         //...
-        'wrapperClass' => PortableConnection::class,
-        'portability'  => PortableConnection::PORTABILITY_ALL,
-        'fetch_case'   => ColumnCase::LOWER,
-    ];
+        new PortableMiddleware(PortableConnection::PORTABILITY_ALL, ColumnCase::LOWER),
+    ]);
 
 This sort of portability handling is pretty expensive because all the result
 rows and columns have to be looped inside PHP before being returned to you.


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| Fixed issues | n/a

#### Summary

The Portability connection is not a valid wrapper class as it does not extend `Doctrine\DBAL\Connection`. The way to use it is through the middleware, to wrap the driver connection.