### PR TITLE
Deprecate altering table configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated configuration-related `Table` methods
+
+The `Table::setSchemaConfig()` method and `$_schemaConfig` property have been deprecated. Pass a `TableConfiguration`
+instance to the constructor instead.
+
+The `Table::_getMaxIdentifierLength()` method has been deprecated.
+
 ## Deprecated `AbstractAsset::_setName()`
 
 Setting object name via `AbstractAsset::_setName()` has been deprecated. Pass the name to the `AbstractAsset`

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -108,6 +108,13 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::_setName" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6635
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::_getMaxIdentifierLength" />
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::setSchemaConfig" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -117,6 +124,12 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedProperty name="Doctrine\DBAL\Platforms\AbstractPlatform::$_keywords" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6635
+                    TODO: remove in 5.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\Table::$_schemaConfig" />
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -202,6 +202,9 @@ abstract class AbstractSchemaManager
         $filter = $this->connection->getConfiguration()->getSchemaAssetsFilter();
         $tables = [];
 
+        $configuration = $this->createSchemaConfig()
+            ->toTableConfiguration();
+
         foreach ($tableColumnsByTable as $tableName => $tableColumns) {
             if (! $filter($tableName)) {
                 continue;
@@ -214,6 +217,7 @@ abstract class AbstractSchemaManager
                 [],
                 $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName] ?? []),
                 $tableOptionsByTable[$tableName] ?? [],
+                $configuration,
             );
         }
 

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -83,6 +83,7 @@ class Schema extends AbstractAsset
         }
 
         foreach ($tables as $table) {
+            $table->setSchemaConfig($this->_schemaConfig);
             $this->_addTable($table);
         }
 
@@ -109,7 +110,6 @@ class Schema extends AbstractAsset
         }
 
         $this->_tables[$tableName] = $table;
-        $table->setSchemaConfig($this->_schemaConfig);
     }
 
     protected function _addSequence(Sequence $sequence): void
@@ -270,7 +270,7 @@ class Schema extends AbstractAsset
      */
     public function createTable(string $name): Table
     {
-        $table = new Table($name);
+        $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
         $this->_addTable($table);
 
         foreach ($this->_schemaConfig->getDefaultTableOptions() as $option => $value) {

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -58,4 +58,9 @@ class SchemaConfig
     {
         $this->defaultTableOptions = $defaultTableOptions;
     }
+
+    public function toTableConfiguration(): TableConfiguration
+    {
+        return new TableConfiguration($this->maxIdentifierLength);
+    }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -61,7 +61,10 @@ class Table extends AbstractAsset
         'create_options' => [],
     ];
 
+    /** @deprecated Pass a {@link TableConfiguration} instance to the constructor instead. */
     protected ?SchemaConfig $_schemaConfig = null;
+
+    private int $maxIdentifierLength;
 
     /**
      * @param array<Column>               $columns
@@ -77,12 +80,17 @@ class Table extends AbstractAsset
         array $uniqueConstraints = [],
         array $fkConstraints = [],
         array $options = [],
+        ?TableConfiguration $configuration = null,
     ) {
         if ($name === '') {
             throw InvalidTableName::new($name);
         }
 
         parent::__construct($name);
+
+        $configuration ??= (new SchemaConfig())->toTableConfiguration();
+
+        $this->maxIdentifierLength = $configuration->getMaxIdentifierLength();
 
         foreach ($columns as $column) {
             $this->_addColumn($column);
@@ -103,9 +111,19 @@ class Table extends AbstractAsset
         $this->_options = array_merge($this->_options, $options);
     }
 
+    /** @deprecated Pass a {@link TableConfiguration} instance to the constructor instead. */
     public function setSchemaConfig(SchemaConfig $schemaConfig): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6635',
+            '%s is deprecated. Pass TableConfiguration to the constructor instead.',
+            __METHOD__,
+        );
+
         $this->_schemaConfig = $schemaConfig;
+
+        $this->maxIdentifierLength = $schemaConfig->getMaxIdentifierLength();
     }
 
     /**
@@ -651,11 +669,17 @@ class Table extends AbstractAsset
         }
     }
 
+    /** @deprecated */
     protected function _getMaxIdentifierLength(): int
     {
-        return $this->_schemaConfig instanceof SchemaConfig
-            ? $this->_schemaConfig->getMaxIdentifierLength()
-            : 63;
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6635',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
+        return $this->maxIdentifierLength;
     }
 
     protected function _addColumn(Column $column): void

--- a/src/Schema/TableConfiguration.php
+++ b/src/Schema/TableConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+/**
+ * Contains platform-specific parameters used for creating and managing objects scoped to a {@see Table}.
+ */
+class TableConfiguration
+{
+    /** @internal The configuration can be only instantiated by a {@see SchemaConfig}. */
+    public function __construct(private readonly int $maxIdentifierLength)
+    {
+    }
+
+    /**
+     * Returns the maximum length of identifiers to be generated for the objects scoped to the table.
+     */
+    public function getMaxIdentifierLength(): int
+    {
+        return $this->maxIdentifierLength;
+    }
+}

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -206,8 +206,16 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testListTableIndexesPrimaryKeyConstraintNameDiffersFromIndexName(): void
     {
-        $table = new Table('list_table_indexes_pk_id_test');
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $table = new Table(
+            'list_table_indexes_pk_id_test',
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
+
         $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $table->addUniqueIndex(['id'], 'id_unique_index');
         $this->dropAndCreateTable($table);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -698,8 +698,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
-        $table = new Table('test_autoincrement');
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $table = new Table(
+            'test_autoincrement',
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->setPrimaryKey(['id']);
 
@@ -716,8 +723,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
-        $table = new Table('test_not_autoincrement');
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $table = new Table(
+            'test_not_autoincrement',
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('other_id', Types::INTEGER);
         $table->setPrimaryKey(['id', 'other_id']);
@@ -735,8 +749,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('id', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
-        $tableFK = new Table('test_fk_rename');
-        $tableFK->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $tableFK = new Table(
+            'test_fk_rename',
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
         $tableFK->addColumn('id', Types::INTEGER);
         $tableFK->addColumn('fk_id', Types::INTEGER);
         $tableFK->setPrimaryKey(['id']);
@@ -749,8 +770,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->createTable($table);
         $this->schemaManager->createTable($tableFK);
 
-        $tableFKNew = new Table('test_fk_rename');
-        $tableFKNew->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $tableFKNew = new Table(
+            'test_fk_rename',
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
         $tableFKNew->addColumn('id', Types::INTEGER);
         $tableFKNew->addColumn('rename_fk_id', Types::INTEGER);
         $tableFKNew->setPrimaryKey(['id']);
@@ -894,8 +922,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     /** @param mixed[] $options */
     protected function getTestTable(string $name, array $options = []): Table
     {
-        $table = new Table($name, [], [], [], [], $options);
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $table = new Table(
+            $name,
+            [],
+            [],
+            [],
+            [],
+            $options,
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
         $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $table->setPrimaryKey(['id']);
         $table->addColumn('test', Types::STRING, ['length' => 255]);
@@ -906,8 +941,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     protected function getTestCompositeTable(string $name): Table
     {
-        $table = new Table($name, [], [], [], [], []);
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
+        $table = new Table(
+            $name,
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
+        );
         $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $table->addColumn('other_id', Types::INTEGER, ['notnull' => true]);
         $table->setPrimaryKey(['id', 'other_id']);

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -93,8 +93,9 @@ abstract class AbstractComparatorTestCase extends TestCase
     {
         $schemaConfig = new SchemaConfig();
 
-        $table = new Table('bugdb', ['integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER))]);
-        $table->setSchemaConfig($schemaConfig);
+        $table = new Table('bugdb', [
+            'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+        ], [], [], [], [], $schemaConfig->toTableConfiguration());
 
         $schema1 = new Schema([$table], [], $schemaConfig);
         $schema2 = new Schema([], [], $schemaConfig);
@@ -109,8 +110,9 @@ abstract class AbstractComparatorTestCase extends TestCase
     {
         $schemaConfig = new SchemaConfig();
 
-        $table = new Table('bugdb', ['integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER))]);
-        $table->setSchemaConfig($schemaConfig);
+        $table = new Table('bugdb', [
+            'integercolumn1' => new Column('integercolumn1', Type::getType(Types::INTEGER)),
+        ], [], [], [], [], $schemaConfig->toTableConfiguration());
 
         $schema1 = new Schema([], [], $schemaConfig);
         $schema2 = new Schema([$table], [], $schemaConfig);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The configuration governs the creation of the inner table objects (e.g. naming autogenerated indexes). Setting the configuration on an existing table, once some of the inner objects may have been created, makes little sense (the objects may need to be regenerated according to the new configuration but this isn't currently implemented).

Besides the maximum identifier length, the table configuration will contain other parameters in the future. Changing them on an existing table will also make no sense.