### PR TITLE
Introduce value objects representing database object names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,18 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated using invalid database object names
+
+Using the following objects with an empty name is deprecated: `Column`, `View`, `Sequence`, `Identifier`.
+
+Using the following objects with a qualified name is deprecated: `Column`, `ForeignKeyConstraint`, `Index`, `Schema`,
+`UniqueConstraint`. If the object name contains a dot, the name should be quoted.
+
+Using the following objects with a name that has more than one qualifier is deprecated: `Sequence`, `Table`, `View`.
+The name should be unqualified or contain one qualifier.
+
+The `AbstractAsset` class has been marked as internal.
+
 ## Deprecated configuration-related `Table` methods
 
 The `Table::setSchemaConfig()` method and `$_schemaConfig` property have been deprecated. Pass a `TableConfiguration`

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -76,6 +76,7 @@
     <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/2099 -->
     <rule ref="Squiz.Commenting.FunctionComment.InvalidNoReturn">
         <exclude-pattern>src/Platforms/AbstractPlatform.php</exclude-pattern>
+        <exclude-pattern>src/Schema/AbstractAsset.php</exclude-pattern>
         <exclude-pattern>src/Schema/AbstractSchemaManager.php</exclude-pattern>
         <exclude-pattern>tests/Platforms/AbstractPlatformTestCase.php</exclude-pattern>
     </rule>
@@ -128,13 +129,14 @@
         <exclude-pattern>src/Driver/SQLSrv/Statement.php</exclude-pattern>
     </rule>
 
-    <!-- This could be considered a bug in the sniff or the shortcoming of the Platform API design
+    <!-- False positives caused by the limitation of PHP_CodeSniffer
          see https://github.com/squizlabs/PHP_CodeSniffer/issues/3035 -->
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
-        <exclude-pattern>src/Platforms/SQLitePlatform.php</exclude-pattern>
         <exclude-pattern>src/Platforms/*/Comparator.php</exclude-pattern>
         <exclude-pattern>src/Driver/PDO/SQLSrv/Connection.php</exclude-pattern>
         <exclude-pattern>src/Driver/PDO/SQLSrv/Statement.php</exclude-pattern>
+        <exclude-pattern>src/Schema/AbstractNamedObject.php</exclude-pattern>
+        <exclude-pattern>src/Schema/Name/UnqualifiedName.php</exclude-pattern>
     </rule>
 
     <!-- This issue is likely fixed in Slevomat Coding Standard 8.0.0 -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -115,6 +115,13 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::_getMaxIdentifierLength" />
                 <referencedMethod name="Doctrine\DBAL\Schema\Table::setSchemaConfig" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6646
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::createNameParser" />
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -206,6 +213,14 @@
                 <file name="tests/Driver/PDO/*/DriverTest.php"/>
                 <file name="tests/Functional/Driver/Mysqli/ConnectionTest.php"/>
                 <file name="tests/Platforms/AbstractPlatformTestCase.php"/>
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6646
+                    TODO: remove in 5.0.0
+
+                    This looks like a Psalm bug.
+                -->
+                <referencedFunction name="Doctrine\DBAL\Schema\AbstractAsset::setName"/>
             </errorLevel>
         </InvalidArgument>
         <InvalidArrayOffset>
@@ -312,6 +327,21 @@
         </PossiblyFalseReference>
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
+                <!--
+                    https://github.com/doctrine/dbal/pull/6646
+                    TODO: remove in 5.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\AbstractAsset::$name"/>
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6646
+                    TODO: remove in 5.0.0
+
+                    For some reason, referencing the property name doesn't work. Furthermore,
+                    the class doesn't reference the property.
+                -->
+                <file name="src/Schema/Table.php"/>
+
                 <!-- See https://github.com/psalm/psalm-plugin-phpunit/issues/107 -->
                 <!-- See https://github.com/sebastianbergmann/phpunit/pull/4610 -->
                 <directory name="tests"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -120,7 +120,7 @@
                     https://github.com/doctrine/dbal/pull/6646
                     TODO: remove in 5.0.0
                 -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::createNameParser" />
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNameParser" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
             </errorLevel>
         </DeprecatedMethod>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Schema\Name\GenericName;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
@@ -77,13 +76,13 @@ abstract class AbstractAsset
     }
 
     /**
-     * Creates a parser for parsing the object name.
+     * Returns a parser for parsing the object name.
      *
      * @deprecated Parse the name in the constructor instead.
      *
      * @return Parser<N>
      */
-    protected function createNameParser(GenericNameParser $genericNameParser): Parser
+    protected function getNameParser(): Parser
     {
         throw NotImplemented::fromMethod(static::class, __FUNCTION__);
     }
@@ -135,7 +134,7 @@ abstract class AbstractAsset
 
         if ($input !== '') {
             try {
-                $parsedName = $this->createNameParser(new GenericNameParser())->parse($input);
+                $parsedName = $this->getNameParser()->parse($input);
             } catch (Throwable $e) {
                 Deprecation::trigger(
                     'doctrine/dbal',

--- a/src/Schema/AbstractNamedObject.php
+++ b/src/Schema/AbstractNamedObject.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidName;
+use Doctrine\DBAL\Schema\Exception\NameIsNotInitialized;
+
+/**
+ * An abstract {@see NamedObject}.
+ *
+ * @template N of Name
+ * @extends AbstractAsset<N>
+ * @implements NamedObject<N>
+ */
+abstract class AbstractNamedObject extends AbstractAsset implements NamedObject
+{
+    /**
+     * The name of the database object.
+     *
+     * Until the validity of the name is enforced, this property isn't guaranteed to be always initialized. The property
+     * can be accessed only if {@see $isNameInitialized} is set to true.
+     *
+     * @var N
+     */
+    protected Name $name;
+
+    public function __construct(string $name)
+    {
+        parent::__construct($name);
+    }
+
+    /**
+     * Returns the object name.
+     *
+     * @return N
+     *
+     * @throws NameIsNotInitialized
+     */
+    public function getObjectName(): Name
+    {
+        if (! $this->isNameInitialized) {
+            throw NameIsNotInitialized::new();
+        }
+
+        return $this->name;
+    }
+
+    protected function setName(?Name $name): void
+    {
+        if ($name === null) {
+            throw InvalidName::fromEmpty();
+        }
+
+        $this->name = $name;
+    }
+}

--- a/src/Schema/AbstractOptionallyNamedObject.php
+++ b/src/Schema/AbstractOptionallyNamedObject.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\NameIsNotInitialized;
+
+/**
+ * An abstract {@see OptionallyNamedObject}.
+ *
+ * @template N of Name
+ * @extends AbstractAsset<N>
+ * @implements OptionallyNamedObject<N>
+ */
+abstract class AbstractOptionallyNamedObject extends AbstractAsset implements OptionallyNamedObject
+{
+    /**
+     * The name of the database object.
+     *
+     * Until the validity of the name is enforced, this property isn't guaranteed to be always initialized. The property
+     * can be accessed only if {@see $isNameInitialized} is set to true.
+     *
+     * @var ?N
+     */
+    protected ?Name $name;
+
+    public function __construct(?string $name)
+    {
+        parent::__construct($name ?? '');
+    }
+
+    public function getObjectName(): ?Name
+    {
+        if (! $this->isNameInitialized) {
+            throw NameIsNotInitialized::new();
+        }
+
+        return $this->name;
+    }
+
+    protected function setName(?Name $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
 
 use function array_merge;
@@ -12,8 +15,10 @@ use function method_exists;
 
 /**
  * Object representation of a database column.
+ *
+ * @extends AbstractNamedObject<UnqualifiedName>
  */
-class Column extends AbstractAsset
+class Column extends AbstractNamedObject
 {
     protected Type $_type;
 
@@ -54,6 +59,11 @@ class Column extends AbstractAsset
 
         $this->setType($type);
         $this->setOptions($options);
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    {
+        return new UnqualifiedNameParser($genericNameParser);
     }
 
     /** @param array<string, mixed> $options */

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
 
@@ -61,9 +61,9 @@ class Column extends AbstractNamedObject
         $this->setOptions($options);
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    protected function getNameParser(): UnqualifiedNameParser
     {
-        return new UnqualifiedNameParser($genericNameParser);
+        return Parsers::getUnqualifiedNameParser();
     }
 
     /** @param array<string, mixed> $options */

--- a/src/Schema/Exception/InvalidIdentifier.php
+++ b/src/Schema/Exception/InvalidIdentifier.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use InvalidArgumentException;
+
+/** @psalm-immutable */
+final class InvalidIdentifier extends InvalidArgumentException implements SchemaException
+{
+    public static function fromEmpty(): self
+    {
+        return new self('Identifier cannot be empty.');
+    }
+}

--- a/src/Schema/Exception/InvalidName.php
+++ b/src/Schema/Exception/InvalidName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use InvalidArgumentException;
+
+/** @psalm-immutable */
+final class InvalidName extends InvalidArgumentException implements SchemaException
+{
+    public static function fromEmpty(): self
+    {
+        return new self('Name cannot be empty.');
+    }
+}

--- a/src/Schema/Exception/NameIsNotInitialized.php
+++ b/src/Schema/Exception/NameIsNotInitialized.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+/** @psalm-immutable */
+final class NameIsNotInitialized extends LogicException implements SchemaException
+{
+    public static function new(): self
+    {
+        return new self('Object name has not been initialized.');
+    }
+}

--- a/src/Schema/Exception/NotImplemented.php
+++ b/src/Schema/Exception/NotImplemented.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class NotImplemented extends LogicException implements SchemaException
+{
+    public static function fromMethod(string $class, string $method): self
+    {
+        return new self(sprintf('Class %s does not implement method %s().', $class, $method));
+    }
+}

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_keys;
@@ -66,9 +66,9 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
         $this->_foreignColumnNames = $this->createIdentifierMap($foreignColumnNames);
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    protected function getNameParser(): UnqualifiedNameParser
     {
-        return new UnqualifiedNameParser($genericNameParser);
+        return Parsers::getUnqualifiedNameParser();
     }
 
     /**

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_keys;
 use function array_map;
@@ -15,8 +18,10 @@ use function substr;
 
 /**
  * An abstraction class for a foreign key constraint.
+ *
+ * @extends AbstractOptionallyNamedObject<UnqualifiedName>
  */
-class ForeignKeyConstraint extends AbstractAsset
+class ForeignKeyConstraint extends AbstractOptionallyNamedObject
 {
     /**
      * Asset identifier instances of the referencing table column names the foreign key constraint is associated with.
@@ -59,6 +64,11 @@ class ForeignKeyConstraint extends AbstractAsset
         $this->_foreignTableName = new Identifier($foreignTableName);
 
         $this->_foreignColumnNames = $this->createIdentifierMap($foreignColumnNames);
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    {
+        return new UnqualifiedNameParser($genericNameParser);
     }
 
     /**

--- a/src/Schema/Identifier.php
+++ b/src/Schema/Identifier.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Name\GenericName;
 use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 
 /**
  * An abstraction class for an asset identifier.
@@ -34,8 +35,8 @@ class Identifier extends AbstractNamedObject
         $this->_setName('"' . $this->getName() . '"');
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): GenericNameParser
+    protected function getNameParser(): GenericNameParser
     {
-        return $genericNameParser;
+        return Parsers::getGenericNameParser();
     }
 }

--- a/src/Schema/Identifier.php
+++ b/src/Schema/Identifier.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Schema\Name\GenericName;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+
 /**
  * An abstraction class for an asset identifier.
  *
@@ -11,8 +14,10 @@ namespace Doctrine\DBAL\Schema;
  * in an abstract class for proper quotation capabilities.
  *
  * @internal
+ *
+ * @extends AbstractNamedObject<GenericName>
  */
-class Identifier extends AbstractAsset
+class Identifier extends AbstractNamedObject
 {
     /**
      * @param string $identifier Identifier name to wrap.
@@ -27,5 +32,10 @@ class Identifier extends AbstractAsset
         }
 
         $this->_setName('"' . $this->getName() . '"');
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): GenericNameParser
+    {
+        return $genericNameParser;
     }
 }

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_filter;
 use function array_keys;
@@ -14,7 +17,8 @@ use function array_shift;
 use function count;
 use function strtolower;
 
-class Index extends AbstractAsset
+/** @extends AbstractOptionallyNamedObject<UnqualifiedName> */
+class Index extends AbstractOptionallyNamedObject
 {
     /**
      * Asset identifier instances of the column names the index is associated with.
@@ -47,7 +51,7 @@ class Index extends AbstractAsset
         array $flags = [],
         private readonly array $options = [],
     ) {
-        parent::__construct($name ?? '');
+        parent::__construct($name);
 
         $this->_isUnique  = $isUnique || $isPrimary;
         $this->_isPrimary = $isPrimary;
@@ -59,6 +63,11 @@ class Index extends AbstractAsset
         foreach ($flags as $flag) {
             $this->addFlag($flag);
         }
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    {
+        return new UnqualifiedNameParser($genericNameParser);
     }
 
     protected function _addColumn(string $column): void

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_filter;
@@ -65,9 +65,9 @@ class Index extends AbstractOptionallyNamedObject
         }
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    protected function getNameParser(): UnqualifiedNameParser
     {
-        return new UnqualifiedNameParser($genericNameParser);
+        return Parsers::getUnqualifiedNameParser();
     }
 
     protected function _addColumn(string $column): void

--- a/src/Schema/Name.php
+++ b/src/Schema/Name.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+/**
+ * Represents a database object name.
+ */
+interface Name
+{
+    /**
+     * Returns the string representation of the name.
+     *
+     * The consumers of this method should not rely on a specific return value. It should be used only for diagnostic
+     * purposes.
+     */
+    public function toString(): string;
+}

--- a/src/Schema/Name/AbstractName.php
+++ b/src/Schema/Name/AbstractName.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+use Doctrine\DBAL\Schema\Name;
+
+use function array_map;
+use function array_merge;
+use function array_values;
+use function implode;
+
+/**
+ * An abstract {@see Name}. Provides the common implementation of the name methods based on the {@see Identifier}s
+ * representing the name.
+ */
+abstract class AbstractName implements Name
+{
+    /** @var non-empty-list<Identifier> $identifiers */
+    protected readonly array $identifiers;
+
+    public function __construct(Identifier $firstIdentifier, Identifier ...$otherIdentifiers)
+    {
+        $this->identifiers = array_merge([$firstIdentifier], array_values($otherIdentifiers));
+    }
+
+    public function toString(): string
+    {
+        return implode('.', array_map(
+            static fn (Identifier $identifier): string => $identifier->toString(),
+            $this->identifiers,
+        ));
+    }
+}

--- a/src/Schema/Name/GenericName.php
+++ b/src/Schema/Name/GenericName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+/**
+ * A generic {@see Name} consisting of one or more identifiers.
+ */
+final class GenericName extends AbstractName
+{
+    /** @return non-empty-list<Identifier> */
+    public function getIdentifiers(): array
+    {
+        return $this->identifiers;
+    }
+}

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -2,12 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\DBAL\Schema\Name\Parser;
+namespace Doctrine\DBAL\Schema\Name;
+
+use Doctrine\DBAL\Schema\Exception\InvalidIdentifier;
+
+use function sprintf;
+use function str_replace;
+use function strlen;
 
 /**
  * Represents an SQL identifier.
- *
- * @internal
  */
 final class Identifier
 {
@@ -15,6 +19,9 @@ final class Identifier
         private readonly string $value,
         private readonly bool $isQuoted,
     ) {
+        if (strlen($this->value) === 0) {
+            throw InvalidIdentifier::fromEmpty();
+        }
     }
 
     public function getValue(): string
@@ -25,6 +32,15 @@ final class Identifier
     public function isQuoted(): bool
     {
         return $this->isQuoted;
+    }
+
+    public function toString(): string
+    {
+        if (! $this->isQuoted) {
+            return $this->value;
+        }
+
+        return sprintf('"%s"', str_replace('"', '""', $this->value));
     }
 
     /**

--- a/src/Schema/Name/OptionallyQualifiedName.php
+++ b/src/Schema/Name/OptionallyQualifiedName.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+/**
+ * An optionally qualified {@see Name} consisting of an unqualified name and an optional unqualified qualifier.
+ */
+final class OptionallyQualifiedName extends AbstractName
+{
+    public function __construct(private readonly Identifier $unqualifiedName, private readonly ?Identifier $qualifier)
+    {
+        if ($qualifier !== null) {
+            parent::__construct($qualifier, $unqualifiedName);
+        } else {
+            parent::__construct($unqualifiedName);
+        }
+    }
+
+    public function getUnqualifiedName(): Identifier
+    {
+        return $this->unqualifiedName;
+    }
+
+    public function getQualifier(): ?Identifier
+    {
+        return $this->qualifier;
+    }
+}

--- a/src/Schema/Name/Parser.php
+++ b/src/Schema/Name/Parser.php
@@ -4,100 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Name;
 
+use Doctrine\DBAL\Schema\Name;
 use Doctrine\DBAL\Schema\Name\Parser\Exception;
-use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedDot;
-use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedNextIdentifier;
-use Doctrine\DBAL\Schema\Name\Parser\Exception\UnableToParseIdentifier;
-use Doctrine\DBAL\Schema\Name\Parser\Identifier;
-
-use function assert;
-use function preg_match;
-use function str_replace;
-use function strlen;
 
 /**
- * Parses a qualified or unqualified SQL-like name.
- *
- * A name can be either unqualified or qualified:
- * - An unqualified name consists of a single identifier.
- * - A qualified name is a sequence of two or more identifiers separated by dots.
- *
- * An identifier can be quoted or unquoted:
- * - A quoted identifier is enclosed in double quotes ("), backticks (`), or square brackets ([]).
- *   The closing quote character can be escaped by doubling it.
- * - An unquoted identifier may contain any character except whitespace, dots, or any of the quote characters.
- *
- * Differences from SQL:
- * 1. Identifiers that are reserved keywords or start with a digit do not need to be quoted.
- * 2. Whitespace is not allowed between identifiers.
+ * Parses a database object name.
  *
  * @internal
+ *
+ * @template N of Name
  */
-final class Parser
+interface Parser
 {
-    private const IDENTIFIER_PATTERN = <<<'PATTERN'
-        /\G
-        (?:
-            "(?<ansi>[^"]*(?:""[^"]*)*)"         # ANSI SQL double-quoted
-          | `(?<mysql>[^`]*(?:``[^`]*)*)`        # MySQL-style backtick-quoted
-          | \[(?<sqlserver>[^]]*(?:]][^]]*)*)]   # SQL Server-style square-bracket-quoted
-          | (?<unquoted>[^\s."`\[\]]+)           # Unquoted
-        )
-        /x
-    PATTERN;
-
     /**
-     * @return list<Identifier>
+     * @return N
      *
      * @throws Exception
      */
-    public function parse(string $input): array
-    {
-        if ($input === '') {
-            return [];
-        }
-
-        $offset      = 0;
-        $identifiers = [];
-        $length      = strlen($input);
-
-        while (true) {
-            if ($offset >= $length) {
-                throw ExpectedNextIdentifier::new();
-            }
-
-            if (preg_match(self::IDENTIFIER_PATTERN, $input, $matches, 0, $offset) === 0) {
-                throw UnableToParseIdentifier::new($offset);
-            }
-
-            if (isset($matches['ansi']) && strlen($matches['ansi']) > 0) {
-                $identifier = Identifier::quoted(str_replace('""', '"', $matches['ansi']));
-            } elseif (isset($matches['mysql']) && strlen($matches['mysql']) > 0) {
-                $identifier = Identifier::quoted(str_replace('``', '`', $matches['mysql']));
-            } elseif (isset($matches['sqlserver']) && strlen($matches['sqlserver']) > 0) {
-                $identifier = Identifier::quoted(str_replace(']]', ']', $matches['sqlserver']));
-            } else {
-                assert(isset($matches['unquoted']) && strlen($matches['unquoted']) > 0);
-                $identifier = Identifier::unquoted($matches['unquoted']);
-            }
-
-            $identifiers[] = $identifier;
-
-            $offset += strlen($matches[0]);
-
-            if ($offset >= $length) {
-                break;
-            }
-
-            $character = $input[$offset];
-
-            if ($character !== '.') {
-                throw ExpectedDot::new($offset, $character);
-            }
-
-            $offset++;
-        }
-
-        return $identifiers;
-    }
+    public function parse(string $input): Name;
 }

--- a/src/Schema/Name/Parser/Exception/InvalidName.php
+++ b/src/Schema/Name/Parser/Exception/InvalidName.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser\Exception;
+
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
+use InvalidArgumentException;
+
+use function sprintf;
+
+/** @internal */
+class InvalidName extends InvalidArgumentException implements Exception
+{
+    public static function forUnqualifiedName(int $count): self
+    {
+        return new self(sprintf('An unqualified name must consist of one identifier, %d given.', $count));
+    }
+
+    public static function forOptionallyQualifiedName(int $count): self
+    {
+        return new self(
+            sprintf('An optionally qualified name must consist of one or two identifiers, %d given.', $count),
+        );
+    }
+}

--- a/src/Schema/Name/Parser/GenericNameParser.php
+++ b/src/Schema/Name/Parser/GenericNameParser.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser;
+
+use Doctrine\DBAL\Schema\Name\GenericName;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\Parser;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedDot;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedNextIdentifier;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\UnableToParseIdentifier;
+
+use function assert;
+use function count;
+use function preg_match;
+use function str_replace;
+use function strlen;
+
+/**
+ * Parses a generic qualified or unqualified SQL-like name.
+ *
+ * A name can be either unqualified or qualified:
+ * - An unqualified name consists of a single identifier.
+ * - A qualified name is a sequence of two or more identifiers separated by dots.
+ *
+ * An identifier can be quoted or unquoted:
+ * - A quoted identifier is enclosed in double quotes ("), backticks (`), or square brackets ([]).
+ * The closing quote character can be escaped by doubling it.
+ * - An unquoted identifier may contain any character except whitespace, dots, or any of the quote characters.
+ *
+ * Differences from SQL:
+ * 1. Identifiers that are reserved keywords or start with a digit do not need to be quoted.
+ * 2. Whitespace is not allowed between identifiers.
+ *
+ * @internal
+ *
+ * @implements Parser<GenericName>
+ */
+final class GenericNameParser implements Parser
+{
+    private const IDENTIFIER_PATTERN = <<<'PATTERN'
+        /\G
+        (?:
+            "(?<ansi>[^"]*(?:""[^"]*)*)"         # ANSI SQL double-quoted
+          | `(?<mysql>[^`]*(?:``[^`]*)*)`        # MySQL-style backtick-quoted
+          | \[(?<sqlserver>[^]]*(?:]][^]]*)*)]   # SQL Server-style square-bracket-quoted
+          | (?<unquoted>[^\s."`\[\]]+)           # Unquoted
+        )
+        /x
+    PATTERN;
+
+    public function parse(string $input): GenericName
+    {
+        $offset      = 0;
+        $identifiers = [];
+        $length      = strlen($input);
+
+        while (true) {
+            if ($offset >= $length) {
+                throw ExpectedNextIdentifier::new();
+            }
+
+            if (preg_match(self::IDENTIFIER_PATTERN, $input, $matches, 0, $offset) === 0) {
+                throw UnableToParseIdentifier::new($offset);
+            }
+
+            if (isset($matches['ansi']) && strlen($matches['ansi']) > 0) {
+                $identifier = Identifier::quoted(str_replace('""', '"', $matches['ansi']));
+            } elseif (isset($matches['mysql']) && strlen($matches['mysql']) > 0) {
+                $identifier = Identifier::quoted(str_replace('``', '`', $matches['mysql']));
+            } elseif (isset($matches['sqlserver']) && strlen($matches['sqlserver']) > 0) {
+                $identifier = Identifier::quoted(str_replace(']]', ']', $matches['sqlserver']));
+            } else {
+                assert(isset($matches['unquoted']) && strlen($matches['unquoted']) > 0);
+                $identifier = Identifier::unquoted($matches['unquoted']);
+            }
+
+            $identifiers[] = $identifier;
+
+            $offset += strlen($matches[0]);
+
+            if ($offset >= $length) {
+                break;
+            }
+
+            $character = $input[$offset];
+
+            if ($character !== '.') {
+                throw ExpectedDot::new($offset, $character);
+            }
+
+            $offset++;
+        }
+
+        assert(count($identifiers) > 0);
+
+        return new GenericName(...$identifiers);
+    }
+}

--- a/src/Schema/Name/Parser/OptionallyQualifiedNameParser.php
+++ b/src/Schema/Name/Parser/OptionallyQualifiedNameParser.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser;
+
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\InvalidName;
+
+use function count;
+
+/**
+ * @internal
+ *
+ * @implements Parser<OptionallyQualifiedName>
+ */
+final class OptionallyQualifiedNameParser implements Parser
+{
+    public function __construct(private readonly GenericNameParser $genericNameParser)
+    {
+    }
+
+    public function parse(string $input): OptionallyQualifiedName
+    {
+        $identifiers = $this->genericNameParser->parse($input)
+            ->getIdentifiers();
+
+        return match (count($identifiers)) {
+            1 => new OptionallyQualifiedName($identifiers[0], null),
+            2 => new OptionallyQualifiedName($identifiers[1], $identifiers[0]),
+            default => throw InvalidName::forOptionallyQualifiedName(count($identifiers)),
+        };
+    }
+}

--- a/src/Schema/Name/Parser/UnqualifiedNameParser.php
+++ b/src/Schema/Name/Parser/UnqualifiedNameParser.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name\Parser;
+
+use Doctrine\DBAL\Schema\Name\Parser;
+use Doctrine\DBAL\Schema\Name\Parser\Exception\InvalidName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+use function count;
+
+/**
+ * @internal
+ *
+ * @implements Parser<UnqualifiedName>
+ */
+final class UnqualifiedNameParser implements Parser
+{
+    public function __construct(private readonly GenericNameParser $genericNameParser)
+    {
+    }
+
+    public function parse(string $input): UnqualifiedName
+    {
+        $identifiers = $this->genericNameParser->parse($input)
+            ->getIdentifiers();
+
+        if (count($identifiers) > 1) {
+            throw InvalidName::forUnqualifiedName(count($identifiers));
+        }
+
+        return new UnqualifiedName($identifiers[0]);
+    }
+}

--- a/src/Schema/Name/Parsers.php
+++ b/src/Schema/Name/Parsers.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+
+/**
+ * A static registry for name parsers.
+ *
+ * @internal This class should be used by {@link AbstractAsset} subclasses only.
+ */
+final class Parsers
+{
+    private static ?UnqualifiedNameParser $unqualifiedNameParser = null;
+
+    private static ?OptionallyQualifiedNameParser $optionallyQualifiedNameParser = null;
+
+    private static ?GenericNameParser $genericNameParser = null;
+
+    /** @codeCoverageIgnore */
+    private function __construct()
+    {
+    }
+
+    public static function getUnqualifiedNameParser(): UnqualifiedNameParser
+    {
+        return self::$unqualifiedNameParser ??= new UnqualifiedNameParser(self::getGenericNameParser());
+    }
+
+    public static function getOptionallyQualifiedNameParser(): OptionallyQualifiedNameParser
+    {
+        return self::$optionallyQualifiedNameParser ??= new OptionallyQualifiedNameParser(self::getGenericNameParser());
+    }
+
+    public static function getGenericNameParser(): GenericNameParser
+    {
+        return self::$genericNameParser ??= new GenericNameParser();
+    }
+}

--- a/src/Schema/Name/UnqualifiedName.php
+++ b/src/Schema/Name/UnqualifiedName.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+/**
+ * An unqualified {@see Name} consisting of a single identifier.
+ */
+final class UnqualifiedName extends AbstractName
+{
+    public function __construct(private readonly Identifier $identifier)
+    {
+        parent::__construct($identifier);
+    }
+
+    public function getIdentifier(): Identifier
+    {
+        return $this->identifier;
+    }
+}

--- a/src/Schema/NamedObject.php
+++ b/src/Schema/NamedObject.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+/**
+ * A database object that has a {@see Name}.
+ *
+ * This interface is intentionally designed to conflict with {@see OptionallyNamedObject}.
+ *
+ * @template N of Name
+ */
+interface NamedObject
+{
+    /**
+     * Returns the object name.
+     *
+     * @return N
+     */
+    public function getObjectName(): Name;
+}

--- a/src/Schema/OptionallyNamedObject.php
+++ b/src/Schema/OptionallyNamedObject.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+/**
+ * A database object that optionally has a {@see Name}.
+ *
+ * This interface is intentionally designed to conflict with {@see NamedObject}.
+ *
+ * @template N of Name
+ */
+interface OptionallyNamedObject
+{
+    /**
+     * Returns the object name or <code>null</code>, if the name is not set.
+     *
+     * @return ?N
+     */
+    public function getObjectName(): ?Name;
+}

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -12,8 +12,8 @@ use Doctrine\DBAL\Schema\Exception\SequenceDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\TableAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\SQL\Builder\CreateSchemaObjectsSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\DropSchemaObjectsSQLBuilder;
@@ -98,9 +98,9 @@ class Schema extends AbstractOptionallyNamedObject
         }
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    protected function getNameParser(): UnqualifiedNameParser
     {
-        return new UnqualifiedNameParser($genericNameParser);
+        return Parsers::getUnqualifiedNameParser();
     }
 
     protected function _addTable(Table $table): void

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -11,6 +11,10 @@ use Doctrine\DBAL\Schema\Exception\SequenceAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\SequenceDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\TableAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\SQL\Builder\CreateSchemaObjectsSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\DropSchemaObjectsSQLBuilder;
 
@@ -41,8 +45,10 @@ use function strtolower;
  * the CREATE/DROP SQL visitors will just filter this queries and do not
  * execute them. Only the queries for the currently connected database are
  * executed.
+ *
+ * @extends AbstractOptionallyNamedObject<UnqualifiedName>
  */
-class Schema extends AbstractAsset
+class Schema extends AbstractOptionallyNamedObject
 {
     /**
      * The namespaces in this schema.
@@ -90,6 +96,11 @@ class Schema extends AbstractAsset
         foreach ($sequences as $sequence) {
             $this->_addSequence($sequence);
         }
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    {
+        return new UnqualifiedNameParser($genericNameParser);
     }
 
     protected function _addTable(Table $table): void
@@ -180,6 +191,8 @@ class Schema extends AbstractAsset
      * Foo) then you will NOT be able to use Doctrine Schema abstraction.
      *
      * Every non-namespaced element is prefixed with this schema name.
+     *
+     * @param AbstractAsset<OptionallyQualifiedName> $asset
      */
     private function normalizeName(AbstractAsset $asset): string
     {

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 
 use function count;
 use function sprintf;
@@ -34,9 +34,9 @@ class Sequence extends AbstractNamedObject
         $this->setInitialValue($initialValue);
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): OptionallyQualifiedNameParser
+    protected function getNameParser(): OptionallyQualifiedNameParser
     {
-        return new OptionallyQualifiedNameParser($genericNameParser);
+        return Parsers::getOptionallyQualifiedNameParser();
     }
 
     public function getAllocationSize(): int

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
+
 use function count;
 use function sprintf;
 
 /**
  * Sequence structure.
+ *
+ * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
-class Sequence extends AbstractAsset
+class Sequence extends AbstractNamedObject
 {
     protected int $allocationSize = 1;
 
@@ -26,6 +32,11 @@ class Sequence extends AbstractAsset
 
         $this->setAllocationSize($allocationSize);
         $this->setInitialValue($initialValue);
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): OptionallyQualifiedNameParser
+    {
+        return new OptionallyQualifiedNameParser($genericNameParser);
     }
 
     public function getAllocationSize(): int

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -13,6 +13,9 @@ use Doctrine\DBAL\Schema\Exception\IndexNameInvalid;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
@@ -28,8 +31,10 @@ use function strtolower;
 
 /**
  * Object Representation of a table.
+ *
+ * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
-class Table extends AbstractAsset
+class Table extends AbstractNamedObject
 {
     /** @var Column[] */
     protected array $_columns = [];
@@ -109,6 +114,11 @@ class Table extends AbstractAsset
         }
 
         $this->_options = array_merge($this->_options, $options);
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): OptionallyQualifiedNameParser
+    {
+        return new OptionallyQualifiedNameParser($genericNameParser);
     }
 
     /** @deprecated Pass a {@link TableConfiguration} instance to the constructor instead. */

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -14,8 +14,8 @@ use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
@@ -116,9 +116,9 @@ class Table extends AbstractNamedObject
         $this->_options = array_merge($this->_options, $options);
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): OptionallyQualifiedNameParser
+    protected function getNameParser(): OptionallyQualifiedNameParser
     {
-        return new OptionallyQualifiedNameParser($genericNameParser);
+        return Parsers::getOptionallyQualifiedNameParser();
     }
 
     /** @deprecated Pass a {@link TableConfiguration} instance to the constructor instead. */

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_keys;
@@ -56,9 +56,9 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
         }
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    protected function getNameParser(): UnqualifiedNameParser
     {
-        return new UnqualifiedNameParser($genericNameParser);
+        return Parsers::getUnqualifiedNameParser();
     }
 
     /**

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_keys;
 use function array_map;
@@ -12,8 +15,10 @@ use function strtolower;
 
 /**
  * Class for a unique constraint.
+ *
+ * @extends AbstractOptionallyNamedObject<UnqualifiedName>
  */
-class UniqueConstraint extends AbstractAsset
+class UniqueConstraint extends AbstractOptionallyNamedObject
 {
     /**
      * Asset identifier instances of the column names the unique constraint is associated with.
@@ -49,6 +54,11 @@ class UniqueConstraint extends AbstractAsset
         foreach ($flags as $flag) {
             $this->addFlag($flag);
         }
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): UnqualifiedNameParser
+    {
+        return new UnqualifiedNameParser($genericNameParser);
     }
 
     /**

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -4,14 +4,25 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
+use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
+
 /**
  * Representation of a Database View.
+ *
+ * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
-class View extends AbstractAsset
+class View extends AbstractNamedObject
 {
     public function __construct(string $name, private readonly string $sql)
     {
         parent::__construct($name);
+    }
+
+    protected function createNameParser(GenericNameParser $genericNameParser): OptionallyQualifiedNameParser
+    {
+        return new OptionallyQualifiedNameParser($genericNameParser);
     }
 
     public function getSql(): string

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 
 /**
  * Representation of a Database View.
@@ -20,9 +20,9 @@ class View extends AbstractNamedObject
         parent::__construct($name);
     }
 
-    protected function createNameParser(GenericNameParser $genericNameParser): OptionallyQualifiedNameParser
+    protected function getNameParser(): OptionallyQualifiedNameParser
     {
-        return new OptionallyQualifiedNameParser($genericNameParser);
+        return Parsers::getOptionallyQualifiedNameParser();
     }
 
     public function getSql(): string

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -107,7 +108,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertTrue($this->hasElementWithName($this->schemaManager->listSequences(), $name));
     }
 
-    /** @param AbstractAsset[] $items */
+    /** @param AbstractAsset<OptionallyQualifiedName>[] $items */
     private function hasElementWithName(array $items, string $name): bool
     {
         $filteredList = $this->filterElementsByName($items, $name);
@@ -120,7 +121,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
      *
      * @return T[]
      *
-     * @template T of AbstractAsset
+     * @template T of AbstractAsset<OptionallyQualifiedName>
      */
     private function filterElementsByName(array $items, string $name): array
     {

--- a/tests/Schema/AbstractAssetTest.php
+++ b/tests/Schema/AbstractAssetTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\DBAL\Schema\GenericName;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -57,7 +59,7 @@ class AbstractAssetTest extends TestCase
     {
         $identifier = new Identifier($name);
 
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6607');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
         $identifier->getQuotedName($platform);
     }
 
@@ -89,5 +91,14 @@ class AbstractAssetTest extends TestCase
             ['id', new PostgreSQLPlatform()],
             ['ID', new PostgreSQLPlatform()],
         ];
+    }
+
+    public function testConstructWithoutArguments(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6610');
+
+        new /** @extends AbstractAsset<GenericName> */
+        class extends AbstractAsset {
+        };
     }
 }

--- a/tests/Schema/AbstractAssetTest.php
+++ b/tests/Schema/AbstractAssetTest.php
@@ -9,8 +9,8 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
-use Doctrine\DBAL\Schema\GenericName;
 use Doctrine\DBAL\Schema\Identifier;
+use Doctrine\DBAL\Schema\Name\GenericName;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -39,9 +39,6 @@ class AbstractAssetTest extends TestCase
             // unquoted name not in normal case qualified by quoted name
             ['"_".id', new OraclePlatform()],
             ['"_".ID', new PostgreSQLPlatform()],
-
-            // name with more than one qualifier
-            ['i.am.overqualified', new MySQLPlatform()],
 
             // parse error
             ['table.', new MySQLPlatform()],
@@ -99,6 +96,15 @@ class AbstractAssetTest extends TestCase
 
         new /** @extends AbstractAsset<GenericName> */
         class extends AbstractAsset {
+        };
+    }
+
+    public function testCreateParserNotImplemented(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
+
+        new /** @extends AbstractAsset<GenericName> */
+        class ('foo') extends AbstractAsset {
         };
     }
 }

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\SchemaDiff;
@@ -810,7 +811,7 @@ abstract class AbstractComparatorTestCase extends TestCase
     }
 
     /**
-     * @param array<AbstractAsset> $assets
+     * @param array<AbstractAsset<UnqualifiedName>> $assets
      *
      * @return array<string>
      */

--- a/tests/Schema/AbstractNamedObjectTest.php
+++ b/tests/Schema/AbstractNamedObjectTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\AbstractNamedObject;
+use Doctrine\DBAL\Schema\Exception\NameIsNotInitialized;
+use Doctrine\DBAL\Schema\Name;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+class AbstractNamedObjectTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testEmptyName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
+
+        new /** @extends AbstractNamedObject<Name> */
+        class ('') extends AbstractNamedObject {
+        };
+    }
+
+    public function testSetAccessToUninitializedName(): void
+    {
+        $object = new /** @extends AbstractNamedObject<Name> */
+        class ('') extends AbstractNamedObject {
+        };
+
+        $this->expectException(NameIsNotInitialized::class);
+        $object->getObjectName();
+    }
+}

--- a/tests/Schema/AbstractOptionallyNamedObjectTest.php
+++ b/tests/Schema/AbstractOptionallyNamedObjectTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\AbstractOptionallyNamedObject;
+use Doctrine\DBAL\Schema\Exception\NameIsNotInitialized;
+use Doctrine\DBAL\Schema\Name;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AbstractOptionallyNamedObjectTest extends TestCase
+{
+    #[DataProvider('emptyNameProvider')]
+    public function testEmptyName(?string $name): void
+    {
+        $object = new /** @extends AbstractOptionallyNamedObject<Name> */
+        class ($name) extends AbstractOptionallyNamedObject {
+        };
+
+        self::assertNull($object->getObjectName());
+    }
+
+    /** @return iterable<string,array{?string}> */
+    public static function emptyNameProvider(): iterable
+    {
+        yield 'empty-string' => [''];
+        yield 'empty-null' => [null];
+    }
+
+    public function testSetAccessToUninitializedName(): void
+    {
+        $object = new /** @extends AbstractOptionallyNamedObject<Name> */
+        class () extends AbstractOptionallyNamedObject {
+            /** @phpstan-ignore constructor.missingParentCall */
+            public function __construct()
+            {
+            }
+        };
+
+        $this->expectException(NameIsNotInitialized::class);
+        $object->getObjectName();
+    }
+}

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -4,18 +4,23 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ColumnTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public function testGet(): void
     {
         $column = $this->createColumn();
@@ -148,5 +153,29 @@ class ColumnTest extends TestCase
         $columnArray = $column->toArray();
         self::assertArrayHasKey('comment', $columnArray);
         self::assertEquals('foo', $columnArray['comment']);
+    }
+
+    /** @throws Exception */
+    public function testEmptyName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
+
+        new Column('', Type::getType(Types::INTEGER));
+    }
+
+    /** @throws Exception */
+    public function testQualifiedName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
+
+        new Column('t.id', Type::getType(Types::INTEGER));
+    }
+
+    /** @throws Exception */
+    public function testGetObjectName(): void
+    {
+        $column = new Column('id', Type::getType(Types::INTEGER));
+
+        self::assertEquals(Identifier::unquoted('id'), $column->getObjectName()->getIdentifier());
     }
 }

--- a/tests/Schema/IdentifierTest.php
+++ b/tests/Schema/IdentifierTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Identifier;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+class IdentifierTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testEmptyName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
+
+        new Identifier('');
+    }
+
+    /** @throws Exception */
+    public function testGetObjectName(): void
+    {
+        $identifier = new Identifier('warehouse.inventory.products.id');
+        $name       = $identifier->getObjectName();
+
+        self::assertEquals([
+            \Doctrine\DBAL\Schema\Name\Identifier::unquoted('warehouse'),
+            \Doctrine\DBAL\Schema\Name\Identifier::unquoted('inventory'),
+            \Doctrine\DBAL\Schema\Name\Identifier::unquoted('products'),
+            \Doctrine\DBAL\Schema\Name\Identifier::unquoted('id'),
+        ], $name->getIdentifiers());
+    }
+}

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -170,5 +172,23 @@ class IndexTest extends TestCase
         self::assertSame('name IS NULL', $idx2->getOption('where'));
         self::assertSame('name IS NULL', $idx2->getOption('WHERE'));
         self::assertSame(['where' => 'name IS NULL'], $idx2->getOptions());
+    }
+
+    /** @throws Exception */
+    public function testGetNonNullObjectName(): void
+    {
+        $index = new Index('idx_user_id', ['user_id']);
+        $name  = $index->getObjectName();
+
+        self::assertNotNull($name);
+        self::assertEquals(Identifier::unquoted('idx_user_id'), $name->getIdentifier());
+    }
+
+    /** @throws Exception */
+    public function testGetNullObjectName(): void
+    {
+        $index = new Index(null, ['user_id']);
+
+        self::assertNull($index->getObjectName());
     }
 }

--- a/tests/Schema/Name/IdentifierTest.php
+++ b/tests/Schema/Name/IdentifierTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Name;
+
+use Doctrine\DBAL\Schema\Exception\InvalidIdentifier;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class IdentifierTest extends TestCase
+{
+    public function testIdentifierCannotBeEmpty(): void
+    {
+        $this->expectException(InvalidIdentifier::class);
+
+        Identifier::unquoted('');
+    }
+
+    #[DataProvider('toStringProvider')]
+    public function testToString(Identifier $identifier, string $expected): void
+    {
+        self::assertSame($expected, $identifier->toString());
+    }
+
+    /** @return iterable<array{Identifier, string}> */
+    public static function toStringProvider(): iterable
+    {
+        yield [Identifier::unquoted('id'), 'id'];
+        yield [Identifier::quoted('name'), '"name"'];
+        yield [Identifier::quoted('"value"'), '"""value"""'];
+    }
+}

--- a/tests/Schema/Name/OptionallyQualifiedNameTest.php
+++ b/tests/Schema/Name/OptionallyQualifiedNameTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Name;
+
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use PHPUnit\Framework\TestCase;
+
+class OptionallyQualifiedNameTest extends TestCase
+{
+    public function testWithQualifier(): void
+    {
+        $unqualifiedName = Identifier::quoted('customers');
+        $qualifier       = Identifier::unquoted('inventory');
+
+        $name = new OptionallyQualifiedName($unqualifiedName, $qualifier);
+
+        self::assertSame($unqualifiedName, $name->getUnqualifiedName());
+        self::assertSame($qualifier, $name->getQualifier());
+
+        self::assertSame('inventory."customers"', $name->toString());
+    }
+
+    public function testWithoutQualifier(): void
+    {
+        $unqualifiedName = Identifier::unquoted('users');
+
+        $name = new OptionallyQualifiedName($unqualifiedName, null);
+
+        self::assertSame($unqualifiedName, $name->getUnqualifiedName());
+        self::assertNull($name->getQualifier());
+
+        self::assertSame('users', $name->toString());
+    }
+}

--- a/tests/Schema/Name/Parser/GenericNameParserTest.php
+++ b/tests/Schema/Name/Parser/GenericNameParserTest.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\DBAL\Tests\Schema\Name;
+namespace Doctrine\DBAL\Tests\Schema\Name\Parser;
 
-use Doctrine\DBAL\Schema\Name\Parser;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\Parser\Exception;
 use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedDot;
 use Doctrine\DBAL\Schema\Name\Parser\Exception\ExpectedNextIdentifier;
 use Doctrine\DBAL\Schema\Name\Parser\Exception\UnableToParseIdentifier;
-use Doctrine\DBAL\Schema\Name\Parser\Identifier;
+use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class ParserTest extends TestCase
+class GenericNameParserTest extends TestCase
 {
-    private Parser $parser;
+    private GenericNameParser $parser;
 
     protected function setUp(): void
     {
-        $this->parser = new Parser();
+        $this->parser = new GenericNameParser();
     }
 
     /**
@@ -31,13 +31,12 @@ class ParserTest extends TestCase
     public function testValidInput(string $input, array $expected): void
     {
         $name = $this->parser->parse($input);
-        self::assertEquals($expected, $name);
+        self::assertEquals($expected, $name->getIdentifiers());
     }
 
     /** @return iterable<array{string, list<Identifier>}> */
     public static function validInputProvider(): iterable
     {
-        yield ['', []];
         yield ['table', [Identifier::unquoted('table')]];
         yield ['schema.table', [Identifier::unquoted('schema'), Identifier::unquoted('table')]];
 
@@ -124,6 +123,8 @@ class ParserTest extends TestCase
     /** @return iterable<array{string, class-string<Exception>}> */
     public static function invalidInputProvider(): iterable
     {
+        yield ['', ExpectedNextIdentifier::class];
+
         yield ['"example.com', UnableToParseIdentifier::class];
         yield ['`example.com', UnableToParseIdentifier::class];
         yield ['[example.com', UnableToParseIdentifier::class];

--- a/tests/Schema/Name/UnqualifiedNameTest.php
+++ b/tests/Schema/Name/UnqualifiedNameTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Name;
+
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use PHPUnit\Framework\TestCase;
+
+class UnqualifiedNameTest extends TestCase
+{
+    public function testWithQualifier(): void
+    {
+        $identifier = Identifier::quoted('id');
+
+        $name = new UnqualifiedName($identifier);
+
+        self::assertSame($identifier, $name->getIdentifier());
+
+        self::assertSame('"id"', $name->toString());
+    }
+}

--- a/tests/Schema/SequenceTest.php
+++ b/tests/Schema/SequenceTest.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class SequenceTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public function testIsAutoincrementFor(): void
     {
         $table = new Table('foo');
@@ -43,5 +48,39 @@ class SequenceTest extends TestCase
         self::assertFalse($sequence2->isAutoIncrementsFor($table));
         self::assertFalse($sequence3->isAutoIncrementsFor($table));
         self::assertFalse($sequence4->isAutoIncrementsFor($table));
+    }
+
+    public function testEmptyName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
+
+        new Sequence('');
+    }
+
+    public function testOverqualifiedName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
+
+        new Sequence('identity.auth.user_id_seq');
+    }
+
+    /** @throws Exception */
+    public function testGetUnqualifiedObjectName(): void
+    {
+        $sequence = new Sequence('user_id_seq');
+        $name     = $sequence->getObjectName();
+
+        self::assertEquals(Identifier::unquoted('user_id_seq'), $name->getUnqualifiedName());
+        self::assertNull($name->getQualifier());
+    }
+
+    /** @throws Exception */
+    public function testGetQualifiedObjectName(): void
+    {
+        $sequence = new Sequence('auth.user_id_seq');
+        $name     = $sequence->getObjectName();
+
+        self::assertEquals(Identifier::unquoted('user_id_seq'), $name->getUnqualifiedName());
+        self::assertEquals(Identifier::unquoted('auth'), $name->getQualifier());
     }
 }

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -966,5 +967,32 @@ class TableTest extends TestCase
 
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6559');
         $table->dropColumn('id');
+    }
+
+    public function testOverqualifiedName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
+
+        new Table('warehouse.inventory.products');
+    }
+
+    /** @throws Exception */
+    public function testGetUnqualifiedObjectName(): void
+    {
+        $table = new Table('products');
+        $name  = $table->getObjectName();
+
+        self::assertEquals(Identifier::unquoted('products'), $name->getUnqualifiedName());
+        self::assertNull($name->getQualifier());
+    }
+
+    /** @throws Exception */
+    public function testGetQualifiedObjectName(): void
+    {
+        $table = new Table('inventory.products');
+        $name  = $table->getObjectName();
+
+        self::assertEquals(Identifier::unquoted('products'), $name->getUnqualifiedName());
+        self::assertEquals(Identifier::unquoted('inventory'), $name->getQualifier());
     }
 }

--- a/tests/Schema/UniqueConstraintTest.php
+++ b/tests/Schema/UniqueConstraintTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+class UniqueConstraintTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    /** @throws Exception */
+    public function testGetNonNullObjectName(): void
+    {
+        $uniqueConstraint = new UniqueConstraint('uq_user_id', ['user_id']);
+        $name             = $uniqueConstraint->getObjectName();
+
+        self::assertNotNull($name);
+        self::assertEquals(Identifier::unquoted('uq_user_id'), $name->getIdentifier());
+    }
+
+    /** @throws Exception */
+    public function testGetNullObjectName(): void
+    {
+        $uniqueConstraint = new UniqueConstraint('', ['user_id']);
+
+        self::assertNull($uniqueConstraint->getObjectName());
+    }
+}

--- a/tests/Schema/ViewTest.php
+++ b/tests/Schema/ViewTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\View;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+class ViewTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testEmptyName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
+
+        new View('', '');
+    }
+
+    public function testOverqualifiedName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
+
+        new View('warehouse.inventory.available_products', '');
+    }
+
+    /** @throws Exception */
+    public function testGetUnqualifiedObjectName(): void
+    {
+        $view = new View('active_users', '');
+        $name = $view->getObjectName();
+
+        self::assertEquals(Identifier::unquoted('active_users'), $name->getUnqualifiedName());
+        self::assertNull($name->getQualifier());
+    }
+
+    /** @throws Exception */
+    public function testGetQualifiedObjectName(): void
+    {
+        $view = new View('inventory.available_products', '');
+        $name = $view->getObjectName();
+
+        self::assertEquals(Identifier::unquoted('available_products'), $name->getUnqualifiedName());
+        self::assertEquals(Identifier::unquoted('inventory'), $name->getQualifier());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

This is a continuation of the effort to improve handling database object names. In this PR, in addition to object names expressed as strings, I'm introducing value objects that represent names.

## Design Overview

### Names

The interface for all names is `Name`. Currently, it has a single method `toString(): string`. There are various implementations of `Name`:
1. `UnqualifiedName` – to be used by the objects that exist within a table and thus cannot have a qualifier (e.g., column name).
2. `OptionallyQualifiedName` – to be used by the objects that exist within a database and optionally may exist in a different schema than the current one (e.g., table name).
3. `GenericName` – to be used for building ad-hoc SQL queries and eventually replace the `Identifier` class.

### Named Objects

All database objects (the subclasses of `AbstractAsset`) will implement one of following interfaces:
1. `NamedObject<N extends Name>` – the ones that have a name of type `N`,
2. `OptionallyNamedObject<N extends Name>` – similar but the name is optional (implemented by indexes and constraints).

The interfaces conflict by design, since each class will have either a `Name` or an optional `?Name`, not both.

### Parsing Names

The `Parser` class introduced earlier has been broken down into a `Parser<N extends Name>` interface and one implementation per `Name` type. `GenericNameParser` parses the string into a generic name which may contain an arbitrary number of identifiers, and other parsers ensure that the name contains exactly as many identifiers as supported by the name.

### Deprecations

Using the names that cannot be parsed is deprecated. Each database object will try to parse its name using the corresponding parser in `_setName()`, and if that fails, a deprecation will trigger. In DBAL 5.0, all this logic will move to the class constructors (see https://github.com/doctrine/dbal/pull/6614).

As part of the implementation, the PR introduces two deprecated methods: `AbstractAsset::createNameParser()` and `AbstractAsset::setObjectName()` – they will be removed in DBAL 5.0 but aren't marked as internal because someone may want to use them to migrate their own implementation of `AbstractAsset`.

The chances that there are implementations of `AbstractAsset` outside of DBAL are very unlikely. Furthermore, the class itself is used in method signatures literally in a couple of places (it's more like a trait). Most likely, it will be removed in DBAL 5.0. With that said, I'm marking it as `@internal` for now.

### Technical Challenges

#### `NamedObject::getObjectName()` and `OptionallyNamedObject::getObjectName()`

This method name sucks. A proper name would be `getName()`, but it's already taken and will be eventually deprecated. Unlike changing the parameter type in a method, I don't know of an easy way to change the return type w/o introducing a new method.

### Next Steps

1. Add `Name::toSQL(): string` as a replacement for `AbstractAsset::getQuotedName()`. I could have done it right now but it wouldn't be used anywhere and would be untested.
2. Try to get rid of `Schema\Identifier` in favor of the corresponding `Name` on a per-case basis – this is where `Name::toSQL()` will be used.
3. Instead of using lowercased old names as object keys (e.g. for columns in the table) use the new keys and apply the normalization logic of the target platform. Thus, `"id"` and `ID` could co-exist for Oracle and IBM DB2 ([reference](https://github.com/doctrine/dbal/issues/4357#issuecomment-911123014)).