### PR TITLE
Add the `getColumnName()` method to the `Result` interface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Add `Result::getColumnName()`
+
+A new method `getColumnName()` has been added to the `Result` interface and must be implemented by
+all drivers and middleware.
+
 ## BC BREAK: Removed support for MariaDB 10.4 and MySQL 5.7
 
 * Upgrade to MariaDB 10.5 or later.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -108,10 +108,6 @@ parameters:
         -
             message: '#^Parameter \#2 \$callback of function array_reduce expects callable\(\(callable&TIn\)\|Closure\(mixed \$value\)\: mixed\|null, callable\(T\)\: T\)\: \(\(callable&TIn\)\|Closure\(mixed \$value\)\: mixed\|null\), Closure\(callable\|null, callable\)\: \(callable\(T\)\: T\) given\.$#'
             path: src/Portability/Converter.php
-
-        # Type check for legacy implementations of the Result interface
-        # TODO: remove in 5.0.0
-        - '~^Call to function method_exists\(\) with Doctrine\\DBAL\\Driver\\Result and ''getColumnName'' will always evaluate to true\.$~'
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/Driver/Middleware/AbstractResultMiddleware.php
+++ b/src/Driver/Middleware/AbstractResultMiddleware.php
@@ -5,11 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Middleware;
 
 use Doctrine\DBAL\Driver\Result;
-use LogicException;
-
-use function get_debug_type;
-use function method_exists;
-use function sprintf;
 
 abstract class AbstractResultMiddleware implements Result
 {
@@ -68,13 +63,6 @@ abstract class AbstractResultMiddleware implements Result
 
     public function getColumnName(int $index): string
     {
-        if (! method_exists($this->wrappedResult, 'getColumnName')) {
-            throw new LogicException(sprintf(
-                'The driver result %s does not support accessing the column name.',
-                get_debug_type($this->wrappedResult),
-            ));
-        }
-
         return $this->wrappedResult->getColumnName($index);
     }
 

--- a/src/Driver/Result.php
+++ b/src/Driver/Result.php
@@ -6,8 +6,6 @@ namespace Doctrine\DBAL\Driver;
 
 /**
  * Driver-level statement execution result.
- *
- * @method string getColumnName(int $index)
  */
 interface Result
 {
@@ -87,6 +85,11 @@ interface Result
      * @throws Exception
      */
     public function columnCount(): int;
+
+    /**
+     * Returns the name of the column in the result set for the given 0-based index.
+     */
+    public function getColumnName(int $index): string;
 
     /**
      * Discards the non-fetched portion of the result, enabling the originating statement to be executed again.

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,15 +7,11 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\Exception\NoKeyValue;
-use LogicException;
 use Traversable;
 
 use function array_shift;
 use function assert;
 use function count;
-use function get_debug_type;
-use function method_exists;
-use function sprintf;
 
 class Result
 {
@@ -266,13 +262,6 @@ class Result
      */
     public function getColumnName(int $index): string
     {
-        if (! method_exists($this->result, 'getColumnName')) {
-            throw new LogicException(sprintf(
-                'The driver result %s does not support accessing the column name.',
-                get_debug_type($this->result),
-            ));
-        }
-
         try {
             return $this->result->getColumnName($index);
         } catch (DriverException $e) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6428

#### Summary

Following #6428, the new `getColumnName()` method becomes mandatory with this PR for all `Result` implementations.