### PR TITLE
Run tests with PHP 8.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,6 +42,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dependencies:
           - "highest"
         extension:
@@ -113,6 +114,8 @@ jobs:
           - "21"
           - "23"
         include:
+          - php-version: "8.4"
+            oracle-version: "23"
           - php-version: "7.4"
             oracle-version: "11"
 
@@ -172,6 +175,8 @@ jobs:
           - "21"
           - "23"
         include:
+          - php-version: "8.4"
+            oracle-version: "23"
           - php-version: "7.4"
             oracle-version: "11"
 
@@ -239,10 +244,16 @@ jobs:
           - php-version: "8.3"
             postgres-version: "16"
             extension: "pgsql"
+          - php-version: "8.4"
+            postgres-version: "16"
+            extension: "pgsql"
           - php-version: "8.2"
             postgres-version: "16"
             extension: "pdo_pgsql"
           - php-version: "8.3"
+            postgres-version: "16"
+            extension: "pdo_pgsql"
+          - php-version: "8.4"
             postgres-version: "16"
             extension: "pdo_pgsql"
 
@@ -328,6 +339,12 @@ jobs:
           - php-version: "8.3"
             mariadb-version: "11.4"
             extension: "pdo_mysql"
+          - php-version: "8.4"
+            mariadb-version: "11.4"
+            extension: "mysqli"
+          - php-version: "8.4"
+            mariadb-version: "11.4"
+            extension: "pdo_mysql"
 
     services:
       mariadb:
@@ -410,6 +427,12 @@ jobs:
             extension: "pdo_mysql"
             custom-entrypoint: >-
               --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
+          - php-version: "8.4"
+            mysql-version: "9.0"
+            extension: "mysqli"
+          - php-version: "8.4"
+            mysql-version: "9.0"
+            extension: "pdo_mysql"
 
     services:
       mysql:
@@ -467,6 +490,7 @@ jobs:
           - "7.4"
           - "8.2"
           - "8.3"
+          - "8.4"
         extension:
           - "sqlsrv"
           - "pdo_sqlsrv"
@@ -534,6 +558,7 @@ jobs:
           - "7.4"
           - "8.2"
           - "8.3"
+          - "8.4"
 
     services:
       ibm_db2:


### PR DESCRIPTION
#### Summary

- Similar to https://github.com/doctrine/dbal/pull/6060
- But not alpha-1 but rc-1 has been released already
- I hope 3.9.x branch is okay. I didn't find a policy for which versions you plan to add new PHP versions, but we from Nextcloud would highly appreciate if it was the 3.9.x branch as we are still struggling with the update to 4.x
