### PR TITLE
Fix renaming to quoted names on SQL Server

### DIFF
--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -848,8 +848,8 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     protected function getQuotedAlterTableRenameIndexSQL(): array
     {
         return [
-            "EXEC sp_rename N'[table].[create]', N'[select]', N'INDEX'",
-            "EXEC sp_rename N'[table].[foo]', N'[bar]', N'INDEX'",
+            "EXEC sp_rename N'[table].[create]', N'select', N'INDEX'",
+            "EXEC sp_rename N'[table].[foo]', N'bar', N'INDEX'",
         ];
     }
 
@@ -867,8 +867,8 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
     {
         return [
-            "EXEC sp_rename N'[schema].[table].[create]', N'[select]', N'INDEX'",
-            "EXEC sp_rename N'[schema].[table].[foo]', N'[bar]', N'INDEX'",
+            "EXEC sp_rename N'[schema].[table].[create]', N'select', N'INDEX'",
+            "EXEC sp_rename N'[schema].[table].[foo]', N'bar', N'INDEX'",
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

The issue was discovered during the work on https://github.com/doctrine/dbal/pull/6589.

`sp_rename` accepts the old name as a qualified name but the new name as a literal value.

Here's my understanding of the `sp_rename` parameters. The caller of the stored procedure should be able to reference a column in some table or a table in some schema, etc. Thus, it should be possible to qualify the old name. But it's not necessary for the new name because the reference to the object being renamed is already established in the old name. Thus, the new name is a literal.

The issue exists in 3.x as well but it's not a clean back-port, so out of the scope.