### PR TITLE
Raise a proper exception when calling `getColumnName()` with negative index

### DIFF
--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -88,11 +88,8 @@ final class ArrayResult implements Result
 
     public function getColumnName(int $index): string
     {
-        if ($this->data === [] || $index > count($this->data[0])) {
-            throw InvalidColumnIndex::new($index);
-        }
-
-        return array_keys($this->data[0])[$index];
+        return array_keys($this->data[0] ?? [])[$index]
+            ?? throw InvalidColumnIndex::new($index);
     }
 
     public function free(): void

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Exception\InvalidColumnIndex;
 use PDO;
 use PDOException;
 use PDOStatement;
+use ValueError;
 
 final class Result implements ResultInterface
 {
@@ -78,15 +79,17 @@ final class Result implements ResultInterface
     {
         try {
             $meta = $this->statement->getColumnMeta($index);
-
-            if ($meta === false) {
-                throw InvalidColumnIndex::new($index);
-            }
-
-            return $meta['name'];
+        } catch (ValueError $exception) {
+            throw InvalidColumnIndex::new($index, $exception);
         } catch (PDOException $exception) {
             throw Exception::new($exception);
         }
+
+        if ($meta === false) {
+            throw InvalidColumnIndex::new($index);
+        }
+
+        return $meta['name'];
     }
 
     public function free(): void

--- a/src/Exception/InvalidColumnIndex.php
+++ b/src/Exception/InvalidColumnIndex.php
@@ -6,14 +6,15 @@ namespace Doctrine\DBAL\Exception;
 
 use Doctrine\DBAL\Exception;
 use LogicException;
+use Throwable;
 
 use function sprintf;
 
 /** @psalm-immutable */
 final class InvalidColumnIndex extends LogicException implements Exception
 {
-    public static function new(int $index): self
+    public static function new(int $index, ?Throwable $previous = null): self
     {
-        return new self(sprintf('Invalid column index "%s".', $index));
+        return new self(sprintf('Invalid column index "%s".', $index), previous: $previous);
     }
 }

--- a/tests/Cache/ArrayStatementTest.php
+++ b/tests/Cache/ArrayStatementTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Cache;
 
 use Doctrine\DBAL\Cache\ArrayResult;
+use Doctrine\DBAL\Exception\InvalidColumnIndex;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 use function array_values;
@@ -47,6 +49,16 @@ class ArrayStatementTest extends TestCase
 
         self::assertSame('username', $statement->getColumnName(0));
         self::assertSame('active', $statement->getColumnName(1));
+    }
+
+    #[TestWith([2])]
+    #[TestWith([-1])]
+    public function testColumnNameWithInvalidIndex(int $index): void
+    {
+        $statement = $this->createTestArrayStatement();
+        $this->expectException(InvalidColumnIndex::class);
+
+        $statement->getColumnName($index);
     }
 
     public function testRowCount(): void

--- a/tests/Functional/ResultMetadataTest.php
+++ b/tests/Functional/ResultMetadataTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Exception\InvalidColumnIndex;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
 use function strtolower;
 
@@ -36,7 +37,9 @@ class ResultMetadataTest extends FunctionalTestCase
         self::assertEquals('alternate_name', strtolower($result->getColumnName(1)));
     }
 
-    public function testColumnNameWithInvalidIndex(): void
+    #[TestWith([2])]
+    #[TestWith([-1])]
+    public function testColumnNameWithInvalidIndex(int $index): void
     {
         $sql = 'SELECT test_int, test_int AS alternate_name FROM result_metadata_table';
 
@@ -47,7 +50,7 @@ class ResultMetadataTest extends FunctionalTestCase
 
         $this->expectException(InvalidColumnIndex::class);
 
-        $result->getColumnName(2);
+        $result->getColumnName($index);
     }
 
     public function testColumnNameWithoutResults(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

Calling `getColumnName()` with a negative index is not valid. We should make sure that we handle this case consistently for all implementations.