### PR TITLE
Deprecate Sequence::isAutoIncrementsFor()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `Sequence::isAutoIncrementsFor()`
+
+The `Sequence::isAutoIncrementsFor()` method has been deprecated.
+
 ## Deprecated using invalid database object names
 
 Using the following objects with an empty name is deprecated: `Column`, `View`, `Sequence`, `Identifier`.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -122,6 +122,12 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNameParser" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6654
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Sequence::isAutoIncrementsFor" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
+use Doctrine\Deprecations\Deprecation;
 
 use function count;
 use function sprintf;
@@ -80,9 +81,18 @@ class Sequence extends AbstractNamedObject
      *
      * This is used inside the comparator to not report sequences as missing,
      * when the "from" schema implicitly creates the sequences.
+     *
+     * @deprecated
      */
     public function isAutoIncrementsFor(Table $table): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6654',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         $primaryKey = $table->getPrimaryKey();
 
         if ($primaryKey === null) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

There are two problems with `Sequence::isAutoIncrementsFor()`:
1. It uses `AbstractAsset::getShortestName()`, which I plan to deprecate and remove (https://github.com/doctrine/dbal/issues/6653).
2. It is improperly designed and doesn't work.

The method checks if a given sequence backs an autoincrement column in the given table. It does that by comparing the sequence name with the name of the sequence that the DBAL would generate for a given table:

https://github.com/doctrine/dbal/blob/6787d4103d2980595215620138a957b1eed1956d/src/Schema/Sequence.php#L116-L118

### Problems with the implementation

This implementation was relevant and worked for PostgreSQL up until https://github.com/doctrine/dbal/pull/5396 but never worked for Oracle:

https://github.com/doctrine/dbal/blob/6429739e2c8f1f7f2b121408d4771748c7f62a3f/src/Platforms/OraclePlatform.php#L676-L677

The autoincrement sequence name there doesn't contain the column name, so it will never match the expected pattern.

The following test will pass on all supported platforms except for Oracle with or without the method in question being used:

```php
public function testAutoIncrementSequenceAreNotCompared(): void
{
    $schema = new Schema();

    $table = $schema->createTable('auto_increment');
    $table->addColumn('id', Types::INTEGER)
        ->setAutoincrement(true);

    $this->dropAndCreateTable($table);

    $sm   = $this->connection->createSchemaManager();
    $diff = $sm->createComparator()
        ->compareSchemas($sm->introspectSchema(), $schema);

    self::assertEmpty($diff->getDroppedSequences());
}
```

### Problems with the design

The logic of detecting autoincrement sequences is platform-specific and should be implemented in platform-specific code (ideally, next to where that name is generated), not in the abstract API.

### Deprecation

Given that the problem with Oracle was never reported, the API design being questionable and the fact that this is a dependency for the deprecation of `AbstractAsset::getShortestName()`, I'm deprecating this method without a replacement at this point.

### Additional considerations

DBAL uses sequences as an implementation detail for autoincrement columns (currently, only for Oracle). This implementation has other flaws (e.g. https://github.com/doctrine/dbal/issues/4997). At some point, we may want to drop the support for sequences as the first class citizen and only use them internally as an implementation detail.