### PR TITLE
Deprecate Table::removeForeignKey() and ::removeUniqueConstraint()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 4.3
+
+## Deprecated `Table::removeForeignKey()` and `::removeUniqueConstraint()`
+
+The usage of `Table::removeForeignKey()` and `::removeUniqueConstraint()` is deprecated. Use `Table::dropForeignKey()`
+and `::dropUniqueConstraint()` respectively instead.
+
 # Upgrade to 4.2
 
 ## Support for new PDO subclasses on PHP 8.4

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -67,6 +67,13 @@
 
                 <!-- TODO for PHPUnit 11 -->
                 <referencedMethod name="PHPUnit\Framework\TestCase::iniSet"/>
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6560
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::removeForeignKey" />
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::removeUniqueConstraint" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 use LogicException;
 
 use function array_merge;
@@ -409,8 +410,24 @@ class Table extends AbstractAsset
 
     /**
      * Removes the foreign key constraint with the given name.
+     *
+     * @deprecated Use {@link dropForeignKey()} instead.
      */
     public function removeForeignKey(string $name): void
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6560',
+            'Table::removeForeignKey() is deprecated. Use Table::removeForeignKey() instead.',
+        );
+
+        $this->dropForeignKey($name);
+    }
+
+    /**
+     * Drops the foreign key constraint with the given name.
+     */
+    public function dropForeignKey(string $name): void
     {
         $name = $this->normalizeIdentifier($name);
 
@@ -447,8 +464,24 @@ class Table extends AbstractAsset
 
     /**
      * Removes the unique constraint with the given name.
+     *
+     * @deprecated Use {@link dropUniqueConstraint()} instead.
      */
     public function removeUniqueConstraint(string $name): void
+    {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6560',
+            'Table::removeUniqueConstraint() is deprecated. Use Table::dropUniqueConstraint() instead.',
+        );
+
+        $this->dropUniqueConstraint($name);
+    }
+
+    /**
+     * Drops the unique constraint with the given name.
+     */
+    public function dropUniqueConstraint(string $name): void
     {
         $name = $this->normalizeIdentifier($name);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The proposed naming is consistent with SQL and with the rest of the `Table::drop*()` method names.