### PR TITLE
Deprecated AbstractAsset namespace-related methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,23 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractAsset` namespace-related methods and property
+
+The following namespace-related methods and property have been deprecated:
+
+- `AbstractAsset::getNamespaceName()`
+- `AbstractAsset::isInDefaultNamespace()`
+- `AbstractAsset::$_namespace`
+
+In order to identify the namespace of an object, use the following methods instead:
+
+```php
+$qualifier = $table->getObjectName()->getQualifier();
+```
+
+If the return value is not null, then it will contain the identifier representing the namespace name – its value and
+whether it's quoted.
+
 ## `Table::__construct()` marked as internal
 
 The `Table::__construct()` method has been marked as internal. Use `Table::editor()` to instantiate an editor and

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -134,6 +134,13 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getShortestName" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6664
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNamespaceName" />
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::isInDefaultNamespace" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -149,6 +156,13 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedProperty name="Doctrine\DBAL\Schema\Table::$_schemaConfig" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6664
+                    TODO: remove in 5.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\AbstractAsset::$_namespace" />
+                <referencedProperty name="Doctrine\DBAL\Schema\Table::$_namespace" />
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -49,6 +49,8 @@ abstract class AbstractAsset
 
     /**
      * Namespace of the asset. If none isset the default namespace is assumed.
+     *
+     * @deprecated Use {@see NamedObject::getObjectName()} and {@see OptionallyQualifiedName::getQualifier()} instead.
      */
     protected ?string $_namespace = null;
 
@@ -231,9 +233,18 @@ abstract class AbstractAsset
 
     /**
      * Is this asset in the default namespace?
+     *
+     * @deprecated
      */
     public function isInDefaultNamespace(string $defaultNamespaceName): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6664',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         return $this->_namespace === $defaultNamespaceName || $this->_namespace === null;
     }
 
@@ -241,9 +252,19 @@ abstract class AbstractAsset
      * Gets the namespace name of this asset.
      *
      * If NULL is returned this means the default namespace is used.
+     *
+     * @deprecated Use {@see NamedObject::getObjectName()} and {@see OptionallyQualifiedName::getQualifier()} instead.
      */
     public function getNamespaceName(): ?string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6664',
+            '%s is deprecated and will be removed in 5.0. Use NamedObject::getObjectName()'
+                . ' and OptionallyQualifiedName::getQualifier() instead.',
+            __METHOD__,
+        );
+
         return $this->_namespace;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

The methods are being deprecated in favor of the API introduced in https://github.com/doctrine/dbal/pull/6646.

The currently available API is declared in the wrong place. For example, a call to `$column->getNamespaceName()` is possible but doesn't make any sense because the column (unlike table) cannot have a qualified name, so the call will always return `null`. Only the objects that implement `NamedObject<OptionallyQualifiedName>` can be namespaced.