### PR TITLE
Add comparison of foreign key names with option to opt-out of this

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -36,6 +36,15 @@ class Configuration
 
     private ?SchemaManagerFactory $schemaManagerFactory = null;
 
+    /**
+     * Whether changes in the foreign key names should be compared.
+     * If you opt-out of this, you need to handle name changes of foreign keys yourself.
+     * Databases created based on the current schema might have different foreign key names
+     * than those migrated from older schemas if you turn this off.
+     * This could lead to incompatible migrations that try to drop non-existent foreign keys.
+     */
+    private bool $compareForeignKeyNames = false;
+
     public function __construct()
     {
         $this->schemaAssetsFilter = static function (): bool {
@@ -152,5 +161,15 @@ class Configuration
         }
 
         return $this;
+    }
+
+    public function getCompareForeignKeyNames(): bool
+    {
+        return $this->compareForeignKeyNames;
+    }
+
+    public function setCompareForeignKeyNames(bool $compareForeignKeyNames): void
+    {
+        $this->compareForeignKeyNames = $compareForeignKeyNames;
     }
 }

--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\MySQL;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\Table;
@@ -23,11 +24,12 @@ class Comparator extends BaseComparator
     /** @internal The comparator can be only instantiated by a schema manager. */
     public function __construct(
         AbstractMySQLPlatform $platform,
+        Configuration $configuration,
         private readonly CharsetMetadataProvider $charsetMetadataProvider,
         private readonly CollationMetadataProvider $collationMetadataProvider,
         private readonly DefaultTableOptions $defaultTableOptions,
     ) {
-        parent::__construct($platform);
+        parent::__construct($platform, $configuration);
     }
 
     public function compareTables(Table $oldTable, Table $newTable): TableDiff

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\SQLServer;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\Table;
@@ -17,9 +18,12 @@ use Doctrine\DBAL\Schema\TableDiff;
 class Comparator extends BaseComparator
 {
     /** @internal The comparator can be only instantiated by a schema manager. */
-    public function __construct(SQLServerPlatform $platform, private readonly string $databaseCollation)
-    {
-        parent::__construct($platform);
+    public function __construct(
+        SQLServerPlatform $platform,
+        Configuration $configuration,
+        private readonly string $databaseCollation,
+    ) {
+        parent::__construct($platform, $configuration);
     }
 
     public function compareTables(Table $oldTable, Table $newTable): TableDiff

--- a/src/Platforms/SQLite/Comparator.php
+++ b/src/Platforms/SQLite/Comparator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\SQLite;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\Table;
@@ -19,9 +20,9 @@ use function strcasecmp;
 class Comparator extends BaseComparator
 {
     /** @internal The comparator can be only instantiated by a schema manager. */
-    public function __construct(SQLitePlatform $platform)
+    public function __construct(SQLitePlatform $platform, Configuration $configuration)
     {
-        parent::__construct($platform);
+        parent::__construct($platform, $configuration);
     }
 
     public function compareTables(Table $oldTable, Table $newTable): TableDiff

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -842,7 +842,7 @@ abstract class AbstractSchemaManager
 
     public function createComparator(): Comparator
     {
-        return new Comparator($this->platform);
+        return new Comparator($this->platform, $this->connection->getConfiguration());
     }
 
     /**

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function array_map;
@@ -17,8 +18,10 @@ use function strtolower;
 class Comparator
 {
     /** @internal The comparator can be only instantiated by a schema manager. */
-    public function __construct(private readonly AbstractPlatform $platform)
-    {
+    public function __construct(
+        private readonly AbstractPlatform $platform,
+        private readonly Configuration $configuration,
+    ) {
     }
 
     /**
@@ -389,6 +392,13 @@ class Comparator
 
     protected function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2): bool
     {
+        if (
+            $this->configuration->getCompareForeignKeyNames()
+            && strtolower($key1->getName()) !== strtolower($key2->getName())
+        ) {
+            return true;
+        }
+
         if (
             array_map('strtolower', $key1->getUnquotedLocalColumns())
             !== array_map('strtolower', $key2->getUnquotedLocalColumns())

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -318,6 +318,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         return new MySQL\Comparator(
             $this->platform,
+            $this->connection->getConfiguration(),
             new CachingCharsetMetadataProvider(
                 new ConnectionCharsetMetadataProvider($this->connection),
             ),

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
@@ -264,7 +265,7 @@ SQL,
     /** @throws Exception */
     public function createComparator(): Comparator
     {
-        return new SQLServer\Comparator($this->platform, $this->getDatabaseCollation());
+        return new SQLServer\Comparator($this->platform, new Configuration(), $this->getDatabaseCollation());
     }
 
     /** @throws Exception */

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -498,7 +499,7 @@ SQL
 
     public function createComparator(): Comparator
     {
-        return new SQLite\Comparator($this->platform);
+        return new SQLite\Comparator($this->platform, new Configuration());
     }
 
     protected function selectTableNames(string $databaseName): Result

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -53,7 +54,7 @@ class ComparatorTest extends FunctionalTestCase
     public function testRenameColumnComparison(): void
     {
         $platform   = $this->connection->getDatabasePlatform();
-        $comparator = new Comparator($platform);
+        $comparator = new Comparator($platform, new Configuration());
 
         $table = new Table('rename_table');
         $table->addColumn('test', Types::STRING, ['default' => 'baz', 'length' => 20]);

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\MySQL;
@@ -689,6 +690,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return new MySQL\Comparator(
             $this->platform,
+            new Configuration(),
             self::createStub(CharsetMetadataProvider::class),
             self::createStub(CollationMetadataProvider::class),
             new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci'),

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -40,7 +41,7 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     protected function createComparator(): Comparator
     {
-        return new Comparator($this->platform);
+        return new Comparator($this->platform, new Configuration());
     }
 
     public function testQuoteIdentifier(): void

--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms\MySQL;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\Comparator;
@@ -13,10 +14,11 @@ use Doctrine\DBAL\Tests\Schema\AbstractComparatorTestCase;
 
 class ComparatorTest extends AbstractComparatorTestCase
 {
-    protected function setUp(): void
+    protected function createComparator(?Configuration $configuration = null): Comparator
     {
-        $this->comparator = new Comparator(
+        return new Comparator(
             new MySQLPlatform(),
+            $configuration ?? new Configuration(),
             self::createStub(CharsetMetadataProvider::class),
             self::createStub(CollationMetadataProvider::class),
             new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci'),

--- a/tests/Platforms/MySQL/MariaDBJsonComparatorTest.php
+++ b/tests/Platforms/MySQL/MariaDBJsonComparatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms\MySQL;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
@@ -27,6 +28,7 @@ class MariaDBJsonComparatorTest extends TestCase
     {
         $this->comparator = new Comparator(
             new MariaDBPlatform(),
+            new Configuration(),
             new class implements CharsetMetadataProvider {
                 public function getDefaultCharsetCollation(string $charset): ?string
                 {

--- a/tests/Platforms/SQLServer/ComparatorTest.php
+++ b/tests/Platforms/SQLServer/ComparatorTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms\SQLServer;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\SQLServer\Comparator;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Tests\Schema\AbstractComparatorTestCase;
 
 class ComparatorTest extends AbstractComparatorTestCase
 {
-    protected function setUp(): void
+    protected function createComparator(?Configuration $configuration = null): Comparator
     {
-        $this->comparator = new Comparator(new SQLServerPlatform(), '');
+        return new Comparator(new SQLServerPlatform(), $configuration ?? new Configuration(), '');
     }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\LockMode;
@@ -32,7 +33,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
     protected function createComparator(): Comparator
     {
-        return new SQLServer\Comparator($this->platform, '');
+        return new SQLServer\Comparator($this->platform, new Configuration(), '');
     }
 
     public function getGenerateTableSql(): string

--- a/tests/Platforms/SQLite/ComparatorTest.php
+++ b/tests/Platforms/SQLite/ComparatorTest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms\SQLite;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\SQLite\Comparator;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Tests\Schema\AbstractComparatorTestCase;
 
 class ComparatorTest extends AbstractComparatorTestCase
 {
-    protected function setUp(): void
+    protected function createComparator(?Configuration $configuration = null): Comparator
     {
-        $this->comparator = new Comparator(new SQLitePlatform());
+        return new Comparator(new SQLitePlatform(), $configuration ?? new Configuration());
     }
 
     public function testCompareChangedBinaryColumn(): void

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLite;
@@ -30,7 +31,7 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
 
     protected function createComparator(): Comparator
     {
-        return new SQLite\Comparator($this->platform);
+        return new SQLite\Comparator($this->platform, new Configuration());
     }
 
     public function getGenerateTableSql(): string

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQL;
 use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
@@ -68,6 +69,7 @@ class MySQLSchemaTest extends TestCase
     {
         return new MySQL\Comparator(
             new MySQLPlatform(),
+            new Configuration(),
             self::createStub(CharsetMetadataProvider::class),
             self::createStub(CollationMetadataProvider::class),
             new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci'),


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6518

#### Summary

- Re-adds changes of #6413
- Additionally add configuration option to opt-out of foreign key name comparison

This PR is targeted at 4.1. I initially tried to target 3.9 (#6520), but that was pretty much not mergeable into 4.1. Using the platform as a go-between for configuration settings seemed wrong, too.

I hope it is okay to inject the Configuration into the Comparator now!? I didn't know how else to configure this behavior. And I'm considering to add another opt-in option for the comparator to enable comparing the implicitly added indexes for FKs, too, in a later PR because these have the same problems in migrations (generated once but then forgotten and untracked).

I'm also not sure what this classifies under. This should be a bug fix, but the conditions under which this hurts are quite rare. So I went with "improvement" because this improves the schema diff.

I've decided to make the behavior opt-out instead of opt-in because it is more dangerous to have wrong FK names than to have extra migration diffs. (You will notice the latter during development, but not the other way around.)