### PR TITLE
Do not introspect incomplete SQLite foreign key constraint

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: removed support for introspection of SQLite foreign key constraints with omitted referenced column names in an incomplete schema
+
+If the SQLite schema manager fails to introspect the columns referenced by a foreign key constraint, instead of
+producing a constraint with empty referenced columns, it will throw an exception.
+
 ## BC BREAK: removed `Table::columnsAreIndexed()`
 
 The `Table::columnsAreIndexed()` method has been removed.

--- a/src/Schema/Exception/UnsupportedSchema.php
+++ b/src/Schema/Exception/UnsupportedSchema.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use RuntimeException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class UnsupportedSchema extends RuntimeException implements SchemaException
+{
+    public static function sqliteMissingForeignKeyConstraintReferencedColumns(
+        string $constraintTableName,
+        string $referencingTableName,
+    ): self {
+        return new self(sprintf(
+            'Unable to introspect foreign key constraint "%s" because the referenced column names are omitted,'
+                . ' and the referenced table "%s" does not exist.',
+            $constraintTableName,
+            $referencingTableName,
+        ));
+    }
+}

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -8,10 +8,10 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Exception\UnsupportedSchema;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_change_key_case;
 use function array_map;
@@ -339,14 +339,10 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             $foreignTableIndexes = $this->_getPortableTableIndexesList([], $value['foreignTable']);
 
             if (! isset($foreignTableIndexes['primary'])) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/6701',
-                    'Introspection of SQLite foreign key constraints with omitted referenced column names'
-                        . ' in an incomplete schema is deprecated.',
+                throw UnsupportedSchema::sqliteMissingForeignKeyConstraintReferencedColumns(
+                    $value['name'],
+                    $value['foreignTable'],
                 );
-
-                continue;
             }
 
             $list[$id]['foreign'] = $foreignTableIndexes['primary']->getColumns();

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -9,21 +9,19 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Exception\UnsupportedSchema;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 use function array_keys;
 use function array_shift;
 
 class SQLiteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
-    use VerifyDeprecations;
-
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
         return $platform instanceof SQLitePlatform;
@@ -75,8 +73,6 @@ EOS);
             ),
         ];
 
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6701');
-
         self::assertEquals($expected, $this->schemaManager->listTableForeignKeys('user'));
     }
 
@@ -91,19 +87,9 @@ CREATE TABLE t1 (
 )
 EOS);
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6701');
+        $this->expectException(UnsupportedSchema::class);
 
-        $expected = [
-            new ForeignKeyConstraint(
-                ['t2_id'],
-                't2',
-                [],
-                '',
-                ['onUpdate' => 'NO ACTION', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false],
-            ),
-        ];
-
-        self::assertEquals($expected, $this->schemaManager->listTableForeignKeys('t1'));
+        $this->schemaManager->listTableForeignKeys('t1');
     }
 
     public function testColumnCollation(): void


### PR DESCRIPTION
The affected behavior was deprecated in https://github.com/doctrine/dbal/pull/6701.