### PR TITLE
Use exception in OCI8 driver, instead of relying on assert

### DIFF
--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -47,15 +47,21 @@ final class Connection implements ConnectionInterface
         return $matches[1];
     }
 
-    /** @throws Parser\Exception */
+    /**
+     * @throws Parser\Exception
+     * @throws Error
+     */
     public function prepare(string $sql): Statement
     {
         $visitor = new ConvertPositionalToNamedPlaceholders();
 
         $this->parser->parse($sql, $visitor);
 
-        $statement = oci_parse($this->connection, $visitor->getSQL());
-        assert(is_resource($statement));
+        $statement = @oci_parse($this->connection, $visitor->getSQL());
+
+        if (! is_resource($statement)) {
+            throw Error::new($this->connection);
+        }
 
         return new Statement($this->connection, $statement, $visitor->getParameterMap(), $this->executionMode);
     }

--- a/tests/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Functional/Driver/OCI8/ConnectionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\OCI8;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Throwable;
+
+class ConnectionTest extends FunctionalTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (TestUtil::isDriverOneOf('oci8')) {
+            return;
+        }
+
+        self::markTestSkipped('This test requires the oci8 driver.');
+    }
+
+    public function testPrepareThrowsErrorOnConnectionLost(): void
+    {
+        $this->markConnectionNotReusable();
+        $this->killCurrentSession();
+
+        $this->expectException(DriverException::class);
+
+        $this->connection->prepare('SELECT * FROM 1');
+    }
+
+    /**
+     * Kill the current session, by using another connection
+     * Oracle doesn't allow you to terminate the current session, so we use a second connection
+     */
+    private function killCurrentSession(): void
+    {
+        $row = $this->connection->fetchNumeric(
+            <<<'SQL'
+SELECT SID, SERIAL#
+FROM V$SESSION
+WHERE AUDSID = USERENV('SESSIONID')
+SQL,
+        );
+
+        self::assertNotFalse($row);
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
+        [$sid, $serialNumber] = $row;
+
+        self::assertNotNull($sid, 'SID is missing.');
+        self::assertNotNull($serialNumber, 'Serial number is missing.');
+
+        $params                               = TestUtil::getConnectionParams();
+        $params['driverOptions']['exclusive'] = true;
+        $secondConnection                     = DriverManager::getConnection($params);
+
+        $sessionParam = $this->connection->quote($sid . ', ' . $serialNumber);
+        $secondConnection->executeStatement('ALTER SYSTEM DISCONNECT SESSION ' . $sessionParam . ' IMMEDIATE');
+
+        // Ensure OCI driver is aware of connection state change by executing any statement
+        try {
+            $this->connection->executeStatement('INVALID SQL');
+        } catch (Throwable) {
+        }
+    }
+}


### PR DESCRIPTION
Fixes a bug where disabled asserts in production left oci_parse() errors unchecked. Now uses explicit checks and exceptions

Fixes #6595

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6595 

#### Summary

Fixes a bug where disabled asserts in production left oci_parse()
errors unchecked. Now uses explicit checks and exceptions
