### PR TITLE
Deprecate AbstractAsset::getShortestName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractAsset::getShortestName()`
+
+The `AbstractAsset::getShortestName()` method has been deprecated. Use `AbstractAsset::getName()` instead.
+
 ## Deprecated `Sequence::isAutoIncrementsFor()`
 
 The `Sequence::isAutoIncrementsFor()` method has been deprecated.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -128,6 +128,12 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\Sequence::isAutoIncrementsFor" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6657
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getShortestName" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -250,9 +250,18 @@ abstract class AbstractAsset
     /**
      * The shortest name is stripped of the default namespace. All other
      * namespaced elements are returned as full-qualified names.
+     *
+     * @deprecated Use {@link getName()} instead.
      */
     public function getShortestName(?string $defaultNamespaceName): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6657',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         $shortestName = $this->getName();
         if ($this->_namespace === $defaultNamespaceName) {
             $shortestName = $this->_name;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

See https://github.com/doctrine/dbal/issues/6653 for details.