### PR TITLE
Deprecate ForeignKeyConstraint features and introduce ForeignKeyConstraintEditor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,32 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `ForeignKeyConstraint` methods, properties and behavior
+
+The following `ForeignKeyConstraint` methods and property have been deprecated:
+
+- `ForeignKeyConstraint::getForeignTableName()`, `ForeignKeyConstraint::getQuotedForeignTableName()`,
+  `ForeignKeyConstraint::getUnqualifiedForeignTableName()`, `ForeignKeyConstraint::$_foreignTableName` – use
+  `ForeignKeyConstraint::getReferencedTableName()` instead.
+- `ForeignKeyConstraint::getLocalColumns()`, `ForeignKeyConstraint::getQuotedLocalColumns()`,
+  `ForeignKeyConstraint::getUnquotedLocalColumns()`, `ForeignKeyConstraint::$_localColumnNames` – use
+  `ForeignKeyConstraint::getReferencingColumnNames()` instead.
+- `ForeignKeyConstraint::getForeignColumns()`, `ForeignKeyConstraint::getQuotedForeignColumns()`,
+  `ForeignKeyConstraint::getUnquotedForeignColumns()`, `ForeignKeyConstraint::$_foreignColumnNames` – use
+  `ForeignKeyConstraint::getReferencedColumnNames()` instead.
+- `ForeignKeyConstraint::getOption()`, `ForeignKeyConstraint::getOptions()`, `ForeignKeyConstraint::hasOption()`,
+  `ForeignKeyConstraint::onUpdate()`, `ForeignKeyConstraint::onDelete()`, `ForeignKeyConstraint::$options` – use
+  `ForeignKeyConstraint::getMatchType()`, `ForeignKeyConstraint::getOnUpdateAction()`,
+  `ForeignKeyConstraint::getOnDeleteAction()` and `ForeignKeyConstraint::getDeferrability()` instead.
+- `ForeignKeyConstraint::intersectsIndexColumns()`.
+
+Additionally,
+1. Extending the `ForeignKeyConstraint` class has been deprecated. Use the `ForeignKeyConstraint` class directly.
+2. Instantiation of a foreign key constraint without referencing or referenced columns is deprecated.
+3. Instantiation of a foreign key constraint with a non-matching number of referencing and referenced columns is
+   deprecated.
+4. The `AbstractPlatform::getForeignKeyBaseDeclarationSQL()` method has been marked as internal.
+
 ## Deprecated `Table::columnsAreIndexed()`
 
 The `Table::columnsAreIndexed()` method has been deprecated.
@@ -27,7 +53,7 @@ This behavior is deprecated.
 In order to mitigate this issue, either ensure that the referenced table is present in the schema when introspecting
 foreign constraints, or provide the referenced column names explicitly in the constraint declaration.
 
-## Deprecated `UniqueConstraint` methods, property and behavior
+## Deprecated `UniqueConstraint` methods, properties and behavior
 
 The following `UniqueConstraint` methods and property have been deprecated:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,7 +32,9 @@ Additionally,
 2. Instantiation of a foreign key constraint without referencing or referenced columns is deprecated.
 3. Instantiation of a foreign key constraint with a non-matching number of referencing and referenced columns is
    deprecated.
-4. The `AbstractPlatform::getForeignKeyBaseDeclarationSQL()` method has been marked as internal.
+4. The `ForeignKeyConstraint` constructor has been marked as internal. Use `ForeignKeyConstraint::editor()` to
+   instantiate an editor and `ForeignKeyConstraintEditor::create()` to create a foreign key constraint.
+5. The `AbstractPlatform::getForeignKeyBaseDeclarationSQL()` method has been marked as internal.
 
 ## Deprecated `Table::columnsAreIndexed()`
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1676,6 +1676,8 @@ abstract class AbstractPlatform
     /**
      * Obtains DBMS specific SQL code portion needed to set the FOREIGN KEY constraint
      * of a column declaration to be used in statements like CREATE TABLE.
+     *
+     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
      */
     public function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -910,9 +910,9 @@ class SQLitePlatform extends AbstractPlatform
             }
 
             $foreignKeys[$key] = new ForeignKeyConstraint(
-                $localColumns,
+                $localColumns, // @phpstan-ignore argument.type
                 $constraint->getForeignTableName(),
-                $constraint->getForeignColumns(),
+                $constraint->getForeignColumns(), // @phpstan-ignore argument.type
                 $constraint->getName(),
                 $constraint->getOptions(),
             );

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -254,18 +254,6 @@ class SQLitePlatform extends AbstractPlatform
         return ! empty($column['unsigned']) ? ' UNSIGNED' : '';
     }
 
-    /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
-    public function getForeignKeyDeclarationSQL(ForeignKeyConstraint $foreignKey): string
-    {
-        return parent::getForeignKeyDeclarationSQL(new ForeignKeyConstraint(
-            $foreignKey->getQuotedLocalColumns($this),
-            $foreignKey->getQuotedForeignTableName($this),
-            $foreignKey->getQuotedForeignColumns($this),
-            $foreignKey->getName(),
-            $foreignKey->getOptions(),
-        ));
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/src/Schema/Exception/InvalidForeignKeyConstraintDefinition.php
+++ b/src/Schema/Exception/InvalidForeignKeyConstraintDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+final class InvalidForeignKeyConstraintDefinition extends LogicException implements SchemaException
+{
+    public static function referencedTableNameNotSet(): self
+    {
+        return new self('Foreign key constraint referenced table name is not set.');
+    }
+
+    public static function referencingColumnNamesNotSet(): self
+    {
+        return new self('Foreign key constraint referencing column names are not set.');
+    }
+
+    public static function referencedColumnNamesNotSet(): self
+    {
+        return new self('Foreign key constraint referenced column names are not set.');
+    }
+}

--- a/src/Schema/Exception/InvalidState.php
+++ b/src/Schema/Exception/InvalidState.php
@@ -11,9 +11,53 @@ use function sprintf;
 
 final class InvalidState extends LogicException implements SchemaException
 {
+    public static function foreignKeyConstraintHasInvalidReferencedTableName(string $constraintName): self
+    {
+        return new self(sprintf(
+            'Foreign key constraint "%s" has invalid referenced table names.',
+            $constraintName,
+        ));
+    }
+
+    public static function foreignKeyConstraintHasInvalidReferencingColumnNames(string $constraintName): self
+    {
+        return new self(sprintf(
+            'Foreign key constraint "%s" has one or more invalid referencing column names.',
+            $constraintName,
+        ));
+    }
+
+    public static function foreignKeyConstraintHasInvalidReferencedColumnNames(string $constraintName): self
+    {
+        return new self(sprintf(
+            'Foreign key constraint "%s" has one or more invalid referenced column name.',
+            $constraintName,
+        ));
+    }
+
+    public static function foreignKeyConstraintHasInvalidMatchType(string $constraintName): self
+    {
+        return new self(sprintf('Foreign key constraint "%s" has invalid match type.', $constraintName));
+    }
+
+    public static function foreignKeyConstraintHasInvalidOnUpdateAction(string $constraintName): self
+    {
+        return new self(sprintf('Foreign key constraint "%s" has invalid ON UPDATE action.', $constraintName));
+    }
+
+    public static function foreignKeyConstraintHasInvalidOnDeleteAction(string $constraintName): self
+    {
+        return new self(sprintf('Foreign key constraint "%s" has invalid ON DELETE action.', $constraintName));
+    }
+
+    public static function foreignKeyConstraintHasInvalidDeferrability(string $constraintName): self
+    {
+        return new self(sprintf('Foreign key constraint "%s" has invalid deferrability.', $constraintName));
+    }
+
     public static function uniqueConstraintHasInvalidColumnNames(string $constraintName): self
     {
-        return new self(sprintf('Unique constraint "%s" has one or more invalid column name.', $constraintName));
+        return new self(sprintf('Unique constraint "%s" has one or more invalid column names.', $constraintName));
     }
 
     public static function uniqueConstraintHasEmptyColumnNames(string $constraintName): self

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -758,4 +758,28 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
 
         return false;
     }
+
+    /**
+     * Instantiates a new foreign key constraint editor.
+     */
+    public static function editor(): ForeignKeyConstraintEditor
+    {
+        return new ForeignKeyConstraintEditor();
+    }
+
+    /**
+     * Instantiates a new foreign key constraint editor and initializes it with the constraint's properties.
+     */
+    public function edit(): ForeignKeyConstraintEditor
+    {
+        return self::editor()
+            ->setName($this->getObjectName())
+            ->setReferencedTableName($this->getReferencedTableName())
+            ->setReferencingColumnNames(...$this->getReferencingColumnNames())
+            ->setReferencedColumnNames(...$this->getReferencedColumnNames())
+            ->setMatchType($this->getMatchType())
+            ->setOnDeleteAction($this->getOnDeleteAction())
+            ->setOnUpdateAction($this->getOnUpdateAction())
+            ->setDeferrability($this->getDeferrability());
+    }
 }

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -29,11 +29,14 @@ use function substr;
  * An abstraction class for a foreign key constraint.
  *
  * @extends AbstractOptionallyNamedObject<UnqualifiedName>
+ * @final This class will be made final in DBAL 5.0.
  */
 class ForeignKeyConstraint extends AbstractOptionallyNamedObject
 {
     /**
      * Asset identifier instances of the referencing table column names the foreign key constraint is associated with.
+     *
+     * @deprecated
      *
      * @var array<string, Identifier>
      */
@@ -41,15 +44,28 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
 
     /**
      * Table or asset identifier instance of the referenced table name the foreign key constraint is associated with.
+     *
+     * @deprecated
      */
     protected Identifier $_foreignTableName;
 
     /**
      * Asset identifier instances of the referenced table column names the foreign key constraint is associated with.
      *
+     * @deprecated
+     *
      * @var array<string, Identifier>
      */
     protected array $_foreignColumnNames;
+
+    /**
+     * Options associated with the foreign key constraint.
+     *
+     * @deprecated
+     *
+     * @var array<string, mixed>
+     */
+    protected array $options;
 
     /**
      * Referencing table column names the foreign key constraint is associated with.
@@ -105,21 +121,49 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     private readonly ?Deferrability $deferrability;
 
     /**
-     * Initializes the foreign key constraint.
+     * @internal Use {@link ForeignKeyConstraint::editor()} to instantiate an editor and
+     *           {@link ForeignKeyConstraintEditor::create()} to create a foreign key constraint.
      *
-     * @param array<int, string>   $localColumnNames   Names of the referencing table columns.
-     * @param string               $foreignTableName   Referenced table.
-     * @param array<int, string>   $foreignColumnNames Names of the referenced table columns.
-     * @param string               $name               Name of the foreign key constraint.
-     * @param array<string, mixed> $options            Options associated with the foreign key constraint.
+     * @param non-empty-list<string> $localColumnNames   Names of the referencing table columns.
+     * @param string                 $foreignTableName   Referenced table.
+     * @param non-empty-list<string> $foreignColumnNames Names of the referenced table columns.
+     * @param string                 $name               Name of the foreign key constraint.
+     * @param array<string, mixed>   $options            Options associated with the foreign key constraint.
      */
     public function __construct(
         array $localColumnNames,
         string $foreignTableName,
         array $foreignColumnNames,
         string $name = '',
-        protected array $options = [],
+        array $options = [],
     ) {
+        $this->options = $options;
+
+        if (count($localColumnNames) < 1) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6728',
+                'Instantiation of a foreign key constraint without local column names is deprecated.',
+            );
+        }
+
+        if (count($foreignColumnNames) < 1) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6728',
+                'Instantiation of a foreign key constraint without foreign column names is deprecated.',
+            );
+        }
+
+        if (count($foreignColumnNames) !== count($localColumnNames)) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6728',
+                'Instantiation of a foreign key constraint with a different number of local and foreign'
+                    . ' column names is deprecated.',
+            );
+        }
+
         parent::__construct($name);
 
         $this->_localColumnNames = $this->createIdentifierMap($localColumnNames);
@@ -251,14 +295,25 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      * Returns the names of the referencing table columns
      * the foreign key constraint is associated with.
      *
+     * @deprecated Use {@see getReferencingColumnNames()} instead.
+     *
      * @return array<int, string>
      */
     public function getLocalColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencingColumnNames() instead.',
+            __METHOD__,
+        );
+
         return array_keys($this->_localColumnNames);
     }
 
     /**
+     * @deprecated Use {@see getReferencingColumnNames()} and {@see UnqualifiedName::toSQL()} instead.
+     *
      * Returns the quoted representation of the referencing table column names
      * the foreign key constraint is associated with.
      *
@@ -272,6 +327,13 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      */
     public function getQuotedLocalColumns(AbstractPlatform $platform): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencingColumnNames() and UnqualifiedName::toSQL() instead.',
+            __METHOD__,
+        );
+
         $columns = [];
 
         foreach ($this->_localColumnNames as $column) {
@@ -282,39 +344,75 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     }
 
     /**
+     * @deprecated Use {@see getReferencingColumnNames()} instead.
+     *
      * Returns unquoted representation of local table column names for comparison with other FK
      *
      * @return array<int, string>
      */
     public function getUnquotedLocalColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencingColumnNames() instead.',
+            __METHOD__,
+        );
+
         return array_map($this->trimQuotes(...), $this->getLocalColumns());
     }
 
     /**
+     * @deprecated Use {@see getReferencedColumnNames()} instead.
+     *
      * Returns unquoted representation of foreign table column names for comparison with other FK
      *
      * @return array<int, string>
      */
     public function getUnquotedForeignColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencedColumnNames() instead.',
+            __METHOD__,
+        );
+
         return array_map($this->trimQuotes(...), $this->getForeignColumns());
     }
 
     /**
+     * @deprecated Use {@see getReferencedTableName()} instead.
+     *
      * Returns the name of the referenced table
      * the foreign key constraint is associated with.
      */
     public function getForeignTableName(): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencedTableName() instead.',
+            __METHOD__,
+        );
+
         return $this->_foreignTableName->getName();
     }
 
     /**
+     * @deprecated Use {@see getReferencedTableName()} instead.
+     *
      * Returns the non-schema qualified foreign table name.
      */
     public function getUnqualifiedForeignTableName(): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencedTableName() instead.',
+            __METHOD__,
+        );
+
         $name     = $this->_foreignTableName->getName();
         $position = strrpos($name, '.');
 
@@ -326,6 +424,8 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     }
 
     /**
+     * @deprecated Use {@see getReferencedTableName()} and {@see OptionallyQualifiedName::toSQL()} instead.
+     *
      * Returns the quoted representation of the referenced table name
      * the foreign key constraint is associated with.
      *
@@ -337,10 +437,19 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      */
     public function getQuotedForeignTableName(AbstractPlatform $platform): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencedTableName() and OptionallyQualifiedName::toSQL() instead.',
+            __METHOD__,
+        );
+
         return $this->_foreignTableName->getQuotedName($platform);
     }
 
     /**
+     * @deprecated Use {@see getReferencedColumnNames()} instead.
+     *
      * Returns the names of the referenced table columns
      * the foreign key constraint is associated with.
      *
@@ -348,10 +457,19 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      */
     public function getForeignColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencedColumnNames() instead.',
+            __METHOD__,
+        );
+
         return array_keys($this->_foreignColumnNames);
     }
 
     /**
+     * @deprecated Use {@see getReferencedColumnNames()} and {@see UnqualifiedName::toSQL()} instead.
+     *
      * Returns the quoted representation of the referenced table column names
      * the foreign key constraint is associated with.
      *
@@ -365,6 +483,13 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      */
     public function getQuotedForeignColumns(AbstractPlatform $platform): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getReferencedColumnNames() and UnqualifiedName::toSQL() instead.',
+            __METHOD__,
+        );
+
         $columns = [];
 
         foreach ($this->_foreignColumnNames as $column) {
@@ -375,47 +500,98 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     }
 
     /**
+     * @deprecated Use {@see getMatchType()}, {@see getOnDeleteAction()}, {@see getOnUpdateAction()} or
+     *             {@see getDeferrability()} instead.
+     *
      * Returns whether or not a given option
      * is associated with the foreign key constraint.
      */
     public function hasOption(string $name): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getMatchType(), getOnDeleteAction(), getOnUpdateAction() or'
+                . ' getDeferrability() instead.',
+            __METHOD__,
+        );
+
         return isset($this->options[$name]);
     }
 
     /**
+     * @deprecated Use {@see getMatchType()}, {@see getOnDeleteAction()}, {@see getOnUpdateAction()} or
+     *             {@see getDeferrability()} instead.
+     *
      * Returns an option associated with the foreign key constraint.
      */
     public function getOption(string $name): mixed
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getMatchType(), getOnDeleteAction(), getOnUpdateAction() or'
+                . ' getDeferrability() instead.',
+            __METHOD__,
+        );
+
         return $this->options[$name];
     }
 
     /**
+     * @deprecated Use {@see getMatchType()}, {@see getOnDeleteAction()}, {@see getOnUpdateAction()} or
+     *             {@see getDeferrability()} instead.
+     *
      * Returns the options associated with the foreign key constraint.
      *
      * @return array<string, mixed>
      */
     public function getOptions(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getMatchType(), getOnDeleteAction(), getOnUpdateAction() or'
+                . ' getDeferrability() instead.',
+            __METHOD__,
+        );
+
         return $this->options;
     }
 
     /**
+     * @deprecated Use {@see getOnUpdateAction()} instead.
+     *
      * Returns the referential action for UPDATE operations
      * on the referenced table the foreign key constraint is associated with.
      */
     public function onUpdate(): ?string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getOnUpdateAction() instead.',
+            __METHOD__,
+        );
+
         return $this->onEvent('onUpdate');
     }
 
     /**
+     * @deprecated Use {@see getOnDeleteAction()} instead.
+     *
      * Returns the referential action for DELETE operations
      * on the referenced table the foreign key constraint is associated with.
      */
     public function onDelete(): ?string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated. Use getOnDeleteAction() instead.',
+            __METHOD__,
+        );
+
         return $this->onEvent('onDelete');
     }
 
@@ -554,6 +730,8 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     }
 
     /**
+     * @deprecated
+     *
      * Checks whether this foreign key constraint intersects the given index columns.
      *
      * Returns `true` if at least one of this foreign key's local columns
@@ -563,6 +741,13 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      */
     public function intersectsIndexColumns(Index $index): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6728',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         foreach ($index->getColumns() as $indexColumn) {
             foreach ($this->_localColumnNames as $localColumn) {
                 if (strtolower($indexColumn) === strtolower($localColumn->getName())) {

--- a/src/Schema/ForeignKeyConstraint/Deferrability.php
+++ b/src/Schema/ForeignKeyConstraint/Deferrability.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\ForeignKeyConstraint;
+
+/**
+ * Represents the information about whether the constraint is or can be deferred.
+ */
+enum Deferrability: string
+{
+    case NOT_DEFERRABLE = 'NOT DEFERRABLE';
+    case DEFERRABLE     = 'DEFERRABLE';
+    case DEFERRED       = 'INITIALLY DEFERRED';
+
+    /**
+     * Returns the SQL representation of the referential action.
+     */
+    public function toSQL(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Schema/ForeignKeyConstraint/MatchType.php
+++ b/src/Schema/ForeignKeyConstraint/MatchType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\ForeignKeyConstraint;
+
+/**
+ * Represents the foreign key constraint's match type.
+ *
+ * @link https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt SQL-92, Subclause 11.8, "<match type>"
+ * @link https://dev.mysql.com/doc/refman/8.4/en/constraint-foreign-key.html
+ * @link https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-REFERENCES
+ * @link https://www.sqlite.org/foreignkeys.html
+ */
+enum MatchType: string
+{
+    case FULL    = 'FULL';
+    case PARTIAL = 'PARTIAL';
+
+    /**
+     * The <code>SIMPLE</code> match type is not part of the SQL-92 standard but is supported by and is the default
+     * for MySQL, PostgreSQL and SQLite.
+     */
+    case SIMPLE = 'SIMPLE';
+
+    /**
+     * Returns the SQL representation of the match type.
+     */
+    public function toSQL(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Schema/ForeignKeyConstraint/ReferentialAction.php
+++ b/src/Schema/ForeignKeyConstraint/ReferentialAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\ForeignKeyConstraint;
+
+/**
+ * Represents the foreign key constraint's referential action.
+ *
+ * @link https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt SQL-92, Subclause 11.8, "<referential action>"
+ * @link https://dev.mysql.com/doc/refman/8.4/en/constraint-foreign-key.html
+ * @link https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-REFERENCES
+ * @link https://learn.microsoft.com/en-us/sql/relational-databases/tables/primary-and-foreign-key-constraints#cascading-referential-integrity
+ * @link https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/constraint.html
+ * @link https://www.ibm.com/docs/en/db2/11.5?topic=constraints-foreign-key-referential
+ * @link https://www.sqlite.org/foreignkeys.html
+ */
+enum ReferentialAction: string
+{
+    case CASCADE     = 'CASCADE';
+    case NO_ACTION   = 'NO ACTION';
+    case SET_DEFAULT = 'SET DEFAULT';
+    case SET_NULL    = 'SET NULL';
+
+    /**
+     * The <code>RESTRICT</code> referential action is not part of the SQL-92 standard but is supported by MySQL,
+     * PostgreSQL, IBM DB2 and SQLite.
+     */
+    case RESTRICT = 'RESTRICT';
+
+    /**
+     * Returns the SQL representation of the referential action.
+     */
+    public function toSQL(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidForeignKeyConstraintDefinition;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+use function array_map;
+use function array_merge;
+use function array_values;
+use function count;
+
+final class ForeignKeyConstraintEditor
+{
+    private ?UnqualifiedName $name = null;
+
+    /** @var list<UnqualifiedName> */
+    private array $referencingColumnNames = [];
+
+    private ?OptionallyQualifiedName $referencedTableName = null;
+
+    /** @var list<UnqualifiedName> */
+    private array $referencedColumnNames = [];
+
+    private MatchType $matchType = MatchType::SIMPLE;
+
+    private ReferentialAction $onUpdateAction = ReferentialAction::NO_ACTION;
+
+    private ReferentialAction $onDeleteAction = ReferentialAction::NO_ACTION;
+
+    private Deferrability $deferrability = Deferrability::NOT_DEFERRABLE;
+
+    /**
+     * @internal Use {@link ForeignKeyConstraint::editor()} or {@link ForeignKeyConstraint::edit()} to create
+     *           an instance.
+     */
+    public function __construct()
+    {
+    }
+
+    public function setName(?UnqualifiedName $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function setReferencingColumnNames(
+        UnqualifiedName $firstColumName,
+        UnqualifiedName ...$otherColumnNames,
+    ): self {
+        $this->referencingColumnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+
+        return $this;
+    }
+
+    public function setReferencedTableName(OptionallyQualifiedName $referencedTableName): self
+    {
+        $this->referencedTableName = $referencedTableName;
+
+        return $this;
+    }
+
+    public function setReferencedColumnNames(
+        UnqualifiedName $firstColumName,
+        UnqualifiedName ...$otherColumnNames,
+    ): self {
+        $this->referencedColumnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+
+        return $this;
+    }
+
+    public function setMatchType(MatchType $matchType): self
+    {
+        $this->matchType = $matchType;
+
+        return $this;
+    }
+
+    public function setOnUpdateAction(ReferentialAction $action): self
+    {
+        $this->onUpdateAction = $action;
+
+        return $this;
+    }
+
+    public function setOnDeleteAction(ReferentialAction $action): self
+    {
+        $this->onDeleteAction = $action;
+
+        return $this;
+    }
+
+    public function setDeferrability(Deferrability $deferrability): self
+    {
+        $this->deferrability = $deferrability;
+
+        return $this;
+    }
+
+    public function create(): ForeignKeyConstraint
+    {
+        if (count($this->referencingColumnNames) < 1) {
+            throw InvalidForeignKeyConstraintDefinition::referencingColumnNamesNotSet();
+        }
+
+        if ($this->referencedTableName === null) {
+            throw InvalidForeignKeyConstraintDefinition::referencedTableNameNotSet();
+        }
+
+        if (count($this->referencedColumnNames) < 1) {
+            throw InvalidForeignKeyConstraintDefinition::referencedColumnNamesNotSet();
+        }
+
+        return new ForeignKeyConstraint(
+            array_map(
+                static fn (UnqualifiedName $columnName) => $columnName->toString(),
+                $this->referencingColumnNames,
+            ),
+            $this->referencedTableName->toString(),
+            array_map(
+                static fn (UnqualifiedName $columnName) => $columnName->toString(),
+                $this->referencedColumnNames,
+            ),
+            $this->name?->toString() ?? '',
+            array_merge([
+                'match' => $this->matchType->value,
+                'onUpdate' => $this->onUpdateAction->value,
+                'onDelete' => $this->onDeleteAction->value,
+            ], match ($this->deferrability) {
+                Deferrability::NOT_DEFERRABLE => [],
+                Deferrability::DEFERRABLE => ['deferrable' => true],
+                Deferrability::DEFERRED => ['deferrable' => true, 'deferred' => true],
+            }),
+        );
+    }
+}

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -474,7 +474,7 @@ SQL;
 
         $conditions[] = 'k.REFERENCED_COLUMN_NAME IS NOT NULL';
 
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY k.ORDINAL_POSITION';
+        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY k.CONSTRAINT_NAME, k.ORDINAL_POSITION';
 
         return $this->connection->executeQuery($sql, $params);
     }

--- a/src/Schema/Name/OptionallyQualifiedName.php
+++ b/src/Schema/Name/OptionallyQualifiedName.php
@@ -27,4 +27,26 @@ final class OptionallyQualifiedName extends AbstractName
     {
         return $this->qualifier;
     }
+
+    /**
+     * Creates an optionally qualified name with all identifiers quoted.
+     */
+    public static function quoted(string $unqualifiedName, ?string $qualifier = null): self
+    {
+        return new self(
+            Identifier::quoted($unqualifiedName),
+            $qualifier !== null ? Identifier::quoted($qualifier) : null,
+        );
+    }
+
+    /**
+     * Creates an optionally qualified name with all identifiers unquoted.
+     */
+    public static function unquoted(string $unqualifiedName, ?string $qualifier = null): self
+    {
+        return new self(
+            Identifier::unquoted($unqualifiedName),
+            $qualifier !== null ? Identifier::unquoted($qualifier) : null,
+        );
+    }
 }

--- a/src/Schema/Name/UnqualifiedName.php
+++ b/src/Schema/Name/UnqualifiedName.php
@@ -18,4 +18,20 @@ final class UnqualifiedName extends AbstractName
     {
         return $this->identifier;
     }
+
+    /**
+     * Creates a quoted unqualified name.
+     */
+    public static function quoted(string $value): self
+    {
+        return new self(Identifier::quoted($value));
+    }
+
+    /**
+     * Creates an unquoted unqualified name.
+     */
+    public static function unquoted(string $value): self
+    {
+        return new self(Identifier::unquoted($value));
+    }
 }

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_key_exists;
-use function array_values;
 use function assert;
 use function implode;
 use function is_string;
@@ -214,8 +213,8 @@ class OracleSchemaManager extends AbstractSchemaManager
             $localColumn   = $this->getQuotedIdentifierName($value['local_column']);
             $foreignColumn = $this->getQuotedIdentifierName($value['foreign_column']);
 
-            $list[$value['constraint_name']]['local'][$value['position']]   = $localColumn;
-            $list[$value['constraint_name']]['foreign'][$value['position']] = $foreignColumn;
+            $list[$value['constraint_name']]['local'][]   = $localColumn;
+            $list[$value['constraint_name']]['foreign'][] = $foreignColumn;
         }
 
         return parent::_getPortableTableForeignKeysList($list);
@@ -227,9 +226,9 @@ class OracleSchemaManager extends AbstractSchemaManager
     protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
     {
         return new ForeignKeyConstraint(
-            array_values($tableForeignKey['local']),
+            $tableForeignKey['local'],
             $this->getQuotedIdentifierName($tableForeignKey['foreignTable']),
-            array_values($tableForeignKey['foreign']),
+            $tableForeignKey['foreign'],
             $this->getQuotedIdentifierName($tableForeignKey['name']),
             ['onDelete' => $tableForeignKey['onDelete']],
         );

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -412,9 +412,9 @@ class Table extends AbstractNamedObject
      *
      * Name is inferred from the local columns.
      *
-     * @param array<int, string>   $localColumnNames
-     * @param array<int, string>   $foreignColumnNames
-     * @param array<string, mixed> $options
+     * @param non-empty-list<string> $localColumnNames
+     * @param non-empty-list<string> $foreignColumnNames
+     * @param array<string, mixed>   $options
      */
     public function addForeignKeyConstraint(
         string $foreignTableName,
@@ -982,9 +982,9 @@ class Table extends AbstractNamedObject
             }
 
             $this->_fkConstraints[$key] = new ForeignKeyConstraint(
-                $localColumns,
+                $localColumns, // @phpstan-ignore argument.type
                 $constraint->getForeignTableName(),
-                $constraint->getForeignColumns(),
+                $constraint->getForeignColumns(), // @phpstan-ignore argument.type
                 $constraint->getName(),
                 $constraint->getOptions(),
             );

--- a/tests/Functional/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Functional/Schema/ForeignKeyConstraintTest.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -53,6 +62,171 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
         $table = $sm->introspectTable('users');
 
         self::assertCount(2, $table->getForeignKeys());
+    }
+
+    /** @throws Exception */
+    #[DataProvider('referentialActionProvider')]
+    public function testOnUpdateIntrospection(ReferentialAction $action): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $this->platformSupportsOnUpdateAction($platform, $action)) {
+            self::markTestSkipped(sprintf(
+                '%s does not support ON UPDATE %s',
+                $platform::class,
+                $action->value,
+            ));
+        }
+
+        $this->testReferentialActionIntrospection(
+            static function (ForeignKeyConstraintEditor $editor, ReferentialAction $action): void {
+                $editor->setOnUpdateAction($action);
+            },
+            $action,
+            static fn (ForeignKeyConstraint $constraint): ReferentialAction => $constraint->getOnUpdateAction(),
+        );
+    }
+
+    /** @throws Exception */
+    #[DataProvider('referentialActionProvider')]
+    public function testOnDeleteIntrospection(ReferentialAction $action): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $this->platformSupportsOnDeleteAction($platform, $action)) {
+            self::markTestSkipped(sprintf(
+                '%s does not support ON DELETE %s',
+                $platform::class,
+                $action->value,
+            ));
+        }
+
+        $this->testReferentialActionIntrospection(
+            static function (ForeignKeyConstraintEditor $editor, ReferentialAction $action): void {
+                $editor->setOnDeleteAction($action);
+            },
+            $action,
+            static fn (ForeignKeyConstraint $constraint): ReferentialAction => $constraint->getOnDeleteAction(),
+        );
+    }
+
+    /**
+     * @param callable(ForeignKeyConstraintEditor, ReferentialAction): void $setter
+     * @param callable(ForeignKeyConstraint): ReferentialAction             $getter
+     *
+     * @throws Exception
+     */
+    private function testReferentialActionIntrospection(
+        callable $setter,
+        ReferentialAction $action,
+        callable $getter,
+    ): void {
+        $this->dropTableIfExists('users');
+        $this->dropTableIfExists('roles');
+
+        $roles = new Table('roles');
+        $roles->addColumn('id', Types::INTEGER);
+        $roles->setPrimaryKey(['id']);
+
+        $editor = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames(
+                UnqualifiedName::unquoted('role_id'),
+            )
+            ->setReferencedTableName($roles->getObjectName())
+            ->setReferencedColumnNames(
+                UnqualifiedName::unquoted('id'),
+            );
+        $setter($editor, $action);
+
+        $users = new Table('users', [
+            new Column('id', Type::getType(Types::INTEGER)),
+            new Column('role_id', Type::getType(Types::INTEGER), ['notnull' => false]),
+        ], [], [], [$editor->create()]);
+        $users->setPrimaryKey(['id']);
+
+        $sm = $this->connection->createSchemaManager();
+
+        $sm->createTable($roles);
+        $sm->createTable($users);
+
+        $constraints = $sm->listTableForeignKeys('users');
+
+        self::assertCount(1, $constraints);
+
+        $constraint = $constraints[0];
+
+        self::assertSame($action, $getter($constraint));
+    }
+
+    /** @return iterable<array{ReferentialAction}> */
+    public static function referentialActionProvider(): iterable
+    {
+        foreach (ReferentialAction::cases() as $referentialAction) {
+            yield $referentialAction->value => [$referentialAction];
+        }
+    }
+
+    private function platformSupportsOnDeleteAction(AbstractPlatform $platform, ReferentialAction $action): bool
+    {
+        return $this->platformSupportsReferentialAction($platform, $action);
+    }
+
+    private function platformSupportsOnUpdateAction(AbstractPlatform $platform, ReferentialAction $action): bool
+    {
+        if ($platform instanceof OraclePlatform) {
+            return false;
+        }
+
+        if ($platform instanceof DB2Platform) {
+            return match ($action) {
+                ReferentialAction::CASCADE,
+                ReferentialAction::SET_DEFAULT,
+                ReferentialAction::SET_NULL => false,
+                default => true,
+            };
+        }
+
+        return $this->platformSupportsReferentialAction($platform, $action);
+    }
+
+    private function platformSupportsReferentialAction(AbstractPlatform $platform, ReferentialAction $action): bool
+    {
+        if (
+            $action === ReferentialAction::RESTRICT
+            && ($platform instanceof AbstractMySQLPlatform || $platform instanceof SQLitePlatform)
+        ) {
+            self::markTestIncomplete(sprintf(
+                'Introspection of referential action %s on %s is currently unsupported',
+                $action->value,
+                $platform::class,
+            ));
+        }
+
+        if ($platform instanceof SQLServerPlatform) {
+            if ($action === ReferentialAction::RESTRICT) {
+                return false;
+            }
+        } elseif ($platform instanceof OraclePlatform) {
+            if ($action === ReferentialAction::SET_DEFAULT || $action === ReferentialAction::RESTRICT) {
+                return false;
+            }
+        } elseif ($platform instanceof DB2Platform) {
+            if ($action === ReferentialAction::SET_DEFAULT) {
+                return false;
+            }
+        } elseif (
+            $platform instanceof AbstractMySQLPlatform
+                && ! $platform instanceof MySQL80Platform
+        ) {
+            if (
+                $action === ReferentialAction::SET_DEFAULT || $action === ReferentialAction::SET_NULL
+                    || $action === ReferentialAction::CASCADE
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -19,6 +19,7 @@ use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 use function array_keys;
 use function array_shift;
+use function array_values;
 
 class SQLiteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -47,6 +48,7 @@ class SQLiteSchemaManagerTest extends SchemaManagerFunctionalTestCase
         return $table;
     }
 
+    /** @throws Exception */
     public function testListForeignKeysFromExistingDatabase(): void
     {
         $this->connection->executeStatement('DROP TABLE IF EXISTS user');
@@ -254,6 +256,7 @@ SQL;
         self::assertSame(['b'], array_keys($this->schemaManager->listTableColumns('t')));
     }
 
+    /** @throws Exception */
     public function testIntrospectMultipleAnonymousForeignKeyConstraints(): void
     {
         $this->dropTableIfExists('album');
@@ -285,25 +288,26 @@ SQL;
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $song        = $schemaManager->introspectTable('song');
-        $foreignKeys = $song->getForeignKeys();
+        $song = $schemaManager->introspectTable('song');
+
+        /** @var list<ForeignKeyConstraint> $foreignKeys */
+        $foreignKeys = array_values($song->getForeignKeys());
         self::assertCount(2, $foreignKeys);
 
-        $foreignKey1 = array_shift($foreignKeys);
-        self::assertNotNull($foreignKey1);
+        $foreignKey1 = $foreignKeys[0];
         self::assertEmpty($foreignKey1->getName());
 
         self::assertSame(['album_id'], $foreignKey1->getLocalColumns());
         self::assertSame(['id'], $foreignKey1->getForeignColumns());
 
-        $foreignKey2 = array_shift($foreignKeys);
-        self::assertNotNull($foreignKey2);
+        $foreignKey2 = $foreignKeys[1];
         self::assertEmpty($foreignKey2->getName());
 
         self::assertSame(['artist_id'], $foreignKey2->getLocalColumns());
         self::assertSame(['id'], $foreignKey2->getForeignColumns());
     }
 
+    /** @throws Exception */
     public function testNoWhitespaceInForeignKeyReference(): void
     {
         $this->dropTableIfExists('notes');
@@ -323,16 +327,18 @@ SQL;
         $this->connection->executeStatement($ddl);
         $notes = $this->schemaManager->introspectTable('notes');
 
-        $foreignKeys = $notes->getForeignKeys();
+        /** @var list<ForeignKeyConstraint> $foreignKeys */
+        $foreignKeys = array_values($notes->getForeignKeys());
         self::assertCount(1, $foreignKeys);
 
-        $foreignKey = array_shift($foreignKeys);
-        self::assertNotNull($foreignKey);
+        $foreignKey = $foreignKeys[0];
+
         self::assertSame(['created_by'], $foreignKey->getLocalColumns());
         self::assertSame('users', $foreignKey->getForeignTableName());
         self::assertSame(['id'], $foreignKey->getForeignColumns());
     }
 
+    /** @throws Exception */
     public function testShorthandInForeignKeyReference(): void
     {
         $this->dropTableIfExists('artist');
@@ -355,12 +361,13 @@ SQL;
 
         $schemaManager = $this->connection->createSchemaManager();
 
-        $song        = $schemaManager->introspectTable('track');
-        $foreignKeys = $song->getForeignKeys();
+        $song = $schemaManager->introspectTable('track');
+
+        /** @var list<ForeignKeyConstraint> $foreignKeys */
+        $foreignKeys = array_values($song->getForeignKeys());
         self::assertCount(1, $foreignKeys);
 
-        $foreignKey1 = array_shift($foreignKeys);
-        self::assertNotNull($foreignKey1);
+        $foreignKey1 = $foreignKeys[0];
         self::assertEmpty($foreignKey1->getName());
 
         self::assertSame(['trackartist'], $foreignKey1->getLocalColumns());

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -97,7 +97,7 @@ EOS);
             new ForeignKeyConstraint(
                 ['t2_id'],
                 't2',
-                [],
+                [], // @phpstan-ignore argument.type
                 '',
                 ['onUpdate' => 'NO ACTION', 'onDelete' => 'NO ACTION', 'deferrable' => false, 'deferred' => false],
             ),

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -518,11 +518,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('CASCADE', $fkeys[0]->getOption('onDelete'));
     }
 
-    protected function getCreateExampleViewSql(): void
-    {
-        self::markTestSkipped('No Create Example View SQL was defined for this SchemaManager');
-    }
-
     public function testSchemaIntrospection(): void
     {
         $this->createTestTable('test_table');
@@ -964,22 +959,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('test', Types::STRING, ['length' => 255]);
 
         return $table;
-    }
-
-    /** @param Table[] $tables */
-    protected function assertHasTable(array $tables): void
-    {
-        $foundTable = false;
-
-        foreach ($tables as $table) {
-            if (strtolower($table->getName()) !== 'list_tables_test_new_name') {
-                continue;
-            }
-
-            $foundTable = true;
-        }
-
-        self::assertTrue($foundTable, 'Could not find new table');
     }
 
     public function testListForeignKeysComposite(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Schema;
@@ -439,10 +438,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $uniqueConstraint = UniqueConstraint::editor()
             ->setName(
-                new UnqualifiedName(Identifier::unquoted('uniq_id')),
+                UnqualifiedName::unquoted('uniq_id'),
             )
             ->setColumnNames(
-                new UnqualifiedName(Identifier::unquoted('id')),
+                UnqualifiedName::unquoted('id'),
             )
             ->create();
 

--- a/tests/Functional/Schema/UniqueConstraintTest.php
+++ b/tests/Functional/Schema/UniqueConstraintTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -25,10 +24,10 @@ final class UniqueConstraintTest extends FunctionalTestCase
             new Column('email', Type::getType(Types::STRING), ['length' => 255]),
         ], [], [
             UniqueConstraint::editor()
-                ->setColumnNames(new UnqualifiedName(Identifier::unquoted('username')))
+                ->setColumnNames(UnqualifiedName::unquoted('username'))
                 ->create(),
             UniqueConstraint::editor()
-                ->setColumnNames(new UnqualifiedName(Identifier::unquoted('email')))
+                ->setColumnNames(UnqualifiedName::unquoted('email'))
                 ->create(),
         ], []);
 

--- a/tests/Functional/UniqueConstraintViolationsTest.php
+++ b/tests/Functional/UniqueConstraintViolationsTest.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -60,8 +59,8 @@ final class UniqueConstraintViolationsTest extends FunctionalTestCase
             );
         } else {
             $createConstraint = UniqueConstraint::editor()
-                ->setName(new UnqualifiedName(Identifier::unquoted($constraintName)))
-                ->setColumnNames(new UnqualifiedName(Identifier::unquoted('unique_field')))
+                ->setName(UnqualifiedName::unquoted($constraintName))
+                ->setColumnNames(UnqualifiedName::unquoted('unique_field'))
                 ->create();
         }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -191,10 +190,10 @@ abstract class AbstractPlatformTestCase extends TestCase
         $where            = 'test IS NULL AND test2 IS NOT NULL';
         $indexDef         = new Index('name', ['test', 'test2'], false, false, [], ['where' => $where]);
         $uniqueConstraint = UniqueConstraint::editor()
-            ->setName(new UnqualifiedName(Identifier::unquoted('name')))
+            ->setName(UnqualifiedName::unquoted('name'))
             ->setColumnNames(
-                new UnqualifiedName(Identifier::unquoted('test')),
-                new UnqualifiedName(Identifier::unquoted('test2')),
+                UnqualifiedName::unquoted('test'),
+                UnqualifiedName::unquoted('test2'),
             )
             ->create();
 

--- a/tests/Schema/ForeignKeyConstraintEditorTest.php
+++ b/tests/Schema/ForeignKeyConstraintEditorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidForeignKeyConstraintDefinition;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use PHPUnit\Framework\TestCase;
+
+class ForeignKeyConstraintEditorTest extends TestCase
+{
+    public function testReferencedTableNameNotSet(): void
+    {
+        $editor = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames($this->createColumnName())
+            ->setReferencedColumnNames($this->createColumnName());
+
+        $this->expectException(InvalidForeignKeyConstraintDefinition::class);
+
+        $editor->create();
+    }
+
+    public function testReferencingColumnNamesNotSet(): void
+    {
+        $editor = ForeignKeyConstraint::editor()
+            ->setReferencedTableName($this->createTableName())
+            ->setReferencedColumnNames($this->createColumnName());
+
+        $this->expectException(InvalidForeignKeyConstraintDefinition::class);
+
+        $editor->create();
+    }
+
+    public function testReferencedColumnNamesNotSet(): void
+    {
+        $editor = ForeignKeyConstraint::editor()
+            ->setReferencedTableName($this->createTableName())
+            ->setReferencingColumnNames($this->createColumnName());
+
+        $this->expectException(InvalidForeignKeyConstraintDefinition::class);
+
+        $editor->create();
+    }
+
+    public function testSetName(): void
+    {
+        $editor = $this->createMinimalValidEditor();
+
+        $constraint = $editor->create();
+        self::assertNull($constraint->getObjectName());
+
+        $name = UnqualifiedName::unquoted('fk_users_id');
+
+        $constraint = $editor
+            ->setName($name)
+            ->create();
+        self::assertEquals($name, $constraint->getObjectName());
+    }
+
+    public function testSetMatchType(): void
+    {
+        $editor = $this->createMinimalValidEditor();
+
+        $constraint = $editor->create();
+        self::assertSame(MatchType::SIMPLE, $constraint->getMatchType());
+
+        $constraint = $editor
+            ->setMatchType(MatchType::FULL)
+            ->create();
+        self::assertSame(MatchType::FULL, $constraint->getMatchType());
+    }
+
+    public function testSetOnUpdateAction(): void
+    {
+        $editor = $this->createMinimalValidEditor();
+
+        $constraint = $editor->create();
+        self::assertSame(ReferentialAction::NO_ACTION, $constraint->getOnUpdateAction());
+
+        $constraint = $editor
+            ->setOnUpdateAction(ReferentialAction::CASCADE)
+            ->create();
+        self::assertSame(ReferentialAction::CASCADE, $constraint->getOnUpdateAction());
+    }
+
+    public function testSetOnDeleteAction(): void
+    {
+        $editor = $this->createMinimalValidEditor();
+
+        $constraint = $editor->create();
+        self::assertSame(ReferentialAction::NO_ACTION, $constraint->getOnDeleteAction());
+
+        $constraint = $editor
+            ->setOnDeleteAction(ReferentialAction::CASCADE)
+            ->create();
+        self::assertSame(ReferentialAction::CASCADE, $constraint->getOnDeleteAction());
+    }
+
+    public function testSetDeferrability(): void
+    {
+        $editor = $this->createMinimalValidEditor();
+
+        $constraint = $editor->create();
+        self::assertSame(Deferrability::NOT_DEFERRABLE, $constraint->getDeferrability());
+
+        $constraint = $editor
+            ->setDeferrability(Deferrability::DEFERRABLE)
+            ->create();
+        self::assertSame(Deferrability::DEFERRABLE, $constraint->getDeferrability());
+    }
+
+    private function createMinimalValidEditor(): ForeignKeyConstraintEditor
+    {
+        return ForeignKeyConstraint::editor()
+            ->setReferencedTableName($this->createTableName())
+            ->setReferencingColumnNames($this->createColumnName())
+            ->setReferencedColumnNames($this->createColumnName());
+    }
+
+    private function createTableName(): OptionallyQualifiedName
+    {
+        return OptionallyQualifiedName::unquoted('users');
+    }
+
+    private function createColumnName(): UnqualifiedName
+    {
+        return UnqualifiedName::unquoted('id');
+    }
+}

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -109,5 +115,170 @@ class ForeignKeyConstraintTest extends TestCase
         $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id']);
 
         self::assertNull($foreignKey->getObjectName());
+    }
+
+    /** @throws Exception */
+    public function testEmptyReferencingColumnNames(): void
+    {
+        $foreignKey = new ForeignKeyConstraint([], 'users', ['id']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getReferencingColumnNames();
+    }
+
+    /** @throws Exception */
+    public function testInvalidReferencingColumnNames(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint([''], 'users', ['id']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getReferencingColumnNames();
+    }
+
+    /** @throws Exception */
+    public function testInvalidReferencedTableName(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], '', ['id']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getReferencedTableName();
+    }
+
+    /** @throws Exception */
+    public function testEmptyReferencedColumnNames(): void
+    {
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', []);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getReferencedColumnNames();
+    }
+
+    /** @throws Exception */
+    public function testInvalidReferencedColumnNames(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getReferencedColumnNames();
+    }
+
+    /** @throws Exception */
+    public function testInvalidMatchType(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id'], '', ['match' => 'MAYBE']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getMatchType();
+    }
+
+    /** @throws Exception */
+    public function testInvalidOnUpdateAction(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id'], '', ['onUpdate' => 'DROP']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getOnUpdateAction();
+    }
+
+    /** @throws Exception */
+    public function testInvalidOnDeleteAction(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id'], '', ['onDelete' => 'DROP']);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getOnDeleteAction();
+    }
+
+    public function testInvalidDeferrability(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id'], '', [
+            'deferrable' => false,
+            'deferred' => true,
+        ]);
+
+        $this->expectException(InvalidState::class);
+        $foreignKey->getDeferrability();
+    }
+
+    /** @param array<string,bool> $options */
+    #[DataProvider('deferrabilityProvider')]
+    public function testParseDeferrability(array $options, Deferrability $expected): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id'], '', $options);
+
+        self::assertEquals($expected, $foreignKey->getDeferrability());
+    }
+
+    /**
+     * The expected behavior here should be consistent with
+     * {@see \Doctrine\DBAL\Tests\Functional\Schema\ForeignKeyConstraintTest::deferrabilityOptionsProvider()}
+     *
+     * @return iterable<array{array<string,bool>,Deferrability}>
+     */
+    public static function deferrabilityProvider(): iterable
+    {
+        $notDeferrable = Deferrability::NOT_DEFERRABLE;
+        $deferrable    = Deferrability::DEFERRABLE;
+        $deferred      = Deferrability::DEFERRED;
+
+        yield 'unspecified' => [[], $notDeferrable];
+
+        // INITIALLY IMMEDIATE implies NOT DEFERRABLE
+        yield 'INITIALLY IMMEDIATE' => [['deferred' => false], $notDeferrable];
+
+        // INITIALLY IMMEDIATE implies DEFERRABLE
+        yield 'INITIALLY DEFERRED' => [['deferred' => true], $deferred];
+
+        // NOT DEFERRABLE implies INITIALLY IMMEDIATE
+        yield 'NOT DEFERRABLE' => [['deferrable' => false], $notDeferrable];
+
+        yield 'NOT DEFERRABLE INITIALLY IMMEDIATE' => [
+            [
+                'deferrable' => false,
+                'deferred' => false,
+            ], $notDeferrable,
+        ];
+
+        // DEFERRABLE implies INITIALLY IMMEDIATE
+        yield 'DEFERRABLE' => [
+            ['deferrable' => true], $deferrable,
+        ];
+
+        yield 'DEFERRABLE INITIALLY IMMEDIATE' => [
+            [
+                'deferrable' => true,
+                'deferred' => false,
+            ], $deferrable,
+        ];
+
+        yield 'DEFERRABLE INITIALLY DEFERRED' => [
+            [
+                'deferrable' => true,
+                'deferred' => true,
+            ],
+            $deferred,
+        ];
+    }
+
+    public function testAllValidProperties(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6728');
+        $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', ['id'], 'fk_user_id');
+
+        self::assertEquals([UnqualifiedName::unquoted('user_id')], $foreignKey->getReferencingColumnNames());
+        self::assertEquals(OptionallyQualifiedName::unquoted('users'), $foreignKey->getReferencedTableName());
+        self::assertEquals([UnqualifiedName::unquoted('id')], $foreignKey->getReferencedColumnNames());
+        self::assertEquals(MatchType::SIMPLE, $foreignKey->getMatchType());
+        self::assertEquals(ReferentialAction::NO_ACTION, $foreignKey->getOnUpdateAction());
+        self::assertEquals(ReferentialAction::NO_ACTION, $foreignKey->getOnDeleteAction());
+        self::assertEquals(Deferrability::NOT_DEFERRABLE, $foreignKey->getDeferrability());
     }
 }

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -120,6 +120,7 @@ class ForeignKeyConstraintTest extends TestCase
     /** @throws Exception */
     public function testEmptyReferencingColumnNames(): void
     {
+        /** @phpstan-ignore argument.type */
         $foreignKey = new ForeignKeyConstraint([], 'users', ['id']);
 
         $this->expectException(InvalidState::class);
@@ -149,6 +150,7 @@ class ForeignKeyConstraintTest extends TestCase
     /** @throws Exception */
     public function testEmptyReferencedColumnNames(): void
     {
+        /** @phpstan-ignore argument.type */
         $foreignKey = new ForeignKeyConstraint(['user_id'], 'users', []);
 
         $this->expectException(InvalidState::class);

--- a/tests/Schema/Name/OptionallyQualifiedNameTest.php
+++ b/tests/Schema/Name/OptionallyQualifiedNameTest.php
@@ -4,34 +4,66 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema\Name;
 
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use PHPUnit\Framework\TestCase;
 
 class OptionallyQualifiedNameTest extends TestCase
 {
-    public function testWithQualifier(): void
+    public function testQualifiedQuoted(): void
     {
-        $unqualifiedName = Identifier::quoted('customers');
-        $qualifier       = Identifier::unquoted('inventory');
+        $name = OptionallyQualifiedName::quoted('customers', 'inventory');
 
-        $name = new OptionallyQualifiedName($unqualifiedName, $qualifier);
+        $unqualifiedName = $name->getUnqualifiedName();
+        self::assertTrue($unqualifiedName->isQuoted());
+        self::assertEquals('customers', $unqualifiedName->getValue());
 
-        self::assertSame($unqualifiedName, $name->getUnqualifiedName());
-        self::assertSame($qualifier, $name->getQualifier());
+        $qualifier = $name->getQualifier();
+        self::assertNotNull($qualifier);
+        self::assertTrue($qualifier->isQuoted());
+        self::assertEquals('inventory', $qualifier->getValue());
 
-        self::assertSame('inventory."customers"', $name->toString());
+        self::assertSame('"inventory"."customers"', $name->toString());
     }
 
-    public function testWithoutQualifier(): void
+    public function testUnqualifiedQuoted(): void
     {
-        $unqualifiedName = Identifier::unquoted('users');
+        $name = OptionallyQualifiedName::quoted('customers');
 
-        $name = new OptionallyQualifiedName($unqualifiedName, null);
+        $unqualifiedName = $name->getUnqualifiedName();
+        self::assertTrue($unqualifiedName->isQuoted());
+        self::assertEquals('customers', $unqualifiedName->getValue());
 
-        self::assertSame($unqualifiedName, $name->getUnqualifiedName());
         self::assertNull($name->getQualifier());
 
-        self::assertSame('users', $name->toString());
+        self::assertSame('"customers"', $name->toString());
+    }
+
+    public function testQualifiedUnquoted(): void
+    {
+        $name = OptionallyQualifiedName::unquoted('customers', 'inventory');
+
+        $unqualifiedName = $name->getUnqualifiedName();
+        self::assertFalse($unqualifiedName->isQuoted());
+        self::assertEquals('customers', $unqualifiedName->getValue());
+
+        $qualifier = $name->getQualifier();
+        self::assertNotNull($qualifier);
+        self::assertFalse($qualifier->isQuoted());
+        self::assertEquals('inventory', $qualifier->getValue());
+
+        self::assertSame('inventory.customers', $name->toString());
+    }
+
+    public function testUnqualifiedUnquoted(): void
+    {
+        $name = OptionallyQualifiedName::unquoted('customers');
+
+        $unqualifiedName = $name->getUnqualifiedName();
+        self::assertFalse($unqualifiedName->isQuoted());
+        self::assertEquals('customers', $unqualifiedName->getValue());
+
+        self::assertNull($name->getQualifier());
+
+        self::assertSame('customers', $name->toString());
     }
 }

--- a/tests/Schema/Name/UnqualifiedNameTest.php
+++ b/tests/Schema/Name/UnqualifiedNameTest.php
@@ -4,20 +4,32 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema\Name;
 
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use PHPUnit\Framework\TestCase;
 
 class UnqualifiedNameTest extends TestCase
 {
-    public function testWithQualifier(): void
+    public function testQuoted(): void
     {
-        $identifier = Identifier::quoted('id');
+        $name = UnqualifiedName::quoted('id');
 
-        $name = new UnqualifiedName($identifier);
+        $identifier = $name->getIdentifier();
 
-        self::assertSame($identifier, $name->getIdentifier());
+        self::assertTrue($identifier->isQuoted());
+        self::assertEquals('id', $identifier->getValue());
 
         self::assertSame('"id"', $name->toString());
+    }
+
+    public function testUnquoted(): void
+    {
+        $name = UnqualifiedName::unquoted('id');
+
+        $identifier = $name->getIdentifier();
+
+        self::assertFalse($identifier->isQuoted());
+        self::assertEquals('id', $identifier->getValue());
+
+        self::assertSame('id', $name->toString());
     }
 }

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -283,21 +283,6 @@ class TableTest extends TestCase
         new Table('foo', $columns, $indexes, [], []);
     }
 
-    public function testConstraints(): void
-    {
-        $constraint = new ForeignKeyConstraint([], 'foo', []);
-
-        $tableA      = new Table('foo', [], [], [], [$constraint]);
-        $constraints = $tableA->getForeignKeys();
-
-        self::assertCount(1, $constraints);
-
-        $constraintNames = array_keys($constraints);
-
-        self::assertSame('fk_8c736521', $constraintNames[0]);
-        self::assertSame($constraint, $constraints['fk_8c736521']);
-    }
-
     public function testOptions(): void
     {
         $table = new Table('foo', [], [], [], [], ['foo' => 'bar']);

--- a/tests/Schema/UniqueConstraintEditorTest.php
+++ b/tests/Schema/UniqueConstraintEditorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Exception\InvalidUniqueConstraintDefinition;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +21,7 @@ class UniqueConstraintEditorTest extends TestCase
 
     public function testSetIsClustered(): void
     {
-        $columnName = new UnqualifiedName(Identifier::unquoted('user_id'));
+        $columnName = UnqualifiedName::unquoted('user_id');
 
         $editor = UniqueConstraint::editor()
             ->setColumnNames($columnName);

--- a/tests/Schema/UniqueConstraintTest.php
+++ b/tests/Schema/UniqueConstraintTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Exception\InvalidState;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -20,12 +19,12 @@ class UniqueConstraintTest extends TestCase
     /** @throws Exception */
     public function testGetNonNullObjectName(): void
     {
-        $name = new UnqualifiedName(Identifier::unquoted('uq_user_id'));
+        $name = UnqualifiedName::unquoted('uq_user_id');
 
         $uniqueConstraint = UniqueConstraint::editor()
             ->setName($name)
             ->setColumnNames(
-                new UnqualifiedName(Identifier::unquoted('user_id')),
+                UnqualifiedName::unquoted('user_id'),
             )
             ->create();
 
@@ -37,7 +36,7 @@ class UniqueConstraintTest extends TestCase
     {
         $uniqueConstraint = UniqueConstraint::editor()
             ->setColumnNames(
-                new UnqualifiedName(Identifier::unquoted('user_id')),
+                UnqualifiedName::unquoted('user_id'),
             )
             ->create();
 
@@ -56,7 +55,7 @@ class UniqueConstraintTest extends TestCase
         $uniqueConstraint = new UniqueConstraint('', ['user_id']);
 
         self::assertEquals([
-            new UnqualifiedName(Identifier::unquoted('user_id')),
+            UnqualifiedName::unquoted('user_id'),
         ], $uniqueConstraint->getColumnNames());
     }
 


### PR DESCRIPTION
This is a continuation of the rework started in https://github.com/doctrine/dbal/pull/6685, now applied to foreign key constraints.