### PR TITLE
Deprecate AbstractAsset::_setName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractAsset::_setName()`
+
+Setting object name via `AbstractAsset::_setName()` has been deprecated. Pass the name to the `AbstractAsset`
+constructor instead.
+
 ## Marked `Identifier` class as internal
 
 In order to build SQL identifiers, use `AbstractPlatform::quoteSingleIdentifier()`.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -102,6 +102,12 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::createReservedKeywordsList" />
                 <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getReservedKeywordsList" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6610
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::_setName" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -45,11 +45,36 @@ abstract class AbstractAsset
 
     private bool $validateFuture = false;
 
+    public function __construct(?string $name = null)
+    {
+        if ($name === null) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6610',
+                'Not passing $name to %s is deprecated.',
+                __METHOD__,
+            );
+
+            return;
+        }
+
+        $this->_setName($name);
+    }
+
     /**
      * Sets the name of this asset.
+     *
+     * @deprecated Use the constructor instead.
      */
     protected function _setName(string $name): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6610',
+            '%s is deprecated. Use the constructor instead.',
+            __METHOD__,
+        );
+
         $input = $name;
 
         if ($this->isIdentifierQuoted($name)) {

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -50,7 +50,8 @@ class Column extends AbstractAsset
      */
     public function __construct(string $name, Type $type, array $options = [])
     {
-        $this->_setName($name);
+        parent::__construct($name);
+
         $this->setType($type);
         $this->setOptions($options);
     }

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -53,7 +53,7 @@ class ForeignKeyConstraint extends AbstractAsset
         string $name = '',
         protected array $options = [],
     ) {
-        $this->_setName($name);
+        parent::__construct($name);
 
         $this->_localColumnNames = $this->createIdentifierMap($localColumnNames);
         $this->_foreignTableName = new Identifier($foreignTableName);

--- a/src/Schema/Identifier.php
+++ b/src/Schema/Identifier.php
@@ -20,7 +20,7 @@ class Identifier extends AbstractAsset
      */
     public function __construct(string $identifier, bool $quote = false)
     {
-        $this->_setName($identifier);
+        parent::__construct($identifier);
 
         if (! $quote || $this->_quoted) {
             return;

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -47,13 +47,9 @@ class Index extends AbstractAsset
         array $flags = [],
         private readonly array $options = [],
     ) {
-        $isUnique = $isUnique || $isPrimary;
+        parent::__construct($name ?? '');
 
-        if ($name !== null) {
-            $this->_setName($name);
-        }
-
-        $this->_isUnique  = $isUnique;
+        $this->_isUnique  = $isUnique || $isPrimary;
         $this->_isPrimary = $isPrimary;
 
         foreach ($columns as $column) {

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -76,9 +76,7 @@ class Schema extends AbstractAsset
 
         $name = $schemaConfig->getName();
 
-        if ($name !== null) {
-            $this->_setName($name);
-        }
+        parent::__construct($name ?? '');
 
         foreach ($namespaces as $namespace) {
             $this->createNamespace($namespace);
@@ -290,7 +288,12 @@ class Schema extends AbstractAsset
     public function renameTable(string $oldName, string $newName): self
     {
         $table = $this->getTable($oldName);
-        $table->_setName($newName);
+
+        $identifier = new Identifier($newName);
+
+        $table->_name      = $identifier->_name;
+        $table->_namespace = $identifier->_namespace;
+        $table->_quoted    = $identifier->_quoted;
 
         $this->dropTable($oldName);
         $this->_addTable($table);

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -22,7 +22,8 @@ class Sequence extends AbstractAsset
         int $initialValue = 1,
         protected ?int $cache = null,
     ) {
-        $this->_setName($name);
+        parent::__construct($name);
+
         $this->setAllocationSize($allocationSize);
         $this->setInitialValue($initialValue);
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -82,7 +82,7 @@ class Table extends AbstractAsset
             throw InvalidTableName::new($name);
         }
 
-        $this->_setName($name);
+        parent::__construct($name);
 
         foreach ($columns as $column) {
             $this->_addColumn($column);
@@ -299,7 +299,8 @@ class Table extends AbstractAsset
         }
 
         $column = $this->getColumn($oldName);
-        $column->_setName($newName);
+
+        $column->_name = $newName;
         unset($this->_columns[$oldName]);
         $this->_addColumn($column);
 

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -40,7 +40,7 @@ class UniqueConstraint extends AbstractAsset
         array $flags = [],
         private readonly array $options = [],
     ) {
-        $this->_setName($name);
+        parent::__construct($name);
 
         foreach ($columns as $column) {
             $this->addColumn($column);

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -11,7 +11,7 @@ class View extends AbstractAsset
 {
     public function __construct(string $name, private readonly string $sql)
     {
-        $this->_setName($name);
+        parent::__construct($name);
     }
 
     public function getSql(): string


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Oftentimes, objects are indexed by name (e.g. table columns or schema tables). There shouldn't be an API to modify the name of the object once it has been constructed. The existing cases where the object name is still modified will be addressed separately by introducing builders and creating a new object with the same properties but a new name.