### PR TITLE
Deprecate reserved keyword lists

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,8 @@ have been deprecated:
 Please refer to the official documentation provided by the respective database vendor for up-to-date information on
 reserved keywords.
 
+Additionally, the `MySQL84Platform` class has been deprecated. Use the `MySQLPlatform` class instead.
+
 ## Deprecated relying on the current implementation of the database object name parser
 
 The current object name parser implicitly quotes identifiers in the following cases:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,18 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated Reserved Keyword Lists
+
+The use of DBAL as the source for platform-specific reserved keyword lists has been deprecated. The following components
+have been deprecated:
+
+1. The `KeywordList` class and all its subclasses.
+2. The methods `AbstractPlatform::createReservedKeywordsList()` and `::getReservedKeywordsList()`.
+3. The `AbstractPlatform::$_keywords` property.
+
+Please refer to the official documentation provided by the respective database vendor for up-to-date information on
+reserved keywords.
+
 ## Deprecated relying on the current implementation of the database object name parser
 
 The current object name parser implicitly quotes identifiers in the following cases:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -52,6 +52,20 @@
                 <referencedClass name="Doctrine\DBAL\Platforms\MariaDB1052Platform" />
                 <referencedClass name="Doctrine\DBAL\Platforms\MySQL80Platform" />
                 <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL120Platform" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6607
+                    TODO: remove in 5.0.0
+                -->
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\KeywordList" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\DB2Keywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MariaDBKeywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MySQLKeywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\MySQL84Keywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\PostgreSQLKeywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\OracleKeywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLiteKeywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLServerKeywords" />
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>
@@ -80,8 +94,24 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::quoteIdentifier" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6607
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::createReservedKeywordsList" />
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getReservedKeywordsList" />
             </errorLevel>
         </DeprecatedMethod>
+        <DeprecatedProperty>
+            <errorLevel type="suppress">
+                <!--
+                    https://github.com/doctrine/dbal/pull/6607
+                    TODO: remove in 5.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Platforms\AbstractPlatform::$_keywords" />
+            </errorLevel>
+        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -66,6 +66,7 @@
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\OracleKeywords" />
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLiteKeywords" />
                 <referencedClass name="Doctrine\DBAL\Platforms\Keywords\SQLServerKeywords" />
+                <referencedClass name="Doctrine\DBAL\Platforms\MySQL84Platform" />
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function array_merge;
@@ -763,8 +764,16 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         ];
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new MySQLKeywords();
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -84,6 +84,8 @@ abstract class AbstractPlatform
 
     /**
      * Holds the KeywordList instance for the current platform.
+     *
+     * @deprecated
      */
     protected ?KeywordList $_keywords = null;
 
@@ -2170,15 +2172,26 @@ abstract class AbstractPlatform
 
     /**
      * Returns the keyword list instance of this platform.
+     *
+     * @deprecated
      */
     final public function getReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         // Store the instance so it doesn't need to be generated on every request.
         return $this->_keywords ??= $this->createReservedKeywordsList();
     }
 
     /**
      * Creates an instance of the reserved keyword list of this platform.
+     *
+     * @deprecated
      */
     abstract protected function createReservedKeywordsList(): KeywordList;
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function count;
@@ -591,8 +592,16 @@ class DB2Platform extends AbstractPlatform
         return false;
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new DB2Keywords();
     }
 

--- a/src/Platforms/Keywords/DB2Keywords.php
+++ b/src/Platforms/Keywords/DB2Keywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * DB2 Keywords.
+ *
+ * @deprecated
  */
 class DB2Keywords extends KeywordList
 {

--- a/src/Platforms/Keywords/KeywordList.php
+++ b/src/Platforms/Keywords/KeywordList.php
@@ -4,17 +4,31 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+use Doctrine\Deprecations\Deprecation;
+
 use function array_flip;
 use function array_map;
 use function strtoupper;
 
 /**
  * Abstract interface for a SQL reserved keyword dictionary.
+ *
+ * @deprecated
  */
 abstract class KeywordList
 {
     /** @var string[]|null */
     private ?array $keywords = null;
+
+    public function __construct()
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            static::class,
+        );
+    }
 
     /**
      * Checks if the given word is a keyword of this dialect/vendor platform.

--- a/src/Platforms/Keywords/MariaDBKeywords.php
+++ b/src/Platforms/Keywords/MariaDBKeywords.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms\Keywords;
 
+/** @deprecated */
 class MariaDBKeywords extends MySQLKeywords
 {
     /**

--- a/src/Platforms/Keywords/MySQL80Keywords.php
+++ b/src/Platforms/Keywords/MySQL80Keywords.php
@@ -9,7 +9,7 @@ use function array_merge;
 /**
  * MySQL 8.0 reserved keywords list.
  *
- * @deprecated This class will be removed once support for MySQL 5.7 is dropped.
+ * @deprecated
  */
 class MySQL80Keywords extends MySQLKeywords
 {

--- a/src/Platforms/Keywords/MySQL84Keywords.php
+++ b/src/Platforms/Keywords/MySQL84Keywords.php
@@ -9,6 +9,8 @@ use function array_merge;
 
 /**
  * MySQL 8.4 reserved keywords list.
+ *
+ * @deprecated
  */
 class MySQL84Keywords extends MySQL80Keywords
 {

--- a/src/Platforms/Keywords/MySQLKeywords.php
+++ b/src/Platforms/Keywords/MySQLKeywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * MySQL Keywordlist.
+ *
+ * @deprecated
  */
 class MySQLKeywords extends KeywordList
 {

--- a/src/Platforms/Keywords/OracleKeywords.php
+++ b/src/Platforms/Keywords/OracleKeywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * Oracle Keywordlist.
+ *
+ * @deprecated
  */
 class OracleKeywords extends KeywordList
 {

--- a/src/Platforms/Keywords/PostgreSQLKeywords.php
+++ b/src/Platforms/Keywords/PostgreSQLKeywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * Reserved keywords list corresponding to the PostgreSQL database platform of the oldest supported version.
+ *
+ * @deprecated
  */
 class PostgreSQLKeywords extends KeywordList
 {

--- a/src/Platforms/Keywords/SQLServerKeywords.php
+++ b/src/Platforms/Keywords/SQLServerKeywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * Reserved keywords list corresponding to the Microsoft SQL Server database platform of the oldest supported version.
+ *
+ * @deprecated
  */
 class SQLServerKeywords extends KeywordList
 {

--- a/src/Platforms/Keywords/SQLiteKeywords.php
+++ b/src/Platforms/Keywords/SQLiteKeywords.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 
 /**
  * SQLite Keywordlist.
+ *
+ * @deprecated
  */
 class SQLiteKeywords extends KeywordList
 {

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\Keywords\MariaDBKeywords;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\JsonType;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_diff_key;
 use function array_merge;
@@ -158,8 +159,16 @@ class MariaDBPlatform extends AbstractMySQLPlatform
         return parent::getColumnDeclarationSQL($name, $column);
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new MariaDBKeywords();
     }
 }

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 8.0 database platform.
@@ -17,6 +18,13 @@ class MySQL80Platform extends MySQLPlatform
 {
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new MySQL80Keywords();
     }
 

--- a/src/Platforms/MySQL84Platform.php
+++ b/src/Platforms/MySQL84Platform.php
@@ -6,14 +6,23 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MySQL84Keywords;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 8.4 database platform.
  */
 class MySQL84Platform extends MySQL80Platform
 {
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new MySQL84Keywords();
     }
 }

--- a/src/Platforms/MySQL84Platform.php
+++ b/src/Platforms/MySQL84Platform.php
@@ -10,6 +10,8 @@ use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 8.4 database platform.
+ *
+ * @deprecated Please use {@link MySQLPlatform} instead.
  */
 class MySQL84Platform extends MySQL80Platform
 {

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the Oracle MySQL database platform
@@ -42,8 +43,16 @@ class MySQLPlatform extends AbstractMySQLPlatform
         return ['ALTER TABLE ' . $tableName . ' RENAME INDEX ' . $oldIndexName . ' TO ' . $index->getQuotedName($this)];
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new MySQLKeywords();
     }
 }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -785,8 +786,16 @@ END;';
         return '';
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new OracleKeywords();
     }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -743,8 +744,16 @@ class PostgreSQLPlatform extends AbstractPlatform
         ];
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new PostgreSQLKeywords();
     }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_map;
@@ -1126,8 +1127,16 @@ class SQLServerPlatform extends AbstractPlatform
         };
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new SQLServerKeywords();
     }
 

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
+use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_combine;
@@ -473,8 +474,16 @@ class SQLitePlatform extends AbstractPlatform
         ];
     }
 
+    /** @deprecated */
     protected function createReservedKeywordsList(): KeywordList
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6607',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return new SQLiteKeywords();
     }
 

--- a/tests/Schema/AbstractAssetTest.php
+++ b/tests/Schema/AbstractAssetTest.php
@@ -57,7 +57,7 @@ class AbstractAssetTest extends TestCase
     {
         $identifier = new Identifier($name);
 
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/XXXX');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6607');
         $identifier->getQuotedName($platform);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The keyword lists will be removed in https://github.com/doctrine/dbal/pull/6589. The `MySQL84Platform` is different from its parent only in the keyword list, so it's also being deprecated.