### PR TITLE
Support precision option in datetime types (PostgreSQL)

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -594,7 +594,11 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
-        return 'TIMESTAMP(0) WITHOUT TIME ZONE';
+        if (! empty($column['without_precision'])) {
+            return 'TIMESTAMP WITHOUT TIME ZONE';
+        }
+
+        return sprintf('TIMESTAMP(%d) WITHOUT TIME ZONE', $column['precision']);
     }
 
     /**
@@ -602,7 +606,11 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getDateTimeTzTypeDeclarationSQL(array $column): string
     {
-        return 'TIMESTAMP(0) WITH TIME ZONE';
+        if (! empty($column['without_precision'])) {
+            return 'TIMESTAMP WITH TIME ZONE';
+        }
+
+        return sprintf('TIMESTAMP(%d) WITH TIME ZONE', $column['precision']);
     }
 
     /**
@@ -662,9 +670,14 @@ class PostgreSQLPlatform extends AbstractPlatform
         return 'TEXT';
     }
 
+    public function getDateTimeFormatString(): string
+    {
+        return 'Y-m-d H:i:s.u';
+    }
+
     public function getDateTimeTzFormatString(): string
     {
-        return 'Y-m-d H:i:sO';
+        return 'Y-m-d H:i:s.uO';
     }
 
     public function getEmptyIdentityInsertSQL(string $quotedTableName, string $quotedIdentifierColumnName): string

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -594,10 +594,6 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
-        if (! empty($column['without_precision'])) {
-            return 'TIMESTAMP WITHOUT TIME ZONE';
-        }
-
         return sprintf('TIMESTAMP(%d) WITHOUT TIME ZONE', $column['precision']);
     }
 
@@ -606,10 +602,6 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getDateTimeTzTypeDeclarationSQL(array $column): string
     {
-        if (! empty($column['without_precision'])) {
-            return 'TIMESTAMP WITH TIME ZONE';
-        }
-
         return sprintf('TIMESTAMP(%d) WITH TIME ZONE', $column['precision']);
     }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\JsonType;
+use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -331,6 +332,20 @@ SQL,
 
                 break;
 
+            case 'timestamp':
+            case 'timestamptz':
+                if (
+                    preg_match(
+                        '([A-Za-z]+\(([0-9]+)\))',
+                        $tableColumn['complete_type'],
+                        $match,
+                    ) === 1
+                ) {
+                    $precision = (int) $match[1];
+                }
+
+                break;
+
             case 'year':
                 $length = null;
                 break;
@@ -373,6 +388,8 @@ SQL,
 
         if ($column->getType() instanceof JsonType) {
             $column->setPlatformOption('jsonb', $jsonb);
+        } elseif ($column->getType() instanceof PhpDateTimeMappingType) {
+            $column->setPlatformOption('without_precision', $precision === null ? true : null);
         }
 
         return $column;

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -342,6 +342,8 @@ SQL,
                     ) === 1
                 ) {
                     $precision = (int) $match[1];
+                } else {
+                    $precision = 6;
                 }
 
                 break;
@@ -388,8 +390,6 @@ SQL,
 
         if ($column->getType() instanceof JsonType) {
             $column->setPlatformOption('jsonb', $jsonb);
-        } elseif ($column->getType() instanceof PhpDateTimeMappingType) {
-            $column->setPlatformOption('without_precision', $precision === null ? true : null);
         }
 
         return $column;

--- a/src/Types/DateTimeImmutableType.php
+++ b/src/Types/DateTimeImmutableType.php
@@ -60,12 +60,6 @@ class DateTimeImmutableType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if ($dateTime !== false) {
-            return $dateTime;
-        }
-
         try {
             return new DateTimeImmutable($value);
         } catch (Exception $e) {

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -60,12 +60,6 @@ class DateTimeType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        $dateTime = DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
-
-        if ($dateTime !== false) {
-            return $dateTime;
-        }
-
         try {
             return new DateTime($value);
         } catch (Exception $e) {

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
+use Exception;
 
 /**
  * Immutable type of {@see DateTimeTzType}.
@@ -59,16 +60,15 @@ class DateTimeTzImmutableType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeTzFormatString(), $value);
-
-        if ($dateTime !== false) {
-            return $dateTime;
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $e) {
+            throw InvalidFormat::new(
+                $value,
+                static::class,
+                $platform->getDateTimeTzFormatString(),
+                $e,
+            );
         }
-
-        throw InvalidFormat::new(
-            $value,
-            static::class,
-            $platform->getDateTimeTzFormatString(),
-        );
     }
 }

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -8,6 +8,7 @@ use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
+use Exception;
 
 /**
  * DateTime type accepting additional information about timezone offsets.
@@ -73,15 +74,15 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
             return $value;
         }
 
-        $dateTime = DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
-        if ($dateTime !== false) {
-            return $dateTime;
+        try {
+            return new DateTime($value);
+        } catch (Exception $e) {
+            throw InvalidFormat::new(
+                $value,
+                static::class,
+                $platform->getDateTimeTzFormatString(),
+                $e,
+            );
         }
-
-        throw InvalidFormat::new(
-            $value,
-            static::class,
-            $platform->getDateTimeTzFormatString(),
-        );
     }
 }

--- a/src/Types/VarDateTimeImmutableType.php
+++ b/src/Types/VarDateTimeImmutableType.php
@@ -11,34 +11,10 @@ use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use Exception;
 
 /**
- * Immutable type of {@see VarDateTimeType}.
+ * @deprecated Use {@see DateTimeImmutableType} instead.
  */
 class VarDateTimeImmutableType extends DateTimeImmutableType
 {
-    /**
-     * @param T $value
-     *
-     * @return (T is null ? null : string)
-     *
-     * @template T
-     */
-    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
-    {
-        if ($value === null) {
-            return $value;
-        }
-
-        if ($value instanceof DateTimeImmutable) {
-            return $value->format($platform->getDateTimeFormatString());
-        }
-
-        throw InvalidType::new(
-            $value,
-            static::class,
-            ['null', DateTimeImmutable::class],
-        );
-    }
-
     /**
      * @param T $value
      *

--- a/src/Types/VarDateTimeType.php
+++ b/src/Types/VarDateTimeType.php
@@ -10,11 +10,7 @@ use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use Exception;
 
 /**
- * Variable DateTime Type using DateTime::__construct() instead of DateTime::createFromFormat().
- *
- * This type has performance implications as it runs twice as long as the regular
- * {@see DateTimeType}, however in certain PostgreSQL configurations with
- * TIMESTAMP(n) columns where n > 0 it is necessary to use this type.
+ * @deprecated Use {@see DateTimeType} instead.
  */
 class VarDateTimeType extends DateTimeType
 {

--- a/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
+++ b/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
@@ -72,6 +72,15 @@ final class ComparatorTest extends FunctionalTestCase
         });
     }
 
+    public function testCompareDatesOfZeroPrecision(): void
+    {
+        $this->testColumnModification(static function (Table $table, string $name): Column {
+            return $table->addColumn($name, Types::DATETIME_IMMUTABLE)->setPrecision(null);
+        }, static function (Column $column): void {
+            $column->setPrecision(0);
+        });
+    }
+
     public function testPlatformOptionsChangedColumnComparison(): void
     {
         $table = new Table('update_json_to_jsonb_table');

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -649,6 +649,34 @@ SQL;
         ));
         self::assertSame(1, $partitionsCount);
     }
+
+    public function testTimestampPrecisionComparison(): void
+    {
+        $offlineTable = new Table('timestamp_columns_test');
+        $offlineTable->addColumn('t_0_wz', Types::DATETIME_MUTABLE, ['precision' => 0]);
+        $offlineTable->addColumn('t_6_wz', Types::DATETIME_MUTABLE, ['precision' => 6]);
+        $offlineTable->addColumn('t_u_wz', Types::DATETIME_MUTABLE, ['precision' => 6]);
+        $offlineTable->addColumn('t_0_tz', Types::DATETIMETZ_MUTABLE, ['precision' => 0]);
+        $offlineTable->addColumn('t_6_tz', Types::DATETIMETZ_MUTABLE, ['precision' => 6]);
+        $offlineTable->addColumn('t_u_tz', Types::DATETIMETZ_MUTABLE, ['precision' => 6]);
+
+        $createTableSQL = <<<'SQL'
+            CREATE TABLE timestamp_columns_test (
+                t_0_wz TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                t_6_wz TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL,
+                t_u_wz TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                t_0_tz TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+                t_6_tz TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+                t_u_tz TIMESTAMP WITH TIME ZONE NOT NULL
+            )
+            SQL;
+
+        $this->connection->executeStatement($createTableSQL);
+
+        $onlineTable = $this->connection->createSchemaManager()->introspectTable($offlineTable->getName());
+
+        self::assertEquals($offlineTable->getColumns(), $onlineTable->getColumns());
+    }
 }
 
 class MoneyType extends Type

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -269,12 +269,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('baz1', Types::DATETIME_MUTABLE);
         $table->addColumn('baz2', Types::TIME_MUTABLE);
         $table->addColumn('baz3', Types::DATE_MUTABLE);
-        $table->addColumn('dt1', Types::DATETIME_IMMUTABLE);
-        $table->addColumn('dt2', Types::DATETIME_IMMUTABLE, ['precision' => 6]);
-        $table->addColumn('dt3', Types::DATETIME_IMMUTABLE, ['platformOptions' => ['without_precision' => true]]);
-        $table->addColumn('dt4', Types::DATETIMETZ_IMMUTABLE);
-        $table->addColumn('dt5', Types::DATETIMETZ_IMMUTABLE, ['precision' => 6]);
-        $table->addColumn('dt6', Types::DATETIMETZ_IMMUTABLE, ['platformOptions' => ['without_precision' => true]]);
         $table->setPrimaryKey(['id']);
 
         return $table;
@@ -348,8 +342,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
         self::assertEquals(true, $columns['baz3']->getNotnull());
         self::assertEquals(null, $columns['baz3']->getDefault());
-
-        self::assertCount(13, $columns);
     }
 
     public function testListTableColumnsWithFixedStringColumn(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -269,6 +269,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('baz1', Types::DATETIME_MUTABLE);
         $table->addColumn('baz2', Types::TIME_MUTABLE);
         $table->addColumn('baz3', Types::DATE_MUTABLE);
+        $table->addColumn('dt1', Types::DATETIME_IMMUTABLE);
+        $table->addColumn('dt2', Types::DATETIME_IMMUTABLE, ['precision' => 6]);
+        $table->addColumn('dt3', Types::DATETIME_IMMUTABLE, ['platformOptions' => ['without_precision' => true]]);
+        $table->addColumn('dt4', Types::DATETIMETZ_IMMUTABLE);
+        $table->addColumn('dt5', Types::DATETIMETZ_IMMUTABLE, ['precision' => 6]);
+        $table->addColumn('dt6', Types::DATETIMETZ_IMMUTABLE, ['platformOptions' => ['without_precision' => true]]);
         $table->setPrimaryKey(['id']);
 
         return $table;
@@ -342,6 +348,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
         self::assertEquals(true, $columns['baz3']->getNotnull());
         self::assertEquals(null, $columns['baz3']->getDefault());
+
+        self::assertCount(13, $columns);
     }
 
     public function testListTableColumnsWithFixedStringColumn(): void

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -78,10 +78,6 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeStringToPHPValue(): void
     {
-        $this->platform->expects(self::once())
-            ->method('getDateTimeFormatString')
-            ->willReturn('Y-m-d H:i:s');
-
         $date = $this->type->convertToPHPValue('2016-01-01 15:58:59', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
@@ -90,10 +86,6 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeStringWithMicrosecondsToPHPValue(): void
     {
-        $this->platform
-            ->method('getDateTimeFormatString')
-            ->willReturn('Y-m-d H:i:s');
-
         $date = $this->type->convertToPHPValue('2016-01-01 15:58:59.123456', $this->platform);
 
         self::assertNotNull($date);
@@ -102,10 +94,6 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeString(): void
     {
-        $this->platform->expects(self::atLeastOnce())
-            ->method('getDateTimeFormatString')
-            ->willReturn('Y-m-d H:i:s');
-
         $this->expectException(ConversionException::class);
 
         $this->type->convertToPHPValue('invalid datetime string', $this->platform);

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -78,10 +78,6 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeWithTimezoneStringToPHPValue(): void
     {
-        $this->platform->expects(self::once())
-            ->method('getDateTimeTzFormatString')
-            ->willReturn('Y-m-d H:i:s T');
-
         $date = $this->type->convertToPHPValue('2016-01-01 15:58:59 UTC', $this->platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
@@ -90,10 +86,6 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeWithTimezoneString(): void
     {
-        $this->platform->expects(self::atLeastOnce())
-            ->method('getDateTimeTzFormatString')
-            ->willReturn('Y-m-d H:i:s T');
-
         $this->expectException(ConversionException::class);
 
         $this->type->convertToPHPValue('invalid datetime with timezone string', $this->platform);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #2873 #6631
| Refers       | #5961

#### Summary

The year was 2025... I made yet another try to add support of microseconds to date-time types.

Looks like a really big work on #5961 is abandoned. Sadly. I've reviewed this PR. I think it modifies too many things and attempts to add microseconds everywhere. It reminds me of PHP 6 in trying to add support for Unicode globally.

Let's make things easy!


#### What it does

It adds to PostgreSQL platform support of microseconds for the next types:

 - DateTimeType
 - DateTimeImmutableType
 - DateTimeTzType
 - DateTimeImmutableTzType

To configure precision (in PostgreSQL documentation it calls "precision," not "scale") of those types, the precision option is available. For backward compatibility, the default precision is zero.

Additionally, it respects precision in schema introspection (fix #6631). In order to distinguish `timestamp` (without precision) and `timestamp(6)` the `without_precision` platform option was added.


#### VarDateTimeType and VarDateTimeImmutableType

According to description of these types, `DateTime::__construct()` twice slower then `DateTime::createFromFormat()`. I cannot remember the times when it was true. In my tests on PHP 8.1 (which is a lower supported version for 4.x), the constructor is slightly faster. 

Script:
```php
$i = 1000000;
while ($i--) {
    $dates[] = date('Y-m-d H:i:s.', random_int(0, 2 << 30)) . random_int(0, 999999);
}

echo end($dates) . PHP_EOL;
echo reset($dates) . PHP_EOL;

$startTime = hrtime(true);
foreach ($dates as $date) {
    $d = new DateTimeImmutable($date);
}

echo hrtime(true) - $startTime, ' ns', PHP_EOL;

$startTime = hrtime(true);
foreach ($dates as $date) {
    $d = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', $date);
}

echo hrtime(true) - $startTime, ' ns', PHP_EOL;
```

Result:
```sh
2029-07-14 20:51:46.103511
1990-10-19 13:16:13.771286
2021394668 ns
2206943091 ns
```

#### What's next

 - [ ] Discuss the PR
 - [ ] Add other platforms
 - [ ] Fix bugs & add more tests
