### PR TITLE
fix: dont expand query on regular named arguments

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1950,10 +1950,6 @@ class Connection
      */
     private function needsArrayParameterConversion(array $params, array $types): bool
     {
-        if (is_string(key($params))) {
-            return true;
-        }
-
         foreach ($types as $type) {
             if (
                 $type === ArrayParameterType::INTEGER


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The SQLParser is always a bottleneck in Shopware Projects. I am optimizing it by preparing our queries so they do not use ArrayParameterType. While doing that, I discovered that it does that when any named parameter is set. Which is not necessary on MySQL. IDK about other.

Here the diff for our queries: (removing arrayparameters completely will remove the ~200ms on any req)
<img width="632" alt="image" src="https://github.com/user-attachments/assets/387756ed-ac05-46af-96af-c5d1f4e16c02">
