### PR TITLE
Deprecate UniqueConstraint features and introduce UniqueConstraintEditor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,7 +25,9 @@ The following `UniqueConstraint` methods and property have been deprecated:
 Additionally,
 1. Extending the `UniqueConstraint` class has been deprecated. Use the `UniqueConstraint` class directly.
 2. Instantiation of a unique constraint without columns is deprecated.
-3. The `AbstractPlatform::getUniqueConstraintDeclarationSQL()` method has been marked as internal.
+3. The `UniqueConstraint` constructor has been marked as internal. Use `UniqueConstraint::editor()` to instantiate an
+   editor and `UniqueConstraintEditor::create()` to create a unique constraint.
+4. The `AbstractPlatform::getUniqueConstraintDeclarationSQL()` method has been marked as internal.
 
 ## Deprecated `AbstractAsset::isIdentifierQuoted()`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,25 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `UniqueConstraint` methods, property and behavior
+
+The following `UniqueConstraint` methods and property have been deprecated:
+
+- `UniqueConstraint::addColumn()` – the constraint should not be modified once instantiated.
+- `UniqueConstraint::addFlag()`, `UniqueConstraint::getFlags()`, `UniqueConstraint::hasFlag()`,
+  `UniqueConstraint::removeFlag()`, `UniqueConstraint::$flags` – the only supported flag is "is clustered". Use
+  `UniqueConstraintEditor::setIsClustered()` to set the flag and `UniqueConstraint::isClustered()` to check it instead.
+- `UniqueConstraint::getColumns()`, `UniqueConstraint::getQuotedColumns()`, `UniqueConstraint::getUnquotedColumns()`,
+  `UniqueConstraint::$columns` – use `UniqueConstraint::getColumnNames()` instead.
+- `UniqueConstraint::getOption()`, `UniqueConstraint::getOptions()`, `UniqueConstraint::hasOption()` – DBAL doesn't
+  support any options for unique constraints. Passing non-empty options to the `UniqueConstraint` constructor is
+  deprecated as well.
+
+Additionally,
+1. Extending the `UniqueConstraint` class has been deprecated. Use the `UniqueConstraint` class directly.
+2. Instantiation of a unique constraint without columns is deprecated.
+3. The `AbstractPlatform::getUniqueConstraintDeclarationSQL()` method has been marked as internal.
+
 ## Deprecated `AbstractAsset::isIdentifierQuoted()`
 
 The `AbstractAsset::isIdentifierQuoted()` method has been deprecated. Parse the name and introspect its identifiers

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -153,6 +153,18 @@
                     TODO: remove in 5.0.0
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::isIdentifierQuoted" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6685
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::addColumn" />
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::addFlag" />
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::getColumns" />
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::getFlags" />
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::getOptions" />
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::getQuotedColumns" />
+                <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::hasFlag" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>
@@ -175,6 +187,13 @@
                 -->
                 <referencedProperty name="Doctrine\DBAL\Schema\AbstractAsset::$_namespace" />
                 <referencedProperty name="Doctrine\DBAL\Schema\Table::$_namespace" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6685
+                    TODO: remove in 5.0.0
+                -->
+                <referencedProperty name="Doctrine\DBAL\Schema\UniqueConstraint::$columns" />
+                <referencedProperty name="Doctrine\DBAL\Schema\UniqueConstraint::$flags" />
             </errorLevel>
         </DeprecatedProperty>
         <DocblockTypeContradiction>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1548,12 +1548,14 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Obtains DBMS specific SQL code portion needed to set a unique
-     * constraint declaration to be used in statements like CREATE TABLE.
+     * Obtains DBMS specific DDL fragment that defines a unique constraint to be used in statements like <code>CREATE
+     * TABLE</code> or <code>ALTER TABLE</code>.
+     *
+     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      *
      * @param UniqueConstraint $constraint The unique constraint definition.
      *
-     * @return string DBMS specific SQL code portion needed to set a constraint.
+     * @return string DBMS specific DDL fragment that defines the constraint.
      */
     public function getUniqueConstraintDeclarationSQL(UniqueConstraint $constraint): string
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1179,13 +1179,7 @@ abstract class AbstractPlatform
      */
     public function getCreateUniqueConstraintSQL(UniqueConstraint $constraint, string $tableName): string
     {
-        $sql = 'ALTER TABLE ' . $tableName . ' ADD';
-
-        if ($constraint->getName() !== '') {
-            $sql .= ' CONSTRAINT ' . $constraint->getQuotedName($this);
-        }
-
-        return $sql . ' UNIQUE (' . implode(', ', $constraint->getQuotedColumns($this)) . ')';
+        return 'ALTER TABLE ' . $tableName . ' ADD ' . $this->getUniqueConstraintDeclarationSQL($constraint);
     }
 
     /**
@@ -1563,7 +1557,7 @@ abstract class AbstractPlatform
      */
     public function getUniqueConstraintDeclarationSQL(UniqueConstraint $constraint): string
     {
-        $columns = $constraint->getColumns();
+        $columns = $constraint->getQuotedColumns($this);
 
         if (count($columns) === 0) {
             throw new InvalidArgumentException('Incomplete definition. "columns" required.');

--- a/src/Schema/Exception/InvalidState.php
+++ b/src/Schema/Exception/InvalidState.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class InvalidState extends LogicException implements SchemaException
+{
+    public static function uniqueConstraintHasInvalidColumnNames(string $constraintName): self
+    {
+        return new self(sprintf('Unique constraint "%s" has one or more invalid column name.', $constraintName));
+    }
+
+    public static function uniqueConstraintHasEmptyColumnNames(string $constraintName): self
+    {
+        return new self(sprintf('Unique constraint "%s" has no column names.', $constraintName));
+    }
+}

--- a/src/Schema/Exception/InvalidUniqueConstraintDefinition.php
+++ b/src/Schema/Exception/InvalidUniqueConstraintDefinition.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+/** @psalm-immutable */
+final class InvalidUniqueConstraintDefinition extends LogicException implements SchemaException
+{
+    public static function columnNamesAreNotSet(): self
+    {
+        return new self('Unique constraint column names are not set.');
+    }
+}

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -161,9 +161,9 @@ class Table extends AbstractNamedObject
     }
 
     /**
-     * @param array<int, string>   $columnNames
-     * @param array<int, string>   $flags
-     * @param array<string, mixed> $options
+     * @param non-empty-list<string> $columnNames
+     * @param array<int, string>     $flags
+     * @param array<string, mixed>   $options
      */
     public function addUniqueConstraint(
         array $columnNames,
@@ -876,9 +876,9 @@ class Table extends AbstractNamedObject
     }
 
     /**
-     * @param array<string|int, string> $columns
-     * @param array<int, string>        $flags
-     * @param array<string, mixed>      $options
+     * @param non-empty-list<string> $columns
+     * @param array<int, string>     $flags
+     * @param array<string, mixed>   $options
      */
     private function _createUniqueConstraint(
         array $columns,
@@ -1000,9 +1000,10 @@ class Table extends AbstractNamedObject
                 continue;
             }
 
+            /** @psalm-suppress InvalidArgument */
             $this->uniqueConstraints[$key] = new UniqueConstraint(
                 $constraint->getName(),
-                $columns,
+                $columns, // @phpstan-ignore argument.type
                 $constraint->getFlags(),
                 $constraint->getOptions(),
             );

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -53,6 +53,9 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
     private bool $failedToParseColumnNames = false;
 
     /**
+     * @internal Use {@link UniqueConstraint::editor()} to instantiate an editor and
+     *           {@link UniqueConstraintEditor::create()} to create a unique constraint.
+     *
      * @param non-empty-list<string> $columns
      * @param array<string>          $flags
      * @param array<string, mixed>   $options
@@ -201,7 +204,7 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
     /**
      * Adds flag for a unique constraint that translates to platform specific handling.
      *
-     * @deprecated
+     * @deprecated Use {@see UniqueConstraintEditor::setIsClustered()} instead.
      *
      * @return $this
      *
@@ -249,7 +252,7 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
     /**
      * Removes a flag.
      *
-     * @deprecated
+     * @deprecated Use {@see UniqueConstraintEditor::setIsClustered()} instead.
      */
     public function removeFlag(string $flag): void
     {
@@ -332,5 +335,24 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
                 $e->getMessage(),
             );
         }
+    }
+
+    /**
+     * Instantiates a new unique constraint editor.
+     */
+    public static function editor(): UniqueConstraintEditor
+    {
+        return new UniqueConstraintEditor();
+    }
+
+    /**
+     * Instantiates a new unique constraint editor and initializes it with the constraint's properties.
+     */
+    public function edit(): UniqueConstraintEditor
+    {
+        return self::editor()
+            ->setName($this->getObjectName())
+            ->setColumnNames(...$this->getColumnNames())
+            ->setIsClustered($this->isClustered());
     }
 }

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -21,11 +21,14 @@ use function strtolower;
  * Represents unique constraint definition.
  *
  * @extends AbstractOptionallyNamedObject<UnqualifiedName>
+ * @final This class will be made final in DBAL 5.0.
  */
 class UniqueConstraint extends AbstractOptionallyNamedObject
 {
     /**
      * Asset identifier instances of the column names the unique constraint is associated with.
+     *
+     * @deprecated
      *
      * @var array<string, Identifier>
      */
@@ -33,6 +36,8 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
 
     /**
      * Platform specific flags
+     *
+     * @deprecated
      *
      * @var array<string, true>
      */
@@ -48,9 +53,9 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
     private bool $failedToParseColumnNames = false;
 
     /**
-     * @param array<string>        $columns
-     * @param array<string>        $flags
-     * @param array<string, mixed> $options
+     * @param non-empty-list<string> $columns
+     * @param array<string>          $flags
+     * @param array<string, mixed>   $options
      */
     public function __construct(
         string $name,
@@ -58,6 +63,23 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
         array $flags = [],
         private readonly array $options = [],
     ) {
+        if (count($columns) < 1) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6685',
+                'Instantiation of a unique constraint without columns is deprecated.',
+            );
+        }
+
+        if (count($options) > 0) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6685',
+                'Using %s options is deprecated.',
+                self::class,
+            );
+        }
+
         parent::__construct($name);
 
         foreach ($columns as $column) {
@@ -92,14 +114,25 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
         return $this->columnNames;
     }
 
-    /** @return list<string> */
+    /**
+     * @deprecated Use {@see getColumnNames()} instead.
+     *
+     * @return list<string>
+     */
     public function getColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated. Use getColumnNames() instead.',
+            __METHOD__,
+        );
+
         return array_keys($this->columns);
     }
 
     /**
-     * Returns the quoted representation of the column names the constraint is associated with.
+     * @deprecated Use {@see getColumnNames()} and {@see UnqualifiedName::toSQL()} instead.
      *
      * But only if they were defined with one or a column name
      * is a keyword reserved by the platform.
@@ -108,9 +141,18 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
      * @param AbstractPlatform $platform The platform to use for quotation.
      *
      * @return list<string>
+     *
+     * Returns the quoted representation of the column names the constraint is associated with.
      */
     public function getQuotedColumns(AbstractPlatform $platform): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated. Use getColumnNames() and UnqualifiedName::toSQL() instead.',
+            __METHOD__,
+        );
+
         $columns = [];
 
         foreach ($this->columns as $column) {
@@ -120,24 +162,46 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
         return $columns;
     }
 
-    /** @return array<int, string> */
+    /**
+     * @deprecated Use {@see getColumnNames()} instead.
+     *
+     * @return array<int, string>
+     */
     public function getUnquotedColumns(): array
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated. Use getColumnNames() instead.',
+            __METHOD__,
+        );
+
         return array_map($this->trimQuotes(...), $this->getColumns());
     }
 
     /**
+     * @deprecated Use {@see isClustered()} instead.
+     *
      * Returns platform specific flags for unique constraint.
      *
      * @return array<int, string>
      */
     public function getFlags(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated. Use isClustered() instead.',
+            __METHOD__,
+        );
+
         return array_keys($this->flags);
     }
 
     /**
      * Adds flag for a unique constraint that translates to platform specific handling.
+     *
+     * @deprecated
      *
      * @return $this
      *
@@ -145,6 +209,13 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
      */
     public function addFlag(string $flag): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         $this->flags[strtolower($flag)] = true;
 
         return $this;
@@ -152,9 +223,18 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
 
     /**
      * Does this unique constraint have a specific flag?
+     *
+     * @deprecated Use {@see isClustered()} instead.
      */
     public function hasFlag(string $flag): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated. Use isClustered() instead.',
+            __METHOD__,
+        );
+
         return isset($this->flags[strtolower($flag)]);
     }
 
@@ -168,30 +248,74 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
 
     /**
      * Removes a flag.
+     *
+     * @deprecated
      */
     public function removeFlag(string $flag): void
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         unset($this->flags[strtolower($flag)]);
     }
 
+    /** @deprecated */
     public function hasOption(string $name): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return isset($this->options[strtolower($name)]);
     }
 
+    /** @deprecated */
     public function getOption(string $name): mixed
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return $this->options[strtolower($name)];
     }
 
-    /** @return array<string, mixed> */
+    /**
+     * @deprecated
+     *
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return $this->options;
     }
 
+    /** @deprecated */
     protected function addColumn(string $column): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6685',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         $this->columns[$column] = new Identifier($column);
 
         $parser = Parsers::getUnqualifiedNameParser();
@@ -203,7 +327,7 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
 
             Deprecation::trigger(
                 'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/XXXX',
+                'https://github.com/doctrine/dbal/pull/6685',
                 'Unable to parse column name: %s.',
                 $e->getMessage(),
             );

--- a/src/Schema/UniqueConstraintEditor.php
+++ b/src/Schema/UniqueConstraintEditor.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidUniqueConstraintDefinition;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+use function array_map;
+use function array_merge;
+use function array_values;
+use function count;
+
+final class UniqueConstraintEditor
+{
+    private ?UnqualifiedName $name = null;
+
+    /** @var list<UnqualifiedName> */
+    private array $columnNames = [];
+
+    private bool $isClustered = false;
+
+    /** @internal Use {@link UniqueConstraint::editor()} or {@link UniqueConstraint::edit()} to create an instance */
+    public function __construct()
+    {
+    }
+
+    public function setName(?UnqualifiedName $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function setColumnNames(UnqualifiedName $firstColumName, UnqualifiedName ...$otherColumnNames): self
+    {
+        $this->columnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+
+        return $this;
+    }
+
+    public function setIsClustered(bool $isClustered): self
+    {
+        $this->isClustered = $isClustered;
+
+        return $this;
+    }
+
+    public function create(): UniqueConstraint
+    {
+        if (count($this->columnNames) < 1) {
+            throw InvalidUniqueConstraintDefinition::columnNamesAreNotSet();
+        }
+
+        return new UniqueConstraint(
+            $this->name?->toString() ?? '',
+            array_map(static fn (UnqualifiedName $columnName) => $columnName->toString(), $this->columnNames),
+            $this->isClustered ? ['clustered'] : [],
+        );
+    }
+}

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -12,7 +12,9 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -435,7 +437,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('id', Types::INTEGER);
         $this->dropAndCreateTable($table);
 
-        $uniqueConstraint = new UniqueConstraint('uniq_id', ['id']);
+        $uniqueConstraint = UniqueConstraint::editor()
+            ->setName(
+                new UnqualifiedName(Identifier::unquoted('uniq_id')),
+            )
+            ->setColumnNames(
+                new UnqualifiedName(Identifier::unquoted('id')),
+            )
+            ->create();
+
         $this->schemaManager->createUniqueConstraint($uniqueConstraint, $table->getName());
 
         // there's currently no API for introspecting unique constraints,

--- a/tests/Functional/Schema/UniqueConstraintTest.php
+++ b/tests/Functional/Schema/UniqueConstraintTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -22,8 +24,12 @@ final class UniqueConstraintTest extends FunctionalTestCase
             new Column('username', Type::getType(Types::STRING), ['length' => 32]),
             new Column('email', Type::getType(Types::STRING), ['length' => 255]),
         ], [], [
-            new UniqueConstraint('', ['username']),
-            new UniqueConstraint('', ['email']),
+            UniqueConstraint::editor()
+                ->setColumnNames(new UnqualifiedName(Identifier::unquoted('username')))
+                ->create(),
+            UniqueConstraint::editor()
+                ->setColumnNames(new UnqualifiedName(Identifier::unquoted('email')))
+                ->create(),
         ], []);
 
         $sm = $this->connection->createSchemaManager();

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -14,6 +14,8 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -188,7 +190,13 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $where            = 'test IS NULL AND test2 IS NOT NULL';
         $indexDef         = new Index('name', ['test', 'test2'], false, false, [], ['where' => $where]);
-        $uniqueConstraint = new UniqueConstraint('name', ['test', 'test2'], [], []);
+        $uniqueConstraint = UniqueConstraint::editor()
+            ->setName(new UnqualifiedName(Identifier::unquoted('name')))
+            ->setColumnNames(
+                new UnqualifiedName(Identifier::unquoted('test')),
+                new UnqualifiedName(Identifier::unquoted('test2')),
+            )
+            ->create();
 
         $expected = ' WHERE ' . $where;
 

--- a/tests/Schema/UniqueConstraintEditorTest.php
+++ b/tests/Schema/UniqueConstraintEditorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidUniqueConstraintDefinition;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use PHPUnit\Framework\TestCase;
+
+class UniqueConstraintEditorTest extends TestCase
+{
+    public function testEmptyColumnNames(): void
+    {
+        $this->expectException(InvalidUniqueConstraintDefinition::class);
+
+        UniqueConstraint::editor()
+            ->create();
+    }
+
+    public function testSetIsClustered(): void
+    {
+        $columnName = new UnqualifiedName(Identifier::unquoted('user_id'));
+
+        $editor = UniqueConstraint::editor()
+            ->setColumnNames($columnName);
+
+        $constraint = $editor->create();
+        self::assertFalse($constraint->isClustered());
+
+        $constraint = $editor
+            ->setIsClustered(true)
+            ->create();
+        self::assertTrue($constraint->isClustered());
+    }
+}

--- a/tests/Schema/UniqueConstraintTest.php
+++ b/tests/Schema/UniqueConstraintTest.php
@@ -20,17 +20,26 @@ class UniqueConstraintTest extends TestCase
     /** @throws Exception */
     public function testGetNonNullObjectName(): void
     {
-        $uniqueConstraint = new UniqueConstraint('uq_user_id', ['user_id']);
-        $name             = $uniqueConstraint->getObjectName();
+        $name = new UnqualifiedName(Identifier::unquoted('uq_user_id'));
 
-        self::assertNotNull($name);
-        self::assertEquals(Identifier::unquoted('uq_user_id'), $name->getIdentifier());
+        $uniqueConstraint = UniqueConstraint::editor()
+            ->setName($name)
+            ->setColumnNames(
+                new UnqualifiedName(Identifier::unquoted('user_id')),
+            )
+            ->create();
+
+        self::assertEquals($name, $uniqueConstraint->getObjectName());
     }
 
     /** @throws Exception */
     public function testGetNullObjectName(): void
     {
-        $uniqueConstraint = new UniqueConstraint('', ['user_id']);
+        $uniqueConstraint = UniqueConstraint::editor()
+            ->setColumnNames(
+                new UnqualifiedName(Identifier::unquoted('user_id')),
+            )
+            ->create();
 
         self::assertNull($uniqueConstraint->getObjectName());
     }

--- a/tests/Schema/UniqueConstraintTest.php
+++ b/tests/Schema/UniqueConstraintTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class UniqueConstraintTest extends TestCase
@@ -30,5 +33,47 @@ class UniqueConstraintTest extends TestCase
         $uniqueConstraint = new UniqueConstraint('', ['user_id']);
 
         self::assertNull($uniqueConstraint->getObjectName());
+    }
+
+    public function testGetColumnNames(): void
+    {
+        $uniqueConstraint = new UniqueConstraint('', ['user_id']);
+
+        self::assertEquals([
+            new UnqualifiedName(Identifier::unquoted('user_id')),
+        ], $uniqueConstraint->getColumnNames());
+    }
+
+    public function testInvalidColumnNames(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/XXXX');
+        $uniqueConstraint = new UniqueConstraint('', ['']);
+
+        $this->expectException(InvalidState::class);
+        $uniqueConstraint->getColumnNames();
+    }
+
+    public function testEmptyColumnNames(): void
+    {
+        $uniqueConstraint = new UniqueConstraint('', []);
+
+        $this->expectException(InvalidState::class);
+        $uniqueConstraint->getColumnNames();
+    }
+
+    /** @param array<string> $flags */
+    #[DataProvider('clusteredFlagsProvider')]
+    public function testIsClustered(array $flags, bool $expected): void
+    {
+        $uniqueConstraint = new UniqueConstraint('', ['user_id'], $flags);
+
+        self::assertSame($expected, $uniqueConstraint->isClustered());
+    }
+
+    /** @return iterable<array{array<string>, bool}> $flags */
+    public static function clusteredFlagsProvider(): iterable
+    {
+        yield 'clustered' => [['clustered'], true];
+        yield 'not clustered' => [[], false];
     }
 }

--- a/tests/Schema/UniqueConstraintTest.php
+++ b/tests/Schema/UniqueConstraintTest.php
@@ -35,6 +35,13 @@ class UniqueConstraintTest extends TestCase
         self::assertNull($uniqueConstraint->getObjectName());
     }
 
+    public function testInstantiateWithOptions(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6685');
+
+        new UniqueConstraint('', ['user_id'], [], ['option' => 'value']);
+    }
+
     public function testGetColumnNames(): void
     {
         $uniqueConstraint = new UniqueConstraint('', ['user_id']);
@@ -46,7 +53,7 @@ class UniqueConstraintTest extends TestCase
 
     public function testInvalidColumnNames(): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/XXXX');
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6685');
         $uniqueConstraint = new UniqueConstraint('', ['']);
 
         $this->expectException(InvalidState::class);
@@ -55,6 +62,12 @@ class UniqueConstraintTest extends TestCase
 
     public function testEmptyColumnNames(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6685');
+
+        /**
+         * @psalm-suppress ArgumentTypeCoercion
+         * @phpstan-ignore argument.type
+         */
         $uniqueConstraint = new UniqueConstraint('', []);
 
         $this->expectException(InvalidState::class);


### PR DESCRIPTION
All these deprecations are targeted at using `UnqualifiedName` as column names instead of using strings. Combined with all other changes, it will make easier to prove the correctness of the code statically with fewer runtime checks and errors.

The `UniqueConstraintEditor`, even though it won't necessarily be used often, is introduced for the following reasons:
1. Consistency with the API of other database objects (currently, `Table`).
2. A natural upgrade path for the upcoming breaking changes in the `UniqueConstraint` constructor.
3. Compared to adding new optional parameters to the constructor, this is a much nicer way to extend the functionality of the class in the future.

### Changes in annotated parameter types
The type of the `$columns` parameter in some methods related to the unique constraints has been changed from `array<string|int, string>` to `non-empty-list<string>`. Given that this change won't have any effects at runtime, I consider it a backwards compatible documentation improvement. A unique constraint without columns cannot exist anyways.

### Some food for thought
1. Unlike `TableEditor::setName()` which accepts `string`, `UniqueConstraintEditor` accepts `UnqualifiedName`. In the hindsight, `TableEditor::setName()` should have accepted an object as well to prevent future breaking changes. I'll see what it takes to change the method signature and reimplement the usages before the 4.3.0 release.
2. Constructing `UnqualifiedName` objects (leave alone `OptionallyQualifiedName`) by hand requires quite some typing. We may want to come up with some sort of API for defining them with fewer keystrokes but it's not critical for now.