### PR TITLE
Add deprecation layer for TableDiff methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.1
 
+## Deprecated `TableDiff` methods
+
+The `TableDiff` methods `getModifiedColumns()` and `getRenamedColumns()` have been merged into a single
+method `getChangedColumns()`. Use this method instead.
+
 ## Deprecated support for MariaDB 10.4 and MySQL 5.7
 
 * Upgrade to MariaDB 10.5 or later.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -59,6 +59,8 @@
                     See https://github.com/doctrine/dbal/pull/6202
                     TODO: remove in 4.0.0
                 -->
+                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getModifiedColumns" />
+                <referencedMethod name="Doctrine\DBAL\Schema\TableDiff::getRenamedColumns" />
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getColumnTypeSQLSnippets" />
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform::getDatabaseNameSQL" />
 

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -39,6 +39,7 @@ class RenameColumnTest extends FunctionalTestCase
         self::assertEqualsIgnoringCase($newColumnName, $columns[0]->getName());
         self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
         self::assertCount(1, self::getRenamedColumns($diff));
+        self::assertCount(1, $diff->getRenamedColumns());
     }
 
     /** @return array<string,Column> */
@@ -79,6 +80,8 @@ class RenameColumnTest extends FunctionalTestCase
         $columns = $table->getColumns();
 
         self::assertCount(1, $diff->getChangedColumns());
+        self::assertCount(1, $diff->getRenamedColumns());
+        self::assertCount(1, $diff->getModifiedColumns());
         self::assertCount(2, $columns);
         self::assertEqualsIgnoringCase($newColumnName, $columns[0]->getName());
         self::assertEqualsIgnoringCase('c2', $columns[1]->getName());

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -74,7 +74,9 @@ class ComparatorTest extends FunctionalTestCase
 
         $compareResult  = $comparator->compareTables($onlineTable, $table);
         $renamedColumns = RenameColumnTest::getRenamedColumns($compareResult);
+        self::assertSame($renamedColumns, $compareResult->getRenamedColumns());
         self::assertCount(3, $compareResult->getChangedColumns());
+        self::assertCount(2, $compareResult->getModifiedColumns());
         self::assertCount(2, $renamedColumns);
         self::assertArrayHasKey('test2', $renamedColumns);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | N/A

#### Summary

#6280 removed columns without explicitly deprecating them. This PR adds the missing deprecation layer.
