### PR TITLE
test: cover nested transactions

### DIFF
--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -2,26 +2,24 @@
 
 namespace Doctrine\DBAL\Tests\Functional;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
 use PDOException;
 
 use function sleep;
 
 class TransactionTest extends FunctionalTestCase
 {
-    protected function setUp(): void
-    {
-        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
-            return;
-        }
-
-        $this->markTestSkipped('Restricted to MySQL.');
-    }
-
     public function testCommitFalse(): void
     {
+        if (! $this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            $this->markTestSkipped('Restricted to MySQL.');
+        }
+
         $this->connection->executeStatement('SET SESSION wait_timeout=1');
 
         self::assertTrue($this->connection->beginTransaction());
@@ -39,5 +37,31 @@ class TransactionTest extends FunctionalTestCase
         } finally {
             $this->connection->close();
         }
+    }
+
+    public function testNestedTransactionWalkthrough(): void
+    {
+        $table = new Table('storage');
+        $table->addColumn('test_int', Types::INTEGER);
+        $table->setPrimaryKey(['test_int']);
+
+        $this->dropAndCreateTable($table);
+
+        $query = 'SELECT count(test_int) FROM storage';
+
+        self::assertSame('0', (string) $this->connection->fetchOne($query));
+
+        $result = $this->connection->transactional(
+            static fn (Connection $connection) => $connection->transactional(
+                static function (Connection $connection) use ($query) {
+                    $connection->insert('storage', ['test_int' => 1]);
+
+                    return $connection->fetchOne($query);
+                },
+            ),
+        );
+
+        self::assertSame('1', (string) $result);
+        self::assertSame('1', (string) $this->connection->fetchOne($query));
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | 

#### Summary

_I managed to break this behaviour in other PR https://github.com/doctrine/dbal/pull/6545 so this should be covered._

It tests basic walkthrough where we nest transactions, propagate the result through the transaction stack and also that it is committed and not rolled back.