### PR TITLE
Added support to override the protocol used when connecting to Oracle.

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -324,6 +324,7 @@ pdo_oci / oci8
 -  ``driverOptions`` (array):
     -  ``exclusive`` (boolean): Once specified for an ``oci8`` connection, forces the driver to always establish
        a new connection instead of reusing an existing one from the connection pool.
+    -  ``protocol`` (string): The protocol used to connect to Oracle (default TCP, Autonomous tends to be TCPS). See `docs.oracle.com/en/enterprise-manager/cloud-control/enterprise-manager-cloud-control/13.4/emsec/secured-communication-tcps-access-databases.html <https://docs.oracle.com/en/enterprise-manager/cloud-control/enterprise-manager-cloud-control/13.4/emsec/secured-communication-tcps-access-databases.html>`_.
 
 pdo_sqlsrv / sqlsrv
 ^^^^^^^^^^^^^^^^^^^

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -74,7 +74,7 @@ final class EasyConnectString
         return self::fromArray([
             'DESCRIPTION' => [
                 'ADDRESS' => [
-                    'PROTOCOL' => 'TCP',
+                    'PROTOCOL' => $params['driverOptions']['protocol'] ?? 'TCP',
                     'HOST' => $params['host'],
                     'PORT' => $params['port'] ?? 1521,
                 ],

--- a/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -57,6 +57,18 @@ class EasyConnectStringTest extends TestCase
                 '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=41521))'
                     . '(CONNECT_DATA=(SID=XE)(INSTANCE_NAME=SALES)(SERVER=POOLED)))',
             ],
+            'tcps-params' => [
+                [
+                    'host' => 'localhost',
+                    'port' => 41521,
+                    'dbname' => 'XE',
+                    'instancename' => 'SALES',
+                    'pooled' => true,
+                    'driverOptions' => ['protocol' => 'TCPS'],
+                ],
+                '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=localhost)(PORT=41521))'
+                . '(CONNECT_DATA=(SID=XE)(INSTANCE_NAME=SALES)(SERVER=POOLED)))',
+            ],
         ];
     }
 }


### PR DESCRIPTION
TCPS is required to be passed in the EasyConnectString to connect to Autonomous databases. Tested against an Oracle Cloud instance using TLS authentication.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature/improvement

Fixes #6593.

#### Summary

Attempted to connect to an autonomous database within Oracle OCI Cloud. Identified the protocol needs to be changed within the connection string to match their requirements. Added a parameter to permit this override. 

TCP remains the default, can be overridden by TCPS and TCPS only. 

