### PR TITLE
Use function db2_field_name

### DIFF
--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Exception\InvalidColumnIndex;
 
 use function db2_fetch_array;
 use function db2_fetch_assoc;
+use function db2_field_name;
 use function db2_free_result;
 use function db2_num_fields;
 use function db2_num_rows;


### PR DESCRIPTION
This is a fix for a coding style violation that can be detected only if the `ibm_db2` extension is loaded.

Ideally, we should run PHP_CodeSniffer with all stubs loaded, but given how insignificant and rare this violation is, I think we're good for now.