### PR TITLE
Add DBTypes that are missing for TypeMapping

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1559,12 +1559,14 @@ class SQLServerPlatform extends AbstractPlatform
             'smalldatetime'    => Types::DATETIME_MUTABLE,
             'smallint'         => Types::SMALLINT,
             'smallmoney'       => Types::INTEGER,
+            'sysname'          => Types::STRING,
             'text'             => Types::TEXT,
             'time'             => Types::TIME_MUTABLE,
             'tinyint'          => Types::SMALLINT,
             'uniqueidentifier' => Types::GUID,
             'varbinary'        => Types::BINARY,
             'varchar'          => Types::STRING,
+            'xml'              => Types::TEXT,
         ];
     }
 

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1145,6 +1145,12 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('uniqueidentifier'));
         self::assertSame(Types::GUID, $this->platform->getDoctrineTypeMapping('uniqueidentifier'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('sysname'));
+        self::assertSame(Types::STRING, $this->platform->getDoctrineTypeMapping('sysname'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('xml'));
+        self::assertSame(Types::Text, $this->platform->getDoctrineTypeMapping('xml'));
     }
 
     protected function getBinaryMaxLength(): int

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1150,7 +1150,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         self::assertSame(Types::STRING, $this->platform->getDoctrineTypeMapping('sysname'));
 
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('xml'));
-        self::assertSame(Types::Text, $this->platform->getDoctrineTypeMapping('xml'));
+        self::assertSame(Types::TEXT, $this->platform->getDoctrineTypeMapping('xml'));
     }
 
     protected function getBinaryMaxLength(): int


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6259 

#### Summary
We've got error because of missing DBTypes on SQLSRV. "Unknown database type sysname requested, Doctrine\DBAL\Platforms\SQLServer2012Platform may not support it.". Once for 'sysname' and for 'xml'.
