### PR TITLE
Refactor AbstractSchemaManager::fetch*/select*() API

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -727,8 +727,6 @@ abstract class AbstractSchemaManager
      * @param array<array<string, mixed>> $rows
      *
      * @return array<string, Column>
-     *
-     * @throws Exception
      */
     protected function _getPortableTableColumnList(string $table, string $database, array $rows): array
     {
@@ -747,8 +745,6 @@ abstract class AbstractSchemaManager
      * Gets Table Column Definition.
      *
      * @param array<string, mixed> $tableColumn
-     *
-     * @throws Exception
      */
     abstract protected function _getPortableTableColumnDefinition(array $tableColumn): Column;
 
@@ -758,8 +754,6 @@ abstract class AbstractSchemaManager
      * @param array<array<string, mixed>> $rows
      *
      * @return array<string, Index>
-     *
-     * @throws Exception
      */
     protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -724,17 +724,17 @@ abstract class AbstractSchemaManager
      *
      * The name of the created column instance however is kept in its case.
      *
-     * @param array<int, array<string, mixed>> $tableColumns
+     * @param array<array<string, mixed>> $rows
      *
      * @return array<string, Column>
      *
      * @throws Exception
      */
-    protected function _getPortableTableColumnList(string $table, string $database, array $tableColumns): array
+    protected function _getPortableTableColumnList(string $table, string $database, array $rows): array
     {
         $list = [];
-        foreach ($tableColumns as $tableColumn) {
-            $column = $this->_getPortableTableColumnDefinition($tableColumn);
+        foreach ($rows as $row) {
+            $column = $this->_getPortableTableColumnDefinition($row);
 
             $name        = strtolower($column->getQuotedName($this->platform));
             $list[$name] = $column;
@@ -755,18 +755,18 @@ abstract class AbstractSchemaManager
     /**
      * Aggregates and groups the index results according to the required data result.
      *
-     * @param array<int, array<string, mixed>> $tableIndexes
+     * @param array<array<string, mixed>> $rows
      *
      * @return array<string, Index>
      *
      * @throws Exception
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
         $result = [];
-        foreach ($tableIndexes as $tableIndex) {
-            $indexName = $keyName = $tableIndex['key_name'];
-            if ($tableIndex['primary']) {
+        foreach ($rows as $row) {
+            $indexName = $keyName = $row['key_name'];
+            if ($row['primary']) {
                 $keyName = 'primary';
             }
 
@@ -777,22 +777,22 @@ abstract class AbstractSchemaManager
                     'lengths' => [],
                 ];
 
-                if (isset($tableIndex['where'])) {
-                    $options['where'] = $tableIndex['where'];
+                if (isset($row['where'])) {
+                    $options['where'] = $row['where'];
                 }
 
                 $result[$keyName] = [
                     'name' => $indexName,
                     'columns' => [],
-                    'unique' => ! $tableIndex['non_unique'],
-                    'primary' => $tableIndex['primary'],
-                    'flags' => $tableIndex['flags'] ?? [],
+                    'unique' => ! $row['non_unique'],
+                    'primary' => $row['primary'],
+                    'flags' => $row['flags'] ?? [],
                     'options' => $options,
                 ];
             }
 
-            $result[$keyName]['columns'][]            = $tableIndex['column_name'];
-            $result[$keyName]['options']['lengths'][] = $tableIndex['length'] ?? null;
+            $result[$keyName]['columns'][]            = $row['column_name'];
+            $result[$keyName]['options']['lengths'][] = $row['length'] ?? null;
         }
 
         $indexes = [];
@@ -817,15 +817,15 @@ abstract class AbstractSchemaManager
     abstract protected function _getPortableViewDefinition(array $view): View;
 
     /**
-     * @param array<int|string, array<string, mixed>> $tableForeignKeys
+     * @param array<array<string, mixed>> $rows
      *
      * @return array<int, ForeignKeyConstraint>
      */
-    protected function _getPortableTableForeignKeysList(array $tableForeignKeys): array
+    protected function _getPortableTableForeignKeysList(array $rows): array
     {
         $list = [];
 
-        foreach ($tableForeignKeys as $value) {
+        foreach ($rows as $value) {
             $list[] = $this->_getPortableTableForeignKeyDefinition($value);
         }
 

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -116,14 +116,14 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
-        foreach ($tableIndexes as &$tableIndexRow) {
-            $tableIndexRow            = array_change_key_case($tableIndexRow, CASE_LOWER);
-            $tableIndexRow['primary'] = (bool) $tableIndexRow['primary'];
+        foreach ($rows as &$row) {
+            $row            = array_change_key_case($row, CASE_LOWER);
+            $row['primary'] = (bool) $row['primary'];
         }
 
-        return parent::_getPortableTableIndexesList($tableIndexes, $tableName);
+        return parent::_getPortableTableIndexesList($rows, $tableName);
     }
 
     /**
@@ -143,11 +143,11 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableForeignKeysList(array $tableForeignKeys): array
+    protected function _getPortableTableForeignKeysList(array $rows): array
     {
         $foreignKeys = [];
 
-        foreach ($tableForeignKeys as $tableForeignKey) {
+        foreach ($rows as $tableForeignKey) {
             $tableForeignKey = array_change_key_case($tableForeignKey, CASE_LOWER);
 
             if (! isset($foreignKeys[$tableForeignKey['index_name']])) {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
@@ -30,8 +29,6 @@ class DB2SchemaManager extends AbstractSchemaManager
 {
     /**
      * {@inheritDoc}
-     *
-     * @throws Exception
      */
     protected function _getPortableTableColumnDefinition(array $tableColumn): Column
     {

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -79,31 +79,31 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
-        foreach ($tableIndexes as $k => $v) {
-            $v = array_change_key_case($v, CASE_LOWER);
-            if ($v['key_name'] === 'PRIMARY') {
-                $v['primary'] = true;
+        foreach ($rows as $i => $row) {
+            $row = array_change_key_case($row, CASE_LOWER);
+            if ($row['key_name'] === 'PRIMARY') {
+                $row['primary'] = true;
             } else {
-                $v['primary'] = false;
+                $row['primary'] = false;
             }
 
-            if (str_contains($v['index_type'], 'FULLTEXT')) {
-                $v['flags'] = ['FULLTEXT'];
-            } elseif (str_contains($v['index_type'], 'SPATIAL')) {
-                $v['flags'] = ['SPATIAL'];
+            if (str_contains($row['index_type'], 'FULLTEXT')) {
+                $row['flags'] = ['FULLTEXT'];
+            } elseif (str_contains($row['index_type'], 'SPATIAL')) {
+                $row['flags'] = ['SPATIAL'];
             }
 
             // Ignore prohibited prefix `length` for spatial index
-            if (! str_contains($v['index_type'], 'SPATIAL')) {
-                $v['length'] = isset($v['sub_part']) ? (int) $v['sub_part'] : null;
+            if (! str_contains($row['index_type'], 'SPATIAL')) {
+                $row['length'] = isset($row['sub_part']) ? (int) $row['sub_part'] : null;
             }
 
-            $tableIndexes[$k] = $v;
+            $rows[$i] = $row;
         }
 
-        return parent::_getPortableTableIndexesList($tableIndexes, $tableName);
+        return parent::_getPortableTableIndexesList($rows, $tableName);
     }
 
     /**
@@ -288,32 +288,32 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableForeignKeysList(array $tableForeignKeys): array
+    protected function _getPortableTableForeignKeysList(array $rows): array
     {
         $list = [];
-        foreach ($tableForeignKeys as $value) {
-            $value = array_change_key_case($value, CASE_LOWER);
-            if (! isset($list[$value['constraint_name']])) {
-                if (! isset($value['delete_rule']) || $value['delete_rule'] === 'RESTRICT') {
-                    $value['delete_rule'] = null;
+        foreach ($rows as $row) {
+            $row = array_change_key_case($row, CASE_LOWER);
+            if (! isset($list[$row['constraint_name']])) {
+                if (! isset($row['delete_rule']) || $row['delete_rule'] === 'RESTRICT') {
+                    $row['delete_rule'] = null;
                 }
 
-                if (! isset($value['update_rule']) || $value['update_rule'] === 'RESTRICT') {
-                    $value['update_rule'] = null;
+                if (! isset($row['update_rule']) || $row['update_rule'] === 'RESTRICT') {
+                    $row['update_rule'] = null;
                 }
 
-                $list[$value['constraint_name']] = [
-                    'name' => $value['constraint_name'],
+                $list[$row['constraint_name']] = [
+                    'name' => $row['constraint_name'],
                     'local' => [],
                     'foreign' => [],
-                    'foreignTable' => $value['referenced_table_name'],
-                    'onDelete' => $value['delete_rule'],
-                    'onUpdate' => $value['update_rule'],
+                    'foreignTable' => $row['referenced_table_name'],
+                    'onDelete' => $row['delete_rule'],
+                    'onUpdate' => $row['update_rule'],
                 ];
             }
 
-            $list[$value['constraint_name']]['local'][]   = $value['column_name'];
-            $list[$value['constraint_name']]['foreign'][] = $value['referenced_column_name'];
+            $list[$row['constraint_name']]['local'][]   = $row['column_name'];
+            $list[$row['constraint_name']]['foreign'][] = $row['referenced_column_name'];
         }
 
         return parent::_getPortableTableForeignKeysList($list);

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -212,8 +212,8 @@ class OracleSchemaManager extends AbstractSchemaManager
                 ];
             }
 
-            $localColumn   = $row['local_column'];
-            $foreignColumn = $row['foreign_column'];
+            $localColumn   = $this->getQuotedIdentifierName($row['local_column']);
+            $foreignColumn = $this->getQuotedIdentifierName($row['foreign_column']);
 
             $list[$row['constraint_name']]['local'][]   = $localColumn;
             $list[$row['constraint_name']]['foreign'][] = $foreignColumn;

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -55,26 +55,26 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
         $indexBuffer = [];
-        foreach ($tableIndexes as $tableIndex) {
-            $tableIndex = array_change_key_case($tableIndex, CASE_LOWER);
+        foreach ($rows as $row) {
+            $row = array_change_key_case($row, CASE_LOWER);
 
-            $keyName = strtolower($tableIndex['name']);
+            $keyName = strtolower($row['name']);
             $buffer  = [];
 
-            if ($tableIndex['is_primary'] === 'P') {
+            if ($row['is_primary'] === 'P') {
                 $keyName              = 'primary';
                 $buffer['primary']    = true;
                 $buffer['non_unique'] = false;
             } else {
                 $buffer['primary']    = false;
-                $buffer['non_unique'] = ! $tableIndex['is_unique'];
+                $buffer['non_unique'] = ! $row['is_unique'];
             }
 
             $buffer['key_name']    = $keyName;
-            $buffer['column_name'] = $this->getQuotedIdentifierName($tableIndex['column_name']);
+            $buffer['column_name'] = $this->getQuotedIdentifierName($row['column_name']);
             $indexBuffer[]         = $buffer;
         }
 
@@ -191,32 +191,32 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableForeignKeysList(array $tableForeignKeys): array
+    protected function _getPortableTableForeignKeysList(array $rows): array
     {
         $list = [];
-        foreach ($tableForeignKeys as $value) {
-            $value = array_change_key_case($value, CASE_LOWER);
-            if (! isset($list[$value['constraint_name']])) {
-                if ($value['delete_rule'] === 'NO ACTION') {
-                    $value['delete_rule'] = null;
+        foreach ($rows as $row) {
+            $row = array_change_key_case($row, CASE_LOWER);
+            if (! isset($list[$row['constraint_name']])) {
+                if ($row['delete_rule'] === 'NO ACTION') {
+                    $row['delete_rule'] = null;
                 }
 
-                $list[$value['constraint_name']] = [
-                    'name' => $this->getQuotedIdentifierName($value['constraint_name']),
+                $list[$row['constraint_name']] = [
+                    'name' => $this->getQuotedIdentifierName($row['constraint_name']),
                     'local' => [],
                     'foreign' => [],
-                    'foreignTable' => $value['references_table'],
-                    'onDelete' => $value['delete_rule'],
-                    'deferrable' => $value['deferrable'] === 'DEFERRABLE',
-                    'deferred' => $value['deferred'] === 'DEFERRED',
+                    'foreignTable' => $row['references_table'],
+                    'onDelete' => $row['delete_rule'],
+                    'deferrable' => $row['deferrable'] === 'DEFERRABLE',
+                    'deferred' => $row['deferred'] === 'DEFERRED',
                 ];
             }
 
-            $localColumn   = $this->getQuotedIdentifierName($value['local_column']);
-            $foreignColumn = $this->getQuotedIdentifierName($value['foreign_column']);
+            $localColumn   = $row['local_column'];
+            $foreignColumn = $row['foreign_column'];
 
-            $list[$value['constraint_name']]['local'][]   = $localColumn;
-            $list[$value['constraint_name']]['foreign'][] = $foreignColumn;
+            $list[$row['constraint_name']]['local'][]   = $localColumn;
+            $list[$row['constraint_name']]['foreign'][] = $foreignColumn;
         }
 
         return parent::_getPortableTableForeignKeysList($list);

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -158,10 +158,10 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
         $buffer = [];
-        foreach ($tableIndexes as $row) {
+        foreach ($rows as $row) {
             $colNumbers    = array_map('intval', explode(' ', $row['indkey']));
             $columnNameSql = sprintf(
                 'SELECT attnum, attname FROM pg_attribute WHERE attrelid=%d AND attnum IN (%s) ORDER BY attnum ASC',

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -180,27 +180,27 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableForeignKeysList(array $tableForeignKeys): array
+    protected function _getPortableTableForeignKeysList(array $rows): array
     {
         $foreignKeys = [];
 
-        foreach ($tableForeignKeys as $tableForeignKey) {
-            $name = $tableForeignKey['ForeignKey'];
+        foreach ($rows as $row) {
+            $name = $row['ForeignKey'];
 
             if (! isset($foreignKeys[$name])) {
                 $foreignKeys[$name] = [
-                    'local_columns' => [$tableForeignKey['ColumnName']],
-                    'foreign_table' => $tableForeignKey['ReferenceTableName'],
-                    'foreign_columns' => [$tableForeignKey['ReferenceColumnName']],
+                    'local_columns' => [$row['ColumnName']],
+                    'foreign_table' => $row['ReferenceTableName'],
+                    'foreign_columns' => [$row['ReferenceColumnName']],
                     'name' => $name,
                     'options' => [
-                        'onUpdate' => str_replace('_', ' ', $tableForeignKey['update_referential_action_desc']),
-                        'onDelete' => str_replace('_', ' ', $tableForeignKey['delete_referential_action_desc']),
+                        'onUpdate' => str_replace('_', ' ', $row['update_referential_action_desc']),
+                        'onDelete' => str_replace('_', ' ', $row['delete_referential_action_desc']),
                     ],
                 ];
             } else {
-                $foreignKeys[$name]['local_columns'][]   = $tableForeignKey['ColumnName'];
-                $foreignKeys[$name]['foreign_columns'][] = $tableForeignKey['ReferenceColumnName'];
+                $foreignKeys[$name]['local_columns'][]   = $row['ColumnName'];
+                $foreignKeys[$name]['foreign_columns'][] = $row['ReferenceColumnName'];
             }
         }
 
@@ -210,15 +210,15 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $tableIndexes, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
     {
-        foreach ($tableIndexes as &$tableIndex) {
-            $tableIndex['non_unique'] = (bool) $tableIndex['non_unique'];
-            $tableIndex['primary']    = (bool) $tableIndex['primary'];
-            $tableIndex['flags']      = $tableIndex['flags'] ? [$tableIndex['flags']] : null;
+        foreach ($rows as &$row) {
+            $row['non_unique'] = (bool) $row['non_unique'];
+            $row['primary']    = (bool) $row['primary'];
+            $row['flags']      = $row['flags'] ? [$row['flags']] : null;
         }
 
-        return parent::_getPortableTableIndexesList($tableIndexes, $tableName);
+        return parent::_getPortableTableIndexesList($rows, $tableName);
     }
 
     /**

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -83,8 +83,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     {
         $table = $this->normalizeName($table);
 
-        $columns = $this->selectForeignKeyColumns('main', $table)
-            ->fetchAllAssociative();
+        $columns = $this->fetchForeignKeyColumns('main', $table);
 
         if (count($columns) > 0) {
             $columns = $this->addDetailsToTableForeignKeyColumns($table, $columns);


### PR DESCRIPTION
## Background

Among others, there are two categories of the schema manager methods related to schema introspection:
1.  `select*()` – performs an SQL query to fetch the data about the schema.
2. `_getPortable*()` – performs parsing of the fetched data.

The  `select*()` ones accept the database name and table name to be introspected. The `_getPortable*()` ones accept the fetched rows to be parsed.

There are some violations of this implicit design. Specifically
1. `_getPortableTableColumnList()` also accepts `string $table`,
2. `_getPortableTableIndexesList()` also  accepts `string $tableName`.

Even though the base implementations of these methods don't use these parameters, they are required by the SQLite schema manager implementation. The reason is that, unlike other supported platforms, SQLite doesn't provide the views that could be used to fetch the metadata representing table or index columns in a single query. To work around that, the SQLite manager, while parsing already fetched metadata, fetches more by querying the database, and that's what it needs the table name for.

## The Problem

As we are transitioning to using object representation of table names, it is challenging to support passing the table name to the parsing methods. The reason is that the table name *is* available as an object if a single table is introspected (then it's passed as a argument of a schema manager's public method); but it's *not* available when the introspection results of multiple tables are being parsed. To support these signatures, we'd have to manually reconstruct those names-as-object which I'd like to avoid.

Instead, I want to refactor the SQLite implementation of methods in question so that they don't require a table name.

## The Solution

In addition to the `abstract select*()` methods, I want to introduce corresponding `fetch*()` ones which will call `select*()` and, instead of returning an SQL `Result`, would return the actual fetched data. This way, instead of implementing the catch-up fetching for SQLite in the parsing methods, we will be able to implement them in the `fetch*()` ones, which is exactly their purpose.

As a result, the table name parameters can be removed from these methods' signatures in 5.0.

### Additional considerations

The introduction of the `select*()` methods in #5268 was a good first step towards a more robust schema introspection API but it's not the final destination and it has its downsides:

1. Limited extensibility. This approach assumes that any data set can be fetched in a single query, which isn't the case for SQLite (and probably PostgreSQL).
2. As a result, the `_getPortable*()` methods, have to interact with the database and can throw runtime exceptions unrelated to parsing.
3. These interactions may result in worse introspection performance because parsing is done on a per-table or per-element basis, so the number of catch-up queries is always a function of the schema size, even if it's possible to make it _O(1)_.
4. It is impossible to statically describe the shape of the rows returned by a `select*()` method while it's possible for the `fetch*()` ones.

### Future scope
1. We can deprecate `select*()` methods in favor of the new `fetch*()` ones are more extensible.
2. I want to arrive at a dedicated interface e.g. `SchemaRepository()` which will declare these `fetch*` methods (see `fetchTableOptionsByTable()` for reference, which instead of returning intermediate associative arrays will return the resulting database objects (e.g. `Column`s). This way, the names of the selected columns, the shapes of the intermediate arrays and the parsing logic will be internal to each implementation w/o being part of the schema manager API.
3. `PostgreSQLSchemaManager::_getPortableTableIndexesList()` still performs some catch-up fetching but it's not a practical problem at this point.