### PR TITLE
Deprecate relying on the current implementation of the database object name parser

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,28 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated relying on the current implementation of the database object name parser
+
+The current object name parser implicitly quotes identifiers in the following cases:
+
+1. If the object name is a reserved keyword (e.g., `select`).
+2. If an unquoted identifier is preceded by a quoted identifier (e.g., `"inventory".product`).
+
+As a result, the original case of such identifiers is preserved on platforms that respect the SQL-92 standard (i.e.,
+identifiers are not upper-cased on Oracle and IBM DB2, and not lower-cased on PostgreSQL). This behavior is deprecated.
+
+If preserving the original case of an identifier is required, please explicitly quote it (e.g., `select` → `"select"`).
+
+Additionally, the current parser exhibits the following defects:
+
+1. It ignores a missing closing quote in a quoted identifier (e.g., `"inventory`).
+2. It allows names with more than two identifiers (e.g., `warehouse.inventory.product`) but only uses the first two,
+   ignoring the remaining ones.
+3. If a quoted identifier contains a dot, it incorrectly treats the part before the dot as a qualifier, despite the
+   identifier being quoted.
+
+Relying on the above behaviors is deprecated.
+
 ## Deprecated `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()`
 
 The `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()` methods have been deprecated.

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -875,4 +875,9 @@ SQL;
 
         return $sql . ' WHERE ' . implode(' AND ', $conditions);
     }
+
+    public function normalizeUnquotedIdentifier(string $identifier): string
+    {
+        return $identifier;
+    }
 }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2294,6 +2294,18 @@ abstract class AbstractPlatform
     }
 
     /**
+     * Changes the case of unquoted identifier in the same way as the given platform would change it if it was specified
+     * in an SQL statement.
+     *
+     * Even though the default behavior is not the most common across supported platforms, it is part of the SQL92
+     * standard.
+     */
+    public function normalizeUnquotedIdentifier(string $identifier): string
+    {
+        return strtoupper($identifier);
+    }
+
+    /**
      * Creates the schema manager that can be used to inspect and change the underlying
      * database schema according to the dialect of the platform.
      */

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -786,4 +786,9 @@ class PostgreSQLPlatform extends AbstractPlatform
     {
         return new PostgreSQLSchemaManager($connection, $this);
     }
+
+    public function normalizeUnquotedIdentifier(string $identifier): string
+    {
+        return strtolower($identifier);
+    }
 }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1241,4 +1241,9 @@ class SQLServerPlatform extends AbstractPlatform
     {
         return new SQLServerSchemaManager($connection, $this);
     }
+
+    public function normalizeUnquotedIdentifier(string $identifier): string
+    {
+        return $identifier;
+    }
 }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -973,4 +973,9 @@ class SQLitePlatform extends AbstractPlatform
     {
         return $subQuery;
     }
+
+    public function normalizeUnquotedIdentifier(string $identifier): string
+    {
+        return $identifier;
+    }
 }

--- a/src/Schema/Name/Parser.php
+++ b/src/Schema/Name/Parser.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedDot;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedNextIdentifier;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\UnableToParseIdentifier;
+use Doctrine\DBAL\Schema\Name\Parser\Identifier;
+
+use function assert;
+use function preg_match;
+use function str_replace;
+use function strlen;
+
+/**
+ * Parses a qualified or unqualified SQL-like name.
+ *
+ * A name can be either unqualified or qualified:
+ * - An unqualified name consists of a single identifier.
+ * - A qualified name is a sequence of two or more identifiers separated by dots.
+ *
+ * An identifier can be quoted or unquoted:
+ * - A quoted identifier is enclosed in double quotes ("), backticks (`), or square brackets ([]).
+ *   The closing quote character can be escaped by doubling it.
+ * - An unquoted identifier may contain any character except whitespace, dots, or any of the quote characters.
+ *
+ * Differences from SQL:
+ * 1. Identifiers that are reserved keywords or start with a digit do not need to be quoted.
+ * 2. Whitespace is not allowed between identifiers.
+ *
+ * @internal
+ */
+final class Parser
+{
+    private const IDENTIFIER_PATTERN = <<<'PATTERN'
+        /\G
+        (?:
+            "(?<ansi>[^"]*(?:""[^"]*)*)"         # ANSI SQL double-quoted
+          | `(?<mysql>[^`]*(?:``[^`]*)*)`        # MySQL-style backtick-quoted
+          | \[(?<sqlserver>[^]]*(?:]][^]]*)*)]   # SQL Server-style square-bracket-quoted
+          | (?<unquoted>[^\s."`\[\]]+)           # Unquoted
+        )
+        /x
+    PATTERN;
+
+    /**
+     * @return list<Identifier>
+     *
+     * @throws Exception
+     */
+    public function parse(string $input): array
+    {
+        if ($input === '') {
+            return [];
+        }
+
+        $offset      = 0;
+        $identifiers = [];
+        $length      = strlen($input);
+
+        while (true) {
+            if ($offset >= $length) {
+                throw ExpectedNextIdentifier::new();
+            }
+
+            if (preg_match(self::IDENTIFIER_PATTERN, $input, $matches, 0, $offset) === 0) {
+                throw UnableToParseIdentifier::new($offset);
+            }
+
+            if (isset($matches['ansi']) && strlen($matches['ansi']) > 0) {
+                $identifier = Identifier::quoted(str_replace('""', '"', $matches['ansi']));
+            } elseif (isset($matches['mysql']) && strlen($matches['mysql']) > 0) {
+                $identifier = Identifier::quoted(str_replace('``', '`', $matches['mysql']));
+            } elseif (isset($matches['sqlserver']) && strlen($matches['sqlserver']) > 0) {
+                $identifier = Identifier::quoted(str_replace(']]', ']', $matches['sqlserver']));
+            } else {
+                assert(isset($matches['unquoted']) && strlen($matches['unquoted']) > 0);
+                $identifier = Identifier::unquoted($matches['unquoted']);
+            }
+
+            $identifiers[] = $identifier;
+
+            $offset += strlen($matches[0]);
+
+            if ($offset >= $length) {
+                break;
+            }
+
+            $character = $input[$offset];
+
+            if ($character !== '.') {
+                throw ExpectedDot::new($offset, $character);
+            }
+
+            $offset++;
+        }
+
+        return $identifiers;
+    }
+}

--- a/src/Schema/Name/Parser/Exception.php
+++ b/src/Schema/Name/Parser/Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser;
+
+use Throwable;
+
+interface Exception extends Throwable
+{
+}

--- a/src/Schema/Name/Parser/Exception/ExpectedDot.php
+++ b/src/Schema/Name/Parser/Exception/ExpectedDot.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser\Exception;
+
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+class ExpectedDot extends LogicException implements Exception
+{
+    public static function new(int $position, string $got): self
+    {
+        return new self(sprintf('Expected dot at position %d, got "%s".', $position, $got));
+    }
+}

--- a/src/Schema/Name/Parser/Exception/ExpectedNextIdentifier.php
+++ b/src/Schema/Name/Parser/Exception/ExpectedNextIdentifier.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser\Exception;
+
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
+use LogicException;
+
+/** @internal */
+class ExpectedNextIdentifier extends LogicException implements Exception
+{
+    public static function new(): self
+    {
+        return new self('Unexpected end of input. Next identifier expected.');
+    }
+}

--- a/src/Schema/Name/Parser/Exception/UnableToParseIdentifier.php
+++ b/src/Schema/Name/Parser/Exception/UnableToParseIdentifier.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser\Exception;
+
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+class UnableToParseIdentifier extends LogicException implements Exception
+{
+    public static function new(int $offset): self
+    {
+        return new self(sprintf('Unable to parse identifier at offset %d.', $offset));
+    }
+}

--- a/src/Schema/Name/Parser/Identifier.php
+++ b/src/Schema/Name/Parser/Identifier.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser;
+
+/**
+ * Represents an SQL identifier.
+ *
+ * @internal
+ */
+final class Identifier
+{
+    private function __construct(
+        private readonly string $value,
+        private readonly bool $isQuoted,
+    ) {
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function isQuoted(): bool
+    {
+        return $this->isQuoted;
+    }
+
+    /**
+     * Creates a quoted identifier.
+     */
+    public static function quoted(string $value): self
+    {
+        return new self($value, true);
+    }
+
+    /**
+     * Creates an unquoted identifier.
+     */
+    public static function unquoted(string $value): self
+    {
+        return new self($value, false);
+    }
+}

--- a/tests/Schema/AbstractAssetTest.php
+++ b/tests/Schema/AbstractAssetTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Identifier;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AbstractAssetTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    #[DataProvider('nameParsingDeprecationProvider')]
+    public function testNameParsingDeprecation(string $name, AbstractPlatform $platform): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
+
+        $identifier = new Identifier($name);
+        $identifier->getQuotedName($platform);
+    }
+
+    /** @return iterable<array{string, AbstractPlatform}> */
+    public static function nameParsingDeprecationProvider(): iterable
+    {
+        return [
+            // unquoted keywords not in normal case
+            ['select', new OraclePlatform()],
+            ['SELECT', new PostgreSQLPlatform()],
+
+            // unquoted name not in normal case qualified by quoted name
+            ['"_".id', new OraclePlatform()],
+            ['"_".ID', new PostgreSQLPlatform()],
+
+            // name with more than one qualifier
+            ['i.am.overqualified', new MySQLPlatform()],
+
+            // parse error
+            ['table.', new MySQLPlatform()],
+            ['"table', new MySQLPlatform()],
+            ['table"', new MySQLPlatform()],
+            [' ', new MySQLPlatform()],
+
+            // incompatible parser behavior
+            ['"example.com"', new MySQLPlatform()],
+        ];
+    }
+
+    #[DataProvider('noNameParsingDeprecationProvider')]
+    public function testNoNameParsingDeprecation(string $name, AbstractPlatform $platform): void
+    {
+        $identifier = new Identifier($name);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/XXXX');
+        $identifier->getQuotedName($platform);
+    }
+
+    /** @return iterable<array{string, AbstractPlatform}> */
+    public static function noNameParsingDeprecationProvider(): iterable
+    {
+        return [
+            // empty name
+            ['', new MySQLPlatform()],
+
+            // name with one qualifier
+            ['schema.table', new MySQLPlatform()],
+
+            // quoted keywords
+            ['"select"', new OraclePlatform()],
+            ['"SELECT"', new PostgreSQLPlatform()],
+
+            // unquoted keywords in normal case
+            ['SELECT', new OraclePlatform()],
+            ['select', new PostgreSQLPlatform()],
+
+            // unquoted keywords in any case on a platform that does not force a case
+            ['SELECT', new MySQLPlatform()],
+            ['select', new MySQLPlatform()],
+
+            // non-keywords in any case
+            ['id', new OraclePlatform()],
+            ['ID', new OraclePlatform()],
+            ['id', new PostgreSQLPlatform()],
+            ['ID', new PostgreSQLPlatform()],
+        ];
+    }
+}

--- a/tests/Schema/Name/ParserTest.php
+++ b/tests/Schema/Name/ParserTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Name;
+
+use Doctrine\DBAL\Schema\Name\Parser;
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedDot;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedNextIdentifier;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\UnableToParseIdentifier;
+use Doctrine\DBAL\Schema\Name\Parser\Identifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ParserTest extends TestCase
+{
+    private Parser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new Parser();
+    }
+
+    /**
+     * @param list<Identifier> $expected
+     *
+     * @throws Exception
+     */
+    #[DataProvider('validInputProvider')]
+    public function testValidInput(string $input, array $expected): void
+    {
+        $name = $this->parser->parse($input);
+        self::assertEquals($expected, $name);
+    }
+
+    /** @return iterable<array{string, list<Identifier>}> */
+    public static function validInputProvider(): iterable
+    {
+        yield ['', []];
+        yield ['table', [Identifier::unquoted('table')]];
+        yield ['schema.table', [Identifier::unquoted('schema'), Identifier::unquoted('table')]];
+
+        yield ['"example.com"', [Identifier::quoted('example.com')]];
+        yield ['`example.com`', [Identifier::quoted('example.com')]];
+        yield ['[example.com]', [Identifier::quoted('example.com')]];
+
+        yield [
+            'a."b".c.`d`.e.[f].g',
+            [
+                Identifier::unquoted('a'),
+                Identifier::quoted('b'),
+                Identifier::unquoted('c'),
+                Identifier::quoted('d'),
+                Identifier::unquoted('e'),
+                Identifier::quoted('f'),
+                Identifier::unquoted('g'),
+            ],
+        ];
+
+        yield ['"schema"."table"', [Identifier::quoted('schema'), Identifier::quoted('table')]];
+        yield ['`schema`.`table`', [Identifier::quoted('schema'), Identifier::quoted('table')]];
+        yield ['[schema].[table]', [Identifier::quoted('schema'), Identifier::quoted('table')]];
+
+        yield [
+            'schema."example.com"',
+            [
+                Identifier::unquoted('schema'),
+                Identifier::quoted('example.com'),
+            ],
+        ];
+
+        yield [
+            '"a""b".`c``d`.[e]]f]',
+            [
+                Identifier::quoted('a"b'),
+                Identifier::quoted('c`d'),
+                Identifier::quoted('e]f'),
+            ],
+        ];
+
+        yield [
+            'schéma."übermäßigkeit".`àçcênt`.[éxtrême].çhâràctér',
+            [
+                Identifier::unquoted('schéma'),
+                Identifier::quoted('übermäßigkeit'),
+                Identifier::quoted('àçcênt'),
+                Identifier::quoted('éxtrême'),
+                Identifier::unquoted('çhâràctér'),
+            ],
+        ];
+
+        yield [
+            '" spaced identifier ".more',
+            [
+                Identifier::quoted(' spaced identifier '),
+                Identifier::unquoted('more'),
+            ],
+        ];
+
+        yield [
+            '0."0".`0`.[0]',
+            [
+                Identifier::unquoted('0'),
+                Identifier::quoted('0'),
+                Identifier::quoted('0'),
+                Identifier::quoted('0'),
+            ],
+        ];
+    }
+
+    /**
+     * @param class-string<Exception> $expectedException
+     *
+     * @throws Exception
+     */
+    #[DataProvider('invalidInputProvider')]
+    public function testInvalidInput(string $input, string $expectedException): void
+    {
+        $this->expectException($expectedException);
+        $this->parser->parse($input);
+    }
+
+    /** @return iterable<array{string, class-string<Exception>}> */
+    public static function invalidInputProvider(): iterable
+    {
+        yield ['"example.com', UnableToParseIdentifier::class];
+        yield ['`example.com', UnableToParseIdentifier::class];
+        yield ['[example.com', UnableToParseIdentifier::class];
+        yield ['schema."example.com', UnableToParseIdentifier::class];
+        yield ['schema.[example.com', UnableToParseIdentifier::class];
+        yield ['schema.`example.com', UnableToParseIdentifier::class];
+
+        yield ['schema.', ExpectedNextIdentifier::class];
+        yield ['schema..', UnableToParseIdentifier::class];
+        yield ['.table', UnableToParseIdentifier::class];
+
+        yield ['schema.table name', ExpectedDot::class];
+        yield ['"schema.[example.com]', UnableToParseIdentifier::class];
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Currently, when building DDL, the DBAL quotes only the identifies that are explicitly quoted or are reserved keywords. The reason for not quoting all of them is that the databases that respect the SQL-92 standard normalize the case of unquoted identifiers but preserve the case of the quoted ones. If the DBAL quoted all identifiers, then an object containing lower-case letters in its name would have to be referenced as quoted in SQL (e.g, `"id"`) on Oracle and IBM DB2. Similarly, a column containing upper-case letters would have to be quoted on PostgreSQL.

The current design has the following major downsides:
1. The need to maintain lists of reserved keywords for supported platforms.
2. Inconsistency of the resulting object names on Oracle and IBM DB2 depending on whether the name is a reserved keyword. For instance, an unquoted column named "id" will be created in the database as upper-case `ID` but unquoted (and implicitly quoted) "select" will be created as lower-case `select`.
3. Lack of auto-quoting the names that aren't keywords but need to be quoted (e.g. the ones that begin with a digit).
4. Potential security issues.

Additionally, the current object name parser is rudimentary and exposes various issue (see https://github.com/doctrine/dbal/issues/4357 for examples).

While the solution proposed in https://github.com/doctrine/dbal/issues/4772 is hard to pull off at once, this change should be a manageable first step. The implementation is drafted in https://github.com/doctrine/dbal/pull/6589.

The logic is the following:
1. Parse the name according to simplified SQL syntax (see the details in the parser's PHPDoc).
2. Normalize unquoted identifiers according to the rules of the destination database platforms.
5. Consistently quote _all_ identifiers. At this point, knowing whether the identifier is a reserved keyword is unnecessary.

The upgrade path:
1. Compare the results of parsing the name using the current and the new implementations.
2. Trigger a deprecation notice in case of mismatch. Besides incorrect parsing of quoted identifiers containing dots, all other deprecations should be possible to address by properly formatting the object name.

The overhead of using two parsers should be insignificant since schema management is usually not a hot path.