### PR TITLE
Implement empty Schema::setName()

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -128,6 +128,16 @@ class Schema extends AbstractAsset
         return Parsers::getUnqualifiedNameParser();
     }
 
+    /**
+     * The object representation of the name isn't used because {@see Schema} is not an {@see AbstractAsset}.
+     *
+     * This method implements the abstract method in the parent class and will be removed once {@see Schema} stops
+     * extending {@see AbstractAsset}.
+     */
+    protected function setName(?Name $name): void
+    {
+    }
+
     protected function _addTable(Table $table): void
     {
         $resolvedName = $this->resolveName($table);


### PR DESCRIPTION
`AbstractAsset` declares `setName()`, which is supposed to be implemented by either of `AbstractNamedObject` and `AbstractOptionallyNamedObject`, which other `AbstractAsset` subclasses extend.

As of https://github.com/doctrine/dbal/pull/6734, `Schema` doesn't extend either of the two with the intention to eventually stop extending `AbstractAsset` as well.

For the time being, it has to implement `setName()` itself.

Fixes https://github.com/doctrine/dbal/issues/6737.