### PR TITLE
Remove unused AbstractSchemaManager method parameters

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -122,8 +122,6 @@ abstract class AbstractSchemaManager
         $database = $this->getDatabase(__METHOD__);
 
         return $this->_getPortableTableColumnList(
-            $table,
-            $database,
             $this->fetchTableColumns($database, $this->normalizeName($table)),
         );
     }
@@ -144,7 +142,6 @@ abstract class AbstractSchemaManager
 
         return $this->_getPortableTableIndexesList(
             $this->fetchIndexColumns($database, $table),
-            $table,
         );
     }
 
@@ -229,9 +226,9 @@ abstract class AbstractSchemaManager
 
             $editor = Table::editor()
                 ->setName($tableName)
-                ->setColumns($this->_getPortableTableColumnList($tableName, $database, $tableColumns))
+                ->setColumns($this->_getPortableTableColumnList($tableColumns))
                 ->setIndexes(
-                    $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? [], $tableName),
+                    $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? []),
                 );
 
             if (isset($foreignKeyColumnsByTable[$tableName])) {
@@ -765,7 +762,7 @@ abstract class AbstractSchemaManager
      *
      * @return array<string, Column>
      */
-    protected function _getPortableTableColumnList(string $table, string $database, array $rows): array
+    protected function _getPortableTableColumnList(array $rows): array
     {
         $list = [];
         foreach ($rows as $row) {
@@ -791,7 +788,7 @@ abstract class AbstractSchemaManager
      *
      * @return array<string, Index>
      */
-    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows): array
     {
         $result = [];
         foreach ($rows as $row) {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -113,14 +113,14 @@ class DB2SchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows): array
     {
         foreach ($rows as &$row) {
             $row            = array_change_key_case($row, CASE_LOWER);
             $row['primary'] = (bool) $row['primary'];
         }
 
-        return parent::_getPortableTableIndexesList($rows, $tableName);
+        return parent::_getPortableTableIndexesList($rows);
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -79,7 +79,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows): array
     {
         foreach ($rows as $i => $row) {
             $row = array_change_key_case($row, CASE_LOWER);
@@ -103,7 +103,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $rows[$i] = $row;
         }
 
-        return parent::_getPortableTableIndexesList($rows, $tableName);
+        return parent::_getPortableTableIndexesList($rows);
     }
 
     /**

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -55,7 +55,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows): array
     {
         $indexBuffer = [];
         foreach ($rows as $row) {
@@ -78,7 +78,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             $indexBuffer[]         = $buffer;
         }
 
-        return parent::_getPortableTableIndexesList($indexBuffer, $tableName);
+        return parent::_getPortableTableIndexesList($indexBuffer);
     }
 
     /**

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -176,7 +176,7 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows): array
     {
         $buffer = [];
         foreach ($rows as $row) {
@@ -207,7 +207,7 @@ SQL,
             }
         }
 
-        return parent::_getPortableTableIndexesList($buffer, $tableName);
+        return parent::_getPortableTableIndexesList($buffer);
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -208,7 +208,7 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function _getPortableTableIndexesList(array $rows, string $tableName): array
+    protected function _getPortableTableIndexesList(array $rows): array
     {
         foreach ($rows as &$row) {
             $row['non_unique'] = (bool) $row['non_unique'];
@@ -216,7 +216,7 @@ SQL,
             $row['flags']      = $row['flags'] ? [$row['flags']] : null;
         }
 
-        return parent::_getPortableTableIndexesList($rows, $tableName);
+        return parent::_getPortableTableIndexesList($rows);
     }
 
     /**


### PR DESCRIPTION
This cleanup is possible as a result of https://github.com/doctrine/dbal/pull/6744.

The affected methods are all protected, and I haven't seen people maintaining their custom platforms or schema managers, so I think it's safe to just modify the signatures w/o documenting it or providing an upgrade path.