### PR TITLE
Deprecate conversion of RESTRICT to NO ACTION

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated usage of `RESTRICT` with Oracle and SQL Server
+
+Relying on automatic conversion of the `RESTRICT` constraint referential action to `NO ACTION` on Oracle and SQL Server
+is deprecated. Use `NO ACTION` instead.
+
 ## Deprecated introspection of SQLite foreign key constraints with omitted referenced column names in an incomplete schema
 
 If the referenced column names are omitted in a foreign key constraint declaration, it implies that the constraint

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -501,6 +501,15 @@ END;';
     {
         $action = strtoupper($action);
 
+        if ($action === 'RESTRICT') {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6707',
+                'Relying on automatic conversion of RESTRICT to NO ACTION for Oracle is deprecated.'
+                    . ' Use NO ACTION explicitly instead.',
+            );
+        }
+
         return match ($action) {
             'RESTRICT',
             'NO ACTION' => '',

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1111,6 +1111,13 @@ class SQLServerPlatform extends AbstractPlatform
     {
         // RESTRICT is not supported, therefore falling back to NO ACTION.
         if (strtoupper($action) === 'RESTRICT') {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6707',
+                'Relying on automatic conversion of RESTRICT to NO ACTION for SQL Server is deprecated.'
+                    . ' Use NO ACTION explicitly instead.',
+            );
+
             return 'NO ACTION';
         }
 


### PR DESCRIPTION
`RESTRICT` is a non-standard constraint referential action which Oracle and SQL Server don't support. DBAL silently replaces them with `NO ACTION`, which is standard, quite similar but not the same.

This replacement complicates testing of the schema introspection because we have to account for that replacement in the assertions. If the user is fine with `NO ACTION`, they should use it (explicitly or as the default).