### PR TITLE
Require pgsql

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,6 +59,7 @@ install:
           Add-Content php.ini "`n extension_dir=ext"
           Add-Content php.ini "`n memory_limit=1G"
           Add-Content php.ini "`n extension=php_openssl.dll"
+          Add-Content php.ini "`n extension=php_pgsql.dll"
           Add-Content php.ini "`n extension=php_mbstring.dll"
           Add-Content php.ini "`n extension=php_fileinfo.dll"
           Add-Content php.ini "`n extension=php_pdo_sqlite.dll"

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {
+        "ext-pgsql": "*",
         "doctrine/coding-standard": "12.0.0",
         "fig/log-test": "^1",
         "jetbrains/phpstorm-stubs": "2023.1",


### PR DESCRIPTION
That extension appears necessary to statically analyze the project with Psalm.
When the extension is not available, there are errors such as "Const PGSQL_TUPLES_OK is not defined".