### PR TITLE
Simplify tracking implicitly created indexes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -102,9 +102,7 @@
 
     <!-- See https://github.com/squizlabs/PHP_CodeSniffer/issues/2837 -->
     <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
-        <exclude-pattern>src/Connection.php</exclude-pattern>
-        <exclude-pattern>src/Schema/Comparator.php</exclude-pattern>
-        <exclude-pattern>src/SQLParserUtils.php</exclude-pattern>
+        <exclude-pattern>src/Schema/Table.php</exclude-pattern>
     </rule>
 
     <!-- some statement classes close cursor using an empty while-loop -->

--- a/src/Schema/Exception/PrimaryKeyAlreadyExists.php
+++ b/src/Schema/Exception/PrimaryKeyAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class PrimaryKeyAlreadyExists extends LogicException implements SchemaException
+{
+    public static function new(string $tableName): self
+    {
+        return new self(
+            sprintf('Primary key was already defined on table "%s".', $tableName),
+        );
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

I'm trying to clean up the codebase before reworking the logic of managing indexes in the schema.

Currently, `Table::$implicitIndexes` contains both the index names as keys and the indexes themselves as values. On the one hand, this is redundant (because all indexes are already contained in `Table::$_indexes`); on the other hand, this is confusing (it is unclear whether `Table::$_indexes` contains all indexes or only the explicitly created ones).

The proposed fix replaces `Table::$implicitIndexes` with `Table::$implicitIndexNames` and addresses both of the above issues.

Additionally, it introduces the `PrimaryKeyAlreadyExists` exception. This isn't strictly necessary here but also addresses two issues:
1. It breaks a complex if statement that checks for the exceptional condition into two simpler ones.
2. It makes the UX less confusing: unlike regular indexes (which must have a unique name and thus are identified by name), there can be only one primary key, so the name of the offending index in the exception message is irrelevant (furthermore, an index isn't guaranteed to have a name).