### PR TITLE
Remove AbstractAsset::getShortestName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractAsset::getShortestName()`
+
+The `AbstractAsset::getShortestName()` method has been removed.
+
 ## BC BREAK: Removed `Sequence::isAutoIncrementsFor()`
 
 The `Sequence::isAutoIncrementsFor()` method has been removed.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -62,12 +62,6 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNameParser" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6657
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getShortestName" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function assert;
@@ -21,7 +20,6 @@ use function crc32;
 use function dechex;
 use function implode;
 use function str_replace;
-use function strtolower;
 use function strtoupper;
 use function substr;
 
@@ -156,29 +154,6 @@ abstract class AbstractAsset
     public function getNamespaceName(): ?string
     {
         return $this->_namespace;
-    }
-
-    /**
-     * The shortest name is stripped of the default namespace. All other
-     * namespaced elements are returned as full-qualified names.
-     *
-     * @deprecated Use {@link getName()} instead.
-     */
-    public function getShortestName(?string $defaultNamespaceName): string
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6657',
-            '%s is deprecated and will be removed in 5.0.',
-            __METHOD__,
-        );
-
-        $shortestName = $this->getName();
-        if ($this->_namespace === $defaultNamespaceName) {
-            $shortestName = $this->_name;
-        }
-
-        return strtolower($shortestName);
     }
 
     /**

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -56,11 +56,11 @@ class Comparator
         foreach ($newSchema->getTables() as $newTable) {
             $newTableName = $newTable->getShortestName($newSchema->getName());
             if (! $oldSchema->hasTable($newTableName)) {
-                $createdTables[] = $newSchema->getTable($newTableName);
+                $createdTables[] = $newTable;
             } else {
                 $tableDiff = $this->compareTables(
                     $oldSchema->getTable($newTableName),
-                    $newSchema->getTable($newTableName),
+                    $newTable,
                 );
 
                 if (! $tableDiff->isEmpty()) {
@@ -87,7 +87,7 @@ class Comparator
                 $createdSequences[] = $newSequence;
             } else {
                 if ($this->diffSequence($newSequence, $oldSchema->getSequence($newSequenceName))) {
-                    $alteredSequences[] = $newSchema->getSequence($newSequenceName);
+                    $alteredSequences[] = $newSequence;
                 }
             }
         }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -54,7 +54,7 @@ class Comparator
         }
 
         foreach ($newSchema->getTables() as $newTable) {
-            $newTableName = $newTable->getShortestName($newSchema->getName());
+            $newTableName = $newTable->getName();
             if (! $oldSchema->hasTable($newTableName)) {
                 $createdTables[] = $newTable;
             } else {
@@ -71,7 +71,7 @@ class Comparator
 
         // Check if there are tables removed
         foreach ($oldSchema->getTables() as $oldTable) {
-            $oldTableName = $oldTable->getShortestName($oldSchema->getName());
+            $oldTableName = $oldTable->getName();
 
             $oldTable = $oldSchema->getTable($oldTableName);
             if ($newSchema->hasTable($oldTableName)) {
@@ -82,7 +82,7 @@ class Comparator
         }
 
         foreach ($newSchema->getSequences() as $newSequence) {
-            $newSequenceName = $newSequence->getShortestName($newSchema->getName());
+            $newSequenceName = $newSequence->getName();
             if (! $oldSchema->hasSequence($newSequenceName)) {
                 $createdSequences[] = $newSequence;
             } else {
@@ -93,7 +93,7 @@ class Comparator
         }
 
         foreach ($oldSchema->getSequences() as $oldSequence) {
-            $oldSequenceName = $oldSequence->getShortestName($oldSchema->getName());
+            $oldSequenceName = $oldSequence->getName();
 
             if ($newSchema->hasSequence($oldSequenceName)) {
                 continue;

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -135,7 +135,13 @@ SQL,
      */
     protected function _getPortableViewDefinition(array $view): View
     {
-        return new View($view['schemaname'] . '.' . $view['viewname'], $view['definition']);
+        if ($view['schemaname'] === $this->getCurrentSchema()) {
+            $name = $view['viewname'];
+        } else {
+            $name = $view['schemaname'] . '.' . $view['viewname'];
+        }
+
+        return new View($name, $view['definition']);
     }
 
     /**
@@ -202,7 +208,7 @@ SQL,
      */
     protected function _getPortableSequenceDefinition(array $sequence): Sequence
     {
-        if ($sequence['schemaname'] !== 'public') {
+        if ($sequence['schemaname'] !== $this->getCurrentSchema()) {
             $sequenceName = $sequence['schemaname'] . '.' . $sequence['relname'];
         } else {
             $sequenceName = $sequence['relname'];

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -128,7 +128,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         return array_filter(
             $items,
             static function (AbstractAsset $item) use ($name): bool {
-                return $item->getShortestName($item->getNamespaceName()) === $name;
+                return strtolower($item->getName()) === $name;
             },
         );
     }

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -600,23 +600,6 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertCount(2, $diff->getCreatedTables());
     }
 
-    public function testFqnSchemaComparisonDifferentSchemaNameButSameTableNoDiff(): void
-    {
-        $config = new SchemaConfig();
-        $config->setName('foo');
-
-        $oldSchema = new Schema([], [], $config);
-        $oldSchema->createTable('foo.bar');
-
-        $newSchema = new Schema();
-        $newSchema->createTable('bar');
-
-        self::assertEquals(
-            new SchemaDiff([], [], [], [], [], [], [], []),
-            $this->comparator->compareSchemas($oldSchema, $newSchema),
-        );
-    }
-
     public function testFqnSchemaComparisonNoSchemaSame(): void
     {
         $config = new SchemaConfig();


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/6657.