### PR TITLE
Rework the continuous integration jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -229,7 +229,7 @@ jobs:
           - "8.3"
         postgres-version:
           - "9.4"
-          - "16"
+          - "11" # We have code specific to 10.0-12.0
           - "17"
         extension:
           - "pgsql"
@@ -306,13 +306,10 @@ jobs:
         mariadb-version:
           # keep in sync with https://mariadb.org/about/#maintenance-policy
           - "10.0"  # Oldest version supported by DBAL
-          - "10.4"  # LTS (Jun 2024)
-          - "10.5"  # LTS (Jun 2025)
-          - "10.6"  # LTS (Jul 2026)
-          - "10.11" # LTS (Feb 2028)
-          - "11.1"  # STS (Aug 2024)
-          - "11.2"  # STS (Nov 2024)
-          - "11.3"  # STS (Feb 2025)
+          - "10.4"  # LTS (Jun 2024) We have code specific to 10.4.3-10.5.2
+          - "10.5"  # LTS (Jun 2025) We have code specific to 10.5.2-10.6.0
+          - "10.6"  # LTS (Jul 2026) We have code specific to 10.6.0-10.10.0
+          - "10.11" # LTS (Feb 2028) We have code specific to ^10.10
           - "11.4"  # LTS (May 2029)
         extension:
           - "mysqli"
@@ -389,7 +386,7 @@ jobs:
           - "8.3"
         mysql-version:
           - "5.7"
-          - "8.0"
+          - "8.0" # We have code specific to ^8.0
           - "9.1"
         extension:
           - "mysqli"
@@ -419,17 +416,6 @@ jobs:
           - php-version: "8.4"
             mysql-version: "9.1"
             extension: "pdo_mysql"
-          # Workaround for https://bugs.mysql.com/114876
-          - php-version: "8.3"
-            mysql-version: "8.4"
-            extension: "mysqli"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
-          - php-version: "8.3"
-            mysql-version: "8.4"
-            extension: "pdo_mysql"
-            custom-entrypoint: >-
-              --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
 
     services:
       mysql:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,9 +38,6 @@ jobs:
           - "ubuntu-22.04"
         php-version:
           - "7.4"
-          - "8.0"
-          - "8.1"
-          - "8.2"
           - "8.3"
           - "8.4"
         dependencies:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,17 +107,17 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.2"
           - "8.3"
         oracle-version:
           - "21"
           - "23"
         include:
+          - php-version: "7.4"
+            oracle-version: "23"
+          - php-version: "8.2"
+            oracle-version: "23"
           - php-version: "8.4"
             oracle-version: "23"
-          - php-version: "7.4"
-            oracle-version: "11"
 
     services:
       oracle:
@@ -168,17 +168,17 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.2"
           - "8.3"
         oracle-version:
           - "21"
           - "23"
         include:
+          - php-version: "7.4"
+            oracle-version: "23"
+          - php-version: "8.2"
+            oracle-version: "23"
           - php-version: "8.4"
             oracle-version: "23"
-          - php-version: "7.4"
-            oracle-version: "11"
 
     services:
       oracle:
@@ -229,7 +229,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.3"
         postgres-version:
           - "9.4"
           - "16"
@@ -238,19 +238,19 @@ jobs:
           - "pgsql"
           - "pdo_pgsql"
         include:
-          - php-version: "8.2"
+          - php-version: "7.4"
             postgres-version: "17"
             extension: "pgsql"
-          - php-version: "8.3"
+          - php-version: "8.2"
             postgres-version: "17"
             extension: "pgsql"
           - php-version: "8.4"
             postgres-version: "17"
             extension: "pgsql"
-          - php-version: "8.2"
+          - php-version: "7.4"
             postgres-version: "17"
             extension: "pdo_pgsql"
-          - php-version: "8.3"
+          - php-version: "8.2"
             postgres-version: "17"
             extension: "pdo_pgsql"
           - php-version: "8.4"
@@ -305,7 +305,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.3"
         mariadb-version:
           # keep in sync with https://mariadb.org/about/#maintenance-policy
           - "10.0"  # Oldest version supported by DBAL
@@ -321,27 +321,21 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.2"
-            mariadb-version: "10.6"
-            extension: "mysqli"
-          - php-version: "8.2"
-            mariadb-version: "10.6"
-            extension: "pdo_mysql"
-          - php-version: "8.2"
+          - php-version: "7.4"
             mariadb-version: "11.4"
             extension: "mysqli"
           - php-version: "8.2"
             mariadb-version: "11.4"
-            extension: "pdo_mysql"
-          - php-version: "8.3"
-            mariadb-version: "11.4"
             extension: "mysqli"
-          - php-version: "8.3"
-            mariadb-version: "11.4"
-            extension: "pdo_mysql"
           - php-version: "8.4"
             mariadb-version: "11.4"
             extension: "mysqli"
+          - php-version: "7.4"
+            mariadb-version: "11.4"
+            extension: "pdo_mysql"
+          - php-version: "8.2"
+            mariadb-version: "11.4"
+            extension: "pdo_mysql"
           - php-version: "8.4"
             mariadb-version: "11.4"
             extension: "pdo_mysql"
@@ -408,13 +402,25 @@ jobs:
         include:
           - config-file-suffix: "-tls"
             php-version: "7.4"
-            mysql-version: "8.0"
+            mysql-version: "9.1"
             extension: "mysqli"
           - php-version: "7.4"
-            mysql-version: "8.0"
+            mysql-version: "9.1"
+            extension: "mysqli"
+          - php-version: "8.2"
+            mysql-version: "9.1"
+            extension: "mysqli"
+          - php-version: "8.4"
+            mysql-version: "9.1"
             extension: "mysqli"
           - php-version: "7.4"
-            mysql-version: "8.0"
+            mysql-version: "9.1"
+            extension: "pdo_mysql"
+          - php-version: "8.2"
+            mysql-version: "9.1"
+            extension: "pdo_mysql"
+          - php-version: "8.4"
+            mysql-version: "9.1"
             extension: "pdo_mysql"
           # Workaround for https://bugs.mysql.com/114876
           - php-version: "8.3"
@@ -427,12 +433,6 @@ jobs:
             extension: "pdo_mysql"
             custom-entrypoint: >-
               --entrypoint sh mysql:8.4 -c "exec docker-entrypoint.sh mysqld --mysql-native-password=ON"
-          - php-version: "8.4"
-            mysql-version: "9.1"
-            extension: "mysqli"
-          - php-version: "8.4"
-            mysql-version: "9.1"
-            extension: "pdo_mysql"
 
     services:
       mysql:


### PR DESCRIPTION
This is an attempt at implementing https://github.com/doctrine/dbal/pull/3347#issuecomment-439231396

- For the latest stable PHP version (which is currently 8.3), test all drivers with all platform versions.
- All other supported PHP versions (7.4, 8.2, nightly), test each driver with the latest version of the platform.


This results in a slight reduction of the number of jobs (from 92 to 85)