### PR TITLE
Deprecate dropping columns referenced by constraints

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated dropping columns referenced by constraints
+
+Dropping columns that are referenced by constraints is deprecated. The constraints should be dropped first.
+
 ## Deprecated `Table::removeForeignKey()` and `::removeUniqueConstraint()`
 
 The usage of `Table::removeForeignKey()` and `::removeUniqueConstraint()` is deprecated. Use `Table::dropForeignKey()`


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

#### Summary

Currently, it is impossible to reference a non-existing column in a constraint being added but it's possible to drop the column afterwards, which will leave the table in an invalid state.

The order of operations in the following test will have to be changed once this deprecation is promoted to exception: https://github.com/doctrine/dbal/blob/33f5589058e803f9757b50a032df0301efc4908d/tests/Schema/TableTest.php#L823-L825

The following is out of scope of this PR:
1. Renaming the column being renamed in referencing indexes and constraints (https://github.com/doctrine/dbal/pull/6578).
2. Dropping the column being dropped from referencing indexes and dropping the eventually empty indexes.