### PR TITLE
feat: add support for `IN (array)` condition with `update()` and `delete()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -370,9 +370,14 @@ class Connection implements ServerVersionProvider
                 continue;
             }
 
-            $columns[]    = $columnName;
-            $values[]     = $value;
-            $conditions[] = $columnName . ' = ?';
+            if (is_array($value)) {
+                $conditions[] = $columnName . ' IN (?)';
+            } else {
+                $conditions[] = $columnName . ' = ?';
+            }
+
+            $columns[] = $columnName;
+            $values[]  = $value;
         }
 
         return [$columns, $values, $conditions];
@@ -383,8 +388,8 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                                  $criteria
-     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     * @param array<string, mixed>                                                        $criteria
+     * @param array<int<0,max>, WrapperParameterType>|array<string, WrapperParameterType> $types
      *
      * @return int|numeric-string The number of affected rows.
      *
@@ -447,9 +452,9 @@ class Connection implements ServerVersionProvider
      *
      * Table expression and columns are not escaped and are not safe for user-input.
      *
-     * @param array<string, mixed>                                                                  $data
-     * @param array<string, mixed>                                                                  $criteria
-     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     * @param array<string, mixed>                                                        $data
+     * @param array<string, mixed>                                                        $criteria
+     * @param array<int<0,max>, WrapperParameterType>|array<string, WrapperParameterType> $types
      *
      * @return int|numeric-string The number of affected rows.
      *
@@ -523,10 +528,10 @@ class Connection implements ServerVersionProvider
     /**
      * Extract ordered type list from an ordered column list and type map.
      *
-     * @param array<int, string>                                                             $columns
-     * @param array<int, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     * @param array<int, string>                                                   $columns
+     * @param array<int, WrapperParameterType>|array<string, WrapperParameterType> $types
      *
-     * @return array<int<0, max>, string|ParameterType|Type>
+     * @return array<int<0, max>, WrapperParameterType>
      */
     private function extractTypeValues(array $columns, array $types): array
     {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
@@ -431,6 +432,41 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testUpdateWithInArray(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'UPDATE TestTable SET text = ? WHERE id IN (?) AND name = ?',
+                [
+                    'some text',
+                    [1, 2],
+                    'foo',
+                ],
+                [
+                    'string',
+                    ArrayParameterType::STRING,
+                    'string',
+                ],
+            );
+
+        $conn->update(
+            'TestTable',
+            ['text' => 'some text'],
+            [
+                'id' => [1, 2],
+                'name' => 'foo',
+            ],
+            [
+                'text' => 'string',
+                'id' => ArrayParameterType::STRING,
+                'name' => 'string',
+            ],
+        );
+    }
+
     public function testDeleteWithIsNull(): void
     {
         $conn = $this->getExecuteStatementMockConnection();
@@ -451,6 +487,37 @@ class ConnectionTest extends TestCase
             ],
             [
                 'id' => 'integer',
+                'name' => 'string',
+            ],
+        );
+    }
+
+    public function testDeleteWithInArray(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'DELETE FROM TestTable WHERE id IN (?) AND name = ?',
+                [
+                    [1, 2],
+                    'foo',
+                ],
+                [
+                    ArrayParameterType::STRING,
+                    'string',
+                ],
+            );
+
+        $conn->delete(
+            'TestTable',
+            [
+                'id' => [1, 2],
+                'name' => 'foo',
+            ],
+            [
+                'id' => ArrayParameterType::STRING,
                 'name' => 'string',
             ],
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature

#### Summary

This add support for `WHERE IN (?, ?...)` condition using `$connection->update()` and `delete()` methods. 

_I was looking for a reason it is not implemented yet in issues and tests but did not find any. IMO it's viable._ 🤔 