### PR TITLE
Remove deprecated

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `Table::removeForeignKey()` and `::removeUniqueConstraint()`
+
+The `Table::removeForeignKey()` and `::removeUniqueConstraint()` have been removed.
+
 ## BC BREAK: Removed `AbstractPlatform` constants
 
 The `CREATE_INDEXES` and `CREATE_FOREIGNKEYS` constants have been removed from the `AbstractPlatform` class.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractPlatform` constants
+
+The `CREATE_INDEXES` and `CREATE_FOREIGNKEYS` constants have been removed from the `AbstractPlatform` class.
+
 ## BC BREAK: Add `Result::getColumnName()`
 
 A new method `getColumnName()` has been added to the `Result` interface and must be implemented by

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,13 +55,6 @@
 
                 <!-- TODO for PHPUnit 11 -->
                 <referencedMethod name="PHPUnit\Framework\TestCase::iniSet"/>
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6560
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::removeForeignKey" />
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::removeUniqueConstraint" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -72,12 +72,6 @@ use function strtoupper;
  */
 abstract class AbstractPlatform
 {
-    /** @deprecated */
-    public const CREATE_INDEXES = 1;
-
-    /** @deprecated */
-    public const CREATE_FOREIGNKEYS = 2;
-
     /** @var string[]|null */
     protected ?array $doctrineTypeMapping = null;
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -437,22 +437,6 @@ class Table extends AbstractAsset
     }
 
     /**
-     * Removes the foreign key constraint with the given name.
-     *
-     * @deprecated Use {@link dropForeignKey()} instead.
-     */
-    public function removeForeignKey(string $name): void
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6560',
-            'Table::removeForeignKey() is deprecated. Use Table::removeForeignKey() instead.',
-        );
-
-        $this->dropForeignKey($name);
-    }
-
-    /**
      * Drops the foreign key constraint with the given name.
      */
     public function dropForeignKey(string $name): void
@@ -488,22 +472,6 @@ class Table extends AbstractAsset
         }
 
         return $this->uniqueConstraints[$name];
-    }
-
-    /**
-     * Removes the unique constraint with the given name.
-     *
-     * @deprecated Use {@link dropUniqueConstraint()} instead.
-     */
-    public function removeUniqueConstraint(string $name): void
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6560',
-            'Table::removeUniqueConstraint() is deprecated. Use Table::dropUniqueConstraint() instead.',
-        );
-
-        $this->dropUniqueConstraint($name);
     }
 
     /**

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -244,7 +244,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 
-    public function testTableRemoveForeignKey(): void
+    public function testTableDropForeignKey(): void
     {
         $tableForeign = new Table('bar');
         $tableForeign->addColumn('id', Types::INTEGER);

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -855,7 +855,7 @@ class TableTest extends TestCase
 
         $table->dropColumn($assetName);
         $table->dropIndex($assetName);
-        $table->removeForeignKey($assetName);
+        $table->dropForeignKey($assetName);
 
         self::assertFalse($table->hasColumn($assetName));
         self::assertFalse($table->hasColumn('foo'));
@@ -918,25 +918,25 @@ class TableTest extends TestCase
         self::assertSame($uniqueConstraints[1], $constraints['fk_d87f7e0cda12812744761484']);
     }
 
-    public function testRemoveUniqueConstraint(): void
+    public function testDropUniqueConstraint(): void
     {
         $table = new Table('foo');
         $table->addColumn('bar', Types::INTEGER);
         $table->addUniqueConstraint(['bar'], 'unique_constraint');
 
-        $table->removeUniqueConstraint('unique_constraint');
+        $table->dropUniqueConstraint('unique_constraint');
 
         self::assertFalse($table->hasUniqueConstraint('unique_constraint'));
     }
 
-    public function testRemoveUniqueConstraintUnknownNameThrowsException(): void
+    public function testDropUniqueConstraintUnknownNameThrowsException(): void
     {
         $this->expectException(SchemaException::class);
 
         $table = new Table('foo');
         $table->addColumn('bar', Types::INTEGER);
 
-        $table->removeUniqueConstraint('unique_constraint');
+        $table->dropUniqueConstraint('unique_constraint');
     }
 
     public function testDropColumnWithForeignKeyConstraint(): void


### PR DESCRIPTION
The removed constants and methods were deprecated in https://github.com/doctrine/dbal/pull/5423 and https://github.com/doctrine/dbal/pull/6560.