### PR TITLE
Mark Identifier as internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Marked `Identifier` class as internal
+
+In order to build SQL identifiers, use `AbstractPlatform::quoteSingleIdentifier()`.
+
 ## Deprecated Reserved Keyword Lists
 
 The use of DBAL as the source for platform-specific reserved keyword lists has been deprecated. The following components

--- a/src/Schema/Identifier.php
+++ b/src/Schema/Identifier.php
@@ -9,6 +9,8 @@ namespace Doctrine\DBAL\Schema;
  *
  * Wraps identifier names like column names in indexes / foreign keys
  * in an abstract class for proper quotation capabilities.
+ *
+ * @internal
  */
 class Identifier extends AbstractAsset
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

`Identifier` is one of those classes that calls `AbstractAsset::_setName()` to update the previously set name. I want to make it impossible to change `AbstractAsset`'s name because oftentimes they are indexed by name (e.g. table columns).

It would be easy to get rid of the second call to `_setName()` but I'd rather eventually replace it with something like `Name` described in https://github.com/doctrine/dbal/issues/4772.

There are no public methods in DBAL that would accept an `Identifier` or `AbstractAsset`, so quite likely it's already used only internally. If someone uses it to quote names, they can use `AbstractPlatform::quoteSingleIdentifier()`.