### PR TITLE
Rename Identifier::toSql() to Identifier::toSQL()

### DIFF
--- a/src/Schema/Name/AbstractName.php
+++ b/src/Schema/Name/AbstractName.php
@@ -28,7 +28,7 @@ abstract class AbstractName implements Name
 
     public function toSQL(AbstractPlatform $platform): string
     {
-        return $this->joinIdentifiers(static fn (Identifier $identifier): string => $identifier->toSql($platform));
+        return $this->joinIdentifiers(static fn (Identifier $identifier): string => $identifier->toSQL($platform));
     }
 
     public function toString(): string

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -35,7 +35,7 @@ final class Identifier
         return $this->isQuoted;
     }
 
-    public function toSql(AbstractPlatform $platform): string
+    public function toSQL(AbstractPlatform $platform): string
     {
         if (! $this->isQuoted) {
             $value = $platform->normalizeUnquotedIdentifier($this->value);


### PR DESCRIPTION
The original name wasn't intentional. `toSQL()` is consistent with the most of other method names ending with "SQL", especially `Name::toSQL()`, which the `Identifier` class backs.