### PR TITLE
Remove final constructor for Type

### DIFF
--- a/src/Types/Exception/TypeArgumentCountError.php
+++ b/src/Types/Exception/TypeArgumentCountError.php
@@ -9,7 +9,6 @@ use Exception;
 
 use function sprintf;
 
-/** @psalm-immutable */
 final class TypeArgumentCountError extends Exception implements TypesException
 {
     public static function new(string $name, ArgumentCountError $previous): self

--- a/src/Types/Exception/TypeArgumentCountError.php
+++ b/src/Types/Exception/TypeArgumentCountError.php
@@ -16,7 +16,7 @@ final class TypeArgumentCountError extends Exception implements TypesException
     {
         return new self(
             sprintf(
-                'To register "%s" use Type::getTypeRegistry()->register instead.',
+                'To register "%s" pass an instance to `Type::addType` instead.',
                 $name,
             ),
             previous: $previous,

--- a/src/Types/Exception/TypeArgumentCountError.php
+++ b/src/Types/Exception/TypeArgumentCountError.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types\Exception;
+
+use ArgumentCountError;
+use Exception;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class TypeArgumentCountError extends Exception implements TypesException
+{
+    public static function new(string $name, ArgumentCountError $previous): self
+    {
+        return new self(
+            sprintf(
+                'To register "%s" use Type::getTypeRegistry()->register instead.',
+                $name,
+            ),
+            previous: $previous,
+        );
+    }
+}

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -134,13 +134,19 @@ abstract class Type
     /**
      * Adds a custom type to the type map.
      *
-     * @param string             $name      The name of the type.
-     * @param class-string<Type> $className The class name of the custom type.
+     * @param string                  $name      The name of the type.
+     * @param class-string<Type>|Type $className The custom type or the class name of the custom type.
      *
      * @throws Exception
      */
-    public static function addType(string $name, string $className): void
+    public static function addType(string $name, string|Type $className): void
     {
+        if ($className instanceof Type) {
+            self::getTypeRegistry()->register($name, $className);
+
+            return;
+        }
+
         try {
             self::getTypeRegistry()->register($name, new $className());
         } catch (ArgumentCountError $e) {

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types;
 
+use ArgumentCountError;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Exception\TypeArgumentCountError;
 
 use function array_map;
 
@@ -50,11 +52,6 @@ abstract class Type
     ];
 
     private static ?TypeRegistry $typeRegistry = null;
-
-    /** @internal Do not instantiate directly - use {@see Type::addType()} method instead. */
-    final public function __construct()
-    {
-    }
 
     /**
      * Converts a value from its PHP representation to its database representation
@@ -144,7 +141,11 @@ abstract class Type
      */
     public static function addType(string $name, string $className): void
     {
-        self::getTypeRegistry()->register($name, new $className());
+        try {
+            self::getTypeRegistry()->register($name, new $className());
+        } catch (ArgumentCountError $e) {
+            throw TypeArgumentCountError::new($name, $e);
+        }
     }
 
     /**

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -145,7 +145,7 @@ abstract class Type
         if (is_string($type)) {
             try {
                 $type = new $type();
-            } catch (ArgumentCountError $e) {
+            } catch (ArgumentCountError $e) { // @phpstan-ignore catch.neverThrown (it can be thrown)
                 throw TypeArgumentCountError::new($name, $e);
             }
         }
@@ -177,7 +177,7 @@ abstract class Type
         if (is_string($type)) {
             try {
                 $type = new $type();
-            } catch (ArgumentCountError $e) {
+            } catch (ArgumentCountError $e) { // @phpstan-ignore catch.neverThrown (it can be thrown)
                 throw TypeArgumentCountError::new($name, $e);
             }
         }

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Types;
 
+use Doctrine\DBAL\Types\Exception\TypeArgumentCountError;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -38,5 +39,13 @@ class TypeTest extends TestCase
 
             yield [$constantValue];
         }
+    }
+
+    public function testAddTypeWhenTypeRequiresArguments(): void
+    {
+        self::expectException(TypeArgumentCountError::class);
+        self::expectExceptionMessage('To register "some_type" use Type::getTypeRegistry()->register instead.');
+
+        Type::addType('some_type', TypeWithConstructor::class);
     }
 }

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -44,8 +44,15 @@ class TypeTest extends TestCase
     public function testAddTypeWhenTypeRequiresArguments(): void
     {
         self::expectException(TypeArgumentCountError::class);
-        self::expectExceptionMessage('To register "some_type" use Type::getTypeRegistry()->register instead.');
+        self::expectExceptionMessage('To register "some_type" pass an instance to `Type::addType` instead.');
 
         Type::addType('some_type', TypeWithConstructor::class);
+    }
+
+    public function testAddTypeInstance(): void
+    {
+        self::assertFalse(Type::hasType('some_type'));
+        Type::addType('some_type', new TypeWithConstructor(true));
+        self::assertTrue(Type::hasType('some_type'));
     }
 }

--- a/tests/Types/TypeWithConstructor.php
+++ b/tests/Types/TypeWithConstructor.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Types\Type;
 
 class TypeWithConstructor extends Type
 {
-    public function __construct(private bool $requirement)
+    public function __construct(public bool $requirement)
     {
     }
 

--- a/tests/Types/TypeWithConstructor.php
+++ b/tests/Types/TypeWithConstructor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class TypeWithConstructor extends Type
+{
+    public function __construct(private bool $requirement)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6704

#### Summary

This allows people to define a constructor when creating custom `Doctrine\DBAL\Types\Type` implementations.

They can be registered by passing an instance to `Type::addType`.

When a class string is passed, and the Type cannot be instantiated, an helpful error message will be thrown.
