### PR TITLE
Deprecate mixing qualified and unqualified names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated mixing unqualified and qualified names in a schema without a default namespace
+
+If a schema lacks a default namespace configuration and has at least one object with an unqualified name, adding or
+referencing objects with qualified names is deprecated.
+
+If a schema lacks a default namespace configuration and has at least one object with a qualified name, adding or
+referencing objects with unqualified names is deprecated.
+
+Mixing unqualified and qualified names is permitted as long as the schema is configured to use a default namespace. In
+this case, the default namespace will be used to resolve unqualified names.
+
 ## Deprecated `AbstractAsset::getQuotedName()`
 
 The `AbstractAsset::getQuotedName()` method has been deprecated. Use `NamedObject::getObjectName()` or

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractAsset::isIdentifierQuoted()`
+
+The `AbstractAsset::isIdentifierQuoted()` method has been deprecated. Parse the name and introspect its identifiers
+individually using `Identifier::isQuoted()` instead.
+
 ## Deprecated mixing unqualified and qualified names in a schema without a default namespace
 
 If a schema lacks a default namespace configuration and has at least one object with an unqualified name, adding or

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -147,6 +147,12 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getQuotedName" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6677
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::isIdentifierQuoted" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -301,9 +301,19 @@ abstract class AbstractAsset
 
     /**
      * Checks if this identifier is quoted.
+     *
+     * @deprecated Parse the name and introspect its identifiers individually using {@see Identifier::isQuoted()}
+     *             instead.
      */
     protected function isIdentifierQuoted(string $identifier): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6677',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         return isset($identifier[0]) && ($identifier[0] === '`' || $identifier[0] === '"' || $identifier[0] === '[');
     }
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -273,6 +273,15 @@ SQL,
         );
     }
 
+    public function createSchemaConfig(): SchemaConfig
+    {
+        $config = parent::createSchemaConfig();
+
+        $config->setName($this->getCurrentSchemaName());
+
+        return $config;
+    }
+
     /** @throws Exception */
     private function getDatabaseCollation(): string
     {
@@ -289,6 +298,15 @@ SQL,
         }
 
         return $this->databaseCollation;
+    }
+
+    /** @throws Exception */
+    private function getCurrentSchemaName(): ?string
+    {
+        $schemaName = $this->connection->fetchOne('SELECT SCHEMA_NAME()');
+        assert($schemaName !== false);
+
+        return $schemaName;
     }
 
     protected function selectTableNames(string $databaseName): Result

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -8,9 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -1091,15 +1089,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testListTableDetailsWithFullQualifiedTableName(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof PostgreSQLPlatform) {
-            $defaultSchemaName = 'public';
-        } elseif ($platform instanceof SQLServerPlatform) {
-            $defaultSchemaName = 'dbo';
-        } else {
+        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
             self::markTestSkipped('Test only works on platforms that support schemas.');
         }
+
+        $schemaConfig = $this->schemaManager->createSchemaConfig();
+
+        $defaultSchemaName = $schemaConfig->getName();
+
+        self::assertNotNull($defaultSchemaName);
 
         $primaryTableName = 'primary_table';
         $foreignTableName = 'foreign_table';


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement/deprecation

Technically, each of the three commits could be contributed as a separate pull request but I'll publish them altogether in the interest of time as each of them depends on the previous one.

### 1. Population of the current SQL Server schema

Technically, the fact that the current SQL Server schema name isn't populated during introspection is a bug. Once introspected, a PostgreSQL schema allows referencing its objects by unqualified or qualified name but the SQL Server schema doesn't. This commit addresses this issue and reworks an existing test to cover this scenario.

### 2. Deprecation of mixing qualified and unqualified names in a schema

Currently, a schema allows registering objects with a mixture of unqualified names (e.g. `customers`) and qualified names (e.g. `public.customers`). It compares names as strings, so in the absence of a default schema name, "customers" ≠ "public.customers", however, it's a logical error because these two values are incomparable (again, similar to "5" and "5 meters").

In order to make the schema API more robust, mixing incomparable types of names is deprecated.

#### <a name="unqualified-names">Using unqualified names</a>

Unqualified names can be used to add objects to or reference objects in a schema only if doesn't contain objects with qualified names or has a default namespace configuration.

#### <a name="qualified-names">Using qualified names</a>

Qualified names can be used to add objects to or reference objects in a schema only if doesn't contain objects with unqualified names.

#### Considered alternatives

Whether a given schema uses unqualified or qualified names is determined at runtime. An even more robust approach would be parameterize the schema class with the type of its objects' names and use this information for static analysis. However, the type of the names is defined by the target database platform, which is determined at runtime based on connection parameters, so the static typing is not feasible.

### 3. Deprecation of `AbstractAsset::isIdentifierQuoted()`

Once these changes are merged into 5.0.x, it will be possible to stop using `AbstractAsset::isIdentifierQuoted()`. At that point, we should be able to remove it.

The problem with this method is that it accepts a name that potentially consists of multiple identifiers and returns the value based on whether the first one is quoted. This is incorrect as each identifier may or may not be quoted individually.