### PR TITLE
Enable platformOptions to be considered for ColumnDiff (PostgreSQL jsonb support)

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -256,6 +256,7 @@ class PostgreSQLPlatform extends AbstractPlatform
                 || $columnDiff->hasScaleChanged()
                 || $columnDiff->hasFixedChanged()
                 || $columnDiff->hasLengthChanged()
+                || $columnDiff->hasPlatformOptionsChanged()
             ) {
                 $type = $newColumn->getType();
 

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -28,6 +28,7 @@ class ColumnDiff
             + (int) $this->hasNotNullChanged()
             + (int) $this->hasNameChanged()
             + (int) $this->hasTypeChanged()
+            + (int) $this->hasPlatformOptionsChanged()
             + (int) $this->hasCommentChanged();
     }
 
@@ -121,6 +122,13 @@ class ColumnDiff
     {
         return $this->hasPropertyChanged(static function (Column $column): string {
             return $column->getComment();
+        });
+    }
+
+    public function hasPlatformOptionsChanged(): bool
+    {
+        return $this->hasPropertyChanged(static function (Column $column): array {
+            return $column->getPlatformOptions();
         });
     }
 

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -104,6 +104,28 @@ class ComparatorTest extends FunctionalTestCase
         self::assertEquals(3, $modifiedOnly->countChangedProperties());
     }
 
+    public function testPlatformOptionsChangedColumnComparison(): void
+    {
+        $platform   = $this->connection->getDatabasePlatform();
+        $comparator = new Comparator($platform);
+
+        $table = new Table('update_json_to_jsonb_table');
+        $table->addColumn('test', Types::JSON);
+
+        $onlineTable = clone $table;
+        $table->getColumn('test')
+            ->setPlatformOption('jsonb', true);
+
+        $compareResult  = $comparator->compareTables($onlineTable, $table);
+        self::assertCount(1, $compareResult->getChangedColumns());
+        self::assertCount(1, $compareResult->getModifiedColumns());
+
+        $changedColumn = $compareResult->getChangedColumns()['test'];
+
+        self::assertTrue($changedColumn->hasPlatformOptionsChanged());
+        self::assertEquals(1, $changedColumn->countChangedProperties());
+    }
+
     /** @return iterable<mixed[]> */
     public static function defaultValueProvider(): iterable
     {

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -104,28 +104,6 @@ class ComparatorTest extends FunctionalTestCase
         self::assertEquals(3, $modifiedOnly->countChangedProperties());
     }
 
-    public function testPlatformOptionsChangedColumnComparison(): void
-    {
-        $platform   = $this->connection->getDatabasePlatform();
-        $comparator = new Comparator($platform);
-
-        $table = new Table('update_json_to_jsonb_table');
-        $table->addColumn('test', Types::JSON);
-
-        $onlineTable = clone $table;
-        $table->getColumn('test')
-            ->setPlatformOption('jsonb', true);
-
-        $compareResult  = $comparator->compareTables($onlineTable, $table);
-        self::assertCount(1, $compareResult->getChangedColumns());
-        self::assertCount(1, $compareResult->getModifiedColumns());
-
-        $changedColumn = $compareResult->getChangedColumns()['test'];
-
-        self::assertTrue($changedColumn->hasPlatformOptionsChanged());
-        self::assertEquals(1, $changedColumn->countChangedProperties());
-    }
-
     /** @return iterable<mixed[]> */
     public static function defaultValueProvider(): iterable
     {

--- a/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
+++ b/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
@@ -72,6 +72,25 @@ final class ComparatorTest extends FunctionalTestCase
         });
     }
 
+    public function testPlatformOptionsChangedColumnComparison(): void
+    {
+        $table = new Table('update_json_to_jsonb_table');
+        $table->addColumn('test', Types::JSON);
+
+        $onlineTable = clone $table;
+        $table->getColumn('test')
+            ->setPlatformOption('jsonb', true);
+
+        $compareResult = $this->comparator->compareTables($onlineTable, $table);
+        self::assertCount(1, $compareResult->getChangedColumns());
+        self::assertCount(1, $compareResult->getModifiedColumns());
+
+        $changedColumn = $compareResult->getChangedColumns()['test'];
+
+        self::assertTrue($changedColumn->hasPlatformOptionsChanged());
+        self::assertEquals(1, $changedColumn->countChangedProperties());
+    }
+
     private function testColumnModification(callable $addColumn, callable $modifyColumn): void
     {
         $table  = new Table('comparator_test');

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -810,16 +810,29 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         ]);
 
         self::assertSame(
-            $this->getAlterTableAddJsonbPlatformOptionSQL(),
+            ['ALTER TABLE mytable ALTER payload TYPE JSONB'],
             $this->platform->getAlterTableSQL($tableDiff),
         );
     }
 
-    /** @return string[] */
-    protected function getAlterTableAddJsonbPlatformOptionSQL(): array
+    public function testAlterTableChangeJsonbToJson(): void
     {
-        return [
-            'ALTER TABLE mytable ALTER payload TYPE JSONB',
-        ];
+        $table = new Table('mytable');
+        $table->addColumn('payload', Types::JSON)->setPlatformOption('jsonb', true);
+
+        $tableDiff = new TableDiff($table, changedColumns: [
+            'payload' => new ColumnDiff(
+                $table->getColumn('payload'),
+                (new Column(
+                    'payload',
+                    Type::getType(Types::JSON),
+                )),
+            ),
+        ]);
+
+        self::assertSame(
+            ['ALTER TABLE mytable ALTER payload TYPE JSON'],
+            $this->platform->getAlterTableSQL($tableDiff),
+        );
     }
 }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -7,9 +7,11 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -790,5 +792,34 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
                 AND    sequence_schema != 'information_schema'",
             $this->platform->getListSequencesSQL('test_db'),
         );
+    }
+
+    public function testAlterTableChangeJsonToJsonb(): void
+    {
+        $table = new Table('mytable');
+        $table->addColumn('payload', Types::JSON);
+
+        $tableDiff = new TableDiff($table, changedColumns: [
+            'payload' => new ColumnDiff(
+                $table->getColumn('payload'),
+                (new Column(
+                    'payload',
+                    Type::getType(Types::JSON),
+                ))->setPlatformOption('jsonb', true),
+            ),
+        ]);
+
+        self::assertSame(
+            $this->getAlterTableAddJsonbPlatformOptionSQL(),
+            $this->platform->getAlterTableSQL($tableDiff),
+        );
+    }
+
+    /** @return string[] */
+    protected function getAlterTableAddJsonbPlatformOptionSQL(): array
+    {
+        return [
+            'ALTER TABLE mytable ALTER payload TYPE JSONB',
+        ];
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #2541

#### Summary

Changing `platformOptions` can also result in schema changes. In my concrete example it was the `jsonb` option for the `JsonType`. I updated first only PostgreSQLPlatform to get feedback if there are any pitfalls in adding these `platformOptions` for consideration of schema changes, wdyt?
