### PR TITLE
ci: nightly - php-8.1 min version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
           - "8.3"
         mariadb-version:
           - "earliest"


### PR DESCRIPTION
The nightly from the 4.0.x branch has 8.1 as the minium version in composer.json.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | CI
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Saw 7.4 failed on CI  - https://github.com/doctrine/dbal/actions/runs/9622482111

Fixed to 8.1 as the low PHP version.

The secret MARIADB_ZULIP_API_KEY also failed. I did check and it is the code without quotes of "do....ad"