### PR TITLE
Fix introspection of table options in non-default schemas

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -38,6 +38,7 @@ use function is_string;
 use function preg_match;
 use function preg_match_all;
 use function sprintf;
+use function str_contains;
 use function str_ends_with;
 use function str_replace;
 use function str_starts_with;
@@ -1777,11 +1778,17 @@ class SQLServerPlatform extends AbstractPlatform
 
     protected function getCommentOnTableSQL(string $tableName, ?string $comment): string
     {
+        if (str_contains($tableName, '.')) {
+            [$schemaName, $tableName] = explode('.', $tableName);
+        } else {
+            $schemaName = 'dbo';
+        }
+
         return $this->getAddExtendedPropertySQL(
             'MS_Description',
             $comment,
             'SCHEMA',
-            $this->quoteStringLiteral('dbo'),
+            $this->quoteStringLiteral($schemaName),
             'TABLE',
             $this->quoteStringLiteral($this->unquoteSingleIdentifier($tableName)),
         );

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -726,7 +726,8 @@ SQL;
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
         $sql = <<<'SQL'
-SELECT c.relname,
+SELECT n.nspname AS schema_name,
+       c.relname AS table_name,
        CASE c.relpersistence WHEN 'u' THEN true ELSE false END as unlogged,
        obj_description(c.oid, 'pg_class') AS comment
 FROM pg_class c
@@ -738,7 +739,12 @@ SQL;
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions);
 
-        return $this->_conn->fetchAllAssociativeIndexed($sql);
+        $tableOptions = [];
+        foreach ($this->_conn->iterateAssociative($sql) as $row) {
+            $tableOptions[$this->_getPortableTableDefinition($row)] = $row;
+        }
+
+        return $tableOptions;
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -227,9 +227,15 @@ SQL,
             $name = $tableForeignKey['ForeignKey'];
 
             if (! isset($foreignKeys[$name])) {
+                $referencedTableName = $tableForeignKey['ReferenceTableName'];
+
+                if ($tableForeignKey['ReferenceSchemaName'] !== 'dbo') {
+                    $referencedTableName = $tableForeignKey['ReferenceSchemaName'] . '.' . $referencedTableName;
+                }
+
                 $foreignKeys[$name] = [
                     'local_columns' => [$tableForeignKey['ColumnName']],
-                    'foreign_table' => $tableForeignKey['ReferenceTableName'],
+                    'foreign_table' => $referencedTableName,
                     'foreign_columns' => [$tableForeignKey['ReferenceColumnName']],
                     'name' => $name,
                     'options' => [
@@ -556,31 +562,29 @@ SQL;
     {
         $sql = <<<'SQL'
           SELECT
-            tbl.name,
+            scm.name AS schema_name,
+            tbl.name AS table_name,
             p.value AS [table_comment]
           FROM
             sys.tables AS tbl
+            JOIN sys.schemas AS scm
+              ON tbl.schema_id = scm.schema_id
             INNER JOIN sys.extended_properties AS p ON p.major_id=tbl.object_id AND p.minor_id=0 AND p.class=1
 SQL;
 
-        $conditions = ["SCHEMA_NAME(tbl.schema_id) = N'dbo'", "p.name = N'MS_Description'"];
-        $params     = [];
+        $conditions = ["p.name = N'MS_Description'"];
 
         if ($tableName !== null) {
-            $conditions[] = "tbl.name = N'" . $tableName . "'";
+            $conditions[] = $this->getTableWhereClause($tableName, 'scm.name', 'tbl.name');
         }
 
         $sql .= ' WHERE ' . implode(' AND ', $conditions);
 
-        /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->_conn->executeQuery($sql, $params)
-            ->fetchAllAssociativeIndexed();
-
         $tableOptions = [];
-        foreach ($metadata as $table => $data) {
+        foreach ($this->_conn->iterateAssociative($sql) as $data) {
             $data = array_change_key_case($data, CASE_LOWER);
 
-            $tableOptions[$table] = [
+            $tableOptions[$this->_getPortableTableDefinition($data)] = [
                 'comment' => $data['table_comment'],
             ];
         }

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1813,6 +1813,49 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         return null;
     }
+
+    public function testTableWithSchema(): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
+            self::markTestSkipped('The currently used database platform does not support schemas.');
+        }
+
+        $this->connection->executeStatement('CREATE SCHEMA nested');
+
+        $nestedRelatedTable = new Table('nested.schemarelated');
+        $column             = $nestedRelatedTable->addColumn('id', Types::INTEGER);
+        $column->setAutoincrement(true);
+        $nestedRelatedTable->setPrimaryKey(['id']);
+
+        $nestedSchemaTable = new Table('nested.schematable');
+        $column            = $nestedSchemaTable->addColumn('id', Types::INTEGER);
+        $column->setAutoincrement(true);
+        $nestedSchemaTable->setPrimaryKey(['id']);
+        $nestedSchemaTable->addForeignKeyConstraint($nestedRelatedTable->getName(), ['id'], ['id']);
+        $nestedSchemaTable->setComment('This is a comment');
+
+        $this->schemaManager->createTable($nestedRelatedTable);
+        $this->schemaManager->createTable($nestedSchemaTable);
+
+        $tableNames = $this->schemaManager->listTableNames();
+        self::assertContains('nested.schematable', $tableNames);
+
+        $tables = $this->schemaManager->listTables();
+        self::assertNotNull($this->findTableByName($tables, 'nested.schematable'));
+
+        $nestedSchemaTable = $this->schemaManager->introspectTable('nested.schematable');
+        self::assertTrue($nestedSchemaTable->hasColumn('id'));
+
+        $primaryKey = $nestedSchemaTable->getPrimaryKey();
+        self::assertNotNull($primaryKey);
+        self::assertEquals(['id'], $primaryKey->getColumns());
+
+        $relatedFks = array_values($nestedSchemaTable->getForeignKeys());
+        self::assertCount(1, $relatedFks);
+        $relatedFk = $relatedFks[0];
+        self::assertEquals('nested.schemarelated', $relatedFk->getForeignTableName());
+        self::assertEquals('This is a comment', $nestedSchemaTable->getComment());
+    }
 }
 
 interface ListTableColumnsDispatchEventListener


### PR DESCRIPTION
When introspecting table options, the PostgreSQL and SQL Server schema managers do not take the schema name into account, so all selected options are mistakenly attributed to the table with the same unqualified name in the default schema.

Additionally, the SQL Server platform cannot create tables with comments in the non-default schema.