### PR TITLE
mysql supports schemas

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -204,6 +204,11 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return true;
     }
 
+    public function supportsSchemas(): bool
+    {
+        return true;
+    }
+
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
     public function supportsInlineColumnComments(): bool
     {

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -217,6 +217,13 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
+    public function testGetCreateSchemaSQL(): void
+    {
+        $schemaName = 'schema';
+        $sql        = $this->platform->getCreateSchemaSQL($schemaName);
+        self::assertEquals('CREATE SCHEMA ' . $schemaName, $sql);
+    }
+
     public function testCreateTableWithFulltextIndex(): void
     {
         $table = new Table('fulltext_table');


### PR DESCRIPTION
I get a deprecation notice on any mysql platform for AbstractPlatform::canEmulateSchemas(). This is called because MySQLPlatform defaults to supportsSchemas = false. That seems wrong. Any MySQL/MariaDB version supports schemas.