### PR TITLE
Rename column in indexes and constraints

### DIFF
--- a/tests/Functional/Schema/ColumnRenameTest.php
+++ b/tests/Functional/Schema/ColumnRenameTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+class ColumnRenameTest extends FunctionalTestCase
+{
+    private AbstractSchemaManager $schemaManager;
+
+    private Comparator $comparator;
+
+    /** @throws Exception */
+    protected function setUp(): void
+    {
+        $this->schemaManager = $this->connection->createSchemaManager();
+        $this->comparator    = $this->schemaManager->createComparator();
+    }
+
+    /** @throws Exception */
+    public function testRenameColumnInIndex(): void
+    {
+        $this->testRenameColumn(static function (Table $table): void {
+            $table->addIndex(['c1', 'c2'], 'idx_c1_c2');
+        });
+    }
+
+    /** @throws Exception */
+    public function testRenameColumnInForeignKeyConstraint(): void
+    {
+        $this->dropTableIfExists('rename_column_referenced');
+
+        $referencedTable = new Table('rename_column_referenced');
+        $referencedTable->addColumn('c1', Types::INTEGER);
+        $referencedTable->addColumn('c2', Types::INTEGER);
+
+        // PostgreSQL requires a unique constraint on the referenced table columns
+        $referencedTable->addUniqueConstraint(['c1', 'c2']);
+
+        $this->connection->createSchemaManager()->createTable($referencedTable);
+
+        $this->testRenameColumn(static function (Table $table): void {
+            $table->addForeignKeyConstraint('rename_column_referenced', ['c1', 'c2'], ['c1', 'c2'], [], 'fk_c1_c2');
+        });
+    }
+
+    /**
+     * @param callable(Table): void $modifier
+     *
+     * @throws Exception
+     */
+    private function testRenameColumn(callable $modifier): void
+    {
+        $this->dropTableIfExists('rename_column');
+
+        $table = new Table('rename_column');
+        $table->addColumn('c1', Types::INTEGER);
+        $table->addColumn('c2', Types::INTEGER);
+        $modifier($table);
+        $table->renameColumn('c1', 'c1a');
+
+        $this->connection->createSchemaManager()->createTable($table);
+
+        self::assertTrue($this->comparator->compareTables(
+            $table,
+            $this->schemaManager->introspectTable('rename_column'),
+        )->isEmpty());
+    }
+}

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -104,6 +104,36 @@ class TableTest extends TestCase
         self::assertCount(0, $table->getRenamedColumns());
     }
 
+    public function testRenameColumnInIndex(): void
+    {
+        $table = new Table('t');
+        $table->addColumn('c1', Types::INTEGER);
+        $table->addColumn('c2', Types::INTEGER);
+        $table->addIndex(['c1', 'c2'], 'idx_c1_c2');
+        $table->renameColumn('c1', 'c1a');
+        self::assertSame(['c1a', 'c2'], $table->getIndex('idx_c1_c2')->getColumns());
+    }
+
+    public function testRenameColumnInForeignKeyConstraint(): void
+    {
+        $table = new Table('t1');
+        $table->addColumn('c1', Types::INTEGER);
+        $table->addColumn('c2', Types::INTEGER);
+        $table->addForeignKeyConstraint('t2', ['c1', 'c2'], ['c1', 'c2'], [], 'fk_c1_c2');
+        $table->renameColumn('c2', 'c2a');
+        self::assertSame(['c1', 'c2a'], $table->getForeignKey('fk_c1_c2')->getLocalColumns());
+    }
+
+    public function testRenameColumnInUniqueConstraint(): void
+    {
+        $table = new Table('t');
+        $table->addColumn('c1', Types::INTEGER);
+        $table->addColumn('c2', Types::INTEGER);
+        $table->addUniqueConstraint(['c1', 'c2'], 'uq_c1_c2');
+        $table->renameColumn('c1', 'c1a');
+        self::assertSame(['c1a', 'c2'], $table->getUniqueConstraint('uq_c1_c2')->getColumns());
+    }
+
     public function testColumnsCaseInsensitive(): void
     {
         $table  = new Table('foo');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Without this feature, once a table column is renamed, the referencing indexes and constraints end up in an invalid state (see the newly added tests). To mitigate this issue, as part of renaming a column, a user would have to drop and re-create all affected indexes and constraints.

Databases (e.g. MySQL) normally handle renaming columns automatically, so I'm trying to implement the same experience in the DBAL. It is also a precondition for one of the next patches I have in progress which will improve the consistency of implicit indexes managed by the DBAL.