### PR TITLE
mariadb: add mariadb-base-image to facilitate upstream "nightlies"

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -293,6 +293,8 @@ jobs:
 
     strategy:
       matrix:
+        mariadb-base-image:
+          - "mariadb"
         php-version:
           - "7.4"
         mariadb-version:
@@ -312,26 +314,36 @@ jobs:
         include:
           - php-version: "8.2"
             mariadb-version: "10.6"
+            mariadb-base-image: "mariadb"
             extension: "mysqli"
           - php-version: "8.2"
             mariadb-version: "10.6"
+            mariadb-base-image: "mariadb"
             extension: "pdo_mysql"
           - php-version: "8.2"
             mariadb-version: "11.4"
+            mariadb-base-image: "mariadb"
             extension: "mysqli"
           - php-version: "8.2"
             mariadb-version: "11.4"
+            mariadb-base-image: "mariadb"
             extension: "pdo_mysql"
           - php-version: "8.3"
             mariadb-version: "11.4"
+            mariadb-base-image: "mariadb"
             extension: "mysqli"
           - php-version: "8.3"
             mariadb-version: "11.4"
+            mariadb-base-image: "mariadb"
             extension: "pdo_mysql"
+          - php-version: "8.3"
+            mariadb-version: "verylatest" # latest beta branch head
+            mariadb-base-image: "quay.io/mariadb-foundation/mariadb-devel"
+            extension: "mysqli"
 
     services:
       mariadb:
-        image: "mariadb:${{ matrix.mariadb-version }}"
+        image: "${{ matrix.mariadb-base-image}}:${{ matrix.mariadb-version }}"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: "doctrine_tests"


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues |

#### Summary

From #6426, add a 90 second test to ensure Doctrine DBAL remains compatible with MariaDB, and users aren't the ones to discover incompatibilities (like #6361).

A quay.io/mariadb-foundation/mariadb-devel:verylatest is what is going to be in the next MariaDB release, including unintentionally breaking features, this is a good change to let MariaDB know before they have committed via release to the stability of the change.

Alternates:
* Let user's find incompatibilities
* Replace last few matrix includes with `mariadb-base-image: "quay.io/mariadb-foundation/mariadb-devel"` tests
* Let MariaDB upstream run DBAL tests if they want to (please don't, I'm struggling to maintain the few language tests that we do run).