### PR TITLE
Implement an EnumType for MySQL/MariaDB

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -196,6 +196,16 @@ type natively, this type is mapped to the ``string`` type internally.
 Values retrieved from the database are always converted to PHP's ``string`` type
 or ``null`` if no data is present.
 
+enum
+++++
+
+Maps and converts a string which is one of a set of predefined values. This
+type is specifically designed for MySQL and MariaDB, where it is mapped to
+the native ``ENUM`` type. For other database vendors, this type is mapped to
+a string field (``VARCHAR``) with the maximum length being the length of the
+longest value in the set. Values retrieved from the database are always
+converted to PHP's ``string`` type or ``null`` if no data is present.
+
 Binary string types
 ^^^^^^^^^^^^^^^^^^^
 

--- a/src/Exception/InvalidColumnType/ColumnValuesRequired.php
+++ b/src/Exception/InvalidColumnType/ColumnValuesRequired.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception\InvalidColumnType;
+
+use Doctrine\DBAL\Exception\InvalidColumnType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+use function get_debug_type;
+use function sprintf;
+
+/** @psalm-immutable */
+final class ColumnValuesRequired extends InvalidColumnType
+{
+    /**
+     * @param AbstractPlatform $platform The target platform
+     * @param string           $type     The SQL column type
+     */
+    public static function new(AbstractPlatform $platform, string $type): self
+    {
+        return new self(
+            sprintf(
+                '%s requires the values of a %s column to be specified',
+                get_debug_type($platform),
+                $type,
+            ),
+        );
+    }
+}

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -33,6 +33,9 @@ class Column extends AbstractAsset
 
     protected bool $_autoincrement = false;
 
+    /** @var list<string> */
+    protected array $_values = [];
+
     /** @var array<string, mixed> */
     protected array $_platformOptions = [];
 
@@ -231,22 +234,41 @@ class Column extends AbstractAsset
         return $this->_comment;
     }
 
+    /**
+     * @param list<string> $values
+     *
+     * @return $this
+     */
+    public function setValues(array $values): static
+    {
+        $this->_values = $values;
+
+        return $this;
+    }
+
+    /** @return list<string> */
+    public function getValues(): array
+    {
+        return $this->_values;
+    }
+
     /** @return array<string, mixed> */
     public function toArray(): array
     {
         return array_merge([
-            'name'          => $this->_name,
-            'type'          => $this->_type,
-            'default'       => $this->_default,
-            'notnull'       => $this->_notnull,
-            'length'        => $this->_length,
-            'precision'     => $this->_precision,
-            'scale'         => $this->_scale,
-            'fixed'         => $this->_fixed,
-            'unsigned'      => $this->_unsigned,
-            'autoincrement' => $this->_autoincrement,
+            'name'             => $this->_name,
+            'type'             => $this->_type,
+            'default'          => $this->_default,
+            'notnull'          => $this->_notnull,
+            'length'           => $this->_length,
+            'precision'        => $this->_precision,
+            'scale'            => $this->_scale,
+            'fixed'            => $this->_fixed,
+            'unsigned'         => $this->_unsigned,
+            'autoincrement'    => $this->_autoincrement,
             'columnDefinition' => $this->_columnDefinition,
-            'comment' => $this->_comment,
+            'comment'          => $this->_comment,
+            'values'           => $this->_values,
         ], $this->_platformOptions);
     }
 }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class EnumType extends Type
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getEnumDeclarationSQL($column);
+    }
+}

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -34,6 +34,7 @@ abstract class Type
         Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
         Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
         Types::DECIMAL              => DecimalType::class,
+        Types::ENUM                 => EnumType::class,
         Types::FLOAT                => FloatType::class,
         Types::GUID                 => GuidType::class,
         Types::INTEGER              => IntegerType::class,

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -23,6 +23,7 @@ final class Types
     public const DATETIMETZ_IMMUTABLE = 'datetimetz_immutable';
     public const DECIMAL              = 'decimal';
     public const FLOAT                = 'float';
+    public const ENUM                 = 'enum';
     public const GUID                 = 'guid';
     public const INTEGER              = 'integer';
     public const JSON                 = 'json';

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -561,7 +561,10 @@ SQL;
         $doctrineTypes = array_keys(Type::getTypesMap());
 
         foreach ($doctrineTypes as $type) {
-            $table->addColumn('col_' . $type, $type, ['length' => 8, 'precision' => 8, 'scale' => 2]);
+            $table->addColumn('col_' . $type, $type, match ($type) {
+                Types::ENUM => ['values' => ['foo', 'bar']],
+                default => ['length' => 8, 'precision' => 8, 'scale' => 2],
+            });
         }
 
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Types/EnumTypeTest.php
+++ b/tests/Functional/Types/EnumTypeTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\EnumType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class EnumTypeTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->dropTableIfExists('my_enum_table');
+    }
+
+    public function testIntrospectEnum(): void
+    {
+        if (! $this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            self::markTestSkipped('This test requires MySQL or MariaDB.');
+        }
+
+        $this->connection->executeStatement(<<< 'SQL'
+            CREATE TABLE my_enum_table (
+                id BIGINT NOT NULL PRIMARY KEY,
+                suit ENUM('hearts', 'diamonds', 'clubs', 'spades') NOT NULL DEFAULT 'hearts'
+            );
+            SQL);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $table         = $schemaManager->introspectTable('my_enum_table');
+
+        self::assertCount(2, $table->getColumns());
+        self::assertTrue($table->hasColumn('suit'));
+        self::assertInstanceOf(EnumType::class, $table->getColumn('suit')->getType());
+        self::assertSame(['hearts', 'diamonds', 'clubs', 'spades'], $table->getColumn('suit')->getValues());
+        self::assertSame('hearts', $table->getColumn('suit')->getDefault());
+    }
+
+    public function testDeployEnum(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schema        = new Schema(schemaConfig: $schemaManager->createSchemaConfig());
+        $table         = $schema->createTable('my_enum_table');
+        $table->addColumn('id', Types::BIGINT, ['notnull' => true]);
+        $table->addColumn('suit', Types::ENUM, [
+            'values' => ['hearts', 'diamonds', 'clubs', 'spades'],
+            'notnull' => true,
+            'default' => 'hearts',
+        ]);
+        $table->setPrimaryKey(['id']);
+
+        $schemaManager->createSchemaObjects($schema);
+
+        $introspectedTable = $schemaManager->introspectTable('my_enum_table');
+
+        self::assertTrue($schemaManager->createComparator()->compareTables($table, $introspectedTable)->isEmpty());
+
+        $this->connection->insert('my_enum_table', ['id' => 1, 'suit' => 'hearts'], ['suit' => Types::ENUM]);
+        $this->connection->insert(
+            'my_enum_table',
+            ['id' => 2, 'suit' => 'diamonds'],
+            ['suit' => Type::getType(Types::ENUM)],
+        );
+
+        self::assertEquals(
+            [[1, 'hearts'], [2, 'diamonds']],
+            $this->connection->fetchAllNumeric('SELECT id, suit FROM my_enum_table ORDER BY id ASC'),
+        );
+    }
+
+    public function testDeployEmptyEnum(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schema        = new Schema(schemaConfig: $schemaManager->createSchemaConfig());
+        $table         = $schema->createTable('my_enum_table');
+        $table->addColumn('id', Types::BIGINT, ['notnull' => true]);
+        $table->addColumn('suit', Types::ENUM);
+        $table->setPrimaryKey(['id']);
+
+        $this->expectException(ColumnValuesRequired::class);
+
+        $schemaManager->createSchemaObjects($schema);
+    }
+
+    /** @param list<string> $expectedValues */
+    #[DataProvider('provideEnumDefinitions')]
+    public function testIntrospectEnumValues(string $definition, array $expectedValues): void
+    {
+        if (! $this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            self::markTestSkipped('This test requires MySQL or MariaDB.');
+        }
+
+        $this->connection->executeStatement(<<< SQL
+            CREATE TABLE my_enum_table (
+                id BIGINT NOT NULL PRIMARY KEY,
+                my_enum $definition DEFAULT NULL
+            );
+            SQL);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $table         = $schemaManager->introspectTable('my_enum_table');
+
+        self::assertInstanceOf(EnumType::class, $table->getColumn('my_enum')->getType());
+        self::assertSame($expectedValues, $table->getColumn('my_enum')->getValues());
+        self::assertNull($table->getColumn('my_enum')->getDefault());
+    }
+
+    /** @return iterable<string, array{string, list<string>}> */
+    public static function provideEnumDefinitions(): iterable
+    {
+        yield 'simple' => ['ENUM("a", "b", "c")', ['a', 'b', 'c']];
+        yield 'empty first' => ['ENUM("", "a", "b", "c")', ['', 'a', 'b', 'c']];
+        yield 'empty in the middle' => ['ENUM("a", "", "b", "c")', ['a', '', 'b', 'c']];
+        yield 'empty last' => ['ENUM("a", "b", "c", "")', ['a', 'b', 'c', '']];
+        yield 'with spaces' => ['ENUM("a b", "c d", "e f")', ['a b', 'c d', 'e f']];
+        yield 'with quotes' => ['ENUM("a\'b", "c\'d", "e\'f")', ['a\'b', 'c\'d', 'e\'f']];
+        yield 'with commas' => ['ENUM("a,b", "c,d", "e,f")', ['a,b', 'c,d', 'e,f']];
+        yield 'with parentheses' => ['ENUM("(a)", "(b)", "(c)")', ['(a)', '(b)', '(c)']];
+        yield 'with quotes and commas' => ['ENUM("a\'b", "c\'d", "e\'f")', ['a\'b', 'c\'d', 'e\'f']];
+        yield 'with quotes and parentheses' => ['ENUM("(a)", "(b)", "(c)")', ['(a)', '(b)', '(c)']];
+        yield 'with commas and parentheses' => ['ENUM("(a,b)", "(c,d)", "(e,f)")', ['(a,b)', '(c,d)', '(e,f)']];
+        yield 'with quotes, commas and parentheses'
+            => ['ENUM("(a\'b)", "(c\'d)", "(e\'f)")', ['(a\'b)', '(c\'d)', '(e\'f)']];
+    }
+}

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -52,6 +52,7 @@ class ColumnTest extends TestCase
             'autoincrement' => false,
             'columnDefinition' => null,
             'comment' => '',
+            'values' => [],
             'foo' => 'bar',
         ];
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | doctrine/migrations#1441 (partly)

#### Summary

This PR adds an `EnumType` that allows us to introspect and diff tables that make use of MySQL's `ENUM` column type.