### PR TITLE
Deprecate Table::columnsAreIndexed()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `Table::columnsAreIndexed()`
+
+The `Table::columnsAreIndexed()` method has been deprecated.
+
 ## Deprecated usage of `RESTRICT` with Oracle and SQL Server
 
 Relying on automatic conversion of the `RESTRICT` constraint referential action to `NO ACTION` on Oracle and SQL Server

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -165,6 +165,12 @@
                 <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::getOptions" />
                 <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::getQuotedColumns" />
                 <referencedMethod name="Doctrine\DBAL\Schema\UniqueConstraint::hasFlag" />
+
+                <!--
+                    https://github.com/doctrine/dbal/pull/6710
+                    TODO: remove in 5.0.0
+                -->
+                <referencedMethod name="Doctrine\DBAL\Schema\Table::columnsAreIndexed" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedProperty>

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -286,10 +286,19 @@ class Table extends AbstractNamedObject
     /**
      * Checks if an index begins in the order of the given columns.
      *
+     * @deprecated
+     *
      * @param array<int, string> $columnNames
      */
     public function columnsAreIndexed(array $columnNames): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6710',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         foreach ($this->getIndexes() as $index) {
             if ($index->spansColumns($columnNames)) {
                 return true;


### PR DESCRIPTION
This method is not used anywhere except for DBAL and ORM tests. It's not really part of the database _abstraction_ (more about mapping the data model to a database schema). It uses only the public API and can be implemented in userland, if necessary.