### PR TITLE
PHPStan 1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/coding-standard": "12.0.0",
         "fig/log-test": "^1",
         "jetbrains/phpstorm-stubs": "2023.1",
-        "phpstan/phpstan": "1.11.10",
+        "phpstan/phpstan": "1.12.0",
         "phpstan/phpstan-strict-rules": "^1.6",
         "phpunit/phpunit": "9.6.20",
         "psalm/plugin-phpunit": "0.18.4",

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -87,7 +87,7 @@ abstract class AbstractDB2Driver implements VersionAwarePlatformDriver
                 '/^(?:[^\s]+\s)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i',
                 $versionString,
                 $versionParts,
-            ) === 0
+            ) !== 1
         ) {
             throw DBALException::invalidPlatformVersionSpecified(
                 $versionString,

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -136,7 +136,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
                 '/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/',
                 $versionString,
                 $versionParts,
-            ) === 0
+            ) !== 1
         ) {
             throw Exception::invalidPlatformVersionSpecified(
                 $versionString,
@@ -182,7 +182,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
                 '/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i',
                 $versionString,
                 $versionParts,
-            ) === 0
+            ) !== 1
         ) {
             throw Exception::invalidPlatformVersionSpecified(
                 $versionString,

--- a/src/Driver/AbstractPostgreSQLDriver.php
+++ b/src/Driver/AbstractPostgreSQLDriver.php
@@ -29,7 +29,7 @@ abstract class AbstractPostgreSQLDriver implements VersionAwarePlatformDriver
      */
     public function createDatabasePlatformForVersion($version)
     {
-        if (preg_match('/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/', $version, $versionParts) === 0) {
+        if (preg_match('/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/', $version, $versionParts) !== 1) {
             throw Exception::invalidPlatformVersionSpecified(
                 $version,
                 '<major_version>.<minor_version>.<patch_version>',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

The new PHPStan release has a deeper understanding of the array shape created by `preg_match()` calls. I've made some adjustments to account for that.
