### PR TITLE
Cover how `transactional()` behaves in different auto commit modes

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -396,13 +396,53 @@ class ConnectionTest extends TestCase
         self::assertTrue($conn->isTransactionActive());
     }
 
+    public function testTransactionIsNotActiveAfterTransactionalInAutoCommitMode(): void
+    {
+        $driverMock = $this->createStub(Driver::class);
+        $driverMock
+            ->method('connect')
+            ->willReturn(
+                $this->createStub(DriverConnection::class),
+            );
+
+        $conn = new Connection([], $driverMock);
+
+        $conn->setAutoCommit(true);
+
+        self::assertFalse($conn->isTransactionActive());
+
+        $conn->transactional(static function (Connection $connection): void {
+        });
+
+        self::assertFalse($conn->isTransactionActive());
+    }
+
+    public function testTransactionIsActiveAfterTransactionalInNoAutoCommitMode(): void
+    {
+        $driverMock = $this->createMock(Driver::class);
+        $driverMock
+            ->method('connect')
+            ->willReturn(
+                $this->createStub(DriverConnection::class),
+            );
+
+        $conn = new Connection([], $driverMock);
+
+        $conn->setAutoCommit(false);
+
+        $conn->transactional(static function (Connection $connection): void {
+        });
+
+        self::assertTrue($conn->isTransactionActive());
+    }
+
     public function testCommitStartsTransactionInNoAutoCommitMode(): void
     {
         $driverMock = $this->createMock(Driver::class);
         $driverMock
             ->method('connect')
             ->willReturn(
-                $this->createMock(DriverConnection::class),
+                $this->createStub(DriverConnection::class),
             );
         $conn = new Connection([], $driverMock);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Covers the concern expressed by @greg0ire https://github.com/doctrine/dbal/pull/6545#issuecomment-2423739575

This ensures the transaction is (not)active based on `autocommmit` mode when interacting with `transactional()`.