### PR TITLE
Deprecate usage of Schema as AbstractAsset

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated using `Schema` as `AbstractAsset`
+
+Relying on the `Schema` class extending `AbstractAsset` is deprecated. Use only the methods declared immediately in
+the `Schema` class itself.
+
 ## Deprecated `ForeignKeyConstraint` methods, properties and behavior
 
 The following `ForeignKeyConstraint` methods and property have been deprecated:

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -52,9 +52,9 @@ use function strtolower;
  * execute them. Only the queries for the currently connected database are
  * executed.
  *
- * @extends AbstractOptionallyNamedObject<UnqualifiedName>
+ * @extends AbstractAsset<UnqualifiedName>
  */
-class Schema extends AbstractOptionallyNamedObject
+class Schema extends AbstractAsset
 {
     /**
      * The namespaces in this schema.
@@ -108,6 +108,19 @@ class Schema extends AbstractOptionallyNamedObject
         foreach ($sequences as $sequence) {
             $this->_addSequence($sequence);
         }
+    }
+
+    /** @deprecated */
+    public function getName(): string
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6734',
+            'Using Schema as AbstractAsset, including %s, is deprecated.',
+            __METHOD__,
+        );
+
+        return parent::getName();
     }
 
     protected function getNameParser(): UnqualifiedNameParser
@@ -259,8 +272,12 @@ class Schema extends AbstractOptionallyNamedObject
      */
     private function resolveName(AbstractAsset $asset): AbstractAsset
     {
-        if ($asset->getNamespaceName() === null && $this->name !== null) {
-            return new Identifier($this->getName() . '.' . $asset->getName());
+        if ($asset->getNamespaceName() === null) {
+            $defaultNamespaceName = $this->getName();
+
+            if ($defaultNamespaceName !== '') {
+                return new Identifier($defaultNamespaceName . '.' . $asset->getName());
+            }
         }
 
         return $asset;

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
-use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -420,28 +418,5 @@ class SchemaTest extends TestCase
 
         self::assertFalse($schema->hasTable('s'));
         self::assertFalse($schema->hasTable('public.s'));
-    }
-
-    public function testQualifiedName(): void
-    {
-        $schemaConfig = new SchemaConfig();
-        $schemaConfig->setName('warehouse.inventory');
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        new Schema([], [], $schemaConfig);
-    }
-
-    /** @throws Exception */
-    public function testGetObjectName(): void
-    {
-        $schemaConfig = new SchemaConfig();
-        $schemaConfig->setName('public');
-
-        $schema = new Schema([], [], $schemaConfig);
-        $name   = $schema->getObjectName();
-
-        self::assertNotNull($name);
-        self::assertEquals(Identifier::unquoted('public'), $name->getIdentifier());
     }
 }


### PR DESCRIPTION
This PR partially reverts https://github.com/doctrine/dbal/pull/6646 with regard to the `Schema` class. That change was applied mechanically to all `AbstractAsset` subclasses before I realized that  even though `Schema` extends `AbstractAsset`, it's not an "asset".

1. All other `AbstractAsset` subclasses use their name to identify a given object among its peers (e.g. the table name is used to identify a table among other tables, etc). The `Schema` name is not the name of the schema, it's the name of the default namespace within the schema, which is used to qualify unqualified object names.
2. Except for `getName()`, DBAL doesn't use any other `Schema` methods inherited from `AbstractAsset`.
3. The default namespace of the schema isn't defined by the user, it's initialized by a schema manager (specifically, the PostgreSQL and SQL Server ones). Unlike other object's names which can be quoted or unquoted and need to be parsed, the schema name is passed as a literal. It doesn't need to be parsed, but implementation inherited from `AbstractAsset` does that.

In 5.0, the default namespace of the schema will remain a private property but won't be exposed outside.

All of the changes are backward-compatible because the changes being reverted haven't been released.