### PR TITLE
Pin the version of PCOV for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,7 +78,9 @@ install:
           $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip"
           Invoke-WebRequest $source -OutFile $destination
           7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vc15-x64.zip > $null
-          $DLLVersion = (Invoke-WebRequest "https://pecl.php.net/rest/r/pcov/stable.txt").Content
+
+          # Pin the version until https://github.com/krakjoe/pcov/issues/117 is resolved
+          $DLLVersion = "1.0.11"
           Invoke-WebRequest https://windows.php.net/downloads/pecl/releases/pcov/$($DLLVersion)/php_pcov-$($DLLVersion)-$($env:php)-nts-vc15-$($env:platform).zip -OutFile pcov.zip
           7z x -y pcov.zip > $null
           Remove-Item c:\tools\php\* -include .zip


### PR DESCRIPTION
Although https://pecl.php.net/rest/r/pcov/stable.txt advertises 1.0.12 as the latest stable release, it cannot be found on windows.php.net. Let us pin the version of PCOV for Windows until that is the case.