### PR TITLE
OCI8: Remove PHP 7 compat code

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,16 +34,6 @@ parameters:
             paths:
                 - src/Schema/Column.php
 
-        # TODO: remove this once the support for PHP 7 is dropped
-        -
-            message: '~^Strict comparison using !== between int and false will always evaluate to true\.$~'
-            paths:
-                - src/Driver/OCI8/Result.php
-        -
-            message: '~^Unreachable statement - code above always terminates\.$~'
-            paths:
-                - src/Driver/OCI8/Result.php
-
         # https://github.com/phpstan/phpstan/issues/4679
         -
             message: '~^Cannot call method writeTemporary\(\) on OCILob\|null\.$~'

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -88,13 +88,7 @@ final class Result implements ResultInterface
 
     public function columnCount(): int
     {
-        $count = oci_num_fields($this->statement);
-
-        if ($count !== false) {
-            return $count;
-        }
-
-        return 0;
+        return oci_num_fields($this->statement);
     }
 
     public function getColumnName(int $index): string


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

On PHP 8, `oci_num_fields()` should always return an integer. 🤞🏻 