### PR TITLE
Remove Table::columnsAreIndexed()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: removed `Table::columnsAreIndexed()`
+
+The `Table::columnsAreIndexed()` method has been removed.
+
 ## BC BREAK: removed support for `RESTRICT` on Oracle and SQL Server
 
 The `RESTRICT` constraint referential action is no longer supported on Oracle and SQL Server.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -62,12 +62,6 @@
                 -->
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::getNameParser" />
                 <referencedMethod name="Doctrine\DBAL\Schema\AbstractAsset::setName" />
-
-                <!--
-                    https://github.com/doctrine/dbal/pull/6710
-                    TODO: remove in 5.0.0
-                -->
-                <referencedMethod name="Doctrine\DBAL\Schema\Table::columnsAreIndexed" />
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -270,31 +270,6 @@ class Table extends AbstractNamedObject
         return $this->addIndex($oldIndex->getColumns(), $newName, $oldIndex->getFlags(), $oldIndex->getOptions());
     }
 
-    /**
-     * Checks if an index begins in the order of the given columns.
-     *
-     * @deprecated
-     *
-     * @param array<int, string> $columnNames
-     */
-    public function columnsAreIndexed(array $columnNames): bool
-    {
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6710',
-            '%s is deprecated.',
-            __METHOD__,
-        );
-
-        foreach ($this->getIndexes() as $index) {
-            if ($index->spansColumns($columnNames)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /** @param array<string, mixed> $options */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -485,8 +485,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('test_foreign', strtolower($fkConstraint->getForeignTableName()));
         self::assertEquals(['foreign_key_test'], array_map('strtolower', $fkConstraint->getLocalColumns()));
         self::assertEquals(['id'], array_map('strtolower', $fkConstraint->getForeignColumns()));
-
-        self::assertTrue($fkTable->columnsAreIndexed($fkConstraint->getLocalColumns()));
     }
 
     public function testListForeignKeys(): void

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -657,16 +657,6 @@ class TableTest extends TestCase
         self::assertNotNull($table->getPrimaryKey());
     }
 
-    public function testAddIndexWithQuotedColumns(): void
-    {
-        $table = new Table('test');
-        $table->addColumn('"foo"', Types::INTEGER);
-        $table->addColumn('bar', Types::INTEGER);
-        $table->addIndex(['"foo"', '"bar"']);
-
-        self::assertTrue($table->columnsAreIndexed(['"foo"', '"bar"']));
-    }
-
     public function testAddForeignKeyWithQuotedColumnsAndTable(): void
     {
         $table = new Table('test');


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/6710.