### PR TITLE
Remove AbstractPlatform::quoteIdentifier()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()`
+
+The `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()` methods have been removed.
+
 ## BC BREAK: Removed `Table::removeForeignKey()` and `::removeUniqueConstraint()`
 
 The `Table::removeForeignKey()` and `::removeUniqueConstraint()` have been removed.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,12 +55,6 @@
 
                 <!-- TODO for PHPUnit 11 -->
                 <referencedMethod name="PHPUnit\Framework\TestCase::iniSet"/>
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6590
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::quoteIdentifier" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -535,34 +535,6 @@ class Connection implements ServerVersionProvider
     }
 
     /**
-     * Quotes a string so it can be safely used as a table or column name, even if
-     * it is a reserved name.
-     *
-     * Delimiting style depends on the underlying database platform that is being used.
-     *
-     * NOTE: Just because you CAN use quoted identifiers does not mean
-     * you SHOULD use them. In general, they end up causing way more
-     * problems than they solve.
-     *
-     * @deprecated Use {@link quoteSingleIdentifier()} individually for each part of a qualified name instead.
-     *
-     * @param string $identifier The identifier to be quoted.
-     *
-     * @return string The quoted identifier.
-     */
-    public function quoteIdentifier(string $identifier): string
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6590',
-            'Use quoteSingleIdentifier() individually for each part of a qualified name instead.',
-            __METHOD__,
-        );
-
-        return $this->getDatabasePlatform()->quoteIdentifier($identifier);
-    }
-
-    /**
      * Quotes a string so that it can be safely used as an identifier in SQL.
      *
      * @throws Exception

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -59,9 +59,9 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return $query;
     }
 
-    public function quoteSingleIdentifier(string $str): string
+    public function quoteSingleIdentifier(string $identifier): string
     {
-        return '`' . str_replace('`', '``', $str) . '`';
+        return '`' . str_replace('`', '``', $identifier) . '`';
     }
 
     public function getRegexpExpression(): string

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -36,7 +36,6 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function addcslashes;
 use function array_map;
@@ -45,7 +44,6 @@ use function array_unique;
 use function array_values;
 use function assert;
 use function count;
-use function explode;
 use function implode;
 use function in_array;
 use function is_array;
@@ -58,7 +56,6 @@ use function mb_strlen;
 use function preg_quote;
 use function preg_replace;
 use function sprintf;
-use function str_contains;
 use function str_replace;
 use function strlen;
 use function strtolower;
@@ -1174,39 +1171,6 @@ abstract class AbstractPlatform
         }
 
         return 'DROP SCHEMA ' . $schemaName;
-    }
-
-    /**
-     * Quotes a string so that it can be safely used as a table or column name,
-     * even if it is a reserved word of the platform. This also detects identifier
-     * chains separated by dot and quotes them independently.
-     *
-     * NOTE: Just because you CAN use quoted identifiers doesn't mean
-     * you SHOULD use them. In general, they end up causing way more
-     * problems than they solve.
-     *
-     * @deprecated Use {@link quoteSingleIdentifier()} individually for each part of a qualified name instead.
-     *
-     * @param string $identifier The identifier name to be quoted.
-     *
-     * @return string The quoted identifier string.
-     */
-    public function quoteIdentifier(string $identifier): string
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6590',
-            'Use quoteSingleIdentifier() individually for each part of a qualified name instead.',
-            __METHOD__,
-        );
-
-        if (str_contains($identifier, '.')) {
-            $parts = array_map($this->quoteSingleIdentifier(...), explode('.', $identifier));
-
-            return implode('.', $parts);
-        }
-
-        return $this->quoteSingleIdentifier($identifier);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1210,15 +1210,11 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Quotes a single identifier (no dot chain separation).
-     *
-     * @param string $str The identifier name to be quoted.
-     *
-     * @return string The quoted identifier string.
+     * Quotes a string so that it can be safely used as an identifier in SQL.
      */
-    public function quoteSingleIdentifier(string $str): string
+    public function quoteSingleIdentifier(string $identifier): string
     {
-        return '"' . str_replace('"', '""', $str) . '"';
+        return '"' . str_replace('"', '""', $identifier) . '"';
     }
 
     /**

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1132,9 +1132,9 @@ class SQLServerPlatform extends AbstractPlatform
         return new SQLServerKeywords();
     }
 
-    public function quoteSingleIdentifier(string $str): string
+    public function quoteSingleIdentifier(string $identifier): string
     {
-        return '[' . str_replace(']', ']]', $str) . ']';
+        return '[' . str_replace(']', ']]', $identifier) . ']';
     }
 
     public function getTruncateTableSQL(string $tableName, bool $cascade = false): string

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -681,11 +681,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testQuoteIdentifier(): void
-    {
-        self::assertEquals('`test`.`test`', $this->platform->quoteIdentifier('test.test'));
-    }
-
     protected function createComparator(): Comparator
     {
         return new MySQL\Comparator(

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -44,11 +44,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         return new Comparator($this->platform, new ComparatorConfig());
     }
 
-    public function testQuoteIdentifier(): void
-    {
-        self::assertEquals('"test"."test"', $this->platform->quoteIdentifier('test.test'));
-    }
-
     #[DataProvider('getReturnsForeignKeyReferentialActionSQL')]
     public function testReturnsForeignKeyReferentialActionSQL(string $action, string $expectedSQL): void
     {

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -553,11 +553,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testQuoteIdentifier(): void
-    {
-        self::assertEquals('[test].[test]', $this->platform->quoteIdentifier('test.test'));
-    }
-
     public function testCreateClusteredIndex(): void
     {
         $idx = new Index('idx', ['id']);


### PR DESCRIPTION
The methods being removed were deprecated in https://github.com/doctrine/dbal/pull/6590.