### PR TITLE
Fix incorrect `transactional()` handling when DB auto-rolled back the transaction

### DIFF
--- a/src/Driver/API/OCI/ExceptionConverter.php
+++ b/src/Driver/API/OCI/ExceptionConverter.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\API\OCI;
 
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Driver\OCI8\Exception\Error;
+use Doctrine\DBAL\Driver\PDO\PDOException;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DatabaseDoesNotExist;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
@@ -17,8 +19,12 @@ use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
 use Doctrine\DBAL\Exception\SyntaxErrorException;
 use Doctrine\DBAL\Exception\TableExistsException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\TransactionRolledBack;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query;
+
+use function explode;
+use function str_replace;
 
 /** @internal */
 final class ExceptionConverter implements ExceptionConverterInterface
@@ -26,7 +32,17 @@ final class ExceptionConverter implements ExceptionConverterInterface
     /** @link http://www.dba-oracle.com/t_error_code_list.htm */
     public function convert(Exception $exception, ?Query $query): DriverException
     {
-        switch ($exception->getCode()) {
+        /** @psalm-var int|'HY000' $code */
+        $code = $exception->getCode();
+        /** @psalm-suppress NoInterfaceProperties */
+        if ($code === 'HY000' && isset($exception->errorInfo[1], $exception->errorInfo[2])) {
+            $errorInfo            = $exception->errorInfo;
+            $exception            = new PDOException($errorInfo[2], $errorInfo[1]);
+            $exception->errorInfo = $errorInfo;
+            $code                 = $exception->getCode();
+        }
+
+        switch ($code) {
             case 1:
             case 2299:
             case 38911:
@@ -57,6 +73,22 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
             case 1918:
                 return new DatabaseDoesNotExist($exception, $query);
+
+            case 2091:
+                //ORA-02091: transaction rolled back
+                //ORA-00001: unique constraint (DOCTRINE.GH3423_UNIQUE) violated
+                [, $causeError] = explode("\n", $exception->getMessage(), 2);
+
+                [$causeCode] = explode(': ', $causeError, 2);
+                $code        = (int) str_replace('ORA-', '', $causeCode);
+
+                if ($exception instanceof PDOException) {
+                    $why = $this->convert(new PDOException($causeError, $code, $exception), $query);
+                } else {
+                    $why = $this->convert(new Error($causeError, null, $code, $exception), $query);
+                }
+
+                return new TransactionRolledBack($why, $query);
 
             case 2289:
             case 2443:

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -142,7 +142,7 @@ final class Connection implements ServerInfoAwareConnection
 
     public function commit(): bool
     {
-        if (! oci_commit($this->connection)) {
+        if (! @oci_commit($this->connection)) {
             throw Error::new($this->connection);
         }
 

--- a/src/Exception/TransactionRolledBack.php
+++ b/src/Exception/TransactionRolledBack.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+/** @psalm-immutable */
+class TransactionRolledBack extends DriverException
+{
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1095,6 +1095,28 @@ class ConnectionTest extends TestCase
             self::assertSame('Original exception', $e->getPrevious()->getMessage());
         }
     }
+
+    /**
+     * We are not sure if this can happen in real life scenario
+     */
+    public function testItFailsDuringCommitBeforeTouchingDb(): void
+    {
+        $connection = new class (['memory' => true], new Driver\SQLite3\Driver()) extends Connection {
+            public function commit(): void
+            {
+                throw new \Exception('Fail before touching the db');
+            }
+
+            public function rollBack(): void
+            {
+                throw new \Exception('Rollback got triggered');
+            }
+        };
+
+        $this->expectExceptionMessage('Rollback got triggered');
+        $connection->transactional(static function (): void {
+        });
+    }
 }
 
 interface ConnectDispatchEventListener

--- a/tests/Functional/ForeignKeyConstraintViolationsTest.php
+++ b/tests/Functional/ForeignKeyConstraintViolationsTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Driver\PDO\PDOException;
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver as PDOPgSQLDriver;
+use Doctrine\DBAL\Driver\PgSQL\Driver as PgSQLDriver;
+use Doctrine\DBAL\Driver\PgSQL\Exception as PgSQLException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Assert;
+use Throwable;
+
+use function sprintf;
+
+final class ForeignKeyConstraintViolationsTest extends FunctionalTestCase
+{
+    private string $constraintName = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof OraclePlatform) {
+            $constraintName = 'FK1';
+        } else {
+            $constraintName = 'fk1';
+        }
+
+        $this->constraintName = $constraintName;
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = new Table('test_t1');
+        $table->addColumn('ref_id', 'integer', ['notnull' => true]);
+        $schemaManager->createTable($table);
+
+        $table2 = new Table('test_t2');
+        $table2->addColumn('id', 'integer', ['notnull' => true]);
+        $table2->setPrimaryKey(['id']);
+        $schemaManager->createTable($table2);
+
+        if ($platform instanceof OraclePlatform) {
+            $this->connection->executeStatement(
+                <<<SQL
+                    ALTER TABLE test_t1 ADD CONSTRAINT $constraintName
+                    FOREIGN KEY (ref_id) REFERENCES test_t2 (id)
+                    DEFERRABLE INITIALLY IMMEDIATE
+                    SQL,
+            );
+        } else {
+            $createConstraint = new ForeignKeyConstraint(['ref_id'], 'test_t2', ['id'], $constraintName);
+
+            $schemaManager->createForeignKey($createConstraint, 'test_t1');
+            if (! $this->supportsDeferrableConstraints()) {
+                return;
+            }
+
+            $this->connection->executeStatement(
+                sprintf('ALTER TABLE test_t1 ALTER CONSTRAINT %s DEFERRABLE', $constraintName),
+            );
+        }
+    }
+
+    public function testTransactionalViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+
+            $connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+
+            $this->expectConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraint(): void
+    {
+        $this->connection->transactional(function (Connection $connection): void {
+            $this->expectConstraintViolation(false);
+            $connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        });
+    }
+
+    public function testTransactionalViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+            $connection->beginTransaction();
+            $connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+            $connection->commit();
+
+            $this->expectConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->beginTransaction();
+
+            try {
+                $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+            } catch (Throwable $t) {
+                $this->connection->rollBack();
+
+                $this->expectConstraintViolation(false);
+
+                throw $t;
+            }
+        });
+    }
+
+    public function testCommitViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+
+        $this->expectConstraintViolation(true);
+        $this->connection->commit();
+    }
+
+    public function testInsertViolatesConstraint(): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    public function testCommitViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        $this->connection->commit();
+
+        $this->expectConstraintViolation(true);
+
+        $this->connection->commit();
+    }
+
+    public function testCommitViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    private function supportsDeferrableConstraints(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        return $platform instanceof OraclePlatform || $platform instanceof PostgreSQLPlatform;
+    }
+
+    private function skipIfDeferrableIsNotSupported(): void
+    {
+        if ($this->supportsDeferrableConstraints()) {
+            return;
+        }
+
+        self::markTestSkipped('Only databases supporting deferrable constraints are eligible for this test.');
+    }
+
+    private function expectConstraintViolation(bool $deferred): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            $this->expectExceptionMessage(
+                sprintf('conflicted with the FOREIGN KEY constraint "%s"', $this->constraintName),
+            );
+
+            return;
+        }
+
+        if ($this->connection->getDatabasePlatform() instanceof DB2Platform) {
+            // No concrete message is provided
+            $this->expectException(DriverException::class);
+
+            return;
+        }
+
+        if ($deferred) {
+            if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~integrity constraint \(.+\.%s\) violated~', $this->constraintName),
+                );
+
+                return;
+            }
+
+            $driver = $this->connection->getDriver();
+            if ($driver instanceof AbstractPostgreSQLDriver) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~violates foreign key constraint "%s"~', $this->constraintName),
+                );
+
+                if ($driver instanceof PDOPgSQLDriver) {
+                    $this->expectException(PDOException::class);
+
+                    return;
+                }
+
+                if ($driver instanceof PgSQLDriver) {
+                    $this->expectException(PgSQLException::class);
+
+                    return;
+                }
+
+                Assert::fail('Unsupported PG driver');
+            }
+
+            Assert::fail('Unsupported platform');
+        } else {
+            $this->expectException(ForeignKeyConstraintViolationException::class);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->dropTable('test_t1');
+        $schemaManager->dropTable('test_t2');
+
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
+    }
+}

--- a/tests/Functional/UniqueConstraintViolationsTest.php
+++ b/tests/Functional/UniqueConstraintViolationsTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Driver\PDO\PDOException;
+use Doctrine\DBAL\Driver\PDO\PgSQL\Driver as PDOPgSQLDriver;
+use Doctrine\DBAL\Driver\PgSQL\Driver as PgSQLDriver;
+use Doctrine\DBAL\Driver\PgSQL\Exception as PgSQLException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Assert;
+use Throwable;
+
+use function sprintf;
+
+final class UniqueConstraintViolationsTest extends FunctionalTestCase
+{
+    private string $constraintName = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof OraclePlatform) {
+            $constraintName = 'C1_UNIQUE';
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $constraintName = 'c1_unique';
+        } else {
+            $constraintName = 'c1_unique';
+        }
+
+        $this->constraintName = $constraintName;
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = new Table('unique_constraint_violations');
+        $table->addColumn('unique_field', 'integer', ['notnull' => true]);
+        $schemaManager->createTable($table);
+
+        if ($platform instanceof OraclePlatform) {
+            $createConstraint = sprintf(
+                'ALTER TABLE unique_constraint_violations ' .
+                'ADD CONSTRAINT %s UNIQUE (unique_field) DEFERRABLE INITIALLY IMMEDIATE',
+                $constraintName,
+            );
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $createConstraint = sprintf(
+                'ALTER TABLE unique_constraint_violations ' .
+                'ADD CONSTRAINT %s UNIQUE (unique_field) DEFERRABLE INITIALLY IMMEDIATE',
+                $constraintName,
+            );
+        } elseif ($platform instanceof SqlitePlatform) {
+            $createConstraint = sprintf(
+                'CREATE UNIQUE INDEX %s ON unique_constraint_violations(unique_field)',
+                $constraintName,
+            );
+        } else {
+            $createConstraint = new UniqueConstraint($constraintName, ['unique_field']);
+        }
+
+        if ($createConstraint instanceof UniqueConstraint) {
+            $schemaManager->createUniqueConstraint($createConstraint, 'unique_constraint_violations');
+        } else {
+            $this->connection->executeStatement($createConstraint);
+        }
+
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+    }
+
+    public function testTransactionalViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+
+            $this->expectUniqueConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraint(): void
+    {
+        $this->connection->transactional(function (Connection $connection): void {
+            $this->expectUniqueConstraintViolation(false);
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        });
+    }
+
+    public function testTransactionalViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+            $connection->beginTransaction();
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+            $connection->commit();
+
+            $this->expectUniqueConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->beginTransaction();
+
+            try {
+                $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+            } catch (Throwable $t) {
+                $this->connection->rollBack();
+
+                $this->expectUniqueConstraintViolation(false);
+
+                throw $t;
+            }
+        });
+    }
+
+    public function testCommitViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+
+        $this->expectUniqueConstraintViolation(true);
+        $this->connection->commit();
+    }
+
+    public function testInsertViolatesConstraint(): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectUniqueConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    public function testCommitViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        $this->connection->commit();
+
+        $this->expectUniqueConstraintViolation(true);
+
+        $this->connection->commit();
+    }
+
+    public function testCommitViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectUniqueConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    private function supportsDeferrableConstraints(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        return $platform instanceof OraclePlatform || $platform instanceof PostgreSQLPlatform;
+    }
+
+    private function skipIfDeferrableIsNotSupported(): void
+    {
+        if ($this->supportsDeferrableConstraints()) {
+            return;
+        }
+
+        self::markTestSkipped('Only databases supporting deferrable constraints are eligible for this test.');
+    }
+
+    private function expectUniqueConstraintViolation(bool $deferred): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            $this->expectExceptionMessage(sprintf("Violation of UNIQUE KEY constraint '%s'", $this->constraintName));
+
+            return;
+        }
+
+        if ($this->connection->getDatabasePlatform() instanceof DB2Platform) {
+            // No concrete message is provided
+            $this->expectException(DriverException::class);
+
+            return;
+        }
+
+        if ($deferred) {
+            if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~unique constraint \(.+\.%s\) violated~', $this->constraintName),
+                );
+
+                return;
+            }
+
+            $driver = $this->connection->getDriver();
+            if ($driver instanceof AbstractPostgreSQLDriver) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~duplicate key value violates unique constraint "%s"~', $this->constraintName),
+                );
+
+                if ($driver instanceof PDOPgSQLDriver) {
+                    $this->expectException(PDOException::class);
+
+                    return;
+                }
+
+                if ($driver instanceof PgSQLDriver) {
+                    $this->expectException(PgSQLException::class);
+
+                    return;
+                }
+
+                Assert::fail('Unsupported PG driver');
+            }
+
+            Assert::fail('Unsupported platform');
+        } else {
+            $this->expectException(UniqueConstraintViolationException::class);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->dropTable('unique_constraint_violations');
+
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #3423

#### Summary

_https://github.com/doctrine/dbal/pull/6543 partially solved what we tried to achieve in https://github.com/doctrine/dbal/pull/4846. With that `There's no active transaction` exception contains the actual exception in `$previous`._

Now, let's get rid of `There's no active transaction` exception which occurs e.g. when using deferred constraints so the violation is checked at the end of the transaction and not during it. Database then rolls back the transaction automatically.

The current faulty flow is following: 

1. on `commit()`, Constrain violation occurs
2. transaction is implicitly aborted and rolled back in database
3. DBAL calls `rollback()`
4. Since there's no active transaction, `There's no active transaction` exception is thrown:

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/c5c7d77f-c783-4902-ad28-689107c6a338">

This PR adjusts the flow so:

1. on `commit()`, Constrain violation occurs
2. transaction is implicitly aborted and rolled back in database
3. DBAL **DOES NOT** call `rollback()` 🥳 

-----------

For DBAL v4 it looks like this https://github.com/doctrine/dbal/pull/6546 (draft, does not contain review changes)