### PR TITLE
feat: add support for function as default value

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1458,7 +1458,7 @@ abstract class AbstractPlatform
         }
 
         if ((bool) preg_match('/^[a-zA-Z_]+\(\)$/', $default)) {
-            return ' DEFAULT ' . $default;
+            return ' DEFAULT (' . $default . ')';
         }
 
         return ' DEFAULT ' . $this->quoteStringLiteral($default);

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -51,6 +51,7 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
+use function preg_match;
 use function preg_quote;
 use function preg_replace;
 use function sprintf;
@@ -1453,6 +1454,10 @@ abstract class AbstractPlatform
         }
 
         if (is_int($default) || is_float($default)) {
+            return ' DEFAULT ' . $default;
+        }
+
+        if ((bool) preg_match('/^[a-zA-Z_]+\(\)$/', $default)) {
             return ' DEFAULT ' . $default;
         }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -329,7 +329,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     public function testGetDefaultValueDeclarationSQLForFunctionDefault(): void
     {
         self::assertEquals(
-            ' DEFAULT gen_random_uuid()',
+            ' DEFAULT (gen_random_uuid())',
             $this->platform->getDefaultValueDeclarationSQL([
                 'type'    => Type::getType(Types::STRING),
                 'default' => 'gen_random_uuid()',

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -326,6 +326,17 @@ abstract class AbstractPlatformTestCase extends TestCase
         }
     }
 
+    public function testGetDefaultValueDeclarationSQLForFunctionDefault(): void
+    {
+        self::assertEquals(
+            ' DEFAULT gen_random_uuid()',
+            $this->platform->getDefaultValueDeclarationSQL([
+                'type'    => Type::getType(Types::STRING),
+                'default' => 'gen_random_uuid()',
+            ]),
+        );
+    }
+
     public function testKeywordList(): void
     {
         $keywordList = $this->platform->getReservedKeywordsList();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
Added support for function as default value, for example `id UUID NOT NULL DEFAULT gen_random_uuid()`
<!-- Provide a summary of your change. -->
