### PR TITLE
Make the schema manager aware of the disabling of type comments

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -1740,6 +1740,10 @@ abstract class AbstractSchemaManager
      */
     public function extractDoctrineTypeFromComment($comment, $currentType)
     {
+        if ($this->_conn->getConfiguration()->getDisableTypeComments()) {
+            return $currentType;
+        }
+
         if ($comment !== null && preg_match('(\(DC2Type:(((?!\)).)+)\))', $comment, $match) === 1) {
             return $match[1];
         }
@@ -1757,6 +1761,10 @@ abstract class AbstractSchemaManager
      */
     public function removeDoctrineTypeFromComment($comment, $type)
     {
+        if ($this->_conn->getConfiguration()->getDisableTypeComments()) {
+            return $comment;
+        }
+
         if ($comment === null) {
             return null;
         }

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
@@ -14,7 +15,12 @@ class DBAL461Test extends TestCase
 {
     public function testIssue(): void
     {
-        $conn     = $this->createMock(Connection::class);
+        $configuration = $this->createStub(Configuration::class);
+        $configuration->method('getDisableTypeComments')->willReturn(false);
+
+        $conn = $this->createMock(Connection::class);
+        $conn->method('getConfiguration')->willReturn($configuration);
+
         $platform = new SQLServer2012Platform();
         $platform->registerDoctrineTypeMapping('numeric', Types::DECIMAL);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

This makes the schema manager aware of the disabling of type comments to disable its special handling of the type comments during introspection.

Without this change, the schema comparison will not remove existing type comments when disabling them because it will still silently remove that part of the comment during introspection (and so won't detect an expected change between the expected empty comment and the introspected comment).
Disabling that stripping logic when disabling type comments corresponds to the behavior of DBAL 4 regarding comments, which is exactly what the configuration option is about.