### PR TITLE
Query Cache mangled if saved by-reference

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -811,7 +811,7 @@ class Connection implements ServerVersionProvider
             }
 
             if (isset($value[$realKey]) && $value[$realKey] instanceof ArrayResult) {
-                return new Result($value[$realKey], $this);
+                return new Result(clone $value[$realKey], $this);
             }
         } else {
             $value = [];
@@ -837,7 +837,7 @@ class Connection implements ServerVersionProvider
 
         $resultCache->save($item);
 
-        return new Result($value[$realKey], $this);
+        return new Result(clone $value[$realKey], $this);
     }
 
     /**

--- a/tests/Connection/CachedQueryTest.php
+++ b/tests/Connection/CachedQueryTest.php
@@ -27,6 +27,10 @@ class CachedQueryTest extends TestCase
         self::assertSame([['foo' => 'bar']], $firstResult
             ->fetchAllAssociative());
         $firstResult->free();
+        $secondResult = $connection->executeCacheQuery('SELECT 1', [], [], $qcp);
+        self::assertSame([['foo' => 'bar']], $secondResult
+            ->fetchAllAssociative());
+        $secondResult->free();
         self::assertSame([['foo' => 'bar']], $connection->executeCacheQuery('SELECT 1', [], [], $qcp)
             ->fetchAllAssociative());
 

--- a/tests/Connection/CachedQueryTest.php
+++ b/tests/Connection/CachedQueryTest.php
@@ -8,27 +8,33 @@ use Doctrine\DBAL\Cache\ArrayResult;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class CachedQueryTest extends TestCase
 {
-    public function testCachedQuery(): void
+    #[DataProvider('providePsrCacheImplementations')]
+    public function testCachedQuery(callable $psrCacheProvider): void
     {
-        $cache = new ArrayAdapter();
+        $cache = $psrCacheProvider();
 
         $connection = $this->createConnection(1, ['foo'], [['bar']]);
         $qcp        = new QueryCacheProfile(0, __FUNCTION__, $cache);
 
-        self::assertSame([['foo' => 'bar']], $connection->executeCacheQuery('SELECT 1', [], [], $qcp)
+        $firstResult = $connection->executeCacheQuery('SELECT 1', [], [], $qcp);
+        self::assertSame([['foo' => 'bar']], $firstResult
             ->fetchAllAssociative());
+        $firstResult->free();
         self::assertSame([['foo' => 'bar']], $connection->executeCacheQuery('SELECT 1', [], [], $qcp)
             ->fetchAllAssociative());
 
         self::assertCount(1, $cache->getItem(__FUNCTION__)->get());
     }
 
-    public function testCachedQueryWithChangedImplementationIsExecutedTwice(): void
+    #[DataProvider('providePsrCacheImplementations')]
+    public function testCachedQueryWithChangedImplementationIsExecutedTwice(callable $psrCacheProvider): void
     {
         $connection = $this->createConnection(2, ['baz'], [['qux']]);
 
@@ -36,21 +42,22 @@ class CachedQueryTest extends TestCase
             'SELECT 1',
             [],
             [],
-            new QueryCacheProfile(0, __FUNCTION__, new ArrayAdapter()),
+            new QueryCacheProfile(0, __FUNCTION__, $psrCacheProvider()),
         )->fetchAllAssociative());
 
         self::assertSame([['baz' => 'qux']], $connection->executeCacheQuery(
             'SELECT 1',
             [],
             [],
-            new QueryCacheProfile(0, __FUNCTION__, new ArrayAdapter()),
+            new QueryCacheProfile(0, __FUNCTION__, $psrCacheProvider()),
         )->fetchAllAssociative());
     }
 
-    public function testOldCacheFormat(): void
+    #[DataProvider('providePsrCacheImplementations')]
+    public function testOldCacheFormat(callable $psrCacheProvider): void
     {
         $connection = $this->createConnection(1, ['foo'], [['bar']]);
-        $cache      = new ArrayAdapter();
+        $cache      = $psrCacheProvider();
         $qcp        = new QueryCacheProfile(0, __FUNCTION__, $cache);
 
         [$cacheKey, $realKey] = $qcp->generateCacheKeys('SELECT 1', [], [], []);
@@ -82,5 +89,16 @@ class CachedQueryTest extends TestCase
             ->willReturn($connection);
 
         return new Connection([], $driver);
+    }
+
+    /**
+     * @return list<list<callable():CacheItemPoolInterface>>
+     */
+    public static function providePsrCacheImplementations(): array
+    {
+        return [
+            'serialized' => [fn() => new ArrayAdapter(0, true)],
+            'by-reference' => [fn() => new ArrayAdapter(0, false)],
+        ];
     }
 }

--- a/tests/Connection/CachedQueryTest.php
+++ b/tests/Connection/CachedQueryTest.php
@@ -91,14 +91,12 @@ class CachedQueryTest extends TestCase
         return new Connection([], $driver);
     }
 
-    /**
-     * @return list<list<callable():CacheItemPoolInterface>>
-     */
+    /** @return array<non-empty-string, list<callable():CacheItemPoolInterface>> */
     public static function providePsrCacheImplementations(): array
     {
         return [
-            'serialized' => [fn() => new ArrayAdapter(0, true)],
-            'by-reference' => [fn() => new ArrayAdapter(0, false)],
+            'serialized' => [static fn () => new ArrayAdapter(0, true)],
+            'by-reference' => [static fn () => new ArrayAdapter(0, false)],
         ];
     }
 }


### PR DESCRIPTION
Bug emerged in https://github.com/doctrine/dbal/pull/6510#discussion_r1804475987

The current implementation of query cache relies on the cache **not** saved by-reference; the bug has never been seen before because by default `new ArrayAdapter()` saves the cache with serialization, hence breaking the by-reference pointer.

Once the _by-reference_ tecnique is used, two issues pop up:

1. `\Doctrine\DBAL\Cache\ArrayResult::$num` is never reset, so once it gets incremented in the first `\Doctrine\DBAL\Cache\ArrayResult::fetch` call, the following calls will always fail
2. Even considering fixing the `$num` property reset, a manual call on `\Doctrine\DBAL\Result::free` will by cascade call the `\Doctrine\DBAL\Cache\ArrayResult::free` method erasing all the saved results

I think that the `ArrayResult` implementation is not the culprit, but rather the #6510 giving to the cache backend the internal object by reference instead of giving it a copy.