### PR TITLE
Change MySQL bool mapping from TINYINT(1) to TINYINT

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -194,7 +194,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      */
     public function getBooleanTypeDeclarationSQL(array $column): string
     {
-        return 'TINYINT(1)';
+        return 'TINYINT';
     }
 
     /**


### PR DESCRIPTION
Since 8.0 MySQL throws whis warning "1681 [HY000] Integer display width is deprecated and will be removed in a future release." when integer column with display width is created

This change is backwards compatible and can be merged into all active branches (does not trigger column type update migration)
