### PR TITLE
Fix dropping the PK on a PostgreSQL table with quoted name

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -29,7 +29,9 @@ use function is_numeric;
 use function is_string;
 use function sprintf;
 use function str_contains;
+use function str_ends_with;
 use function strtolower;
+use function substr;
 use function trim;
 
 /**
@@ -363,7 +365,11 @@ class PostgreSQLPlatform extends AbstractPlatform
     public function getDropIndexSQL(string $name, string $table): string
     {
         if ($name === '"primary"') {
-            $constraintName = $table . '_pkey';
+            if (str_ends_with($table, '"')) {
+                $constraintName = substr($table, 0, -1) . '_pkey"';
+            } else {
+                $constraintName = $table . '_pkey';
+            }
 
             return $this->getDropConstraintSQL($constraintName, $table);
         }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -458,9 +458,11 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertEquals($expectedSql, $sql);
     }
 
-    public function testDroppingPrimaryKey(): void
+    /** @param list<string> $expectedSql */
+    #[DataProvider('dropPrimaryKeyProvider')]
+    public function testDroppingPrimaryKey(string $tableName, array $expectedSql): void
     {
-        $oldTable = new Table('mytable');
+        $oldTable = new Table($tableName);
         $oldTable->addColumn('id', 'integer');
         $oldTable->setPrimaryKey(['id']);
 
@@ -472,9 +474,16 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 
         $sql = $this->platform->getAlterTableSQL($diff);
 
-        $expectedSql = ['ALTER TABLE mytable DROP CONSTRAINT mytable_pkey'];
-
         self::assertEquals($expectedSql, $sql);
+    }
+
+    /** @return iterable<array{string,list<string>}> */
+    public static function dropPrimaryKeyProvider(): iterable
+    {
+        return [
+            ['test', ['ALTER TABLE test DROP CONSTRAINT test_pkey']],
+            ['"test"', ['ALTER TABLE "test" DROP CONSTRAINT "test_pkey"']],
+        ];
     }
 
     #[DataProvider('dataCreateSequenceWithCache')]


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

The issue was discovered during the work on https://github.com/doctrine/dbal/pull/6589.

If a table name passed to `PostgreSQLPlatform#getDropIndexSQL()` is quoted, it will generate invalid SQL (see the test).

The fix is a quite ugly as the code parses the provided string. This is inherent to the current platform and schema management API design where `string $name` can contain virtually anything (quoted or unquoted, qualified or unqualified name) and is meant to be used to in _concatenation_ with other SQL fragments, _not parsed_. We will address this design issue later by making object names value objects. 