### PR TITLE
Fix deferrable/deferred constraint DDL on PostgreSQL

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -182,18 +182,20 @@ class PostgreSQLPlatform extends AbstractPlatform
 
         $query .= parent::getAdvancedForeignKeyOptionsSQL($foreignKey);
 
-        if ($foreignKey->hasOption('deferrable') && $foreignKey->getOption('deferrable') !== false) {
-            $query .= ' DEFERRABLE';
-        } else {
-            $query .= ' NOT DEFERRABLE';
+        if ($foreignKey->hasOption('deferrable')) {
+            if ($foreignKey->getOption('deferrable') !== false) {
+                $query .= ' DEFERRABLE';
+            } else {
+                $query .= ' NOT DEFERRABLE';
+            }
         }
 
-        if (
-            $foreignKey->hasOption('deferred') && $foreignKey->getOption('deferred') !== false
-        ) {
-            $query .= ' INITIALLY DEFERRED';
-        } else {
-            $query .= ' INITIALLY IMMEDIATE';
+        if ($foreignKey->hasOption('deferred')) {
+            if ($foreignKey->getOption('deferred') !== false) {
+                $query .= ' INITIALLY DEFERRED';
+            } else {
+                $query .= ' INITIALLY IMMEDIATE';
+            }
         }
 
         return $query;

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -126,7 +126,12 @@ SQL,
             $foreignTable,
             $foreignColumns,
             $tableForeignKey['conname'],
-            ['onUpdate' => $onUpdate, 'onDelete' => $onDelete],
+            [
+                'onUpdate' => $onUpdate,
+                'onDelete' => $onDelete,
+                'deferrable' => $tableForeignKey['condeferrable'],
+                'deferred' => $tableForeignKey['condeferred'],
+            ],
         );
     }
 
@@ -517,7 +522,9 @@ SQL;
 
         $sql .= <<<'SQL'
                   quote_ident(r.conname) as conname,
-                  pg_get_constraintdef(r.oid, true) as condef
+                  pg_get_constraintdef(r.oid, true) as condef,
+                  r.condeferrable,
+                  r.condeferred
                   FROM pg_constraint r
                       JOIN pg_class AS tc ON tc.oid = r.conrelid
                       JOIN pg_namespace tn ON tn.oid = tc.relnamespace

--- a/tests/Functional/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Functional/Schema/ForeignKeyConstraintTest.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function array_intersect_key;
+use function array_values;
+use function sprintf;
 
 final class ForeignKeyConstraintTest extends FunctionalTestCase
 {
@@ -45,5 +53,102 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
         $table = $sm->introspectTable('users');
 
         self::assertCount(2, $table->getForeignKeys());
+    }
+
+    /**
+     * @param array<string,bool> $options
+     * @param array<string,bool> $expectedOptions
+     *
+     * @throws Exception
+     */
+    #[DataProvider('deferrabilityOptionsProvider')]
+    public function testDeferrabilityIntrospection(array $options, array $expectedOptions): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestIncomplete('Not all combinations of options are currently properly introspected on SQLite.');
+        } elseif (! $platform instanceof PostgreSQLPlatform) {
+            self::markTestSkipped(sprintf(
+                'Introspection of constraint deferrability is currently unsupported on %s.',
+                $platform::class,
+            ));
+        }
+
+        $this->dropTableIfExists('users');
+        $this->dropTableIfExists('roles');
+
+        $roles = new Table('roles');
+        $roles->addColumn('id', Types::INTEGER);
+        $roles->setPrimaryKey(['id']);
+
+        $users = new Table('users', [
+            new Column('id', Type::getType(Types::INTEGER)),
+            new Column('role_id', Type::getType(Types::INTEGER)),
+        ], [], [], [
+            new ForeignKeyConstraint(['role_id'], 'roles', ['id'], '', $options),
+        ]);
+        $users->setPrimaryKey(['id']);
+
+        $sm = $this->connection->createSchemaManager();
+        $sm->createTable($roles);
+        $sm->createTable($users);
+
+        $table = $sm->introspectTable('users');
+
+        /** @var list<ForeignKeyConstraint> $constraints */
+        $constraints = array_values($table->getForeignKeys());
+        self::assertCount(1, $constraints);
+        $constraint = $constraints[0];
+
+        $actualOptions = array_intersect_key($constraint->getOptions(), $expectedOptions);
+
+        self::assertEquals($expectedOptions, $actualOptions);
+    }
+
+    /** @return iterable<array{array<string,bool>,array<string,bool>}> */
+    public static function deferrabilityOptionsProvider(): iterable
+    {
+        $notDeferrable = ['deferrable' => false, 'deferred' => false];
+        $deferrable    = ['deferrable' => true, 'deferred' => false];
+        $deferred      = ['deferrable' => true, 'deferred' => true];
+
+        yield 'unspecified' => [[], $notDeferrable];
+
+        // INITIALLY IMMEDIATE implies NOT DEFERRABLE
+        yield 'INITIALLY IMMEDIATE' => [['deferred' => false], $notDeferrable];
+
+        // INITIALLY IMMEDIATE implies DEFERRABLE
+        yield 'INITIALLY DEFERRED' => [['deferred' => true], $deferred];
+
+        // NOT DEFERRABLE implies INITIALLY IMMEDIATE
+        yield 'NOT DEFERRABLE' => [['deferrable' => false], $notDeferrable];
+
+        yield 'NOT DEFERRABLE INITIALLY IMMEDIATE' => [
+            [
+                'deferrable' => false,
+                'deferred' => false,
+            ], $notDeferrable,
+        ];
+
+        // DEFERRABLE implies INITIALLY IMMEDIATE
+        yield 'DEFERRABLE' => [
+            ['deferrable' => true], $deferrable,
+        ];
+
+        yield 'DEFERRABLE INITIALLY IMMEDIATE' => [
+            [
+                'deferrable' => true,
+                'deferred' => false,
+            ], $deferrable,
+        ];
+
+        yield 'DEFERRABLE INITIALLY DEFERRED' => [
+            [
+                'deferrable' => true,
+                'deferred' => true,
+            ],
+            $deferred,
+        ];
     }
 }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -53,7 +53,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     protected function getGenerateForeignKeySql(): string
     {
         return 'ALTER TABLE test ADD FOREIGN KEY (fk_name_id)'
-            . ' REFERENCES other_table (id) NOT DEFERRABLE INITIALLY IMMEDIATE';
+            . ' REFERENCES other_table (id)';
     }
 
     public function testGeneratesForeignKeySqlForNonStandardOptions(): void
@@ -67,7 +67,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
         self::assertEquals(
             'CONSTRAINT my_fk FOREIGN KEY (foreign_id)'
-            . ' REFERENCES my_table (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE',
+            . ' REFERENCES my_table (id) ON DELETE CASCADE',
             $this->platform->getForeignKeyDeclarationSQL($foreignKey),
         );
 
@@ -80,7 +80,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
         self::assertEquals(
             'CONSTRAINT my_fk FOREIGN KEY (foreign_id)'
-            . ' REFERENCES my_table (id) MATCH full NOT DEFERRABLE INITIALLY IMMEDIATE',
+            . ' REFERENCES my_table (id) MATCH full',
             $this->platform->getForeignKeyDeclarationSQL($foreignKey),
         );
 
@@ -93,7 +93,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
         self::assertEquals(
             'CONSTRAINT my_fk FOREIGN KEY (foreign_id)'
-            . ' REFERENCES my_table (id) DEFERRABLE INITIALLY IMMEDIATE',
+            . ' REFERENCES my_table (id) DEFERRABLE',
             $this->platform->getForeignKeyDeclarationSQL($foreignKey),
         );
 
@@ -106,7 +106,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
         self::assertEquals(
             'CONSTRAINT my_fk FOREIGN KEY (foreign_id)'
-            . ' REFERENCES my_table (id) NOT DEFERRABLE INITIALLY DEFERRED',
+            . ' REFERENCES my_table (id) INITIALLY DEFERRED',
             $this->platform->getForeignKeyDeclarationSQL($foreignKey),
         );
 
@@ -119,7 +119,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
         self::assertEquals(
             'CONSTRAINT my_fk FOREIGN KEY (foreign_id)'
-            . ' REFERENCES my_table (id) NOT DEFERRABLE INITIALLY DEFERRED',
+            . ' REFERENCES my_table (id) INITIALLY DEFERRED',
             $this->platform->getForeignKeyDeclarationSQL($foreignKey),
         );
 
@@ -366,11 +366,11 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
             . 'foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
             'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
-            . ' REFERENCES "foreign" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+            . ' REFERENCES "foreign" ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
-            . ' REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+            . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
-            . ' REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE',
+            . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/improvement

In order to test the fix, we need to introduce introspection of the deferrable and deferred constraint options for Postgres (currently only supported on SQLite). Because of that, I'm targeting 4.3.x.

Currently, we cannot run the integration test against SQLite because introspection there is implemented by parsing the constraint DDL, and SQLite reports it as is, so the test cases where one explicitly specified attribute implies the other may fail. We will fix it separately by introducing a better data model for constraints.

Fixes https://github.com/doctrine/dbal/issues/6717.