### PR TITLE
Remove SQLite "schema emulation" leftovers

### DIFF
--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -565,7 +565,7 @@ SQL;
 
         if ($tableName !== null) {
             $conditions[] = 't.name = ?';
-            $params[]     = str_replace('.', '__', $tableName);
+            $params[]     = $tableName;
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, c.cid';
@@ -590,7 +590,7 @@ SQL;
 
         if ($tableName !== null) {
             $conditions[] = 't.name = ?';
-            $params[]     = str_replace('.', '__', $tableName);
+            $params[]     = $tableName;
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, i.seq';
@@ -616,7 +616,7 @@ SQL;
 
         if ($tableName !== null) {
             $conditions[] = 't.name = ?';
-            $params[]     = str_replace('.', '__', $tableName);
+            $params[]     = $tableName;
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, p.id DESC, p.seq';


### PR DESCRIPTION
The support for schema emulation was removed in https://github.com/doctrine/dbal/pull/4804.