### PR TITLE
Fix creation of unnamed unique constraints

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1170,8 +1170,13 @@ abstract class AbstractPlatform
      */
     public function getCreateUniqueConstraintSQL(UniqueConstraint $constraint, string $tableName): string
     {
-        return 'ALTER TABLE ' . $tableName . ' ADD CONSTRAINT ' . $constraint->getQuotedName($this) . ' UNIQUE'
-            . ' (' . implode(', ', $constraint->getQuotedColumns($this)) . ')';
+        $sql = 'ALTER TABLE ' . $tableName . ' ADD';
+
+        if ($constraint->getName() !== '') {
+            $sql .= ' CONSTRAINT ' . $constraint->getQuotedName($this);
+        }
+
+        return $sql . ' UNIQUE (' . implode(', ', $constraint->getQuotedColumns($this)) . ')';
     }
 
     /**
@@ -1546,9 +1551,10 @@ abstract class AbstractPlatform
             throw new InvalidArgumentException('Incomplete definition. "columns" required.');
         }
 
-        $chunks = ['CONSTRAINT'];
+        $chunks = [];
 
         if ($constraint->getName() !== '') {
+            $chunks[] = 'CONSTRAINT';
             $chunks[] = $constraint->getQuotedName($this);
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -829,7 +829,7 @@ abstract class AbstractPlatform
 
         foreach ($table->getIndexes() as $index) {
             if (! $index->isPrimary()) {
-                $options['indexes'][$index->getQuotedName($this)] = $index;
+                $options['indexes'][] = $index;
 
                 continue;
             }
@@ -839,7 +839,7 @@ abstract class AbstractPlatform
         }
 
         foreach ($table->getUniqueConstraints() as $uniqueConstraint) {
-            $options['uniqueConstraints'][$uniqueConstraint->getQuotedName($this)] = $uniqueConstraint;
+            $options['uniqueConstraints'][] = $uniqueConstraint;
         }
 
         if ($createForeignKeys) {

--- a/tests/Functional/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Functional/Schema/ForeignKeyConstraintTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+final class ForeignKeyConstraintTest extends FunctionalTestCase
+{
+    public function testUnnamedForeignKeyConstraint(): void
+    {
+        $this->dropTableIfExists('users');
+        $this->dropTableIfExists('roles');
+        $this->dropTableIfExists('teams');
+
+        $roles = new Table('roles');
+        $roles->addColumn('id', Types::INTEGER);
+        $roles->setPrimaryKey(['id']);
+
+        $teams = new Table('teams');
+        $teams->addColumn('id', Types::INTEGER);
+        $teams->setPrimaryKey(['id']);
+
+        $users = new Table('users', [
+            new Column('id', Type::getType(Types::INTEGER)),
+            new Column('role_id', Type::getType(Types::INTEGER)),
+            new Column('team_id', Type::getType(Types::INTEGER)),
+        ], [], [], [
+            new ForeignKeyConstraint(['role_id'], 'roles', ['id']),
+            new ForeignKeyConstraint(['team_id'], 'teams', ['id']),
+        ]);
+        $users->setPrimaryKey(['id']);
+
+        $sm = $this->connection->createSchemaManager();
+        $sm->createTable($roles);
+        $sm->createTable($teams);
+        $sm->createTable($users);
+
+        $table = $sm->introspectTable('users');
+
+        self::assertCount(2, $table->getForeignKeys());
+    }
+}

--- a/tests/Functional/Schema/UniqueConstraintTest.php
+++ b/tests/Functional/Schema/UniqueConstraintTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+final class UniqueConstraintTest extends FunctionalTestCase
+{
+    public function testUnnamedUniqueConstraint(): void
+    {
+        $this->dropTableIfExists('users');
+
+        $users = new Table('users', [
+            new Column('id', Type::getType(Types::INTEGER)),
+            new Column('username', Type::getType(Types::STRING), ['length' => 32]),
+            new Column('email', Type::getType(Types::STRING), ['length' => 255]),
+        ], [], [
+            new UniqueConstraint('', ['username']),
+            new UniqueConstraint('', ['email']),
+        ], []);
+
+        $sm = $this->connection->createSchemaManager();
+        $sm->createTable($users);
+
+        // we want to assert that the two empty names don't clash, but introspection of unique constraints is currently
+        // not supported. for now, we just assert that the table can be created without exceptions.
+        $this->expectNotToPerformAssertions();
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

Note that even though the `$name` parameter in the `UniqueConstraint` constructor isn't nullable, the original implementation attempted to handle constraints with empty name: https://github.com/doctrine/dbal/blob/b0cc669255241ee656361dd903fc727ad3de9e08/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php#L2396-L2397

Also, constraint names in SQL are optional for all supported platforms. Therefore, I consider the behavior of improper handling of unnamed constraints a bug.

Two issues are being fixed:
1. If the unique constraint name is omitted (empty), the DBAL will generate invalid DDL (both in the case of `CREATE TABLE` and `ALTER TABLE`).
2. If there are more than one unique constraint with omitted name, their definitions will clash and only one will be created.

Both of these edge cases are correctly handled for foreign key constraints, which can be referenced as the proper implementation.