### PR TITLE
Add MariaDb1010Platform for fetchTableOptionsByTable

### DIFF
--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -45,6 +45,7 @@ MariaDB
 -  ``MariaDb1043Platform`` for version 10.4.3 and above.
 -  ``MariaDb1052Platform`` for version 10.5.2 and above.
 -  ``MariaDb1060Platform`` for version 10.6 and above.
+-  ``MariaDb1010Platform`` for version 10.10 and above.
 
 Oracle
 ^^^^^^

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\MySQL;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1010Platform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
@@ -41,6 +42,10 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '10.10.0', '>=')) {
+                return new MariaDb1010Platform();
+            }
+
             if (version_compare($mariaDbVersion, '10.6.0', '>=')) {
                 return new MariaDb1060Platform();
             }

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -1468,4 +1468,30 @@ SQL
 
         return $result;
     }
+
+    public function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): string
+    {
+        $sql = <<<'SQL'
+    SELECT t.TABLE_NAME,
+           t.ENGINE,
+           t.AUTO_INCREMENT,
+           t.TABLE_COMMENT,
+           t.CREATE_OPTIONS,
+           t.TABLE_COLLATION,
+           ccsa.CHARACTER_SET_NAME
+      FROM information_schema.TABLES t
+        INNER JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ccsa
+          ON ccsa.COLLATION_NAME = t.TABLE_COLLATION
+SQL;
+
+        $conditions = ['t.TABLE_SCHEMA = ?'];
+
+        if ($tableName !== null) {
+            $conditions[] = 't.TABLE_NAME = ?';
+        }
+
+        $conditions[] = "t.TABLE_TYPE = 'BASE TABLE'";
+
+        return $sql . ' WHERE ' . implode(' AND ', $conditions);
+    }
 }

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -1469,7 +1469,7 @@ SQL
         return $result;
     }
 
-    public function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): string
+    public function fetchTableOptionsByTable(bool $includeTableName): string
     {
         $sql = <<<'SQL'
     SELECT t.TABLE_NAME,
@@ -1486,7 +1486,7 @@ SQL;
 
         $conditions = ['t.TABLE_SCHEMA = ?'];
 
-        if ($tableName !== null) {
+        if ($includeTableName) {
             $conditions[] = 't.TABLE_NAME = ?';
         }
 

--- a/src/Platforms/MariaDb1010Platform.php
+++ b/src/Platforms/MariaDb1010Platform.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+
+use function implode;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 10.10 database platform.
+ */
+class MariaDb1010Platform extends MariaDb1060Platform
+{
+    public function createSelectSQLBuilder(): SelectSQLBuilder
+    {
+        return AbstractPlatform::createSelectSQLBuilder();
+    }
+
+    public function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): string
+    {
+        // MariaDB-10.10.1 added FULL_COLLATION_NAME to the information_schema.COLLATION_CHARACTER_SET_APPLICABILITY.
+        // A base collation like uca1400_ai_ci can refer to multiple character sets. The value in the
+        // information_schema.TABLES.TABLE_COLLATION corresponds to the full collation name.
+        $sql = <<<'SQL'
+    SELECT t.TABLE_NAME,
+           t.ENGINE,
+           t.AUTO_INCREMENT,
+           t.TABLE_COMMENT,
+           t.CREATE_OPTIONS,
+           t.TABLE_COLLATION,
+           ccsa.CHARACTER_SET_NAME
+      FROM information_schema.TABLES t
+        INNER JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ccsa
+          ON ccsa.FULL_COLLATION_NAME = t.TABLE_COLLATION
+SQL;
+
+        $conditions = ['t.TABLE_SCHEMA = ?'];
+
+        if ($tableName !== null) {
+            $conditions[] = 't.TABLE_NAME = ?';
+        }
+
+        $conditions[] = "t.TABLE_TYPE = 'BASE TABLE'";
+
+        return $sql . ' WHERE ' . implode(' AND ', $conditions);
+    }
+}

--- a/src/Platforms/MariaDb1010Platform.php
+++ b/src/Platforms/MariaDb1010Platform.php
@@ -16,7 +16,7 @@ class MariaDb1010Platform extends MariaDb1060Platform
         return AbstractPlatform::createSelectSQLBuilder();
     }
 
-    public function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): string
+    public function fetchTableOptionsByTable(bool $includeTableName): string
     {
         // MariaDB-10.10.1 added FULL_COLLATION_NAME to the information_schema.COLLATION_CHARACTER_SET_APPLICABILITY.
         // A base collation like uca1400_ai_ci can refer to multiple character sets. The value in the
@@ -36,7 +36,7 @@ SQL;
 
         $conditions = ['t.TABLE_SCHEMA = ?'];
 
-        if ($tableName !== null) {
+        if ($includeTableName) {
             $conditions[] = 't.TABLE_NAME = ?';
         }
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -557,36 +557,12 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
-        // MariaDB-10.10.1 added FULL_COLLATION_NAME to the information_schema.COLLATION_CHARACTER_SET_APPLICABILITY.
-        // A base collation like uca1400_ai_ci can refer to multiple character sets. The value in the
-        // information_schema.TABLES.TABLE_COLLATION corresponds to the full collation name.
-        // The MariaDB executable comment syntax with version, /*M!101001, is exclusively executed on
-        // MariaDB-10.10.1+ servers for backwards compatibility, and compatiblity to MySQL servers.
-        $sql = <<<'SQL'
-    SELECT t.TABLE_NAME,
-           t.ENGINE,
-           t.AUTO_INCREMENT,
-           t.TABLE_COMMENT,
-           t.CREATE_OPTIONS,
-           t.TABLE_COLLATION,
-           ccsa.CHARACTER_SET_NAME
-      FROM information_schema.TABLES t
-        INNER JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ccsa
-	     ON /*M!101001 ccsa.FULL_COLLATION_NAME = t.TABLE_COLLATION OR */
-               ccsa.COLLATION_NAME = t.TABLE_COLLATION
-SQL;
+        $sql = $this->_platform->fetchTableOptionsByTable($databaseName, $tableName);
 
-        $conditions = ['t.TABLE_SCHEMA = ?'];
-        $params     = [$databaseName];
-
+        $params = [$databaseName];
         if ($tableName !== null) {
-            $conditions[] = 't.TABLE_NAME = ?';
-            $params[]     = $tableName;
+            $params[] = $tableName;
         }
-
-        $conditions[] = "t.TABLE_TYPE = 'BASE TABLE'";
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions);
 
         /** @var array<string,array<string,mixed>> $metadata */
         $metadata = $this->_conn->executeQuery($sql, $params)

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -557,7 +557,7 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
-        $sql = $this->_platform->fetchTableOptionsByTable($databaseName, $tableName);
+        $sql = $this->_platform->fetchTableOptionsByTable($tableName !== null);
 
         $params = [$databaseName];
         if ($tableName !== null) {

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2111Platform;
 use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MariaDb1010Platform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MariaDb1060Platform;
@@ -65,7 +66,7 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['10.5.2-MariaDB-1~lenny-log', MariaDB1052Platform::class],
             ['mariadb-10.6.0', MariaDb1060Platform::class],
             ['mariadb-10.9.3', MariaDb1060Platform::class],
-            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDb1060Platform::class],
+            ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDb1010Platform::class],
         ];
     }
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional\Query;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MariaDb1010Platform;
 use Doctrine\DBAL\Platforms\MariaDb1060Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
@@ -117,7 +118,7 @@ final class QueryBuilderTest extends FunctionalTestCase
 
         if ($platform instanceof MySQLPlatform) {
             if ($platform instanceof MariaDBPlatform) {
-                if (! $platform instanceof MariaDb1060Platform) {
+                if (! ($platform instanceof MariaDb1060Platform || $platform instanceof MariaDb1010Platform)) {
                     return false;
                 }
             } elseif (! $platform instanceof MySQL80Platform) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6361

#### Summary

As requested: https://github.com/doctrine/dbal/pull/6425#discussion_r1631197858

The diverging MariaDB-10.10.1+ implementation of retrieving table options split the implementation so that its now in the AbstractMySQLPlatform and the MariaDB specific implementation in MariaDBPlatform.

On CI  - I don't follow the 'useless $sql' error.