### PR TITLE
Deprecate AbstractPlatform::quoteIdentifier()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()`
+
+The `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()` methods have been deprecated.
+Use the corresponding `quoteSingleIdentifier()` method individually for each part of a qualified name instead.
+
 ## Deprecated dropping columns referenced by constraints
 
 Dropping columns that are referenced by constraints is deprecated. The constraints should be dropped first.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -74,6 +74,12 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::removeForeignKey" />
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::removeUniqueConstraint" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6590
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::quoteIdentifier" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -544,13 +544,32 @@ class Connection implements ServerVersionProvider
      * you SHOULD use them. In general, they end up causing way more
      * problems than they solve.
      *
+     * @deprecated Use {@link quoteSingleIdentifier()} individually for each part of a qualified name instead.
+     *
      * @param string $identifier The identifier to be quoted.
      *
      * @return string The quoted identifier.
      */
     public function quoteIdentifier(string $identifier): string
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6590',
+            'Use quoteSingleIdentifier() individually for each part of a qualified name instead.',
+            __METHOD__,
+        );
+
         return $this->getDatabasePlatform()->quoteIdentifier($identifier);
+    }
+
+    /**
+     * Quotes a string so that it can be safely used as an identifier in SQL.
+     *
+     * @throws Exception
+     */
+    public function quoteSingleIdentifier(string $identifier): string
+    {
+        return $this->getDatabasePlatform()->quoteSingleIdentifier($identifier);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -36,6 +36,7 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function addcslashes;
 use function array_map;
@@ -1190,12 +1191,21 @@ abstract class AbstractPlatform
      * you SHOULD use them. In general, they end up causing way more
      * problems than they solve.
      *
+     * @deprecated Use {@link quoteSingleIdentifier()} individually for each part of a qualified name instead.
+     *
      * @param string $identifier The identifier name to be quoted.
      *
      * @return string The quoted identifier string.
      */
     public function quoteIdentifier(string $identifier): string
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6590',
+            'Use quoteSingleIdentifier() individually for each part of a qualified name instead.',
+            __METHOD__,
+        );
+
         if (str_contains($identifier, '.')) {
             $parts = array_map($this->quoteSingleIdentifier(...), explode('.', $identifier));
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -525,7 +525,7 @@ class SQLServerPlatform extends AbstractPlatform
             );
         }
 
-        return 'DROP CONSTRAINT ' . $this->quoteIdentifier(
+        return 'DROP CONSTRAINT ' . $this->quoteSingleIdentifier(
             $column->getPlatformOption(self::OPTION_DEFAULT_CONSTRAINT_NAME),
         );
     }

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -131,7 +131,7 @@ abstract class AbstractAsset
         $keywords = $platform->getReservedKeywordsList();
         $parts    = explode('.', $this->getName());
         foreach ($parts as $k => $v) {
-            $parts[$k] = $this->_quoted || $keywords->isKeyword($v) ? $platform->quoteIdentifier($v) : $v;
+            $parts[$k] = $this->_quoted || $keywords->isKeyword($v) ? $platform->quoteSingleIdentifier($v) : $v;
         }
 
         return implode('.', $parts);

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -305,7 +305,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     private function getQuotedIdentifierName(string $identifier): string
     {
         if (preg_match('/[a-z]/', $identifier) === 1) {
-            return $this->platform->quoteIdentifier($identifier);
+            return $this->platform->quoteSingleIdentifier($identifier);
         }
 
         return $identifier;

--- a/tests/Functional/Platform/QuotingTest.php
+++ b/tests/Functional/Platform/QuotingTest.php
@@ -43,7 +43,7 @@ class QuotingTest extends FunctionalTestCase
         }
 
         $query = $platform->getDummySelectSQL(
-            'NULL AS ' . $platform->quoteIdentifier($identifier),
+            'NULL AS ' . $platform->quoteSingleIdentifier($identifier),
         );
 
         $row = $this->connection->fetchAssociative($query);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1316,8 +1316,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        $this->dropTableIfExists($platform->quoteIdentifier('user'));
-        $this->dropTableIfExists($platform->quoteIdentifier('group'));
+        $this->dropTableIfExists($platform->quoteSingleIdentifier('user'));
+        $this->dropTableIfExists($platform->quoteSingleIdentifier('group'));
 
         $schema = new Schema();
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -524,7 +524,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         ]);
 
         self::assertStringContainsString(
-            $this->platform->quoteIdentifier('select'),
+            $this->platform->quoteSingleIdentifier('select'),
             implode(';', $this->platform->getAlterTableSQL($tableDiff)),
         );
     }

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -276,7 +276,7 @@ class TestUtil
                         $value = $platform->quoteStringLiteral($value);
                     }
 
-                    return $value . ' ' . $platform->quoteIdentifier($column);
+                    return $value . ' ' . $platform->quoteSingleIdentifier($column);
                 }, $columnNames, $row)),
             );
         }, $rows));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The current implementation of the method is pointless. The purpose of quoting an identifier in SQL is to prevent its value from being interpreted as SQL and retain its literal value. Thus, identifiers containing special characters (e.g. dots or spaces) need to be quoted.

An SQL name consists of one (unqualified) or more (qualified) identifiers separated with a dot, where each of them may be quoted individually.

The current implementation _parses_ the provided identifier as a _qualified name_ before quoting. So if the provided value contains a dot, it will be interpreted as part of the SQL syntax. This is the opposite of what quoting an identifier is for.

### Method naming issues

A method named `quoteIdentifier()` should do exactly what `quoteSingleIdentifier()` does. The "single" qualifier in `quoteSingleIdentifier()` is redundant. Multiple identifiers cannot be parsed or quoted together. Unfortunately, we cannot just rename `quoteSingleIdentifier()` to `quoteIdentifier()` in 5.0.

Another approach would be to introduce `enquoteIdentifier()` similar to [JDBC](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Statement.html). This way, we could deprecate both of the existing methods in favor of this one. However, it would be inconsistent in naming with the rest of the "quote" methods.

Given that there's no obvious better naming, I'm leaving it as is for now and I'm open to ideas.

### Changes in the tests

In the modified tests, `quoteIdentifier()` was used where `quoteSingleIdentifier()` should have been used (quoting an identifier, not a qualified name). Quite likely, such an issue exists in the code of the applications that depend on the DBAL. These test modifications are acceptable as they don't compensate for any breaking changes. On the contrary, they improve the documentation aspect of the tests.