### PR TITLE
Default to distinct union queries

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -322,7 +322,7 @@ To combine multiple ``SELECT`` queries into one result-set you can pass SQL Part
 or QueryBuilder instances to one of the following methods:
 
 * ``union(string|QueryBuilder $part)``
-* ``addUnion(string|QueryBuilder $part, UnionType $type)``
+* ``addUnion(string|QueryBuilder $part, UnionType $type = UnionType::DISTINCT)``
 
 .. code-block:: php
 
@@ -330,9 +330,9 @@ or QueryBuilder instances to one of the following methods:
 
     $queryBuilder
         ->union('SELECT 1 AS field')
-        ->addUnion('SELECT 2 AS field', UnionType::DISTINCT)
-        ->addUnion('SELECT 3 AS field', UnionType::DISTINCT)
-        ->addUnion('SELECT 3 as field', UnionType::DISTINCT);
+        ->addUnion('SELECT 2 AS field')
+        ->addUnion('SELECT 3 AS field')
+        ->addUnion('SELECT 3 as field');
 
     $queryBuilder
         ->union('SELECT 1 AS field')

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -542,7 +542,7 @@ class QueryBuilder
      *
      * @return $this
      */
-    public function addUnion(string|QueryBuilder $part, UnionType $type): self
+    public function addUnion(string|QueryBuilder $part, UnionType $type = UnionType::DISTINCT): self
     {
         $this->type = QueryType::UNION;
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -124,7 +124,7 @@ final class QueryBuilderTest extends FunctionalTestCase
         self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
     }
 
-    public function testUnionReturnsExpectedResult(): void
+    public function testUnionDistinctReturnsExpectedResult(): void
     {
         $expectedRows = $this->prepareExpectedRows([['field_one' => 1], ['field_one' => 2]]);
         $platform     = $this->connection->getDatabasePlatform();
@@ -132,6 +132,19 @@ final class QueryBuilderTest extends FunctionalTestCase
         $qb->union($platform->getDummySelectSQL('2 as field_one'))
             ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
             ->addUnion($platform->getDummySelectSQL('1 as field_one'), UnionType::DISTINCT)
+            ->orderBy('field_one', 'ASC');
+
+        self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    public function testUnionIsDistinctByDefault(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['field_one' => 1], ['field_one' => 2]]);
+        $platform     = $this->connection->getDatabasePlatform();
+        $qb           = $this->connection->createQueryBuilder();
+        $qb->union($platform->getDummySelectSQL('2 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'))
+            ->addUnion($platform->getDummySelectSQL('1 as field_one'))
             ->orderBy('field_one', 'ASC');
 
         self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -1472,6 +1472,15 @@ class QueryBuilderTest extends TestCase
         self::assertSame('SELECT 1 AS field_one UNION SELECT 2 as field_one', $qb->getSQL());
     }
 
+    public function testUnionIsDistinctByDefault(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->union('SELECT 1 AS field_one')
+            ->addUnion('SELECT 2 as field_one');
+
+        self::assertSame('SELECT 1 AS field_one UNION SELECT 2 as field_one', $qb->getSQL());
+    }
+
     public function testUnionAndOrderByReturnsUnionQueryWithOrderBy(): void
     {
         $qb = new QueryBuilder($this->conn);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6369

#### Summary

I think that people usually want to have a distinct union, if they build a union query. This would also be in line with SQL where a `UNION` without any additional keywords would produce a distinct union.

cc @sbuerk