### PR TITLE
Fix parsing quoted table name on SQLite

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -508,9 +508,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
 
     private function parseColumnCollationFromSQL(string $column, string $sql): ?string
     {
-        $pattern = '{(?:\W' . preg_quote($column) . '\W|\W'
-            . preg_quote($this->_platform->quoteSingleIdentifier($column))
-            . '\W)[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}is';
+        $pattern = '{' . $this->buildIdentifierPattern($column)
+            . '[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}is';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
             return null;
@@ -522,9 +521,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
     private function parseTableCommentFromSQL(string $table, string $sql): ?string
     {
         $pattern = '/\s* # Allow whitespace characters at start of line
-CREATE\sTABLE # Match "CREATE TABLE"
-(?:\W"' . preg_quote($this->_platform->quoteSingleIdentifier($table), '/') . '"\W|\W' . preg_quote($table, '/')
-            . '\W) # Match table name (quoted and unquoted)
+CREATE\sTABLE' . $this->buildIdentifierPattern($table) . '
 ( # Start capture
    (?:\s*--[^\n]*\n?)+ # Capture anything that starts with whitespaces followed by -- until the end of the line(s)
 )/ix';
@@ -540,8 +537,8 @@ CREATE\sTABLE # Match "CREATE TABLE"
 
     private function parseColumnCommentFromSQL(string $column, string $sql): ?string
     {
-        $pattern = '{[\s(,](?:\W' . preg_quote($this->_platform->quoteSingleIdentifier($column))
-            . '\W|\W' . preg_quote($column) . '\W)(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
+        $pattern = '{[\s(,]' . $this->buildIdentifierPattern($column)
+            . '(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
             return null;
@@ -550,6 +547,22 @@ CREATE\sTABLE # Match "CREATE TABLE"
         $comment = preg_replace('{^\s*--}m', '', rtrim($match[1], "\n"));
 
         return $comment === '' ? null : $comment;
+    }
+
+    /**
+     * Returns a regular expression pattern that matches the given unquoted or quoted identifier.
+     */
+    private function buildIdentifierPattern(string $identifier): string
+    {
+        return '(?:' . implode('|', array_map(
+            static function (string $sql): string {
+                return '\W' . preg_quote($sql, '/') . '\W';
+            },
+            [
+                $identifier,
+                $this->_platform->quoteSingleIdentifier($identifier),
+            ],
+        )) . ')';
     }
 
     /** @throws Exception */

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -397,4 +397,25 @@ SQL;
             $createTableTrackSql,
         );
     }
+
+    /**
+     * This test duplicates {@see parent::testCommentInTable()} with the only difference that the name of the table
+     * being created is quoted. It is only meant to cover the logic of parsing the SQLite CREATE TABLE statement
+     * when the table name is quoted.
+     *
+     * Running the same test for all platforms, on the one hand, won't produce additional coverage, and on the other,
+     * is not feasible due to the differences in case sensitivity depending on whether the name is quoted.
+     *
+     * Once all identifiers are quoted by default, this test can be removed.
+     */
+    public function testCommentInQuotedTable(): void
+    {
+        $table = new Table('"table_with_comment"');
+        $table->addColumn('id', Types::INTEGER);
+        $table->setComment('This is a comment');
+        $this->dropAndCreateTable($table);
+
+        $table = $this->schemaManager->introspectTable('table_with_comment');
+        self::assertSame('This is a comment', $table->getComment());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

The issue was discovered during the work on https://github.com/doctrine/dbal/pull/6589.

The pattern used in `parseTableCommentFromSQL()` was invalid. It would wrap the value returned by `quoteSingleIdentifier()` in another set of quotes. It would only work for unquoted table names, which would be handled but the other pattern – the one that matches an unquoted name.

