### PR TITLE
Deprecate introspection of incomplete SQLite schema

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated introspection of SQLite foreign key constraints with omitted referenced column names in an incomplete schema
+
+If the referenced column names are omitted in a foreign key constraint declaration, it implies that the constraint
+references the primary key columns of the referenced table. If the referenced table is not present in the schema, the
+constraint cannot be properly introspected, and the referenced column names are introspected as an empty list.
+This behavior is deprecated.
+
+In order to mitigate this issue, either ensure that the referenced table is present in the schema when introspecting
+foreign constraints, or provide the referenced column names explicitly in the constraint declaration.
+
 ## Deprecated `UniqueConstraint` methods, property and behavior
 
 The following `UniqueConstraint` methods and property have been deprecated:

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_map;
@@ -338,6 +339,13 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             $foreignTableIndexes = $this->_getPortableTableIndexesList([], $value['foreignTable']);
 
             if (! isset($foreignTableIndexes['primary'])) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6701',
+                    'Introspection of SQLite foreign key constraints with omitted referenced column names'
+                        . ' in an incomplete schema is deprecated.',
+                );
+
                 continue;
             }
 

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -322,20 +322,26 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             $list[$id]['local'][] = $value['from'];
 
             if ($value['to'] === null) {
-                // Inferring a shorthand form for the foreign key constraint, where the "to" field is empty.
-                // @see https://www.sqlite.org/foreignkeys.html#fk_indexes.
-                $foreignTableIndexes = $this->_getPortableTableIndexesList([], $value['table']);
-
-                if (! isset($foreignTableIndexes['primary'])) {
-                    continue;
-                }
-
-                $list[$id]['foreign'] = [...$list[$id]['foreign'], ...$foreignTableIndexes['primary']->getColumns()];
-
                 continue;
             }
 
             $list[$id]['foreign'][] = $value['to'];
+        }
+
+        foreach ($list as $id => $value) {
+            if (count($value['foreign']) !== 0) {
+                continue;
+            }
+
+            // Inferring a shorthand form for the foreign key constraint, where the "to" field is empty.
+            // @see https://www.sqlite.org/foreignkeys.html#fk_indexes.
+            $foreignTableIndexes = $this->_getPortableTableIndexesList([], $value['foreignTable']);
+
+            if (! isset($foreignTableIndexes['primary'])) {
+                continue;
+            }
+
+            $list[$id]['foreign'] = $foreignTableIndexes['primary']->getColumns();
         }
 
         return parent::_getPortableTableForeignKeysList($list);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation

### Background

The SQL _syntax_ allows omitting referenced column names in a foreign key constraint declaration. In this case, it's implied that the constraint references the primary key columns. Normally, databases (e.g. Postgres) present the resulting definition of the constraint in the introspection schema (i.e. the actual column names) however, SQLite reports the _original_ SQL statement.

A foreign key constraint declaration that was declared with omitted column names is reported as not referencing any columns. And if the referenced table doesn't exist (which SQLite allows), we get a foreign key without columns.  

This is a very corner case that shouldn't happen normally. However, if it does, DBAL should throw an exception instead of producing invalid results.

### Problem statement

From the data _model_ standpoint, a foreign key constraint definition without columns doesn't make sense and will be impossible to construct in 5.0. 

### Refactoring

Additionally, the introspection code has been refactored. The current implementation reads as "if the `to` column contains null, then introspect the referenced table PK and add its columns to the existing columns". While this is technically correct, the "add to the existing columns" case will never happen because there will be only one row representing a foreign key without columns. Instead, we introspect all keys and then fetch the PKs for the ones that don't have columns. This is easier to comprehend and easier to put the deprecation logic to.