### PR TITLE
Deprecate support for Postgres 10 and 11

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,10 +13,11 @@ awareness about deprecated code.
 The `TableDiff` methods `getModifiedColumns()` and `getRenamedColumns()` have been merged into a single
 method `getChangedColumns()`. Use this method instead.
 
-## Deprecated support for MariaDB 10.4 and MySQL 5.7
+## Deprecated support for MariaDB 10.4, MySQL 5.7 and Postgres 10 + 11
 
 * Upgrade to MariaDB 10.5 or later.
 * Upgrade to MySQL 8.0 or later.
+* Upgrade to Postgres 12 or later.
 
 ## Add `Result::getColumnName()`
 

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -58,8 +58,7 @@ Microsoft SQL Server
 PostgreSQL
 ^^^^^^^^^^
 
--  ``PostgreSQLPlatform`` for version 9.4 and above.
--  ``PostgreSQL100Platform`` for version 10.0 and above.
+-  ``PostgreSQLPlatform`` for version 10.0 and above.
 -  ``PostgreSQL120Platform`` for version 12.0 and above.
 
 IBM DB2

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -51,6 +51,7 @@
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords" />
                 <referencedClass name="Doctrine\DBAL\Platforms\MariaDB1052Platform" />
                 <referencedClass name="Doctrine\DBAL\Platforms\MySQL80Platform" />
+                <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL120Platform" />
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
 use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\ServerVersionProvider;
+use Doctrine\Deprecations\Deprecation;
 
 use function preg_match;
 use function version_compare;
@@ -39,6 +40,12 @@ abstract class AbstractPostgreSQLDriver implements Driver
         if (version_compare($version, '12.0', '>=')) {
             return new PostgreSQL120Platform();
         }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6495',
+            'Support for Postgres < 12 is deprecated and will be removed in DBAL 5',
+        );
 
         return new PostgreSQLPlatform();
     }

--- a/src/Platforms/PostgreSQL120Platform.php
+++ b/src/Platforms/PostgreSQL120Platform.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms;
 
 /**
  * Provides the behavior, features and SQL dialect of the PostgreSQL 12.0 database platform.
+ *
+ * @deprecated This class will be removed once support for Postgres < 12 is dropped.
  */
 class PostgreSQL120Platform extends PostgreSQLPlatform
 {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -33,7 +33,8 @@ use function strtolower;
 use function trim;
 
 /**
- * Provides the behavior, features and SQL dialect of the PostgreSQL 9.4+ database platform.
+ * Provides the behavior, features and SQL dialect of the PostgreSQL database platform
+ * of the oldest supported version.
  */
 class PostgreSQLPlatform extends AbstractPlatform
 {

--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -71,7 +71,8 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['10.0', PostgreSQLPlatform::class],
             ['11.0', PostgreSQLPlatform::class],
             ['12.0', PostgreSQL120Platform::class],
-            ['13.3', PostgreSQL120Platform::class],
+            ['13.16', PostgreSQL120Platform::class],
+            ['16.4', PostgreSQL120Platform::class],
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6199

#### Summary

PR #6199 introduced a new platform class for Postgres 12 and I'd like to immediately deprecate that class. Currently, we support Postgres 10 and above, but [the lowest maintained branch is actually 12](https://www.postgresql.org/support/versioning/).

This deprecation would allow us to merge the two Postgres platform classes again in 5.0.
