### PR TITLE
Mark internal AbstractPlatform methods as protected

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -203,14 +203,12 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsInlineColumnComments(): bool
+    protected function supportsInlineColumnComments(): bool
     {
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsColumnCollation(): bool
+    protected function supportsColumnCollation(): bool
     {
         return true;
     }
@@ -677,14 +675,12 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return $this->getUnsignedDeclaration($column) . $autoinc;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getColumnCharsetDeclarationSQL(string $charset): string
+    protected function getColumnCharsetDeclarationSQL(string $charset): string
     {
         return 'CHARACTER SET ' . $charset;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
     {
         $query = '';
         if ($foreignKey->hasOption('match')) {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -745,8 +745,6 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to drop a constraint.
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
     protected function getDropConstraintSQL(string $name, string $table): string
     {
@@ -790,11 +788,7 @@ abstract class AbstractPlatform
         return new DefaultUnionSQLBuilder($this);
     }
 
-    /**
-     * @internal
-     *
-     * @return list<string>
-     */
+    /** @return list<string> */
     final protected function getCreateTableWithoutForeignKeysSQL(Table $table): array
     {
         return $this->buildCreateTableSQL($table, false);
@@ -930,8 +924,7 @@ abstract class AbstractPlatform
         );
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getCommentOnColumnSQL(string $tableName, string $columnName, string $comment): string
+    protected function getCommentOnColumnSQL(string $tableName, string $columnName, string $comment): string
     {
         $tableName  = new Identifier($tableName);
         $columnName = new Identifier($columnName);
@@ -946,10 +939,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to create inline comment on a column.
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function getInlineColumnCommentSQL(string $comment): string
+    protected function getInlineColumnCommentSQL(string $comment): string
     {
         if (! $this->supportsInlineColumnComments()) {
             throw NotSupported::new(__METHOD__);
@@ -1334,8 +1325,6 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to declare a generic type
      * column to be used in statements like CREATE TABLE.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param string  $name   The name the column to be declared.
      * @param mixed[] $column An associative array with the name of the properties
      *                        of the column being declared as array indexes. Currently, the types
@@ -1359,7 +1348,7 @@ abstract class AbstractPlatform
      *
      * @return string DBMS specific SQL code portion that should be used to declare the column.
      */
-    public function getColumnDeclarationSQL(string $name, array $column): string
+    protected function getColumnDeclarationSQL(string $name, array $column): string
     {
         if (isset($column['columnDefinition'])) {
             $declaration = $column['columnDefinition'];
@@ -1411,13 +1400,11 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set a default value
      * declaration to be used in statements like CREATE TABLE.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param mixed[] $column The column definition array.
      *
      * @return string DBMS specific SQL code portion needed to set a default value.
      */
-    public function getDefaultValueDeclarationSQL(array $column): string
+    protected function getDefaultValueDeclarationSQL(array $column): string
     {
         if (! isset($column['default'])) {
             return empty($column['notnull']) ? ' DEFAULT NULL' : '';
@@ -1525,13 +1512,11 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set an index
      * declaration to be used in statements like CREATE TABLE.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param Index $index The index definition.
      *
      * @return string DBMS specific SQL code portion needed to set an index.
      */
-    public function getIndexDeclarationSQL(Index $index): string
+    protected function getIndexDeclarationSQL(Index $index): string
     {
         $columns = $index->getColumns();
 
@@ -1555,12 +1540,10 @@ abstract class AbstractPlatform
      * Obtain DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      * of a column declaration to be used in statements like CREATE TABLE.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @return string DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      *                of a column declaration.
      */
-    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {
         $sql  = $this->getForeignKeyBaseDeclarationSQL($foreignKey);
         $sql .= $this->getAdvancedForeignKeyOptionsSQL($foreignKey);
@@ -1572,11 +1555,9 @@ abstract class AbstractPlatform
      * Returns the FOREIGN KEY query section dealing with non-standard options
      * as MATCH, INITIALLY DEFERRED, ON UPDATE, ...
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param ForeignKeyConstraint $foreignKey The foreign key definition.
      */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
     {
         $query = '';
         if ($foreignKey->hasOption('onUpdate')) {
@@ -1593,11 +1574,9 @@ abstract class AbstractPlatform
     /**
      * Returns the given referential action in uppercase if valid, otherwise throws an exception.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param string $action The foreign key referential action.
      */
-    public function getForeignKeyReferentialActionSQL(string $action): string
+    protected function getForeignKeyReferentialActionSQL(string $action): string
     {
         $upper = strtoupper($action);
 
@@ -1646,14 +1625,12 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set the CHARACTER SET
      * of a column declaration to be used in statements like CREATE TABLE.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param string $charset The name of the charset.
      *
      * @return string DBMS specific SQL code portion needed to set the CHARACTER SET
      *                of a column declaration.
      */
-    public function getColumnCharsetDeclarationSQL(string $charset): string
+    protected function getColumnCharsetDeclarationSQL(string $charset): string
     {
         return '';
     }
@@ -1662,14 +1639,12 @@ abstract class AbstractPlatform
      * Obtains DBMS specific SQL code portion needed to set the COLLATION
      * of a column declaration to be used in statements like CREATE TABLE.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @param string $collation The name of the collation.
      *
      * @return string DBMS specific SQL code portion needed to set the COLLATION
      *                of a column declaration.
      */
-    public function getColumnCollationDeclarationSQL(string $collation): string
+    protected function getColumnCollationDeclarationSQL(string $collation): string
     {
         return $this->supportsColumnCollation() ? 'COLLATE ' . $this->quoteSingleIdentifier($collation) : '';
     }
@@ -1915,10 +1890,8 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports partial indexes.
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function supportsPartialIndexes(): bool
+    protected function supportsPartialIndexes(): bool
     {
         return false;
     }
@@ -1957,30 +1930,24 @@ abstract class AbstractPlatform
 
     /**
      * Whether this platform support to add inline column comments as postfix.
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function supportsInlineColumnComments(): bool
+    protected function supportsInlineColumnComments(): bool
     {
         return false;
     }
 
     /**
      * Whether this platform support the proprietary syntax "COMMENT ON asset".
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function supportsCommentOnStatement(): bool
+    protected function supportsCommentOnStatement(): bool
     {
         return false;
     }
 
     /**
      * Does this platform support column collation?
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function supportsColumnCollation(): bool
+    protected function supportsColumnCollation(): bool
     {
         return false;
     }

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -206,8 +206,7 @@ class DB2Platform extends AbstractPlatform
         return 'SELECT NAME, TEXT FROM SYSIBM.SYSVIEWS';
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsCommentOnStatement(): bool
+    protected function supportsCommentOnStatement(): bool
     {
         return true;
     }
@@ -227,8 +226,7 @@ class DB2Platform extends AbstractPlatform
         return 'CURRENT TIMESTAMP';
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getIndexDeclarationSQL(Index $index): string
+    protected function getIndexDeclarationSQL(Index $index): string
     {
         // Index declaration in statements like CREATE TABLE is not supported.
         throw NotSupported::new(__METHOD__);
@@ -488,10 +486,8 @@ class DB2Platform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function getDefaultValueDeclarationSQL(array $column): string
+    protected function getDefaultValueDeclarationSQL(array $column): string
     {
         if (isset($column['autoincrement']) && $column['autoincrement'] === true) {
             return '';

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -58,7 +58,7 @@ class MariaDBPlatform extends AbstractMySQLPlatform
     }
 
     /** {@inheritDoc} */
-    public function getColumnDeclarationSQL(string $name, array $column): string
+    protected function getColumnDeclarationSQL(string $name, array $column): string
     {
         // MariaDb forces column collation to utf8mb4_bin where the column was declared as JSON so ignore
         // collation and character set for json columns as attempting to set them can cause an error.

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -19,11 +19,9 @@ class MySQLPlatform extends AbstractMySQLPlatform
      *
      * Oracle MySQL does not support default values on TEXT/BLOB columns until 8.0.13.
      *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
-     *
      * @link https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html#mysqld-8-0-13-data-types
      */
-    public function getDefaultValueDeclarationSQL(array $column): string
+    protected function getDefaultValueDeclarationSQL(array $column): string
     {
         if ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) {
             unset($column['default']);

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -477,8 +477,7 @@ END;';
         return $this->getDropConstraintSQL($foreignKey, $table);
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
     {
         $referentialAction = '';
 
@@ -493,8 +492,7 @@ END;';
         return '';
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getForeignKeyReferentialActionSQL(string $action): string
+    protected function getForeignKeyReferentialActionSQL(string $action): string
     {
         $action = strtoupper($action);
 
@@ -630,10 +628,8 @@ END;';
 
     /**
      * {@inheritDoc}
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function getColumnDeclarationSQL(string $name, array $column): string
+    protected function getColumnDeclarationSQL(string $name, array $column): string
     {
         if (isset($column['columnDefinition'])) {
             $declaration = $column['columnDefinition'];
@@ -682,8 +678,7 @@ END;';
         return $identitySequenceIdentifier->getQuotedName($this);
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsCommentOnStatement(): bool
+    protected function supportsCommentOnStatement(): bool
     {
         return true;
     }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -127,14 +127,12 @@ class PostgreSQLPlatform extends AbstractPlatform
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsPartialIndexes(): bool
+    protected function supportsPartialIndexes(): bool
     {
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsCommentOnStatement(): bool
+    protected function supportsCommentOnStatement(): bool
     {
         return true;
     }
@@ -168,8 +166,7 @@ class PostgreSQLPlatform extends AbstractPlatform
                 WHERE  view_definition IS NOT NULL';
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
     {
         $query = '';
 
@@ -738,10 +735,8 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function getDefaultValueDeclarationSQL(array $column): string
+    protected function getDefaultValueDeclarationSQL(array $column): string
     {
         if (isset($column['autoincrement']) && $column['autoincrement'] === true) {
             return '';
@@ -750,8 +745,7 @@ class PostgreSQLPlatform extends AbstractPlatform
         return parent::getDefaultValueDeclarationSQL($column);
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsColumnCollation(): bool
+    protected function supportsColumnCollation(): bool
     {
         return true;
     }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -117,8 +117,7 @@ class SQLServerPlatform extends AbstractPlatform
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsColumnCollation(): bool
+    protected function supportsColumnCollation(): bool
     {
         return true;
     }
@@ -1103,8 +1102,7 @@ class SQLServerPlatform extends AbstractPlatform
         return 'ROLLBACK TRANSACTION ' . $savepoint;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getForeignKeyReferentialActionSQL(string $action): string
+    protected function getForeignKeyReferentialActionSQL(string $action): string
     {
         // RESTRICT is not supported, therefore falling back to NO ACTION.
         if (strtoupper($action) === 'RESTRICT') {
@@ -1146,10 +1144,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
-     *
-     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
-    public function getColumnDeclarationSQL(string $name, array $column): string
+    protected function getColumnDeclarationSQL(string $name, array $column): string
     {
         if (isset($column['columnDefinition'])) {
             $declaration = $column['columnDefinition'];
@@ -1169,7 +1165,7 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * SQL Server does not support quoting collation identifiers.
      */
-    public function getColumnCollationDeclarationSQL(string $collation): string
+    protected function getColumnCollationDeclarationSQL(string $collation): string
     {
         return 'COLLATE ' . $collation;
     }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -251,8 +251,7 @@ class SQLitePlatform extends AbstractPlatform
         return ! empty($column['unsigned']) ? ' UNSIGNED' : '';
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {
         return parent::getForeignKeyDeclarationSQL(new ForeignKeyConstraint(
             $foreignKey->getQuotedLocalColumns($this),
@@ -372,8 +371,7 @@ class SQLitePlatform extends AbstractPlatform
         return "SELECT name, sql FROM sqlite_master WHERE type='view' AND sql NOT NULL";
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
+    protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
     {
         $query = parent::getAdvancedForeignKeyOptionsSQL($foreignKey);
 
@@ -398,14 +396,12 @@ class SQLitePlatform extends AbstractPlatform
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsColumnCollation(): bool
+    protected function supportsColumnCollation(): bool
     {
         return true;
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function supportsInlineColumnComments(): bool
+    protected function supportsInlineColumnComments(): bool
     {
         return true;
     }
@@ -417,8 +413,7 @@ class SQLitePlatform extends AbstractPlatform
         return 'DELETE FROM ' . $tableIdentifier->getQuotedName($this);
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getInlineColumnCommentSQL(string $comment): string
+    protected function getInlineColumnCommentSQL(string $comment): string
     {
         if ($comment === '') {
             return '';

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -654,27 +654,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
-    public function testColumnCharsetDeclarationSQL(): void
-    {
-        self::assertSame(
-            'CHARACTER SET ascii',
-            $this->platform->getColumnCharsetDeclarationSQL('ascii'),
-        );
-    }
-
-    public function testSupportsColumnCollation(): void
-    {
-        self::assertTrue($this->platform->supportsColumnCollation());
-    }
-
-    public function testColumnCollationDeclarationSQL(): void
-    {
-        self::assertSame(
-            'COLLATE `ascii_general_ci`',
-            $this->platform->getColumnCollationDeclarationSQL('ascii_general_ci'),
-        );
-    }
-
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -45,12 +44,6 @@ abstract class AbstractPlatformTestCase extends TestCase
         return new Comparator($this->platform, new ComparatorConfig());
     }
 
-    #[DataProvider('getReturnsForeignKeyReferentialActionSQL')]
-    public function testReturnsForeignKeyReferentialActionSQL(string $action, string $expectedSQL): void
-    {
-        self::assertSame($expectedSQL, $this->platform->getForeignKeyReferentialActionSQL($action));
-    }
-
     /** @return mixed[][] */
     public static function getReturnsForeignKeyReferentialActionSQL(): iterable
     {
@@ -62,12 +55,6 @@ abstract class AbstractPlatformTestCase extends TestCase
             ['SET DEFAULT', 'SET DEFAULT'],
             ['CaScAdE', 'CASCADE'],
         ];
-    }
-
-    public function testGetInvalidForeignKeyReferentialActionSQL(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->platform->getForeignKeyReferentialActionSQL('unknown');
     }
 
     public function testGetUnknownDoctrineMappingType(): void
@@ -179,34 +166,6 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     abstract public function getGenerateUniqueIndexSql(): string;
 
-    public function testGeneratesPartialIndexesSqlOnlyWhenSupportingPartialIndexes(): void
-    {
-        $where            = 'test IS NULL AND test2 IS NOT NULL';
-        $indexDef         = new Index('name', ['test', 'test2'], false, false, [], ['where' => $where]);
-        $uniqueConstraint = new UniqueConstraint('name', ['test', 'test2'], [], []);
-
-        $expected = ' WHERE ' . $where;
-
-        $indexes = [];
-
-        if ($this->supportsInlineIndexDeclaration()) {
-            $indexes[] = $this->platform->getIndexDeclarationSQL($indexDef);
-        }
-
-        $uniqueConstraintSQL = $this->platform->getUniqueConstraintDeclarationSQL($uniqueConstraint);
-        self::assertStringEndsNotWith($expected, $uniqueConstraintSQL, 'WHERE clause should NOT be present');
-
-        $indexes[] = $this->platform->getCreateIndexSQL($indexDef, 'table');
-
-        foreach ($indexes as $index) {
-            if ($this->platform->supportsPartialIndexes()) {
-                self::assertStringEndsWith($expected, $index, 'WHERE clause should be present');
-            } else {
-                self::assertStringEndsNotWith($expected, $index, 'WHERE clause should NOT be present');
-            }
-        }
-    }
-
     public function testGeneratesForeignKeyCreationSql(): void
     {
         $fk = new ForeignKeyConstraint(['fk_name_id'], 'other_table', ['id']);
@@ -257,70 +216,6 @@ abstract class AbstractPlatformTestCase extends TestCase
             'ALTER TABLE test ADD CONSTRAINT constraint_fk FOREIGN KEY (fk_name) REFERENCES %s (id)',
             $quotedForeignTable,
         );
-    }
-
-    public function testGetCustomColumnDeclarationSql(): void
-    {
-        self::assertEquals(
-            'foo MEDIUMINT(6) UNSIGNED',
-            $this->platform->getColumnDeclarationSQL('foo', ['columnDefinition' => 'MEDIUMINT(6) UNSIGNED']),
-        );
-    }
-
-    public function testGetDefaultValueDeclarationSQL(): void
-    {
-        // non-timestamp value will get single quotes
-        self::assertEquals(" DEFAULT 'non_timestamp'", $this->platform->getDefaultValueDeclarationSQL([
-            'type' => Type::getType(Types::STRING),
-            'default' => 'non_timestamp',
-        ]));
-    }
-
-    public function testGetDefaultValueDeclarationSQLDateTime(): void
-    {
-        $types = [
-            Types::DATETIME_MUTABLE,
-            Types::DATETIMETZ_MUTABLE,
-            Types::DATETIME_IMMUTABLE,
-            Types::DATETIMETZ_IMMUTABLE,
-        ];
-        // timestamps on datetime types should not be quoted
-        foreach ($types as $type) {
-            self::assertSame(
-                ' DEFAULT ' . $this->platform->getCurrentTimestampSQL(),
-                $this->platform->getDefaultValueDeclarationSQL([
-                    'type'    => Type::getType($type),
-                    'default' => $this->platform->getCurrentTimestampSQL(),
-                ]),
-            );
-        }
-    }
-
-    public function testGetDefaultValueDeclarationSQLForIntegerTypes(): void
-    {
-        foreach ([Types::BIGINT, Types::INTEGER, Types::SMALLINT] as $type) {
-            self::assertEquals(
-                ' DEFAULT 1',
-                $this->platform->getDefaultValueDeclarationSQL([
-                    'type'    => Type::getType($type),
-                    'default' => 1,
-                ]),
-            );
-        }
-    }
-
-    public function testGetDefaultValueDeclarationSQLForDateType(): void
-    {
-        $currentDateSql = $this->platform->getCurrentDateSQL();
-        foreach ([Types::DATE_MUTABLE, Types::DATE_IMMUTABLE] as $type) {
-            self::assertSame(
-                ' DEFAULT ' . $currentDateSql,
-                $this->platform->getDefaultValueDeclarationSQL([
-                    'type'    => Type::getType($type),
-                    'default' => $currentDateSql,
-                ]),
-            );
-        }
     }
 
     public function testQuotedColumnInPrimaryKeyPropagation(): void
@@ -458,36 +353,7 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     abstract protected function getQuotesReservedKeywordInTruncateTableSQL(): string;
 
-    public function testQuotesReservedKeywordInIndexDeclarationSQL(): void
-    {
-        $index = new Index('select', ['foo']);
-
-        if (! $this->supportsInlineIndexDeclaration()) {
-            $this->expectException(Exception::class);
-        }
-
-        self::assertSame(
-            $this->getQuotesReservedKeywordInIndexDeclarationSQL(),
-            $this->platform->getIndexDeclarationSQL($index),
-        );
-    }
-
     abstract protected function getQuotesReservedKeywordInIndexDeclarationSQL(): string;
-
-    protected function supportsInlineIndexDeclaration(): bool
-    {
-        return true;
-    }
-
-    public function testSupportsCommentOnStatement(): void
-    {
-        self::assertSame($this->supportsCommentOnStatement(), $this->platform->supportsCommentOnStatement());
-    }
-
-    protected function supportsCommentOnStatement(): bool
-    {
-        return false;
-    }
 
     public function testGetCreateSchemaSQL(): void
     {
@@ -763,25 +629,9 @@ abstract class AbstractPlatformTestCase extends TestCase
         return "COMMENT ON COLUMN \"MYTABLE\".\"ID\" IS 'This is a comment'";
     }
 
-    public function testGetCommentOnColumnSQLWithoutQuoteCharacter(): void
-    {
-        self::assertEquals(
-            $this->getQuotedCommentOnColumnSQLWithoutQuoteCharacter(),
-            $this->platform->getCommentOnColumnSQL('mytable', 'id', 'This is a comment'),
-        );
-    }
-
     protected function getQuotedCommentOnColumnSQLWithQuoteCharacter(): string
     {
         return "COMMENT ON COLUMN \"MYTABLE\".\"ID\" IS 'It''s a quote !'";
-    }
-
-    public function testGetCommentOnColumnSQLWithQuoteCharacter(): void
-    {
-        self::assertEquals(
-            $this->getQuotedCommentOnColumnSQLWithQuoteCharacter(),
-            $this->platform->getCommentOnColumnSQL('mytable', 'id', "It's a quote !"),
-        );
     }
 
     /**
@@ -790,28 +640,6 @@ abstract class AbstractPlatformTestCase extends TestCase
      * @return string[]
      */
     abstract protected function getCommentOnColumnSQL(): array;
-
-    public function testGetCommentOnColumnSQL(): void
-    {
-        self::assertSame(
-            $this->getCommentOnColumnSQL(),
-            [
-                $this->platform->getCommentOnColumnSQL('foo', 'bar', 'comment'), // regular identifiers
-                $this->platform->getCommentOnColumnSQL('`Foo`', '`BAR`', 'comment'), // explicitly quoted identifiers
-                $this->platform->getCommentOnColumnSQL('select', 'from', 'comment'), // reserved keyword identifiers
-            ],
-        );
-    }
-
-    #[DataProvider('getGeneratesInlineColumnCommentSQL')]
-    public function testGeneratesInlineColumnCommentSQL(string $comment, string $expectedSql): void
-    {
-        if (! $this->platform->supportsInlineColumnComments()) {
-            self::markTestSkipped(sprintf('%s does not support inline column comments.', $this->platform::class));
-        }
-
-        self::assertSame($expectedSql, $this->platform->getInlineColumnCommentSQL($comment));
-    }
 
     /** @return mixed[][] */
     public static function getGeneratesInlineColumnCommentSQL(): iterable
@@ -847,21 +675,6 @@ abstract class AbstractPlatformTestCase extends TestCase
     protected static function getInlineColumnEmptyCommentSQL(): string
     {
         return "COMMENT ''";
-    }
-
-    public function testThrowsExceptionOnGeneratingInlineColumnCommentSQLIfUnsupported(): void
-    {
-        if ($this->platform->supportsInlineColumnComments()) {
-            self::markTestSkipped(sprintf('%s supports inline column comments.', $this->platform::class));
-        }
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(
-            'Operation "' . AbstractPlatform::class . '::getInlineColumnCommentSQL" is not supported by platform.',
-        );
-        $this->expectExceptionCode(0);
-
-        $this->platform->getInlineColumnCommentSQL('unsupported');
     }
 
     public function testQuoteStringLiteral(): void

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -544,16 +544,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         return 'TRUNCATE "SELECT" IMMEDIATE';
     }
 
-    protected function supportsInlineIndexDeclaration(): bool
-    {
-        return false;
-    }
-
-    protected function supportsCommentOnStatement(): bool
-    {
-        return true;
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -124,11 +123,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         self::assertTrue($this->platform->supportsSavepoints());
     }
 
-    protected function supportsCommentOnStatement(): bool
-    {
-        return true;
-    }
-
     public function getGenerateIndexSql(): string
     {
         return 'CREATE INDEX "MY_IDX" ON mytable ("USER_NAME", "LAST_LOGIN")';
@@ -142,28 +136,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
     protected function getGenerateForeignKeySql(): string
     {
         return 'ALTER TABLE test ADD FOREIGN KEY ("FK_NAME_ID") REFERENCES "OTHER_TABLE" ("ID")';
-    }
-
-    /** @param mixed[] $options */
-    #[DataProvider('getGeneratesAdvancedForeignKeyOptionsSQLData')]
-    public function testGeneratesAdvancedForeignKeyOptionsSQL(array $options, string $expectedSql): void
-    {
-        $foreignKey = new ForeignKeyConstraint(['foo'], 'foreign_table', ['bar'], '', $options);
-
-        self::assertSame($expectedSql, $this->platform->getAdvancedForeignKeyOptionsSQL($foreignKey));
-    }
-
-    /** @return mixed[][] */
-    public static function getGeneratesAdvancedForeignKeyOptionsSQLData(): iterable
-    {
-        return [
-            [[], ''],
-            [['onUpdate' => 'CASCADE'], ''],
-            [['onDelete' => 'CASCADE'], ' ON DELETE CASCADE'],
-            [['onDelete' => 'NO ACTION'], ''],
-            [['onDelete' => 'RESTRICT'], ''],
-            [['onUpdate' => 'SET NULL', 'onDelete' => 'SET NULL'], ' ON DELETE SET NULL'],
-        ];
     }
 
     /**

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -52,87 +51,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         return 'ALTER TABLE test ADD FOREIGN KEY ("fk_name_id")'
             . ' REFERENCES "other_table" ("id") NOT DEFERRABLE INITIALLY IMMEDIATE';
-    }
-
-    public function testGeneratesForeignKeySqlForNonStandardOptions(): void
-    {
-        $foreignKey = new ForeignKeyConstraint(
-            ['foreign_id'],
-            'my_table',
-            ['id'],
-            'my_fk',
-            ['onDelete' => 'CASCADE'],
-        );
-        self::assertEquals(
-            'CONSTRAINT "my_fk" FOREIGN KEY ("foreign_id")'
-            . ' REFERENCES "my_table" ("id") ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE',
-            $this->platform->getForeignKeyDeclarationSQL($foreignKey),
-        );
-
-        $foreignKey = new ForeignKeyConstraint(
-            ['foreign_id'],
-            'my_table',
-            ['id'],
-            'my_fk',
-            ['match' => 'full'],
-        );
-        self::assertEquals(
-            'CONSTRAINT "my_fk" FOREIGN KEY ("foreign_id")'
-            . ' REFERENCES "my_table" ("id") MATCH full NOT DEFERRABLE INITIALLY IMMEDIATE',
-            $this->platform->getForeignKeyDeclarationSQL($foreignKey),
-        );
-
-        $foreignKey = new ForeignKeyConstraint(
-            ['foreign_id'],
-            'my_table',
-            ['id'],
-            'my_fk',
-            ['deferrable' => true],
-        );
-        self::assertEquals(
-            'CONSTRAINT "my_fk" FOREIGN KEY ("foreign_id")'
-            . ' REFERENCES "my_table" ("id") DEFERRABLE INITIALLY IMMEDIATE',
-            $this->platform->getForeignKeyDeclarationSQL($foreignKey),
-        );
-
-        $foreignKey = new ForeignKeyConstraint(
-            ['foreign_id'],
-            'my_table',
-            ['id'],
-            'my_fk',
-            ['deferred' => true],
-        );
-        self::assertEquals(
-            'CONSTRAINT "my_fk" FOREIGN KEY ("foreign_id")'
-            . ' REFERENCES "my_table" ("id") NOT DEFERRABLE INITIALLY DEFERRED',
-            $this->platform->getForeignKeyDeclarationSQL($foreignKey),
-        );
-
-        $foreignKey = new ForeignKeyConstraint(
-            ['foreign_id'],
-            'my_table',
-            ['id'],
-            'my_fk',
-            ['deferred' => true],
-        );
-        self::assertEquals(
-            'CONSTRAINT "my_fk" FOREIGN KEY ("foreign_id")'
-            . ' REFERENCES "my_table" ("id") NOT DEFERRABLE INITIALLY DEFERRED',
-            $this->platform->getForeignKeyDeclarationSQL($foreignKey),
-        );
-
-        $foreignKey = new ForeignKeyConstraint(
-            ['foreign_id'],
-            'my_table',
-            ['id'],
-            'my_fk',
-            ['deferrable' => true, 'deferred' => true, 'match' => 'full'],
-        );
-        self::assertEquals(
-            'CONSTRAINT "my_fk" FOREIGN KEY ("foreign_id")'
-            . ' REFERENCES "my_table" ("id") MATCH full DEFERRABLE INITIALLY DEFERRED',
-            $this->platform->getForeignKeyDeclarationSQL($foreignKey),
-        );
     }
 
     public function testGeneratesSqlSnippets(): void
@@ -241,20 +159,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    #[DataProvider('serialTypes')]
-    public function testGetDefaultValueDeclarationSQLIgnoresTheDefaultKeyWhenTheFieldIsSerial(string $type): void
-    {
-        $sql = $this->platform->getDefaultValueDeclarationSQL(
-            [
-                'autoincrement' => true,
-                'type'          => Type::getType($type),
-                'default'       => 1,
-            ],
-        );
-
-        self::assertSame('', $sql);
-    }
-
     public function testGeneratesTypeDeclarationForIntegers(): void
     {
         self::assertEquals(
@@ -308,11 +212,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testSupportsSequences(): void
     {
         self::assertTrue($this->platform->supportsSequences());
-    }
-
-    protected function supportsCommentOnStatement(): bool
-    {
-        return true;
     }
 
     public function testModifyLimitQuery(): void
@@ -705,11 +604,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertEquals(Types::TEXT, $this->platform->getDoctrineTypeMapping('tsvector'));
     }
 
-    public function testSupportsPartialIndexes(): void
-    {
-        self::assertTrue($this->platform->supportsPartialIndexes());
-    }
-
     public function testGetCreateTableSQLWithUniqueConstraints(): void
     {
         $table = new Table('foo');
@@ -737,14 +631,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             ],
             $this->platform->getCreateTableSQL($table),
             'Comments are added to table.',
-        );
-    }
-
-    public function testColumnCollationDeclarationSQL(): void
-    {
-        self::assertEquals(
-            'COLLATE "en_US.UTF-8"',
-            $this->platform->getColumnCollationDeclarationSQL('en_US.UTF-8'),
         );
     }
 

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1026,33 +1026,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         self::assertEquals($expectedSql, $sql);
     }
 
-    public function testGetDefaultValueDeclarationSQLForDateType(): void
-    {
-        $currentDateSql = $this->platform->getCurrentDateSQL();
-        foreach ([Types::DATE_MUTABLE, Types::DATE_IMMUTABLE] as $type) {
-            self::assertSame(
-                ' DEFAULT CONVERT(date, GETDATE())',
-                $this->platform->getDefaultValueDeclarationSQL([
-                    'type' => Type::getType($type),
-                    'default' => $currentDateSql,
-                ]),
-            );
-        }
-    }
-
-    public function testSupportsColumnCollation(): void
-    {
-        self::assertTrue($this->platform->supportsColumnCollation());
-    }
-
-    public function testColumnCollationDeclarationSQL(): void
-    {
-        self::assertSame(
-            'COLLATE Latin1_General_CS_AS_KS_WS',
-            $this->platform->getColumnCollationDeclarationSQL('Latin1_General_CS_AS_KS_WS'),
-        );
-    }
-
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -624,11 +624,6 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testSupportsColumnCollation(): void
-    {
-        self::assertTrue($this->platform->supportsColumnCollation());
-    }
-
     public function testGetCreateTableSQLWithColumnCollation(): void
     {
         $table = new Table('foo');


### PR DESCRIPTION
These methods were marked as platform-internal in https://github.com/doctrine/dbal/pull/5568.

Due to the removal of the tests, code coverage has dropped by ~5%. Those tests either duplicate the code (assertions against `supports()` methods) or cover SQL expressions (which should be done via functional tests). Such tests have shown to provide negligible value and at the same time require maintenance.

![Farquaad_sacrifice_quote](https://github.com/user-attachments/assets/c91fff37-ed4c-4f45-b789-3d3f084ef919)
