### PR TITLE
Fix max string length resolution in `AbstractPlatform::getEnumDeclaration()`

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -52,6 +52,7 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
+use function key;
 use function max;
 use function mb_strlen;
 use function preg_quote;
@@ -209,7 +210,11 @@ abstract class AbstractPlatform
             throw ColumnValuesRequired::new($this, 'ENUM');
         }
 
-        return $this->getStringTypeDeclarationSQL(['length' => max(...array_map(mb_strlen(...), $column['values']))]);
+        $length = count($column['values']) > 1
+            ? max(...array_map(mb_strlen(...), $column['values']))
+            : mb_strlen($column['values'][key($column['values'])]);
+
+        return $this->getStringTypeDeclarationSQL(['length' => $length]);
     }
 
     /**

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -694,4 +694,13 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci'),
         );
     }
+
+    /** @return array<string, array{array<string>, string}> */
+    public static function getEnumDeclarationSQLProvider(): array
+    {
+        return [
+            'single value' => [['foo'], "ENUM('foo')"],
+            'multiple values' => [['foo', 'bar1'], "ENUM('foo', 'bar1')"],
+        ];
+    }
 }

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -595,4 +595,13 @@ EOD;
             ['CHAR(12)', ['length' => 12, 'fixed' => true]],
         ];
     }
+
+    /** @return array<string, array{array<string>, string}> */
+    public static function getEnumDeclarationSQLProvider(): array
+    {
+        return [
+            'single value' => [['foo'], 'VARCHAR2(3)'],
+            'multiple values' => [['foo', 'bar1'], 'VARCHAR2(4)'],
+        ];
+    }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1124,4 +1124,13 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         self::assertEquals('DATETIMEOFFSET(6)', $this->platform->getDateTimeTzTypeDeclarationSQL([]));
     }
+
+    /** @return array<string, array{array<string>, string}> */
+    public static function getEnumDeclarationSQLProvider(): array
+    {
+        return [
+            'single value' => [['foo'], 'NVARCHAR(3)'],
+            'multiple values' => [['foo', 'bar1'], 'NVARCHAR(4)'],
+        ];
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

Fixes a situation where an enum type only contains 1 case. This results in passing only a single integer argument to the max() method, which is not valid and returns the error "max(): Argument 1 ($value) must be of type array, int given".
