### PR TITLE
Passive support for partitioned tables on Postgres

### DIFF
--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL120Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
@@ -597,6 +598,56 @@ SQL;
             'int->bigint' => ['integer', 'bigint', 'BIGINT'],
             'bigint->int' => ['bigint', 'integer', 'INT'],
         ];
+    }
+
+    public function testPartitionTable(): void
+    {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS partitioned_table');
+        $this->connection->executeStatement(
+            'CREATE TABLE partitioned_table (id INT) PARTITION BY LIST (id);',
+        );
+        $this->connection->executeStatement('CREATE TABLE partition PARTITION OF partitioned_table FOR VALUES IN (1);');
+        try {
+            $this->schemaManager->introspectTable('partition');
+        } catch (TableDoesNotExist $e) {
+        }
+
+        self::assertNotNull($e ?? null, 'Partition table should not be introspected');
+
+        $tableFrom = $this->schemaManager->introspectTable('partitioned_table');
+
+        $tableTo = $this->schemaManager->introspectTable('partitioned_table');
+        $tableTo->addColumn('foo', Types::INTEGER);
+
+        $platform = $this->connection->getDatabasePlatform();
+        $diff     = $this->schemaManager->createComparator()->compareTables($tableFrom, $tableTo);
+
+        $sql = $platform->getAlterTableSQL($diff);
+        self::assertSame(['ALTER TABLE partitioned_table ADD foo INT NOT NULL'], $sql);
+
+        $this->schemaManager->alterTable($diff);
+
+        $tableFinal = $this->schemaManager->introspectTable('partitioned_table');
+        self::assertTrue($tableFinal->hasColumn('id'));
+        self::assertTrue($tableFinal->hasColumn('foo'));
+
+        $partitionedTableCount = (int) ($this->connection->fetchOne(
+            "select count(*) as count from pg_class where relname = 'partitioned_table' and relkind = 'p'",
+        ));
+        self::assertSame(1, $partitionedTableCount);
+
+        $partitionsCount = (int) ($this->connection->fetchOne(
+            <<<'SQL'
+            select count(*) as count
+            from pg_class parent
+            inner join pg_inherits on pg_inherits.inhparent = parent.oid
+            inner join pg_class child on pg_inherits.inhrelid = child.oid 
+                and child.relkind = 'r'
+                and child.relname = 'partition'
+            where parent.relname = 'partitioned_table' and parent.relkind = 'p';
+            SQL,
+        ));
+        self::assertSame(1, $partitionsCount);
     }
 }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

Partitioned tables is a complex topic which [is not fully supported by Doctrine](https://github.com/doctrine/dbal/issues/4657).

Currently, with PostgreSQL, Doctrine does not "see" partitioned tables, and only "sees" partitions, which is problematic and should be done the other way. This PR fixes this in `PostgreSQLSchemaManager::selectTableColumns()`.

**Before this PR:**
- does not see at all "partitioned tables" (which are the actual tables related to an entity)
- doctrine suggest to remove all "partitions"

**After this PR:**
- `doctrine:schema:validate` is happy, even if tables have been partitioned manually

see https://github.com/doctrine/dbal/issues/4657#issuecomment-2326389747

Note: I'd want to see if maintainers folks are willing to accept such modification before digging into the tests for this