### PR TITLE
Cover scenario `BEGIN TRANSACTION; COMMIT; BEGIN TRANSACTION; --failure`

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use RuntimeException;
 use stdClass;
 
 /** @requires extension pdo_mysql */
@@ -409,6 +410,35 @@ class ConnectionTest extends TestCase
         $conn->setAutoCommit(false);
         $conn->connect();
         $conn->commit();
+
+        self::assertTrue($conn->isTransactionActive());
+    }
+
+    public function testBeginTransactionFailureAfterCommitInNoAutoCommitMode(): void
+    {
+        $driverConnectionMock = $this->createMock(DriverConnection::class);
+        $driverConnectionMock->expects(self::exactly(2))
+            ->method('beginTransaction')
+            ->willReturnOnConsecutiveCalls(
+                true,
+                self::throwException(new RuntimeException()),
+            );
+
+        $driver = $this->createStub(Driver::class);
+        $driver
+            ->method('connect')
+            ->willReturn(
+                $driverConnectionMock,
+            );
+        $conn = new Connection([], $driver);
+
+        $conn->setAutoCommit(false);
+
+        $conn->connect();
+        try {
+            $conn->commit();
+        } catch (RuntimeException $e) {
+        }
 
         self::assertTrue($conn->isTransactionActive());
     }


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Covers the concern expressed by @greg0ire https://github.com/doctrine/dbal/pull/6545#issuecomment-2412377607

Transaction should not be rolled back in autocommit=false mode when `BEGIN TRANSACTION` fails due to network error or similar after `COMMIT`.