### PR TITLE
Enable Windows Update service on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,6 +44,8 @@ init:
 
 ## Install PHP and composer, and run the appropriate composer command
 install:
+    - sc config wuauserv start=auto
+    - net start wuauserv
     - ps: |
         # Check if installation is cached
         if (!(Test-Path c:\tools\php)) {

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,9 +49,9 @@ install:
     - ps: |
         # Check if installation is cached
         if (!(Test-Path c:\tools\php)) {
-          appveyor-retry choco install --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version 7.4.27
+          appveyor-retry choco install --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version 7.4.27
           # install sqlite
-          appveyor-retry choco install -y sqlite
+          appveyor-retry choco install --no-progress -y sqlite
           Get-ChildItem -Path c:\tools\php
           cd c:\tools\php
 


### PR DESCRIPTION
Recently, AppVeyor builds started failing with the following error message ([example](https://ci.appveyor.com/project/doctrine/dbal/builds/50990027/job/vebsrmi277uyw1yb)):
```
Installing KB3035131...
WARNING: Update KB3035131 installation failed (exit code 1058).
WARNING: More details may be found in the installation log (C:\Users\appveyor\AppData\Local\Temp\1\chocolatey\KB3035131.Install.evt) or the system CBS log (C:\windows\Logs\CBS\CBS.log).
ERROR: Update KB3035131 installation failed (exit code 1058).
The install of KB3035131 was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\KB3035131\Tools\ChocolateyInstall.ps1'.
 See log for details.
Failed to install KB3033929 because a previous dependency failed.
Failed to install vcredist140 because a previous dependency failed.
Failed to install php because a previous dependency failed.
```

Not sure what happened (maybe it was just cache invalidation) but the 8-year old fix from https://github.com/phpmd/phpmd/pull/426 seems to work. I also temporarily applied the same changes to https://github.com/doctrine/dbal/pull/6600 to test the fix on 4.2.x ([build](https://ci.appveyor.com/project/doctrine/dbal/builds/50990873)).

Additionally, let's disable download progress in `choco install` commands. This way, the build log reduces from 3-6-10K lines to ~600 ([example](https://ci.appveyor.com/project/doctrine/dbal/builds/50990857/job/dhi5mt5wnxxj4vvq)).