### PR TITLE
Remove AbstractAsset namespace-related methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractAsset` namespace-related methods and property
+
+The following namespace-related methods and property have been removed:
+
+- `AbstractAsset::getNamespaceName()`
+- `AbstractAsset::isInDefaultNamespace()`
+- `AbstractAsset::$_namespace`
+
 ## BC BREAK: Removed `AbstractAsset::getShortestName()`
 
 The `AbstractAsset::getShortestName()` method has been removed.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -62,25 +62,8 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNameParser" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6664
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNamespaceName" />
-                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::isInDefaultNamespace" />
             </errorLevel>
         </DeprecatedMethod>
-        <DeprecatedProperty>
-            <errorLevel type="suppress">
-                <!--
-                    https://github.com/doctrine/dbal/pull/6664
-                    TODO: remove in 5.0.0
-                -->
-                <referencedProperty name="Doctrine\DBAL\Schema\AbstractAsset::$_namespace" />
-                <referencedProperty name="Doctrine\DBAL\Schema\Table::$_namespace" />
-            </errorLevel>
-        </DeprecatedProperty>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!--

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function assert;
@@ -38,13 +37,6 @@ use function substr;
 abstract class AbstractAsset
 {
     protected string $_name = '';
-
-    /**
-     * Namespace of the asset. If none isset the default namespace is assumed.
-     *
-     * @deprecated Use {@see NamedObject::getObjectName()} and {@see OptionallyQualifiedName::getQualifier()} instead.
-     */
-    protected ?string $_namespace = null;
 
     protected bool $_quoted = false;
 
@@ -87,26 +79,10 @@ abstract class AbstractAsset
         $count = count($identifiers);
         assert($count > 0);
 
-        switch ($count) {
-            case 1:
-                $namespace = null;
-                $name      = $identifiers[0];
-                break;
-
-            case 2:
-                /** @psalm-suppress PossiblyUndefinedArrayOffset */
-                [$namespace, $name] = $identifiers;
-                break;
-
-            default:
-                $namespace = null;
-                $name      = $identifiers[$count - 1];
-                break;
-        }
+        $name = $identifiers[$count - 1];
 
         $this->_name       = $name->getValue();
         $this->_quoted     = $name->isQuoted();
-        $this->_namespace  = $namespace?->getValue();
         $this->identifiers = $identifiers;
     }
 
@@ -132,43 +108,6 @@ abstract class AbstractAsset
     protected function setName(?Name $name): void
     {
         throw NotImplemented::fromMethod(static::class, __FUNCTION__);
-    }
-
-    /**
-     * Is this asset in the default namespace?
-     *
-     * @deprecated
-     */
-    public function isInDefaultNamespace(string $defaultNamespaceName): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6664',
-            '%s is deprecated and will be removed in 5.0.',
-            __METHOD__,
-        );
-
-        return $this->_namespace === $defaultNamespaceName || $this->_namespace === null;
-    }
-
-    /**
-     * Gets the namespace name of this asset.
-     *
-     * If NULL is returned this means the default namespace is used.
-     *
-     * @deprecated Use {@see NamedObject::getObjectName()} and {@see OptionallyQualifiedName::getQualifier()} instead.
-     */
-    public function getNamespaceName(): ?string
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6664',
-            '%s is deprecated and will be removed in 5.0. Use NamedObject::getObjectName()'
-                . ' and OptionallyQualifiedName::getQualifier() instead.',
-            __METHOD__,
-        );
-
-        return $this->_namespace;
     }
 
     /**
@@ -200,11 +139,10 @@ abstract class AbstractAsset
      */
     public function getName(): string
     {
-        if ($this->_namespace !== null) {
-            return $this->_namespace . '.' . $this->_name;
-        }
-
-        return $this->_name;
+        return implode('.', array_map(
+            static fn (Identifier $identifier): string => $identifier->getValue(),
+            $this->identifiers,
+        ));
     }
 
     /**

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -104,42 +104,53 @@ class Schema extends AbstractOptionallyNamedObject
 
     protected function _addTable(Table $table): void
     {
-        $namespaceName = $table->getNamespaceName();
-        $tableName     = $this->normalizeName($table);
+        $name = $table->getObjectName();
 
-        if (isset($this->_tables[$tableName])) {
-            throw TableAlreadyExists::new($tableName);
+        $normalizedName = $this->normalizeName($name);
+
+        if (isset($this->_tables[$normalizedName])) {
+            throw TableAlreadyExists::new($normalizedName);
         }
 
-        if (
-            $namespaceName !== null
-            && ! $table->isInDefaultNamespace($this->getName())
-            && ! $this->hasNamespace($namespaceName)
-        ) {
-            $this->createNamespace($namespaceName);
-        }
+        $this->ensureNamespaceExists($name);
 
-        $this->_tables[$tableName] = $table;
+        $this->_tables[$normalizedName] = $table;
     }
 
     protected function _addSequence(Sequence $sequence): void
     {
-        $namespaceName = $sequence->getNamespaceName();
-        $seqName       = $this->normalizeName($sequence);
+        $name = $sequence->getObjectName();
 
-        if (isset($this->_sequences[$seqName])) {
-            throw SequenceAlreadyExists::new($seqName);
+        $normalizedName = $this->normalizeName($name);
+
+        if (isset($this->_sequences[$normalizedName])) {
+            throw SequenceAlreadyExists::new($normalizedName);
         }
 
-        if (
-            $namespaceName !== null
-            && ! $sequence->isInDefaultNamespace($this->getName())
-            && ! $this->hasNamespace($namespaceName)
-        ) {
-            $this->createNamespace($namespaceName);
+        $this->ensureNamespaceExists($name);
+
+        $this->_sequences[$normalizedName] = $sequence;
+    }
+
+    private function ensureNamespaceExists(OptionallyQualifiedName $name): void
+    {
+        $qualifier = $name->getQualifier();
+
+        if ($qualifier === null) {
+            return;
         }
 
-        $this->_sequences[$seqName] = $sequence;
+        $namespaceName = $qualifier->getValue();
+
+        if ($namespaceName === $this->getName()) {
+            return;
+        }
+
+        if ($this->hasNamespace($namespaceName)) {
+            return;
+        }
+
+        $this->createNamespace($namespaceName);
     }
 
     /**
@@ -190,16 +201,13 @@ class Schema extends AbstractOptionallyNamedObject
      * Foo) then you will NOT be able to use Doctrine Schema abstraction.
      *
      * Every non-namespaced element is prefixed with this schema name.
-     *
-     * @param AbstractAsset<OptionallyQualifiedName> $asset
      */
-    private function normalizeName(AbstractAsset $asset): string
+    private function normalizeName(OptionallyQualifiedName $name): string
     {
-        $name = $asset->getName();
+        $namespaceName = $name->getQualifier()?->getValue()
+            ?? $this->getName();
 
-        if ($asset->getNamespaceName() === null) {
-            $name = $this->getName() . '.' . $name;
-        }
+        $name = $namespaceName . '.' . $name->getUnqualifiedName()->getValue();
 
         return strtolower($name);
     }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -300,13 +300,10 @@ class Schema extends AbstractOptionallyNamedObject
      */
     public function renameTable(string $oldName, string $newName): self
     {
-        $table = $this->getTable($oldName);
-
-        $identifier = new Identifier($newName);
-
-        $table->_name      = $identifier->_name;
-        $table->_namespace = $identifier->_namespace;
-        $table->_quoted    = $identifier->_quoted;
+        $table = $this->getTable($oldName)
+            ->edit()
+            ->setName($newName)
+            ->create();
 
         $this->dropTable($oldName);
         $this->_addTable($table);

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -71,15 +71,13 @@ class SchemaTest extends TestCase
 
     public function testRenameTable(): void
     {
-        $tableName = 'foo';
-        $table     = new Table($tableName);
-        $schema    = new Schema([$table]);
+        $table  = new Table('foo');
+        $schema = new Schema([$table]);
 
         self::assertTrue($schema->hasTable('foo'));
         $schema->renameTable('foo', 'bar');
         self::assertFalse($schema->hasTable('foo'));
         self::assertTrue($schema->hasTable('bar'));
-        self::assertSame($table, $schema->getTable('bar'));
     }
 
     public function testDropTable(): void


### PR DESCRIPTION
The methods and the property being removed were deprecated in https://github.com/doctrine/dbal/pull/6664.

Additionally, there's a breaking change since the table being renamed is no longer mutated but copied. I don't think it deserves an upgrade note since the original behavior exploited a hack with the modification of a protected property.