### PR TITLE
Fix incorrect `transactional()` handling when DB auto-rolled back the transaction (v4)

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -12,12 +12,17 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection\StaticServerVersionProvider;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\Exception as TheDriverException;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\Exception\CommitFailedRollbackOnly;
 use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\NoActiveTransaction;
 use Doctrine\DBAL\Exception\SavepointsNotSupported;
+use Doctrine\DBAL\Exception\TransactionRolledBack;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -931,16 +936,35 @@ class Connection implements ServerVersionProvider
 
         try {
             $res = $func($this);
-            $this->commit();
 
             $successful = true;
-
-            return $res;
         } finally {
             if (! $successful) {
                 $this->rollBack();
             }
         }
+
+        $shouldRollback = true;
+        try {
+            $this->commit();
+
+            $shouldRollback = false;
+        } catch (TheDriverException $t) {
+            $shouldRollback = ! (
+                $t instanceof TransactionRolledBack
+                || $t instanceof UniqueConstraintViolationException
+                || $t instanceof ForeignKeyConstraintViolationException
+                || $t instanceof DeadlockException
+            );
+
+            throw $t;
+        } finally {
+            if ($shouldRollback) {
+                $this->rollBack();
+            }
+        }
+
+        return $res;
     }
 
     /**
@@ -1019,17 +1043,26 @@ class Connection implements ServerVersionProvider
 
         $connection = $this->connect();
 
-        if ($this->transactionNestingLevel === 1) {
-            try {
-                $connection->commit();
-            } catch (Driver\Exception $e) {
-                throw $this->convertException($e);
+        try {
+            if ($this->transactionNestingLevel === 1) {
+                try {
+                    $connection->commit();
+                } catch (Driver\Exception $e) {
+                    throw $this->convertException($e);
+                }
+            } else {
+                $this->releaseSavepoint($this->_getNestedTransactionSavePointName());
             }
-        } else {
-            $this->releaseSavepoint($this->_getNestedTransactionSavePointName());
+        } finally {
+            $this->updateTransactionStateAfterCommit();
         }
+    }
 
-        --$this->transactionNestingLevel;
+    private function updateTransactionStateAfterCommit(): void
+    {
+        if ($this->transactionNestingLevel !== 0) {
+            --$this->transactionNestingLevel;
+        }
 
         if ($this->autoCommit !== false || $this->transactionNestingLevel !== 0) {
             return;

--- a/src/Driver/API/OCI/ExceptionConverter.php
+++ b/src/Driver/API/OCI/ExceptionConverter.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Driver\API\OCI;
 
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Driver\OCI8\Exception\Error;
+use Doctrine\DBAL\Driver\PDO\Exception as DriverPDOException;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\DatabaseDoesNotExist;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
@@ -17,8 +19,14 @@ use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
 use Doctrine\DBAL\Exception\SyntaxErrorException;
 use Doctrine\DBAL\Exception\TableExistsException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\DBAL\Exception\TransactionRolledBack;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query;
+
+use function assert;
+use function count;
+use function explode;
+use function str_replace;
 
 /** @internal */
 final class ExceptionConverter implements ExceptionConverterInterface
@@ -40,6 +48,26 @@ final class ExceptionConverter implements ExceptionConverterInterface
             12545 => new ConnectionException($exception, $query),
             1400 => new NotNullConstraintViolationException($exception, $query),
             1918 => new DatabaseDoesNotExist($exception, $query),
+            2091 => (function () use ($exception, $query) {
+                //SQLSTATE[HY000]: General error: 2091 OCITransCommit: ORA-02091: transaction rolled back
+                //ORA-00001: unique constraint (DOCTRINE.GH3423_UNIQUE) violated
+                $lines = explode("\n", $exception->getMessage(), 2);
+                assert(count($lines) >= 2);
+
+                [, $causeError] = $lines;
+
+                [$causeCode] = explode(': ', $causeError, 2);
+                $code        = (int) str_replace('ORA-', '', $causeCode);
+
+                $sqlState = $exception->getSQLState();
+                if ($exception instanceof DriverPDOException) {
+                    $why = $this->convert(new DriverPDOException($causeError, $sqlState, $code, $exception), $query);
+                } else {
+                    $why = $this->convert(new Error($causeError, $sqlState, $code, $exception), $query);
+                }
+
+                return new TransactionRolledBack($why, $query);
+            })(),
             2289,
             2443,
             4080 => new DatabaseObjectNotFoundException($exception, $query),

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -95,7 +95,7 @@ final class Connection implements ConnectionInterface
 
     public function commit(): void
     {
-        if (! oci_commit($this->connection)) {
+        if (! @oci_commit($this->connection)) {
             throw Error::new($this->connection);
         }
 

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -14,6 +14,7 @@ use function oci_cancel;
 use function oci_error;
 use function oci_fetch_all;
 use function oci_fetch_array;
+use function oci_field_name;
 use function oci_num_fields;
 use function oci_num_rows;
 

--- a/src/Exception/TransactionRolledBack.php
+++ b/src/Exception/TransactionRolledBack.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+/** @psalm-immutable */
+class TransactionRolledBack extends DriverException
+{
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -675,4 +675,26 @@ class ConnectionTest extends TestCase
             self::assertSame('Original exception', $e->getPrevious()->getMessage());
         }
     }
+
+    /**
+     * We are not sure if this can happen in real life scenario
+     */
+    public function testItFailsDuringCommitBeforeTouchingDb(): void
+    {
+        $connection = new class (['memory' => true], new Driver\SQLite3\Driver()) extends Connection {
+            public function commit(): void
+            {
+                throw new \Exception('Fail before touching the db');
+            }
+
+            public function rollBack(): void
+            {
+                throw new \Exception('Rollback got triggered');
+            }
+        };
+
+        $this->expectExceptionMessage('Rollback got triggered');
+        $connection->transactional(static function (): void {
+        });
+    }
 }

--- a/tests/Functional/ForeignKeyConstraintViolationsTest.php
+++ b/tests/Functional/ForeignKeyConstraintViolationsTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Assert;
+use Throwable;
+
+use function sprintf;
+
+final class ForeignKeyConstraintViolationsTest extends FunctionalTestCase
+{
+    private string $constraintName = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof OraclePlatform) {
+            $constraintName = 'FK1';
+        } else {
+            $constraintName = 'fk1';
+        }
+
+        $this->constraintName = $constraintName;
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = new Table('test_t1');
+        $table->addColumn('ref_id', 'integer', ['notnull' => true]);
+        $schemaManager->createTable($table);
+
+        $table2 = new Table('test_t2');
+        $table2->addColumn('id', 'integer', ['notnull' => true]);
+        $table2->setPrimaryKey(['id']);
+        $schemaManager->createTable($table2);
+
+        if ($platform instanceof OraclePlatform) {
+            $this->connection->executeStatement(
+                <<<SQL
+                    ALTER TABLE test_t1 ADD CONSTRAINT $constraintName
+                    FOREIGN KEY (ref_id) REFERENCES test_t2 (id)
+                    DEFERRABLE INITIALLY IMMEDIATE
+                    SQL,
+            );
+        } else {
+            $createConstraint = new ForeignKeyConstraint(['ref_id'], 'test_t2', ['id'], $constraintName);
+
+            $schemaManager->createForeignKey($createConstraint, 'test_t1');
+            if (! $this->supportsDeferrableConstraints()) {
+                return;
+            }
+
+            $this->connection->executeStatement(
+                sprintf('ALTER TABLE test_t1 ALTER CONSTRAINT %s DEFERRABLE', $constraintName),
+            );
+        }
+    }
+
+    public function testTransactionalViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+
+            $connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+
+            $this->expectConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraint(): void
+    {
+        $this->connection->transactional(function (Connection $connection): void {
+            $this->expectConstraintViolation(false);
+            $connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        });
+    }
+
+    public function testTransactionalViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+            $connection->beginTransaction();
+            $connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+            $connection->commit();
+
+            $this->expectConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->beginTransaction();
+
+            try {
+                $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+            } catch (Throwable $t) {
+                $this->connection->rollBack();
+
+                $this->expectConstraintViolation(false);
+
+                throw $t;
+            }
+        });
+    }
+
+    public function testCommitViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+
+        $this->expectConstraintViolation(true);
+        $this->connection->commit();
+    }
+
+    public function testInsertViolatesConstraint(): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    public function testCommitViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        $this->connection->commit();
+
+        $this->expectConstraintViolation(true);
+
+        $this->connection->commit();
+    }
+
+    public function testCommitViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO test_t1 VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    private function supportsDeferrableConstraints(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        return $platform instanceof OraclePlatform || $platform instanceof PostgreSQLPlatform;
+    }
+
+    private function skipIfDeferrableIsNotSupported(): void
+    {
+        if ($this->supportsDeferrableConstraints()) {
+            return;
+        }
+
+        self::markTestSkipped('Only databases supporting deferrable constraints are eligible for this test.');
+    }
+
+    private function expectConstraintViolation(bool $deferred): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            $this->expectExceptionMessage(
+                sprintf('conflicted with the FOREIGN KEY constraint "%s"', $this->constraintName),
+            );
+
+            return;
+        }
+
+        if ($this->connection->getDatabasePlatform() instanceof DB2Platform) {
+            // No concrete message is provided
+            $this->expectException(DriverException::class);
+
+            return;
+        }
+
+        if ($deferred) {
+            if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~integrity constraint \(.+\.%s\) violated~', $this->constraintName),
+                );
+
+                return;
+            }
+
+            $driver = $this->connection->getDriver();
+            if ($driver instanceof AbstractPostgreSQLDriver) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~violates foreign key constraint "%s"~', $this->constraintName),
+                );
+
+                $this->expectException(ForeignKeyConstraintViolationException::class);
+
+                return;
+            }
+
+            Assert::fail('Unsupported platform');
+        } else {
+            $this->expectException(ForeignKeyConstraintViolationException::class);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->dropTable('test_t1');
+        $schemaManager->dropTable('test_t2');
+
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
+    }
+}

--- a/tests/Functional/UniqueConstraintViolationsTest.php
+++ b/tests/Functional/UniqueConstraintViolationsTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Assert;
+use Throwable;
+
+use function sprintf;
+
+final class UniqueConstraintViolationsTest extends FunctionalTestCase
+{
+    private string $constraintName = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof OraclePlatform) {
+            $constraintName = 'C1_UNIQUE';
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $constraintName = 'c1_unique';
+        } else {
+            $constraintName = 'c1_unique';
+        }
+
+        $this->constraintName = $constraintName;
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = new Table('unique_constraint_violations');
+        $table->addColumn('unique_field', 'integer', ['notnull' => true]);
+        $schemaManager->createTable($table);
+
+        if ($platform instanceof OraclePlatform) {
+            $createConstraint = sprintf(
+                'ALTER TABLE unique_constraint_violations ' .
+                'ADD CONSTRAINT %s UNIQUE (unique_field) DEFERRABLE INITIALLY IMMEDIATE',
+                $constraintName,
+            );
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $createConstraint = sprintf(
+                'ALTER TABLE unique_constraint_violations ' .
+                'ADD CONSTRAINT %s UNIQUE (unique_field) DEFERRABLE INITIALLY IMMEDIATE',
+                $constraintName,
+            );
+        } elseif ($platform instanceof SQLitePlatform) {
+            $createConstraint = sprintf(
+                'CREATE UNIQUE INDEX %s ON unique_constraint_violations(unique_field)',
+                $constraintName,
+            );
+        } else {
+            $createConstraint = new UniqueConstraint($constraintName, ['unique_field']);
+        }
+
+        if ($createConstraint instanceof UniqueConstraint) {
+            $schemaManager->createUniqueConstraint($createConstraint, 'unique_constraint_violations');
+        } else {
+            $this->connection->executeStatement($createConstraint);
+        }
+
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+    }
+
+    public function testTransactionalViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+
+            $this->expectUniqueConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraint(): void
+    {
+        $this->connection->transactional(function (Connection $connection): void {
+            $this->expectUniqueConstraintViolation(false);
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        });
+    }
+
+    public function testTransactionalViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+            $connection->beginTransaction();
+            $connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+            $connection->commit();
+
+            $this->expectUniqueConstraintViolation(true);
+        });
+    }
+
+    public function testTransactionalViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->connection->transactional(function (Connection $connection): void {
+            $connection->beginTransaction();
+
+            try {
+                $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+            } catch (Throwable $t) {
+                $this->connection->rollBack();
+
+                $this->expectUniqueConstraintViolation(false);
+
+                throw $t;
+            }
+        });
+    }
+
+    public function testCommitViolatesDeferredConstraint(): void
+    {
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+
+        $this->expectUniqueConstraintViolation(true);
+        $this->connection->commit();
+    }
+
+    public function testInsertViolatesConstraint(): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectUniqueConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    public function testCommitViolatesDeferredConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement(sprintf('SET CONSTRAINTS "%s" DEFERRED', $this->constraintName));
+        $this->connection->beginTransaction();
+        $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        $this->connection->commit();
+
+        $this->expectUniqueConstraintViolation(true);
+
+        $this->connection->commit();
+    }
+
+    public function testCommitViolatesConstraintWhileUsingTransactionNesting(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSavepoints()) {
+            self::markTestSkipped('This test requires the platform to support savepoints.');
+        }
+
+        $this->skipIfDeferrableIsNotSupported();
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+
+        try {
+            $this->connection->executeStatement('INSERT INTO unique_constraint_violations VALUES (1)');
+        } catch (Throwable $t) {
+            $this->connection->rollBack();
+
+            $this->expectUniqueConstraintViolation(false);
+
+            throw $t;
+        }
+    }
+
+    private function supportsDeferrableConstraints(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        return $platform instanceof OraclePlatform || $platform instanceof PostgreSQLPlatform;
+    }
+
+    private function skipIfDeferrableIsNotSupported(): void
+    {
+        if ($this->supportsDeferrableConstraints()) {
+            return;
+        }
+
+        self::markTestSkipped('Only databases supporting deferrable constraints are eligible for this test.');
+    }
+
+    private function expectUniqueConstraintViolation(bool $deferred): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            $this->expectExceptionMessage(sprintf("Violation of UNIQUE KEY constraint '%s'", $this->constraintName));
+
+            return;
+        }
+
+        if ($this->connection->getDatabasePlatform() instanceof DB2Platform) {
+            // No concrete message is provided
+            $this->expectException(DriverException::class);
+
+            return;
+        }
+
+        if ($deferred) {
+            if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~unique constraint \(.+\.%s\) violated~', $this->constraintName),
+                );
+
+                return;
+            }
+
+            $driver = $this->connection->getDriver();
+            if ($driver instanceof AbstractPostgreSQLDriver) {
+                $this->expectExceptionMessageMatches(
+                    sprintf('~duplicate key value violates unique constraint "%s"~', $this->constraintName),
+                );
+
+                $this->expectException(UniqueConstraintViolationException::class);
+
+                return;
+            }
+
+            Assert::fail('Unsupported platform');
+        } else {
+            $this->expectException(UniqueConstraintViolationException::class);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->dropTable('unique_constraint_violations');
+
+        $this->markConnectionNotReusable();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This is how https://github.com/doctrine/dbal/pull/6545 looks like for v4