### PR TITLE
SQLite partial indexes support

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -987,4 +987,9 @@ class SQLitePlatform extends AbstractPlatform
     {
         return $identifier;
     }
+
+    public function supportsPartialIndexes(): bool
+    {
+        return true;
+    }
 }

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -151,6 +151,16 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             $idx['primary']    = false;
             $idx['non_unique'] = ! $tableIndex['unique'];
 
+            if ($tableIndex['partial'] === 1) {
+                $idx['where'] = $this->connection->fetchOne(
+                    <<<'SQL'
+                    SELECT SUBSTR(sql, INSTR(sql, 'WHERE') + 6)
+                    FROM sqlite_master WHERE type = 'index' AND name = (?)
+                    SQL,
+                    [$keyName],
+                );
+            }
+
             $indexArray = $this->connection->fetchAllAssociative('SELECT * FROM PRAGMA_INDEX_INFO (?)', [$keyName]);
 
             foreach ($indexArray as $indexColumnRow) {

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -154,7 +154,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             if ($tableIndex['partial'] === 1) {
                 $idx['where'] = $this->connection->fetchOne(
                     <<<'SQL'
-                    SELECT SUBSTR(sql, INSTR(sql, 'WHERE') + 6)
+                    SELECT SUBSTR(sql, INSTR(lower(sql), 'where ') + LENGTH('where '))
                     FROM sqlite_master WHERE type = 'index' AND name = (?)
                     SQL,
                     [$keyName],

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -462,4 +462,27 @@ SQL;
         self::assertTrue($onlineTable->getIndex('simple_partial_index')->hasOption('where'));
         self::assertSame('(id IS NULL)', $onlineTable->getIndex('simple_partial_index')->getOption('where'));
     }
+
+    public function testPartialIndexWhenTableColumnsContainTheKeywordWhere(): void
+    {
+        $offlineTable = new Table('person');
+        $offlineTable->addColumn('id', Types::INTEGER);
+        $offlineTable->addColumn('somewhere', Types::STRING);
+        $offlineTable->addColumn('name', Types::STRING);
+        $offlineTable->addColumn('email', Types::STRING);
+        $offlineTable->addUniqueIndex(['id', 'somewhere'], 'simple_partial_index', ['where' => '(id IS NULL)']);
+
+        $this->dropAndCreateTable($offlineTable);
+
+        $onlineTable = $this->schemaManager->introspectTable('person');
+
+        self::assertTrue(
+            $this->schemaManager->createComparator()
+                ->compareTables($offlineTable, $onlineTable)
+                ->isEmpty(),
+        );
+        self::assertTrue($onlineTable->hasIndex('simple_partial_index'));
+        self::assertTrue($onlineTable->getIndex('simple_partial_index')->hasOption('where'));
+        self::assertSame('(id IS NULL)', $onlineTable->getIndex('simple_partial_index')->getOption('where'));
+    }
 }

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -435,4 +435,31 @@ SQL;
         self::assertTrue($onlineTable->getIndex('simple_partial_index')->hasOption('where'));
         self::assertSame('(id IS NULL)', $onlineTable->getIndex('simple_partial_index')->getOption('where'));
     }
+
+    public function testPartialIndexWhenIndexCreatedLowercase(): void
+    {
+        $offlineTable = new Table('person');
+        $offlineTable->addColumn('id', Types::INTEGER);
+        $offlineTable->addColumn('name', Types::STRING);
+        $offlineTable->addColumn('email', Types::STRING);
+
+        $this->dropAndCreateTable($offlineTable);
+        $this->connection->executeStatement(
+            <<<'SQL'
+            CREATE UNIQUE INDEX simple_partial_index ON person (id, name) where (id IS NULL)
+            SQL,
+        );
+
+        $onlineTable = $this->schemaManager->introspectTable('person');
+
+        self::assertSame(
+            'simple_partial_index',
+            $this->schemaManager->createComparator()
+                ->compareTables($offlineTable, $onlineTable)
+                ->getAddedIndexes()['simple_partial_index']->getName(),
+        );
+        self::assertTrue($onlineTable->hasIndex('simple_partial_index'));
+        self::assertTrue($onlineTable->getIndex('simple_partial_index')->hasOption('where'));
+        self::assertSame('(id IS NULL)', $onlineTable->getIndex('simple_partial_index')->getOption('where'));
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This adds support for partial indexes to the SQLitePlatform. Similar as the PostgresPlatform provides. 
