### PR TITLE
Remove AbstractAsset::_setName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractAsset::_setName()`
+
+The `AbstractAsset::_setName()` method has been removed.
+
 ## BC BREAK: Removed Reserved Keyword Lists
 
 The following components have been removed:
@@ -36,7 +40,7 @@ The `AbstractPlatform::quoteIdentifier()` and `Connection::quoteIdentifier()` me
 
 ## BC BREAK: Removed `Table::removeForeignKey()` and `::removeUniqueConstraint()`
 
-The `Table::removeForeignKey()` and `::removeUniqueConstraint()` have been removed.
+The `Table::removeForeignKey()` and `::removeUniqueConstraint()` methods have been removed.
 
 ## BC BREAK: Removed `AbstractPlatform` constants
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,12 +55,6 @@
 
                 <!-- TODO for PHPUnit 11 -->
                 <referencedMethod name="PHPUnit\Framework\TestCase::iniSet"/>
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6610
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::_setName" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/Identifier.php
+++ b/src/Schema/Identifier.php
@@ -14,18 +14,4 @@ namespace Doctrine\DBAL\Schema;
  */
 class Identifier extends AbstractAsset
 {
-    /**
-     * @param string $identifier Identifier name to wrap.
-     * @param bool   $quote      Whether to force quoting the given identifier.
-     */
-    public function __construct(string $identifier, bool $quote = false)
-    {
-        parent::__construct($identifier);
-
-        if (! $quote || $this->_quoted) {
-            return;
-        }
-
-        $this->_setName('"' . $this->getName() . '"');
-    }
 }


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/6610.