### PR TITLE
Add missing sentence and placeholder.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -563,7 +563,10 @@ class Connection implements ServerVersionProvider
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/6590',
-            'Use quoteSingleIdentifier() individually for each part of a qualified name instead.',
+            <<<'DEPRECATION'
+            Method %s is deprecated and will be removed in 5.0.
+            Use quoteSingleIdentifier() individually for each part of a qualified name instead.
+            DEPRECATION,
             __METHOD__,
         );
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1214,7 +1214,10 @@ abstract class AbstractPlatform
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/6590',
-            'Use quoteSingleIdentifier() individually for each part of a qualified name instead.',
+            <<<'DEPRECATION'
+            Method %s is deprecated and will be removed in 5.0.
+            Use quoteSingleIdentifier() individually for each part of a qualified name instead.
+            DEPRECATION,
             __METHOD__,
         );
 


### PR DESCRIPTION
Right now, the message is confusing, it looks like this:

> 4) /home/greg/dev/doctrine-orm/patch/vendor/doctrine/deprecations/src/Deprecation.php:208
Use quoteSingleIdentifier() individually for each part of a qualified name instead. (AbstractPlatform.php:1214 called by DefaultQuoteStrategy.php:27, https://github.com/doctrine/dbal/pull/6590, package doctrine/dbal)