### PR TITLE
Introduce AbstractSchemaManager::getCurrentSchemaName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `PostgreSQLSchemaManager` methods related to the current schema
+
+The following `PostgreSQLSchemaManager` methods have been deprecated:
+- `getCurrentSchema()` - use `getCurrentSchemaName()` instead
+- `determineCurrentSchema()` - use `determineCurrentSchemaName()` instead
+
 ## Deprecated using `Schema` as `AbstractAsset`
 
 Relying on the `Schema` class extending `AbstractAsset` is deprecated. Use only the methods declared immediately in

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -35,8 +35,6 @@ use const CASE_LOWER;
  */
 class PostgreSQLSchemaManager extends AbstractSchemaManager
 {
-    private ?string $currentSchema = null;
-
     /**
      * {@inheritDoc}
      */
@@ -52,27 +50,22 @@ SQL,
         );
     }
 
-    public function createSchemaConfig(): SchemaConfig
-    {
-        $config = parent::createSchemaConfig();
-
-        $config->setName($this->getCurrentSchema());
-
-        return $config;
-    }
-
     /**
      * Returns the name of the current schema.
+     *
+     * @deprecated Use {@link getCurrentSchemaName()} instead
      *
      * @throws Exception
      */
     protected function getCurrentSchema(): ?string
     {
-        return $this->currentSchema ??= $this->determineCurrentSchema();
+        return $this->getCurrentSchemaName();
     }
 
     /**
      * Determines the name of the current schema.
+     *
+     * @deprecated Use {@link determineCurrentSchemaName()} instead
      *
      * @throws Exception
      */
@@ -82,6 +75,11 @@ SQL,
         assert(is_string($currentSchema));
 
         return $currentSchema;
+    }
+
+    protected function determineCurrentSchemaName(): ?string
+    {
+        return $this->determineCurrentSchema();
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -240,7 +240,7 @@ SQL,
      */
     protected function _getPortableTableDefinition(array $table): string
     {
-        if ($table['schema_name'] !== 'dbo') {
+        if ($table['schema_name'] !== $this->getCurrentSchemaName()) {
             return $table['schema_name'] . '.' . $table['table_name'];
         }
 
@@ -273,15 +273,6 @@ SQL,
         );
     }
 
-    public function createSchemaConfig(): SchemaConfig
-    {
-        $config = parent::createSchemaConfig();
-
-        $config->setName($this->getCurrentSchemaName());
-
-        return $config;
-    }
-
     /** @throws Exception */
     private function getDatabaseCollation(): string
     {
@@ -300,8 +291,7 @@ SQL,
         return $this->databaseCollation;
     }
 
-    /** @throws Exception */
-    private function getCurrentSchemaName(): ?string
+    protected function determineCurrentSchemaName(): ?string
     {
         $schemaName = $this->connection->fetchOne('SELECT SCHEMA_NAME()');
         assert($schemaName !== false);

--- a/tests/Functional/Schema/Db2SchemaManagerTest.php
+++ b/tests/Functional/Schema/Db2SchemaManagerTest.php
@@ -21,4 +21,9 @@ class Db2SchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->schemaManager->listDatabases();
     }
+
+    public function getExpectedDefaultSchemaName(): ?string
+    {
+        return null;
+    }
 }

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -615,4 +615,9 @@ SQL;
             ' The column should be changed from VARCAHR TO INT',
         );
     }
+
+    public function getExpectedDefaultSchemaName(): ?string
+    {
+        return null;
+    }
 }

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -278,4 +278,9 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $columns = $schemaManager->listTableColumns('"tester"');
         self::assertCount(1, $columns);
     }
+
+    public function getExpectedDefaultSchemaName(): ?string
+    {
+        return null;
+    }
 }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -608,6 +608,12 @@ SQL;
         ));
         self::assertSame(1, $partitionsCount);
     }
+
+    /** @link https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC */
+    public function getExpectedDefaultSchemaName(): string
+    {
+        return 'public';
+    }
 }
 
 class MoneyType extends Type

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -144,4 +144,10 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertSame(-1, $table->getColumn('col_nvarchar_max')->getLength());
         self::assertSame(128, $table->getColumn('col_nvarchar')->getLength());
     }
+
+    /** @link https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/ownership-and-user-schema-separation?view=sql-server-ver16#the-dbo-schema */
+    public function getExpectedDefaultSchemaName(): string
+    {
+        return 'dbo';
+    }
 }

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -442,4 +442,9 @@ SQL;
         $table = $this->schemaManager->introspectTable('table_with_comment');
         self::assertSame('This is a comment', $table->getComment());
     }
+
+    public function getExpectedDefaultSchemaName(): ?string
+    {
+        return null;
+    }
 }

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1340,14 +1340,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         return null;
     }
-}
 
-interface ListTableColumnsDispatchEventListener
-{
-    public function onSchemaColumnDefinition(): void;
-}
+    /** @throws Exception */
+    public function testDefaultSchemaName(): void
+    {
+        self::assertSame(
+            $this->getExpectedDefaultSchemaName(),
+            $this->schemaManager->createSchemaConfig()->getName(),
+        );
+    }
 
-interface ListTableIndexesDispatchEventListener
-{
-    public function onSchemaIndexDefinition(): void;
+    abstract public function getExpectedDefaultSchemaName(): ?string;
 }


### PR DESCRIPTION
Currently, the logic of building qualified or unqualified table/view/sequence names during schema introspection is scattered across schema managers implementations an is inconsistent. On the one hand, this is okay since some database platforms support schemas, and others don't. However, at a high level, the introspection logic it the same for all platforms:

1. Query the introspection schema and group rows by the table to which they belong.
2. If the platform supports schemas, do not include the default schema into the name (so that `accounts` remains represented as `accounts`, not `public.accounts` on Postgres or `dbo.accounts` on SQL Server).

As part of the work on on introspecting table names as objects, I want to make this logic explicitly written in the code. And for that, the API of all schema managers should be consistent.