### PR TITLE
[Need Help] Testing boolean comparison using ParameterType

### DIFF
--- a/tests/Functional/Query/QueryBuilderBoolTest.php
+++ b/tests/Functional/Query/QueryBuilderBoolTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Query;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+final class QueryBuilderBoolTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $table = new Table('for_update');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addColumn('b1', Types::BOOLEAN, ['notnull' => false]);
+        $table->setPrimaryKey(['id']);
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('for_update', ['id' => 1, 'b1' => true]);
+        $this->connection->insert('for_update', ['id' => 2, 'b1' => false]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (! $this->connection->isTransactionActive()) {
+            return;
+        }
+
+        $this->connection->rollBack();
+    }
+
+    public function testDeleteBooleanTrue(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestSkipped('Skipping on SQLite');
+        }
+
+        $qb1 = $this->connection->createQueryBuilder();
+        $qb1->delete('for_update')
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(true, ParameterType::BOOLEAN)))
+            ->executeStatement();
+
+        $qb2 = $this->connection->createQueryBuilder();
+        $qb2->select('id')
+            ->from('for_update');
+
+        self::assertEquals([2], $qb2->fetchFirstColumn());
+    }
+
+    public function testDeleteBooleanTrueWithWrongType(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestSkipped('Skipping on SQLite');
+        }
+
+        $qb1 = $this->connection->createQueryBuilder();
+        $qb1->delete('for_update')
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(true, Types::BOOLEAN)))
+            ->executeStatement();
+
+        $qb2 = $this->connection->createQueryBuilder();
+        $qb2->select('id')
+            ->from('for_update');
+
+        self::assertEquals([2], $qb2->fetchFirstColumn());
+    }
+
+    public function testDeleteBooleanFalse(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestSkipped('Skipping on SQLite');
+        }
+
+        $qb1 = $this->connection->createQueryBuilder();
+        $qb1->delete('for_update')
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(false, ParameterType::BOOLEAN)))
+            ->executeStatement();
+
+        $qb2 = $this->connection->createQueryBuilder();
+        $qb2->select('id')
+            ->from('for_update');
+
+        self::assertEquals([1], $qb2->fetchFirstColumn());
+    }
+
+    public function testDeleteBooleanFalseWithWrongType(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestSkipped('Skipping on SQLite');
+        }
+
+        $qb1 = $this->connection->createQueryBuilder();
+        $qb1->delete('for_update')
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(false, Types::BOOLEAN)))
+            ->executeStatement();
+
+        $qb2 = $this->connection->createQueryBuilder();
+        $qb2->select('id')
+            ->from('for_update');
+
+        self::assertEquals([1], $qb2->fetchFirstColumn());
+    }
+}

--- a/tests/Functional/Query/QueryBuilderBoolTest.php
+++ b/tests/Functional/Query/QueryBuilderBoolTest.php
@@ -21,8 +21,8 @@ final class QueryBuilderBoolTest extends FunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $this->connection->insert('for_update', ['id' => 1, 'b1' => true]);
-        $this->connection->insert('for_update', ['id' => 2, 'b1' => false]);
+        $this->connection->insert('for_update', ['id' => 1, 'b1' => 1]);
+        $this->connection->insert('for_update', ['id' => 2, 'b1' => 0]);
     }
 
     protected function tearDown(): void
@@ -44,7 +44,7 @@ final class QueryBuilderBoolTest extends FunctionalTestCase
 
         $qb1 = $this->connection->createQueryBuilder();
         $qb1->delete('for_update')
-            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(true, ParameterType::BOOLEAN)))
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(1, ParameterType::BOOLEAN)))
             ->executeStatement();
 
         $qb2 = $this->connection->createQueryBuilder();
@@ -64,7 +64,7 @@ final class QueryBuilderBoolTest extends FunctionalTestCase
 
         $qb1 = $this->connection->createQueryBuilder();
         $qb1->delete('for_update')
-            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(true, Types::BOOLEAN)))
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(1, Types::BOOLEAN)))
             ->executeStatement();
 
         $qb2 = $this->connection->createQueryBuilder();
@@ -84,7 +84,7 @@ final class QueryBuilderBoolTest extends FunctionalTestCase
 
         $qb1 = $this->connection->createQueryBuilder();
         $qb1->delete('for_update')
-            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(false, ParameterType::BOOLEAN)))
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(0, ParameterType::BOOLEAN)))
             ->executeStatement();
 
         $qb2 = $this->connection->createQueryBuilder();
@@ -104,7 +104,7 @@ final class QueryBuilderBoolTest extends FunctionalTestCase
 
         $qb1 = $this->connection->createQueryBuilder();
         $qb1->delete('for_update')
-            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(false, Types::BOOLEAN)))
+            ->where($qb1->expr()->eq('b1', $qb1->createNamedParameter(0, Types::BOOLEAN)))
             ->executeStatement();
 
         $qb2 = $this->connection->createQueryBuilder();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | To-Be-Raised-If-Needed

#### Summary

In Nextcloud we started to experience strange behaviour with Oracle when using boolean `FALSE` in WHERE-clauses with parameters.
The behaviour works as expected, when as parameter type we pass `Doctrine\DBAL\Types\Types::BOOLEAN` instead of `Doctrine\DBAL\ParameterType::BOOLEAN` in our code base, but I think from the doc blocks and declarations this is not what should be done.

This fix can also not be confirmed here using the 4.1.x branch as a base, but my test at least is failing with the same problem/bug: Using `false` in a where condition seems to not be possible?
- passing `false` => https://github.com/doctrine/dbal/actions/runs/12902066473/job/35975109513?pr=6526#step:6:75
- passing `0` => https://github.com/doctrine/dbal/actions/runs/11011277241/job/30575035189?pr=6526#step:6:73