### PR TITLE
Revert workaround for persistent PDO connections

### DIFF
--- a/src/Driver/PDO/PDOConnect.php
+++ b/src/Driver/PDO/PDOConnect.php
@@ -18,8 +18,7 @@ trait PDOConnect
         string $password,
         array $options,
     ): PDO {
-        // see https://github.com/php/php-src/issues/16314
-        if (PHP_VERSION_ID < 80400 || ($options[PDO::ATTR_PERSISTENT] ?? false) === true) {
+        if (PHP_VERSION_ID < 80400) {
             return new PDO($dsn, $username, $password, $options);
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

The PHP bug php/php-src#16314 I needed to work around in #6532 has been fixed in the meantime. Let's remove the workaround.
