### PR TITLE
Feature: Add method to check VARCHAR support without length specification

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1951,6 +1951,14 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Does this platform support VARCHAR type without specifying length?
+     */
+    public function supportsVarcharWithoutLength(): bool
+    {
+        return false;
+    }
+
+    /**
      * Whether this platform support to add inline column comments as postfix.
      *
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
@@ -1976,16 +1984,6 @@ abstract class AbstractPlatform
      * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
     public function supportsColumnCollation(): bool
-    {
-        return false;
-    }
-
-    /**
-     * Does this platform support VARCHAR type without specifying length?
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     */
-    public function supportsVarcharWithoutLength(): bool
     {
         return false;
     }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1981,6 +1981,16 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Does this platform support VARCHAR type without specifying length?
+     *
+     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
+     */
+    public function supportsVarcharWithoutLength(): bool
+    {
+        return false;
+    }
+
+    /**
      * Gets the format string, as accepted by the date() function, that describes
      * the format of a stored datetime value of this platform.
      *

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -138,6 +138,12 @@ class PostgreSQLPlatform extends AbstractPlatform
         return true;
     }
 
+    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
+    public function supportsVarcharWithoutLength(): bool
+    {
+        return true;
+    }
+
     /** @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy. */
     public function getListDatabasesSQL(): string
     {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -126,6 +126,11 @@ class PostgreSQLPlatform extends AbstractPlatform
         return true;
     }
 
+    public function supportsVarcharWithoutLength(): bool
+    {
+        return true;
+    }
+
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
     public function supportsPartialIndexes(): bool
     {
@@ -134,12 +139,6 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
     public function supportsCommentOnStatement(): bool
-    {
-        return true;
-    }
-
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsVarcharWithoutLength(): bool
     {
         return true;
     }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -400,6 +400,11 @@ class SQLitePlatform extends AbstractPlatform
         return true;
     }
 
+    public function supportsVarcharWithoutLength(): bool
+    {
+        return true;
+    }
+
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
     public function supportsColumnCollation(): bool
     {
@@ -408,12 +413,6 @@ class SQLitePlatform extends AbstractPlatform
 
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
     public function supportsInlineColumnComments(): bool
-    {
-        return true;
-    }
-
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsVarcharWithoutLength(): bool
     {
         return true;
     }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -412,6 +412,12 @@ class SQLitePlatform extends AbstractPlatform
         return true;
     }
 
+    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
+    public function supportsVarcharWithoutLength(): bool
+    {
+        return true;
+    }
+
     public function getTruncateTableSQL(string $tableName, bool $cascade = false): string
     {
         $tableIdentifier = new Identifier($tableName);

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -312,6 +312,11 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         return true;
     }
 
+    public function testSupportsVarcharWithoutLength(): void
+    {
+        self::assertTrue($this->platform->supportsVarcharWithoutLength());
+    }
+
     public function testModifyLimitQuery(): void
     {
         $sql = $this->platform->modifyLimitQuery('SELECT * FROM user', 10, 0);

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -599,6 +599,11 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         self::assertTrue($this->platform->supportsColumnCollation());
     }
 
+    public function testSupportsVarcharWithoutLength(): void
+    {
+        self::assertTrue($this->platform->supportsVarcharWithoutLength());
+    }
+
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature

#### Summary

A method has been added to allow disabling the length check for `VARCHAR` in the ORM3 for platforms that support it. This is related to this issue https://github.com/doctrine/orm/issues/11502.

If this PR is approved, I plan to add the following check in the ORM at:
https://github.com/doctrine/orm/blob/9d4f54b9a476f13479c3845350b12c466873fc42/src/Tools/SchemaTool.php#L463-L465

The check is:
```php
       if(! $this->platform->supportsVarcharWithoutLength()) {
            if (strtolower($columnType) === 'string' && $options['length'] === null) {
                $options['length'] = 255;
            }
        }
```

I am not sure if this should be added to DBAL3 because, due to a bug in schema definition, it is already supported. And considering that the schema definition method was changed in DBAL4 but not in DBAL3, I assume there are some hidden issues or that it was done to avoid breaking backward compatibility for people who are unknowingly using this bug.