### PR TITLE
Distinguish between Appveyor and github-action

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -124,4 +124,5 @@ test_script:
 
 after_test:
   - appveyor DownloadFile https://codecov.io/bash -FileName codecov.sh
-  - bash codecov.sh -f clover.xml
+  - SET upload_name=appveyor-%db%-%db_version%-%driver%-php-%php%
+  - bash codecov.sh -f clover.xml -n %upload_name%

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -679,5 +679,6 @@ jobs:
         with:
           directory: reports
           fail_ci_if_error: true
+          name: github-action
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Right now, the Codecov UI displays downloads in a confusing way: You get an "appveyor" header, and then 2 list items with links to appveyor, followed by one list item with a link to Github.

We didn't specify that appveyor name anywhere, maybe Codecov behaves differently on that platform. Let us see if specifying a name in the github action that uploads to Codecov allows to clarify things.

![Screenshot 2024-11-02 at 17-41-43 Codecov](https://github.com/user-attachments/assets/91fdb734-f834-4f58-b95a-b40ea6e2bf68)

:point_up: screenshot from https://app.codecov.io/github/doctrine/dbal/commit/976f3f374e25806542d789dba2f813db31274d40

The last link leads to https://github.com/doctrine/dbal/actions/runs/11615595861
