### PR TITLE
Fix typo in PostgreSql documentation reference

### DIFF
--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -93,7 +93,7 @@ and absolutely not portable.
 -  **engine** (string): The DB engine used for the table. Currently only supported on MySQL.
 
 -  **unlogged** (boolean): Set a PostgreSQL table type as
-  `unlogged <https://www.postgresql.org/docs/current/sql-createtable.htmll>`_
+  `unlogged <https://www.postgresql.org/docs/current/sql-createtable.html>`_
 
 Column
 ~~~~~~


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

I read https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/schema-representation.html and clicked a link. This link resulted in a 404. Glad it is just a typo away to be fixed :) 