### PR TITLE
add filterAssetNames to get asset tables

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -309,7 +309,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function tablesExist($names)
+    public function tablesExist($names, bool $filterAssetNames = true)
     {
         if (is_string($names)) {
             Deprecation::trigger(
@@ -322,7 +322,12 @@ abstract class AbstractSchemaManager
 
         $names = array_map('strtolower', (array) $names);
 
-        return count($names) === count(array_intersect($names, array_map('strtolower', $this->listTableNames())));
+        return count($names) === count(
+            array_intersect(
+                $names,
+                array_map('strtolower', $this->listTableNames($filterAssetNames)),
+            ),
+        );
     }
 
     /**
@@ -332,14 +337,14 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
         $sql = $this->_platform->getListTablesSQL();
 
         $tables     = $this->_conn->fetchAllAssociative($sql);
         $tableNames = $this->_getPortableTablesList($tables);
 
-        return $this->filterAssetNames($tableNames);
+        return $filterAssetNames ? $this->filterAssetNames($tableNames) : $tableNames;
     }
 
     /**
@@ -347,16 +352,16 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function doListTableNames(): array
+    protected function doListTableNames(bool $filterAssetNames = true): array
     {
         $database = $this->getDatabase(__METHOD__);
 
-        return $this->filterAssetNames(
-            $this->_getPortableTablesList(
-                $this->selectTableNames($database)
-                    ->fetchAllAssociative(),
-            ),
+        $tableNames = $this->_getPortableTablesList(
+            $this->selectTableNames($database)
+                ->fetchAllAssociative(),
         );
+
+        return $filterAssetNames ? $this->filterAssetNames($tableNames) : $tableNames;
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -30,9 +30,9 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
-        return $this->doListTableNames();
+        return $this->doListTableNames($filterAssetNames);
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -53,9 +53,9 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
-        return $this->doListTableNames();
+        return $this->doListTableNames($filterAssetNames);
     }
 
     /**

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -31,9 +31,9 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
-        return $this->doListTableNames();
+        return $this->doListTableNames($filterAssetNames);
     }
 
     /**

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -43,9 +43,9 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
-        return $this->doListTableNames();
+        return $this->doListTableNames($filterAssetNames);
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -35,9 +35,9 @@ class SQLServerSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
-        return $this->doListTableNames();
+        return $this->doListTableNames($filterAssetNames);
     }
 
     /**

--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -44,9 +44,9 @@ class SqliteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableNames()
+    public function listTableNames(bool $filterAssetNames = true)
     {
-        return $this->doListTableNames();
+        return $this->doListTableNames($filterAssetNames);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | (https://github.com/doctrine/DoctrineMigrationsBundle/issues/584)

#### Summary

add a parameter to can get all tables (with assets), use for a bug in migrations, TableMetadataStorage appear as not initialized

need https://github.com/doctrine/migrations/pull/1484