### PR TITLE
Remove Sequence::isAutoIncrementsFor()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `Sequence::isAutoIncrementsFor()`
+
+The `Sequence::isAutoIncrementsFor()` method has been removed.
+
 ## BC BREAK: Removed support for altering `Table` configuration
 
 The `Table::setSchemaConfig()` and `::_getMaxIdentifierLength()` methods and the `Table::$_schemaConfig` property have

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -62,12 +62,6 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNameParser" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6654
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\Sequence::isAutoIncrementsFor" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -84,9 +84,7 @@ class Comparator
         foreach ($newSchema->getSequences() as $newSequence) {
             $newSequenceName = $newSequence->getShortestName($newSchema->getName());
             if (! $oldSchema->hasSequence($newSequenceName)) {
-                if (! $this->isAutoIncrementSequenceInSchema($oldSchema, $newSequence)) {
-                    $createdSequences[] = $newSequence;
-                }
+                $createdSequences[] = $newSequence;
             } else {
                 if ($this->diffSequence($newSequence, $oldSchema->getSequence($newSequenceName))) {
                     $alteredSequences[] = $newSchema->getSequence($newSequenceName);
@@ -95,10 +93,6 @@ class Comparator
         }
 
         foreach ($oldSchema->getSequences() as $oldSequence) {
-            if ($this->isAutoIncrementSequenceInSchema($newSchema, $oldSequence)) {
-                continue;
-            }
-
             $oldSequenceName = $oldSequence->getShortestName($oldSchema->getName());
 
             if ($newSchema->hasSequence($oldSequenceName)) {
@@ -118,17 +112,6 @@ class Comparator
             $alteredSequences,
             $droppedSequences,
         );
-    }
-
-    private function isAutoIncrementSequenceInSchema(Schema $schema, Sequence $sequence): bool
-    {
-        foreach ($schema->getTables() as $table) {
-            if ($sequence->isAutoIncrementsFor($table)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public function diffSequence(Sequence $sequence1, Sequence $sequence2): bool

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -7,10 +7,6 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
-use Doctrine\Deprecations\Deprecation;
-
-use function count;
-use function sprintf;
 
 /**
  * Sequence structure.
@@ -74,47 +70,5 @@ class Sequence extends AbstractNamedObject
         $this->cache = $cache;
 
         return $this;
-    }
-
-    /**
-     * Checks if this sequence is an autoincrement sequence for a given table.
-     *
-     * This is used inside the comparator to not report sequences as missing,
-     * when the "from" schema implicitly creates the sequences.
-     *
-     * @deprecated
-     */
-    public function isAutoIncrementsFor(Table $table): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6654',
-            '%s is deprecated and will be removed in 5.0.',
-            __METHOD__,
-        );
-
-        $primaryKey = $table->getPrimaryKey();
-
-        if ($primaryKey === null) {
-            return false;
-        }
-
-        $pkColumns = $primaryKey->getColumns();
-
-        if (count($pkColumns) !== 1) {
-            return false;
-        }
-
-        $column = $table->getColumn($pkColumns[0]);
-
-        if (! $column->getAutoincrement()) {
-            return false;
-        }
-
-        $sequenceName      = $this->getShortestName($table->getNamespaceName());
-        $tableName         = $table->getShortestName($table->getNamespaceName());
-        $tableSequenceName = sprintf('%s_%s_seq', $tableName, $column->getShortestName($table->getNamespaceName()));
-
-        return $tableSequenceName === $sequenceName;
     }
 }

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -633,45 +633,6 @@ abstract class AbstractComparatorTestCase extends TestCase
         );
     }
 
-    public function testAutoIncrementSequences(): void
-    {
-        $oldSchema = new Schema();
-        $table     = $oldSchema->createTable('foo');
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
-        $oldSchema->createSequence('foo_id_seq');
-
-        $newSchema = new Schema();
-        $table     = $newSchema->createTable('foo');
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
-
-        self::assertCount(0, $diff->getDroppedSequences());
-    }
-
-    /**
-     * Check that added autoincrement sequence is not populated in newSequences
-     */
-    public function testAutoIncrementNoSequences(): void
-    {
-        $oldSchema = new Schema();
-        $table     = $oldSchema->createTable('foo');
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $newSchema = new Schema();
-        $table     = $newSchema->createTable('foo');
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
-        $newSchema->createSequence('foo_id_seq');
-
-        $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
-
-        self::assertCount(0, $diff->getCreatedSequences());
-    }
-
     public function testComparesNamespaces(): void
     {
         $oldSchema = new Schema([], [], null, ['foo', 'bar']);

--- a/tests/Schema/SequenceTest.php
+++ b/tests/Schema/SequenceTest.php
@@ -8,48 +8,12 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Sequence;
-use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class SequenceTest extends TestCase
 {
     use VerifyDeprecations;
-
-    public function testIsAutoincrementFor(): void
-    {
-        $table = new Table('foo');
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $sequence  = new Sequence('foo_id_seq');
-        $sequence2 = new Sequence('bar_id_seq');
-        $sequence3 = new Sequence('other.foo_id_seq');
-
-        self::assertTrue($sequence->isAutoIncrementsFor($table));
-        self::assertFalse($sequence2->isAutoIncrementsFor($table));
-        self::assertFalse($sequence3->isAutoIncrementsFor($table));
-    }
-
-    public function testIsAutoincrementForCaseInsensitive(): void
-    {
-        $table = new Table('foo');
-        $table->addColumn('ID', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['ID']);
-
-        $sequence  = new Sequence('foo_id_seq');
-        $sequence1 = new Sequence('foo_ID_seq');
-        $sequence2 = new Sequence('bar_id_seq');
-        $sequence3 = new Sequence('bar_ID_seq');
-        $sequence4 = new Sequence('other.foo_id_seq');
-
-        self::assertTrue($sequence->isAutoIncrementsFor($table));
-        self::assertTrue($sequence1->isAutoIncrementsFor($table));
-        self::assertFalse($sequence2->isAutoIncrementsFor($table));
-        self::assertFalse($sequence3->isAutoIncrementsFor($table));
-        self::assertFalse($sequence4->isAutoIncrementsFor($table));
-    }
 
     public function testEmptyName(): void
     {


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/6654.