### PR TITLE
Deprecate AbstractAsset::getQuotedName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractAsset::getQuotedName()`
+
+The `AbstractAsset::getQuotedName()` method has been deprecated. Use `NamedObject::getObjectName()` or
+`OptionallyQualifiedName::getObjectName()` followed by `Name::toSQL()` instead.
+
 ## Deprecated `AbstractAsset` namespace-related methods and property
 
 The following namespace-related methods and property have been deprecated:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -141,6 +141,12 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNamespaceName" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::isInDefaultNamespace" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6674
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getQuotedName" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -330,9 +330,19 @@ abstract class AbstractAsset
     /**
      * Gets the quoted representation of this asset but only if it was defined with one. Otherwise
      * return the plain unquoted value as inserted.
+     *
+     * @deprecated Use {@see NamedObject::getObjectName()} or {@see OptionallyQualifiedName::getObjectName()} followed
+     * by {@see Name::toSQL()} instead.
      */
     public function getQuotedName(AbstractPlatform $platform): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6674',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         $keywords = $platform->getReservedKeywordsList();
         $parts    = $normalizedParts = [];
 

--- a/src/Schema/Name.php
+++ b/src/Schema/Name.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 /**
  * Represents a database object name.
  */
 interface Name
 {
+    /**
+     * Returns the SQL representation of the name for the given platform.
+     */
+    public function toSQL(AbstractPlatform $platform): string;
+
     /**
      * Returns the string representation of the name.
      *

--- a/src/Schema/Name/AbstractName.php
+++ b/src/Schema/Name/AbstractName.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Name;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Name;
 
 use function array_map;
@@ -25,11 +26,19 @@ abstract class AbstractName implements Name
         $this->identifiers = array_merge([$firstIdentifier], array_values($otherIdentifiers));
     }
 
+    public function toSQL(AbstractPlatform $platform): string
+    {
+        return $this->joinIdentifiers(static fn (Identifier $identifier): string => $identifier->toSql($platform));
+    }
+
     public function toString(): string
     {
-        return implode('.', array_map(
-            static fn (Identifier $identifier): string => $identifier->toString(),
-            $this->identifiers,
-        ));
+        return $this->joinIdentifiers(static fn (Identifier $identifier): string => $identifier->toString());
+    }
+
+    /** @param callable(Identifier): string $mapper */
+    private function joinIdentifiers(callable $mapper): string
+    {
+        return implode('.', array_map($mapper, $this->identifiers));
     }
 }

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Name;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Exception\InvalidIdentifier;
 
 use function sprintf;
@@ -32,6 +33,17 @@ final class Identifier
     public function isQuoted(): bool
     {
         return $this->isQuoted;
+    }
+
+    public function toSql(AbstractPlatform $platform): string
+    {
+        if (! $this->isQuoted) {
+            $value = $platform->normalizeUnquotedIdentifier($this->value);
+        } else {
+            $value = $this->value;
+        }
+
+        return $platform->quoteSingleIdentifier($value);
     }
 
     public function toString(): string


### PR DESCRIPTION
The current method is mostly okay but has its issues:
1. If the name of an `OptionallyNamedObject` is not specified, this method will quietly return empty string. Having to call `getObjectName(): ?N` will allow to enforce handling unspecified names via the static analysis.
2. Some objects, besides its own name reference other names (e.g. the foreign key constraint). Having class itself responsible for building SQL for all kinds of its name requires the introduction of an additional `getQuoted...()` method per name.

### <a name="technical-details">Technical details</a>
1. This PR adds a method to an interface but it hasn't yet been released, so it's not a breaking change.
2. I didn't add tests for `Name::toSQL()` because on the one hand, there's no default platform to test against; on the other, I don't believe we want to test the interaction with `AbstractPlatform` via mocking. Since this method is about SQL, it should be tested via integration testing. In 5.0.x, this method will be extensively tested by existing tests.