### PR TITLE
Fix update/delete aliases in documentation

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -309,7 +309,7 @@ user-input:
     <?php
 
     $queryBuilder
-        ->update('users', 'u')
+        ->update('users u')
         ->set('u.logins', 'u.logins + 1')
         ->set('u.last_login', '?')
         ->setParameter(0, $userInputLastLogin)

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -580,8 +580,8 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->delete('users')
-     *         ->where('users.id = :user_id')
+     *         ->delete('users u')
+     *         ->where('u.id = :user_id')
      *         ->setParameter(':user_id', 1);
      * </code>
      *
@@ -606,9 +606,9 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->update('counters')
-     *         ->set('counters.value', 'counters.value + 1')
-     *         ->where('counters.id = ?');
+     *         ->update('counters c')
+     *         ->set('c.value', 'c.value + 1')
+     *         ->where('c.id = ?');
      * </code>
      *
      * @param string $table The table whose rows are subject to the update.
@@ -785,7 +785,7 @@ class QueryBuilder
      *
      * <code>
      *     $qb = $conn->createQueryBuilder()
-     *         ->update('counters', 'c')
+     *         ->update('counters c')
      *         ->set('c.value', 'c.value + 1')
      *         ->where('c.id = ?');
      * </code>
@@ -821,7 +821,7 @@ class QueryBuilder
      *     $or->add($qb->expr()->eq('c.id', 1));
      *     $or->add($qb->expr()->eq('c.id', 2));
      *
-     *     $qb->update('counters', 'c')
+     *     $qb->update('counters c')
      *         ->set('c.value', 'c.value + 1')
      *         ->where($or);
      * </code>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| Fixed issues | Incorrect & inconsistent QueryBuilder documentation for aliases in update/delete

#### Summary

In #6394  the documentation was partially updated to remove aliases for the documentation for the update method, as the separate parameter for it was removed in the upgrade from 3.x to 4.x. 

Inline aliasing is still possible, and I suspect this was the reason the extra parameter was removed. ( `->update('users alias1', 'alias2')`)?

This PR readds the alias to the documentation for the occurences in the linked PR, and also updates the other occurences in docblocks + the online documentation.