### PR TITLE
Adapt to mssql-docker breaking change

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -489,7 +489,7 @@ jobs:
           MSSQL_COLLATION: "${{ matrix.collation }}"
 
         options: >-
-          --health-cmd "echo quit | /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -l 1 -U sa -P Doctrine2018"
+          --health-cmd "echo quit | /opt/mssql-tools18/bin/sqlcmd -C -S 127.0.0.1 -l 1 -U sa -P Doctrine2018"
 
         ports:
           - "1433:1433"


### PR DESCRIPTION
2 things need to change:

- the path to the binary, which is now secure by default;
- the addition of the -C flag, telling sqlcmd to trust the certificate of the server.

Quote from the documentation:

> In SQL Server 2022 (16.x) CU 14 and later versions, container images
> include the new mssql-tools18 package. The previous directory
> /opt/mssql-tools/bin is being phased out. The new directory for
> Microsoft ODBC 18 tools is /opt/mssql-tools18/bin, aligning with the
> latest tools offering. For more information about changes and security
> enhancements, see https://techcommunity.microsoft.com/t5/sql-server-blog/odbc-driver-18-0-for-sql-server-released/ba-p/3169228

See https://github.com/microsoft/mssql-docker/issues/892