### PR TITLE
Introduce table editor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## `Table::__construct()` marked as internal
+
+The `Table::__construct()` method has been marked as internal. Use `Table::editor()` to instantiate an editor and
+`TableEditor::create()` to create a table.
+
 ## Deprecated `AbstractAsset::getShortestName()`
 
 The `AbstractAsset::getShortestName()` method has been deprecated. Use `AbstractAsset::getName()` instead.

--- a/src/Schema/Exception/InvalidTableDefinition.php
+++ b/src/Schema/Exception/InvalidTableDefinition.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+/** @psalm-immutable */
+final class InvalidTableDefinition extends LogicException implements SchemaException
+{
+    public static function nameNotSet(): self
+    {
+        return new self('Table name is not set.');
+    }
+}

--- a/src/Schema/Name.php
+++ b/src/Schema/Name.php
@@ -12,8 +12,7 @@ interface Name
     /**
      * Returns the string representation of the name.
      *
-     * The consumers of this method should not rely on a specific return value. It should be used only for diagnostic
-     * purposes.
+     * If passed to the corresponding parser, the name should be parsed back to an equivalent object.
      */
     public function toString(): string;
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -283,12 +283,13 @@ class Schema extends AbstractOptionallyNamedObject
      */
     public function createTable(string $name): Table
     {
-        $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
-        $this->_addTable($table);
+        $table = Table::editor()
+            ->setName($name)
+            ->setOptions($this->_schemaConfig->getDefaultTableOptions())
+            ->setConfiguration($this->_schemaConfig->toTableConfiguration())
+            ->create();
 
-        foreach ($this->_schemaConfig->getDefaultTableOptions() as $option => $value) {
-            $table->addOption($option, $value);
-        }
+        $this->_addTable($table);
 
         return $table;
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -848,6 +848,31 @@ class Table extends AbstractNamedObject
     }
 
     /**
+     * Instantiates a new table editor.
+     */
+    public static function editor(): TableEditor
+    {
+        return new TableEditor();
+    }
+
+    /**
+     * Instantiates a new table editor and initializes it with the table's properties.
+     */
+    public function edit(): TableEditor
+    {
+        return self::editor()
+            ->setName($this->getObjectName()->toString())
+            ->setColumns($this->_columns)
+            ->setIndexes($this->_indexes)
+            ->setUniqueConstraints($this->uniqueConstraints)
+            ->setForeignKeyConstraints($this->_fkConstraints)
+            ->setOptions($this->_options)
+            ->setConfiguration(
+                new TableConfiguration($this->maxIdentifierLength),
+            );
+    }
+
+    /**
      * @param array<string|int, string> $columns
      * @param array<int, string>        $flags
      * @param array<string, mixed>      $options

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -72,6 +72,9 @@ class Table extends AbstractNamedObject
     private int $maxIdentifierLength;
 
     /**
+     * @internal Use {@link Table::editor()} to instantiate an editor and {@link TableEditor::create()}
+     *           to create a table.
+     *
      * @param array<Column>               $columns
      * @param array<Index>                $indexes
      * @param array<UniqueConstraint>     $uniqueConstraints

--- a/src/Schema/TableConfiguration.php
+++ b/src/Schema/TableConfiguration.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Schema;
 /**
  * Contains platform-specific parameters used for creating and managing objects scoped to a {@see Table}.
  */
-class TableConfiguration
+final class TableConfiguration
 {
     /** @internal The configuration can be only instantiated by a {@see SchemaConfig}. */
     public function __construct(private readonly int $maxIdentifierLength)

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
+
+final class TableEditor
+{
+    private ?string $name = null;
+
+    /** @var array<Column> */
+    private array $columns = [];
+
+    /** @var array<Index> */
+    private array $indexes = [];
+
+    /** @var array<UniqueConstraint> */
+    private array $uniqueConstraints = [];
+
+    /** @var array<ForeignKeyConstraint> */
+    private array $foreignKeyConstraints = [];
+
+    /** @var array<string, mixed> */
+    private array $options = [];
+
+    private ?TableConfiguration $configuration = null;
+
+    /** @internal Use {@link Table::editor()} or {@link Table::edit()} to create an instance */
+    public function __construct()
+    {
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /** @param array<Column> $columns */
+    public function setColumns(array $columns): self
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    /** @param array<Index> $indexes */
+    public function setIndexes(array $indexes): self
+    {
+        $this->indexes = $indexes;
+
+        return $this;
+    }
+
+    /** @param array<UniqueConstraint> $uniqueConstraints */
+    public function setUniqueConstraints(array $uniqueConstraints): self
+    {
+        $this->uniqueConstraints = $uniqueConstraints;
+
+        return $this;
+    }
+
+    /** @param array<ForeignKeyConstraint> $foreignKeyConstraints */
+    public function setForeignKeyConstraints(array $foreignKeyConstraints): self
+    {
+        $this->foreignKeyConstraints = $foreignKeyConstraints;
+
+        return $this;
+    }
+
+    /** @param array<string, mixed> $options */
+    public function setOptions(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function setConfiguration(TableConfiguration $configuration): self
+    {
+        $this->configuration = $configuration;
+
+        return $this;
+    }
+
+    public function create(): Table
+    {
+        if ($this->name === null) {
+            throw InvalidTableDefinition::nameNotSet();
+        }
+
+        return new Table(
+            $this->name,
+            $this->columns,
+            $this->indexes,
+            $this->uniqueConstraints,
+            $this->foreignKeyConstraints,
+            $this->options,
+            $this->configuration,
+        );
+    }
+}

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
+use Doctrine\DBAL\Schema\Table;
+use PHPUnit\Framework\TestCase;
+
+class TableEditorTest extends TestCase
+{
+    public function testSetName(): void
+    {
+        $table = (new Table('accounts'))
+            ->edit()
+            ->setName('contacts')
+            ->create();
+
+        self::assertSame('contacts', $table->getName());
+    }
+
+    public function testNameNotSet(): void
+    {
+        $this->expectException(InvalidTableDefinition::class);
+
+        Table::editor()->create();
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature

### Motivation

The introduction of the table editor should facilitate the following improvements:
1. Eventually make tables immutable.
2. Reduce the amount of validation that needs to be performed in the case of multi-step modification of a table (see https://github.com/doctrine/dbal/pull/6559#issuecomment-2427122844).
3. Get rid of this hack: https://github.com/doctrine/dbal/blob/e7e26153cacc7f3451658df8e46a253a6bfe6f82/src/Schema/Schema.php#L305-L309 I just realized that replacing it with building a new table would be a BC break because the editor would create a new table instance instead of modifying an existing one.
4. Unify the process of table creation. For instance, currently, table columns can be specified in the constructor or added via `addColumn()` but the primary key can be set only via `setPrimaryKey()`.

Being able to get rid of the hack is why I'm introducing the editor now. I want to start deprecating end removing the name-related properties of `AbstractIdentifier` in favor of the recently introduced value objects, but this hack won't with the new properties because they are private (not protected).

### Implementation details

The editor (specifically, the class and method naming) is modeled after the table editor in [Debezium](https://github.com/debezium/debezium/blob/v3.0.0.Final/debezium-core/src/main/java/io/debezium/relational/TableEditor.java).

I implemented the necessary minimum of the methods that would allow to rework the hack but then realized that it's a BC break. However, this API allows to replace the direct usage of the Table constructor in the library code with the builder, so I think we can introduce it as is.

I didn't touch the tests because
1. This is a lot of mechanical work (I can do it later).
2. The test code that uses the builder won't be as streamlined as the library code because the builder doesn't yet support all initial table properties (e.g. the primary key).

### Additional changes

The first two commits make minor changes in the code that wasn't released yet.