### PR TITLE
Ensure PostgreSQL field length change is executed again

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -252,6 +252,7 @@ class PostgreSQLPlatform extends AbstractPlatform
                 || $columnDiff->hasPrecisionChanged()
                 || $columnDiff->hasScaleChanged()
                 || $columnDiff->hasFixedChanged()
+                || $columnDiff->hasLengthChanged()
             ) {
                 $type = $newColumn->getType();
 

--- a/tests/Functional/Platform/AlterColumnLengthChangeTest.php
+++ b/tests/Functional/Platform/AlterColumnLengthChangeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Platform;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+class AlterColumnLengthChangeTest extends FunctionalTestCase
+{
+    public function testColumnLengthIsChanged(): void
+    {
+        $table = new Table('test_alter_length');
+        $table->addColumn('c1', Types::STRING)->setLength(50);
+
+        $this->dropAndCreateTable($table);
+
+        $sm      = $this->connection->createSchemaManager();
+        $table   = $sm->introspectTable('test_alter_length');
+        $columns = $table->getColumns();
+        self::assertCount(1, $columns);
+        self::assertSame(50, $columns[0]->getLength());
+
+        $table->getColumn('c1')->setLength(100);
+
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('test_alter_length'), $table);
+
+        $sm->alterTable($diff);
+
+        $table   = $sm->introspectTable('test_alter_length');
+        $columns = $table->getColumns();
+
+        self::assertCount(1, $columns);
+        self::assertSame(100, $columns[0]->getLength());
+    }
+}


### PR DESCRIPTION
With #6280 quite some changes has been applied,
which removed the code path to create alter sql
statement if length of a field has changed.

This change adds a general test for this case
and reimplement the accidently removed code
from the `PostgreSQLPlatform`.
