### PR TITLE
fix typo in docs

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -409,7 +409,7 @@ Connect to your Postgres server and run the ``SHOW server_version`` query::
     (1 row)
 
 In the example above, ``15.2 (Debian 15.2-1.pgdg110+1)`` is the correct value for
-``server Version``.
+``serverVersion``.
 
 Other Platforms
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fix typo in docs/en/reference/configuration.rst

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | n/a

#### Summary

<!-- Provide a summary of your change. -->
Fix typo where a variable has a wrong space in docs/en/reference/configuration.rst