### PR TITLE
CI: Add MySQL 9, reduce test matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -378,57 +378,34 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.1"
+          - "8.3"
         mysql-version:
           - "5.7"
           - "8.0"
+          - "9.0"
         extension:
           - "mysqli"
           - "pdo_mysql"
         config-file-suffix:
           - ""
         include:
-          - mysql-version: "8.0"
-            # https://stackoverflow.com/questions/60902904/how-to-pass-mysql-native-password-to-mysql-service-in-github-actions
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.0 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
           - config-file-suffix: "-tls"
             php-version: "7.4"
             mysql-version: "8.0"
             extension: "mysqli"
-          - php-version: "8.2"
-            mysql-version: "8.0"
-            extension: "mysqli"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.0 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-          - php-version: "8.2"
-            mysql-version: "8.0"
-            extension: "pdo_mysql"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.0 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-          - php-version: "8.3"
-            mysql-version: "8.0"
-            extension: "mysqli"
-          - php-version: "8.3"
-            mysql-version: "8.0"
-            extension: "pdo_mysql"
           - php-version: "7.4"
-            mysql-version: "8.4"
+            mysql-version: "8.0"
             extension: "mysqli"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
           - php-version: "7.4"
-            mysql-version: "8.4"
+            mysql-version: "8.0"
             extension: "pdo_mysql"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
-          - php-version: "8.1"
+          # Workaround for https://bugs.mysql.com/114876
+          - php-version: "8.3"
             mysql-version: "8.4"
             extension: "mysqli"
             custom-entrypoint: >-
               --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
-          - php-version: "8.1"
+          - php-version: "8.3"
             mysql-version: "8.4"
             extension: "pdo_mysql"
             custom-entrypoint: >-

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -51,6 +51,8 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['8', MySQL80Platform::class],
             ['8.0', MySQL80Platform::class],
             ['8.0.11', MySQL80Platform::class],
+            ['8.4.1', MySQL80Platform::class],
+            ['9.0.0', MySQL80Platform::class],
             ['6', MySQL57Platform::class],
             ['10.0.15-MariaDB-1~wheezy', MySQLPlatform::class],
             ['5.5.5-10.1.25-MariaDB', MySQLPlatform::class],


### PR DESCRIPTION
MySQL 9 has been released and 8.4 has been declared to be the LTS release. I've added MySQL 9 to the test matrix and took the opportunity to shrink the test matrix a little. Our CI is othen blocked because of too many concurrent jobs, so we might not want to test all possible permutations of PHP and MySQL versions.

Taking into account that we're going to maintain the 3.x branch for a little longer, we need a strategy for not letting the test matrix grow exponentially with every future PHP or DBMS release.

My proposal for MySQL:

* Test all supported MySQL versions (currently: 5.7, 8.0, 8.4, 9.0) with the latest PHP version (currently 8.3).
* Test the oldest supported PHP release (currently 7.4) against one release only (MySQL 8.0) only.

All other PHP releases are tested against SQLite already.

If this proposal is accepted, I'd like to work out a similar strategy for the other supported DBMS. I think we should also document that strategy properly then.