### PR TITLE
Deprecate empty index name

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,7 +40,8 @@ The `Sequence::isAutoIncrementsFor()` method has been deprecated.
 
 ## Deprecated using invalid database object names
 
-Using the following objects with an empty name is deprecated: `Column`, `View`, `Sequence`, `Identifier`.
+Using the following objects with an empty name is deprecated: `Table`, `Column`, `Index`, `View`, `Sequence`,
+`Identifier`.
 
 Using the following objects with a qualified name is deprecated: `Column`, `ForeignKeyConstraint`, `Index`, `Schema`,
 `UniqueConstraint`. If the object name contains a dot, the name should be quoted.

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -237,21 +237,21 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
-        if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
+        if (! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $definition) {
                 $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 
         // add all indexes
-        if (isset($options['indexes']) && ! empty($options['indexes'])) {
+        if (! empty($options['indexes'])) {
             foreach ($options['indexes'] as $definition) {
                 $queryFields .= ', ' . $this->getIndexDeclarationSQL($definition);
             }
         }
 
         // attach all primary keys
-        if (isset($options['primary']) && ! empty($options['primary'])) {
+        if (! empty($options['primary'])) {
             $keyColumns   = array_unique(array_values($options['primary']));
             $queryFields .= ', PRIMARY KEY(' . implode(', ', $keyColumns) . ')';
         }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -987,17 +987,17 @@ abstract class AbstractPlatform
     {
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
-        if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
+        if (! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $definition) {
                 $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 
-        if (isset($options['primary']) && ! empty($options['primary'])) {
+        if (! empty($options['primary'])) {
             $columnListSql .= ', PRIMARY KEY(' . implode(', ', array_unique(array_values($options['primary']))) . ')';
         }
 
-        if (isset($options['indexes']) && ! empty($options['indexes'])) {
+        if (! empty($options['indexes'])) {
             foreach ($options['indexes'] as $definition) {
                 $columnListSql .= ', ' . $this->getIndexDeclarationSQL($definition);
             }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -385,7 +385,7 @@ class PostgreSQLPlatform extends AbstractPlatform
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
-        if (isset($options['primary']) && ! empty($options['primary'])) {
+        if (! empty($options['primary'])) {
             $keyColumns   = array_unique(array_values($options['primary']));
             $queryFields .= ', PRIMARY KEY(' . implode(', ', $keyColumns) . ')';
         }
@@ -396,7 +396,7 @@ class PostgreSQLPlatform extends AbstractPlatform
 
         $sql = [$query];
 
-        if (isset($options['indexes']) && ! empty($options['indexes'])) {
+        if (! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index) {
                 $sql[] = $this->getCreateIndexSQL($index, $name);
             }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -208,13 +208,13 @@ class SQLServerPlatform extends AbstractPlatform
 
         $columnListSql = $this->getColumnDeclarationListSQL($columns);
 
-        if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
+        if (! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $definition) {
                 $columnListSql .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
         }
 
-        if (isset($options['primary']) && ! empty($options['primary'])) {
+        if (! empty($options['primary'])) {
             $flags = '';
             if (isset($options['primary_index']) && $options['primary_index']->hasFlag('nonclustered')) {
                 $flags = ' NONCLUSTERED';
@@ -235,7 +235,7 @@ class SQLServerPlatform extends AbstractPlatform
 
         $sql = [$query];
 
-        if (isset($options['indexes']) && ! empty($options['indexes'])) {
+        if (! empty($options['indexes'])) {
             foreach ($options['indexes'] as $index) {
                 $sql[] = $this->getCreateIndexSQL($index, $name);
             }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -273,7 +273,7 @@ class SQLitePlatform extends AbstractPlatform
     {
         $queryFields = $this->getColumnDeclarationListSQL($columns);
 
-        if (isset($options['uniqueConstraints']) && ! empty($options['uniqueConstraints'])) {
+        if (! empty($options['uniqueConstraints'])) {
             foreach ($options['uniqueConstraints'] as $definition) {
                 $queryFields .= ', ' . $this->getUniqueConstraintDeclarationSQL($definition);
             }
@@ -300,13 +300,13 @@ class SQLitePlatform extends AbstractPlatform
             return $query;
         }
 
-        if (isset($options['indexes']) && ! empty($options['indexes'])) {
+        if (! empty($options['indexes'])) {
             foreach ($options['indexes'] as $indexDef) {
                 $query[] = $this->getCreateIndexSQL($indexDef, $name);
             }
         }
 
-        if (isset($options['unique']) && ! empty($options['unique'])) {
+        if (! empty($options['unique'])) {
             foreach ($options['unique'] as $indexDef) {
                 $query[] = $this->getCreateIndexSQL($indexDef, $name);
             }

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -17,8 +17,8 @@ use function array_shift;
 use function count;
 use function strtolower;
 
-/** @extends AbstractOptionallyNamedObject<UnqualifiedName> */
-class Index extends AbstractOptionallyNamedObject
+/** @extends AbstractNamedObject<UnqualifiedName> */
+class Index extends AbstractNamedObject
 {
     /**
      * Asset identifier instances of the column names the index is associated with.
@@ -51,7 +51,7 @@ class Index extends AbstractOptionallyNamedObject
         array $flags = [],
         private readonly array $options = [],
     ) {
-        parent::__construct($name);
+        parent::__construct($name ?? '');
 
         $this->_isUnique  = $isUnique || $isPrimary;
         $this->_isPrimary = $isPrimary;

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IndexTest extends TestCase
 {
+    use VerifyDeprecations;
+
     /** @param mixed[] $options */
     private function createIndex(bool $unique = false, bool $primary = false, array $options = []): Index
     {
@@ -174,21 +176,24 @@ class IndexTest extends TestCase
         self::assertSame(['where' => 'name IS NULL'], $idx2->getOptions());
     }
 
-    /** @throws Exception */
-    public function testGetNonNullObjectName(): void
+    public function testEmptyName(): void
     {
-        $index = new Index('idx_user_id', ['user_id']);
-        $name  = $index->getObjectName();
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
 
-        self::assertNotNull($name);
-        self::assertEquals(Identifier::unquoted('idx_user_id'), $name->getIdentifier());
+        new Index(null, ['user_id']);
     }
 
-    /** @throws Exception */
-    public function testGetNullObjectName(): void
+    public function testQualifiedName(): void
     {
-        $index = new Index(null, ['user_id']);
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
 
-        self::assertNull($index->getObjectName());
+        new Index('auth.idx_user_id', ['user_id']);
+    }
+
+    public function testGetObjectName(): void
+    {
+        $index = new Index('idx_user_id', ['user_id']);
+
+        self::assertEquals(Identifier::unquoted('idx_user_id'), $index->getObjectName()->getIdentifier());
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

Of all supported platforms, only PostgreSQL allows to omit the name in the `CREATE INDEX` statement (it will generate it internally). The rest of the platform require the index name to be defined as part of their syntax.

Handling of the `null` value of the `$name` name parameter of the `Index` constructor was added in #2854. Quite likely, it was done in order to satisfy a test for the code that would use an index to create a primary key constraint. Thus, there was a false assumption that given that constraints can be unnamed, indexes should be as well (see https://github.com/doctrine/dbal/pull/2854#discussion_r255289671).

Unlike foreign key and unique constraints, for which DBAL generates the name, if it's omitted in the definition, it doesn't do that for indexes, so two indexes with empty name cannot even co-exist in a table definition:
```php
new Table('t', [
    new Column('c1', Type::getType('integer')),
    new Column('c2', Type::getType('integer')),
], [
    new Index(null, ['c1']),
    new Index(null, ['c2']),
]);

// Doctrine\DBAL\Schema\Exception\IndexAlreadyExists:
//   An index with name "" was already defined on table "t".
```