### PR TITLE
Revert "Merge pull request #6413 from achterin/bugfix/foreign_key_name_change_detection"

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -555,10 +555,6 @@ class Comparator
      */
     public function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2)
     {
-        if (strtolower($key1->getName()) !== strtolower($key2->getName())) {
-            return true;
-        }
-
         if (
             array_map('strtolower', $key1->getUnquotedLocalColumns())
             !== array_map('strtolower', $key2->getUnquotedLocalColumns())

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -652,7 +652,7 @@ class AbstractComparatorTestCase extends TestCase
         self::assertFalse($tableDiff);
     }
 
-    public function testDetectIndexNameChange(): void
+    public function testCompareIndexBasedOnPropertiesNotName(): void
     {
         $tableA = new Table('foo');
         $tableA->addColumn('id', Types::INTEGER);
@@ -672,7 +672,7 @@ class AbstractComparatorTestCase extends TestCase
         );
     }
 
-    public function testDetectForeignKeyNameChange(): void
+    public function testCompareForeignKeyBasedOnPropertiesNotName(): void
     {
         $tableA = new Table('foo');
         $tableA->addColumn('id', Types::INTEGER);
@@ -683,9 +683,8 @@ class AbstractComparatorTestCase extends TestCase
         $tableB->addForeignKeyConstraint('bar', ['id'], ['id'], [], 'bar_constraint');
 
         $tableDiff = $this->comparator->diffTable($tableA, $tableB);
-        self::assertNotFalse($tableDiff);
-        self::assertCount(1, $tableDiff->addedForeignKeys);
-        self::assertCount(1, $tableDiff->removedForeignKeys);
+
+        self::assertFalse($tableDiff);
     }
 
     public function testCompareForeignKeyRestrictNoActionAreTheSame(): void


### PR DESCRIPTION
This reverts commit 080aab5a9588f137ef3e1ad7e0d056a4517b4e16, reversing changes made to a5d2bafb2b009cca29837db45ac6febe6c963859.


See https://github.com/doctrine/dbal/issues/6437#issuecomment-2169396717
