### PR TITLE
lowercase version tag before checking if mariadb

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -38,7 +38,7 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
      */
     public function createDatabasePlatformForVersion($version)
     {
-        $mariadb = stripos($version, 'mariadb') !== false;
+        $mariadb = stripos(strtolower($version), 'mariadb') !== false;
 
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | (none)
#### Summary

This fixes a bug where MariaDB was not detected as MariaDB because the version tag that was automatically added by PDO has uppercase characters while the check only checks for lowercase characters.
My specific case was the mariadb image on https://hub.docker.com/_/mariadb and a custom image based on https://hub.docker.com/_/php where pdo_mysql is installed using [mlocati/docker-php-extension-installer](https://github.com/mlocati/docker-php-extension-installer)

I considered changing the lowercase character to MariaDB with uppercase characters but it felt like like a no brainer that this would probably do harm as well.