### PR TITLE
Refactor building schema introspection queries

### DIFF
--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -23,6 +23,8 @@ use const CASE_LOWER;
 /**
  * IBM Db2 Schema Manager.
  *
+ * @link https://www.ibm.com/docs/en/db2/11.5?topic=sql-catalog-views
+ *
  * @extends AbstractSchemaManager<DB2Platform>
  */
 class DB2SchemaManager extends AbstractSchemaManager
@@ -194,10 +196,10 @@ class DB2SchemaManager extends AbstractSchemaManager
     protected function selectTableNames(string $databaseName): Result
     {
         $sql = <<<'SQL'
-SELECT NAME
-FROM SYSIBM.SYSTABLES
+SELECT TABNAME AS NAME
+FROM SYSCAT.TABLES
 WHERE TYPE = 'T'
-  AND CREATOR = ?
+  AND TABSCHEMA = ?
 SQL;
 
         return $this->connection->executeQuery($sql, [$databaseName]);
@@ -336,17 +338,17 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
-        $sql = 'SELECT NAME, REMARKS';
+        $sql = 'SELECT TABNAME AS NAME, REMARKS';
 
         $conditions = [];
         $params     = [];
 
         if ($tableName !== null) {
-            $conditions[] = 'NAME = ?';
+            $conditions[] = 'TABNAME = ?';
             $params[]     = $tableName;
         }
 
-        $sql .= ' FROM SYSIBM.SYSTABLES';
+        $sql .= ' FROM SYSCAT.TABLES';
 
         if ($conditions !== []) {
             $sql .= ' WHERE ' . implode(' AND ', $conditions);

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -438,7 +438,7 @@ SQL;
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT DISTINCT';
+        $sql = 'SELECT';
 
         if ($tableName === null) {
             $sql .= ' k.TABLE_NAME,';

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -26,6 +26,7 @@ use function implode;
 use function is_string;
 use function preg_match;
 use function preg_match_all;
+use function sprintf;
 use function str_contains;
 use function strtok;
 use function strtolower;
@@ -367,17 +368,23 @@ SQL;
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $columnTypeSQL = $this->platform->getColumnTypeSQLSnippet('c', $databaseName);
+        // The schema name is passed multiple times as a literal in the WHERE clause instead of using a JOIN condition
+        // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
+        // caused by https://bugs.mysql.com/bug.php?id=81347
+        $conditions = ['c.TABLE_SCHEMA = ?', 't.TABLE_SCHEMA = ?'];
+        $params     = [$databaseName, $databaseName];
 
-        $sql = 'SELECT';
-
-        if ($tableName === null) {
-            $sql .= ' c.TABLE_NAME,';
+        if ($tableName !== null) {
+            $conditions[] = 't.TABLE_NAME = ?';
+            $params[]     = $tableName;
         }
 
-        $sql .= <<<SQL
+        $sql = sprintf(
+            <<<'SQL'
+SELECT
+       c.TABLE_NAME,
        c.COLUMN_NAME        AS field,
-       $columnTypeSQL       AS type,
+       %s                   AS type,
        c.IS_NULLABLE        AS `null`,
        c.COLUMN_KEY         AS `key`,
        c.COLUMN_DEFAULT     AS `default`,
@@ -388,41 +395,20 @@ SQL;
 FROM information_schema.COLUMNS c
     INNER JOIN information_schema.TABLES t
         ON t.TABLE_NAME = c.TABLE_NAME
-SQL;
-
-        // The schema name is passed multiple times as a literal in the WHERE clause instead of using a JOIN condition
-        // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
-        // caused by https://bugs.mysql.com/bug.php?id=81347
-        $conditions = ['c.TABLE_SCHEMA = ?', 't.TABLE_SCHEMA = ?', "t.TABLE_TYPE = 'BASE TABLE'"];
-        $params     = [$databaseName, $databaseName];
-
-        if ($tableName !== null) {
-            $conditions[] = 't.TABLE_NAME = ?';
-            $params[]     = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY ORDINAL_POSITION';
+ WHERE %s
+   AND t.TABLE_TYPE = 'BASE TABLE'
+ORDER BY c.TABLE_NAME,
+         c.ORDINAL_POSITION
+SQL,
+            $this->platform->getColumnTypeSQLSnippet('c', $databaseName),
+            implode(' AND ', $conditions),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
-
-        if ($tableName === null) {
-            $sql .= ' TABLE_NAME,';
-        }
-
-        $sql .= <<<'SQL'
-        NON_UNIQUE  AS Non_Unique,
-        INDEX_NAME  AS Key_name,
-        COLUMN_NAME AS Column_Name,
-        SUB_PART    AS Sub_Part,
-        INDEX_TYPE  AS Index_Type
-FROM information_schema.STATISTICS
-SQL;
-
         $conditions = ['TABLE_SCHEMA = ?'];
         $params     = [$databaseName];
 
@@ -431,20 +417,43 @@ SQL;
             $params[]     = $tableName;
         }
 
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY SEQ_IN_INDEX';
+        $sql = sprintf(
+            <<<'SQL'
+SELECT
+        TABLE_NAME,
+        NON_UNIQUE  AS Non_Unique,
+        INDEX_NAME  AS Key_name,
+        COLUMN_NAME AS Column_Name,
+        SUB_PART    AS Sub_Part,
+        INDEX_TYPE  AS Index_Type
+FROM information_schema.STATISTICS
+WHERE %s
+ORDER BY TABLE_NAME,
+         SEQ_IN_INDEX
+SQL,
+            implode(' AND ', $conditions),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        // The schema name is passed multiple times in the WHERE clause instead of using a JOIN condition
+        // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
+        // caused by https://bugs.mysql.com/bug.php?id=81347
+        $conditions = ['k.TABLE_SCHEMA = ?', 'c.CONSTRAINT_SCHEMA = ?'];
+        $params     = [$databaseName, $databaseName];
 
-        if ($tableName === null) {
-            $sql .= ' k.TABLE_NAME,';
+        if ($tableName !== null) {
+            $conditions[] = 'k.TABLE_NAME = ?';
+            $params[]     = $tableName;
         }
 
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+SELECT
+            k.TABLE_NAME,
             k.CONSTRAINT_NAME,
             k.COLUMN_NAME,
             k.REFERENCED_TABLE_NAME,
@@ -456,25 +465,14 @@ FROM information_schema.key_column_usage k
 INNER JOIN information_schema.referential_constraints c
 ON c.CONSTRAINT_NAME = k.CONSTRAINT_NAME
 AND c.TABLE_NAME = k.TABLE_NAME
-SQL;
-
-        $conditions = ['k.TABLE_SCHEMA = ?'];
-        $params     = [$databaseName];
-
-        if ($tableName !== null) {
-            $conditions[] = 'k.TABLE_NAME = ?';
-            $params[]     = $tableName;
-        }
-
-        // The schema name is passed multiple times in the WHERE clause instead of using a JOIN condition
-        // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
-        // caused by https://bugs.mysql.com/bug.php?id=81347
-        $conditions[] = 'c.CONSTRAINT_SCHEMA = ?';
-        $params[]     = $databaseName;
-
-        $conditions[] = 'k.REFERENCED_COLUMN_NAME IS NOT NULL';
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY k.CONSTRAINT_NAME, k.ORDINAL_POSITION';
+WHERE %s
+AND k.REFERENCED_COLUMN_NAME IS NOT NULL
+ORDER BY k.TABLE_NAME,
+         k.CONSTRAINT_NAME,
+         k.ORDINAL_POSITION
+SQL,
+            implode(' AND ', $conditions),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -16,6 +16,7 @@ use function assert;
 use function implode;
 use function is_string;
 use function preg_match;
+use function sprintf;
 use function str_contains;
 use function str_replace;
 use function str_starts_with;
@@ -330,13 +331,18 @@ SQL;
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $conditions = ['C.OWNER = :OWNER'];
+        $params     = ['OWNER' => $databaseName];
 
-        if ($tableName === null) {
-            $sql .= ' C.TABLE_NAME,';
+        if ($tableName !== null) {
+            $conditions[]         = 'C.TABLE_NAME = :TABLE_NAME';
+            $params['TABLE_NAME'] = $tableName;
         }
 
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+          SELECT
+                 C.TABLE_NAME,
                  C.COLUMN_NAME,
                  C.DATA_TYPE,
                  C.DATA_DEFAULT,
@@ -354,30 +360,29 @@ SQL;
            ON D.OWNER = C.OWNER
                   AND D.TABLE_NAME = C.TABLE_NAME
                   AND D.COLUMN_NAME = C.COLUMN_NAME
-SQL;
-
-        $conditions = ['C.OWNER = :OWNER'];
-        $params     = ['OWNER' => $databaseName];
-
-        if ($tableName !== null) {
-            $conditions[]         = 'C.TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY C.COLUMN_ID';
+           WHERE %s
+        ORDER BY C.TABLE_NAME, C.COLUMN_ID
+SQL,
+            implode(' AND ', $conditions),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $conditions = ['IND_COL.INDEX_OWNER = :OWNER'];
+        $params     = ['OWNER' => $databaseName];
 
-        if ($tableName === null) {
-            $sql .= ' IND_COL.TABLE_NAME,';
+        if ($tableName !== null) {
+            $conditions[]         = 'IND_COL.TABLE_NAME = :TABLE_NAME';
+            $params['TABLE_NAME'] = $tableName;
         }
 
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+          SELECT
+                 IND_COL.TABLE_NAME,
                  IND_COL.INDEX_NAME AS NAME,
                  IND.INDEX_TYPE AS TYPE,
                  DECODE(IND.UNIQUENESS, 'NONUNIQUE', 0, 'UNIQUE', 1) AS IS_UNIQUE,
@@ -391,31 +396,31 @@ SQL;
        LEFT JOIN ALL_CONSTRAINTS CON
               ON CON.OWNER = IND_COL.INDEX_OWNER
              AND CON.INDEX_NAME = IND_COL.INDEX_NAME
-SQL;
-
-        $conditions = ['IND_COL.INDEX_OWNER = :OWNER'];
-        $params     = ['OWNER' => $databaseName];
-
-        if ($tableName !== null) {
-            $conditions[]         = 'IND_COL.TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY IND_COL.TABLE_NAME, IND_COL.INDEX_NAME'
-            . ', IND_COL.COLUMN_POSITION';
+           WHERE %s
+        ORDER BY IND_COL.TABLE_NAME,
+                 IND_COL.INDEX_NAME,
+                 IND_COL.COLUMN_POSITION
+SQL,
+            implode(' AND ', $conditions),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $conditions = ["ALC.CONSTRAINT_TYPE = 'R'", 'COLS.OWNER = :OWNER'];
+        $params     = ['OWNER' => $databaseName];
 
-        if ($tableName === null) {
-            $sql .= ' COLS.TABLE_NAME,';
+        if ($tableName !== null) {
+            $conditions[]         = 'COLS.TABLE_NAME = :TABLE_NAME';
+            $params['TABLE_NAME'] = $tableName;
         }
 
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+          SELECT
+                 COLS.TABLE_NAME,
                  ALC.CONSTRAINT_NAME,
                  ALC.DELETE_RULE,
                  ALC.DEFERRABLE,
@@ -429,18 +434,13 @@ SQL;
        LEFT JOIN ALL_CONS_COLUMNS R_COLS ON R_COLS.OWNER = ALC.R_OWNER AND
                  R_COLS.CONSTRAINT_NAME = ALC.R_CONSTRAINT_NAME AND
                  R_COLS.POSITION = COLS.POSITION
-SQL;
-
-        $conditions = ["ALC.CONSTRAINT_TYPE = 'R'", 'COLS.OWNER = :OWNER'];
-        $params     = ['OWNER' => $databaseName];
-
-        if ($tableName !== null) {
-            $conditions[]         = 'COLS.TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY COLS.TABLE_NAME, COLS.CONSTRAINT_NAME'
-            . ', COLS.POSITION';
+           WHERE %s
+        ORDER BY COLS.TABLE_NAME,
+                 COLS.CONSTRAINT_NAME,
+                 COLS.POSITION
+SQL,
+            implode(' AND ', $conditions),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
@@ -450,8 +450,6 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
-        $sql = 'SELECT TABLE_NAME, COMMENTS';
-
         $conditions = ['OWNER = :OWNER'];
         $params     = ['OWNER' => $databaseName];
 
@@ -460,19 +458,20 @@ SQL;
             $params['TABLE_NAME'] = $tableName;
         }
 
-        $sql .= ' FROM ALL_TAB_COMMENTS WHERE ' . implode(' AND ', $conditions);
-
-        /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->connection->executeQuery($sql, $params)
-            ->fetchAllAssociativeIndexed();
+        $sql = sprintf(
+            <<<'SQL'
+      SELECT TABLE_NAME,
+             COMMENTS
+        FROM ALL_TAB_COMMENTS
+      WHERE %s
+   ORDER BY TABLE_NAME
+SQL,
+            implode(' AND ', $conditions),
+        );
 
         $tableOptions = [];
-        foreach ($metadata as $table => $data) {
-            $data = array_change_key_case($data, CASE_LOWER);
-
-            $tableOptions[$table] = [
-                'comment' => $data['comments'],
-            ];
+        foreach ($this->connection->iterateKeyValue($sql, $params) as $table => $comments) {
+            $tableOptions[$table] = ['comment' => $comments];
         }
 
         return $tableOptions;

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Types\Type;
 use function array_change_key_case;
 use function array_key_exists;
 use function array_map;
-use function array_merge;
 use function assert;
 use function explode;
 use function implode;
@@ -412,13 +411,13 @@ SQL;
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT ';
+        $params = [];
 
-        if ($tableName === null) {
-            $sql .= 'c.relname AS table_name, n.nspname AS schema_name,';
-        }
-
-        $sql .= sprintf(<<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+            n.nspname AS schema_name,
+            c.relname AS table_name,
             a.attnum,
             quote_ident(a.attname) AS field,
             t.typname AS type,
@@ -450,41 +449,37 @@ SQL;
                     ON d.objid = c.oid
                         AND d.deptype = 'e'
                         AND d.classid = (SELECT oid FROM pg_class WHERE relname = 'pg_class')
-            SQL, $this->platform->getDefaultColumnValueSQLSnippet());
-
-        $conditions = array_merge([
-            'a.attnum > 0',
-            'd.refobjid IS NULL',
-
-            // 'r' for regular tables - 'p' for partitioned tables
-            "c.relkind IN('r', 'p')",
-
-            // exclude partitions (tables that inherit from partitioned tables)
-            <<<'SQL'
-            NOT EXISTS (
-                SELECT 1 
-                FROM pg_inherits 
-                INNER JOIN pg_class parent on pg_inherits.inhparent = parent.oid 
-                    AND parent.relkind = 'p' 
-                WHERE inhrelid = c.oid
-            )
+            WHERE a.attnum > 0
+                AND d.refobjid IS NULL
+                -- 'r' for regular tables - 'p' for partitioned tables
+                AND c.relkind IN('r', 'p')
+                -- exclude partitions (tables that inherit from partitioned tables)
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM pg_inherits
+                    INNER JOIN pg_class parent on pg_inherits.inhparent = parent.oid
+                        AND parent.relkind = 'p'
+                    WHERE inhrelid = c.oid
+                )
+                AND %s
+            ORDER BY a.attnum
             SQL,
-        ], $this->buildQueryConditions($tableName));
+            $this->platform->getDefaultColumnValueSQLSnippet(),
+            implode(' AND ', $this->buildQueryConditions($tableName, $params)),
+        );
 
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY a.attnum';
-
-        return $this->connection->executeQuery($sql);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $params = [];
 
-        if ($tableName === null) {
-            $sql .= ' tc.relname AS table_name, tn.nspname AS schema_name,';
-        }
-
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+                   tn.nspname AS schema_name,
+                   tc.relname AS table_name,
                    quote_ident(ic.relname) AS relname,
                    i.indisunique,
                    i.indisprimary,
@@ -497,28 +492,26 @@ SQL;
                    JOIN pg_class AS ic ON ic.oid = i.indexrelid
              WHERE ic.oid IN (
                 SELECT indexrelid
-                FROM pg_index i, pg_class c, pg_namespace n
-SQL;
+                FROM pg_index i
+                JOIN pg_class AS c ON c.oid = i.indrelid
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE %s)
+            SQL,
+            implode(' AND ', $this->buildQueryConditions($tableName, $params)),
+        );
 
-        $conditions = array_merge([
-            'c.oid = i.indrelid',
-            'c.relnamespace = n.oid',
-        ], $this->buildQueryConditions($tableName));
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ')';
-
-        return $this->connection->executeQuery($sql);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $params = [];
 
-        if ($tableName === null) {
-            $sql .= ' tc.relname AS table_name, tn.nspname AS schema_name,';
-        }
-
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+           SELECT
+                  tn.nspname AS schema_name,
+                  tc.relname AS table_name,
                   quote_ident(r.conname) as conname,
                   pg_get_constraintdef(r.oid, true) as condef,
                   r.condeferrable,
@@ -529,14 +522,16 @@ SQL;
                   WHERE r.conrelid IN
                   (
                       SELECT c.oid
-                      FROM pg_class c, pg_namespace n
-SQL;
+                      FROM pg_class c
+                        JOIN pg_namespace n
+                            ON n.oid = c.relnamespace
+                        WHERE %s)
+                  AND r.contype = 'f'
+        SQL,
+            implode(' AND ', $this->buildQueryConditions($tableName, $params)),
+        );
 
-        $conditions = array_merge(['n.oid = c.relnamespace'], $this->buildQueryConditions($tableName));
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ") AND r.contype = 'f'";
-
-        return $this->connection->executeQuery($sql);
+        return $this->connection->executeQuery($sql, $params);
     }
 
     /**
@@ -544,37 +539,47 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
-        $sql = <<<'SQL'
-SELECT c.relname,
-       CASE c.relpersistence WHEN 'u' THEN true ELSE false END as unlogged,
-       obj_description(c.oid, 'pg_class') AS comment
-FROM pg_class c
-     INNER JOIN pg_namespace n
-         ON n.oid = c.relnamespace
-SQL;
+        $params = [];
 
-        $conditions = array_merge(["c.relkind = 'r'"], $this->buildQueryConditions($tableName));
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT c.relname,
+                   CASE c.relpersistence WHEN 'u' THEN true ELSE false END as unlogged,
+                   obj_description(c.oid, 'pg_class') AS comment
+            FROM pg_class c
+                 INNER JOIN pg_namespace n
+                     ON n.oid = c.relnamespace
+            WHERE
+                  c.relkind = 'r'
+              AND %s
+            SQL,
+            implode(' AND ', $this->buildQueryConditions($tableName, $params)),
+        );
 
-        $sql .= ' WHERE ' . implode(' AND ', $conditions);
-
-        return $this->connection->fetchAllAssociativeIndexed($sql);
+        return $this->connection->fetchAllAssociativeIndexed($sql, $params);
     }
 
-    /** @return list<string> */
-    private function buildQueryConditions(?string $tableName): array
+    /**
+     * @param list<int|string> $params
+     *
+     * @return non-empty-list<string>
+     */
+    private function buildQueryConditions(?string $tableName, array &$params): array
     {
         $conditions = [];
 
         if ($tableName !== null) {
             if (str_contains($tableName, '.')) {
                 [$schemaName, $tableName] = explode('.', $tableName);
-                $conditions[]             = 'n.nspname = ' . $this->platform->quoteStringLiteral($schemaName);
+
+                $conditions[] = 'n.nspname = ?';
+                $params[]     = $schemaName;
             } else {
                 $conditions[] = 'n.nspname = ANY(current_schemas(false))';
             }
 
-            $identifier   = new Identifier($tableName);
-            $conditions[] = 'c.relname = ' . $this->platform->quoteStringLiteral($identifier->getName());
+            $conditions[] = 'c.relname = ?';
+            $params[]     = $tableName;
         }
 
         $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 
-use function array_change_key_case;
 use function assert;
 use function explode;
 use function func_get_arg;
@@ -22,8 +21,6 @@ use function sprintf;
 use function str_contains;
 use function str_replace;
 use function strtok;
-
-use const CASE_LOWER;
 
 /**
  * SQL Server Schema Manager.
@@ -303,8 +300,8 @@ SQL,
     {
         // The "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
         $sql = <<<'SQL'
-SELECT name AS table_name,
-       SCHEMA_NAME(schema_id) AS schema_name
+SELECT SCHEMA_NAME(schema_id) AS schema_name,
+       name AS table_name
 FROM sys.tables
 WHERE name != 'sysdiagrams'
 ORDER BY name
@@ -315,13 +312,13 @@ SQL;
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $params = [];
 
-        if ($tableName === null) {
-            $sql .= ' tbl.name AS table_name, scm.name AS schema_name,';
-        }
-
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+                SELECT
+                          scm.name AS schema_name,
+                          tbl.name AS table_name,
                           col.name,
                           type.name AS type,
                           col.max_length AS length,
@@ -348,30 +345,26 @@ SQL;
                 ON        tbl.object_id = prop.major_id
                 AND       col.column_id = prop.minor_id
                 AND       prop.name = 'MS_Description'
-SQL;
-
-        // The "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
-        $conditions = ["tbl.name != 'sysdiagrams'"];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = $this->getTableWhereClause($tableName, 'scm.name', 'tbl.name');
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions);
+                WHERE     %s
+                ORDER BY  scm.name,
+                          tbl.name,
+                          col.column_id
+SQL,
+            $this->getWhereClause($tableName, 'scm.name', 'tbl.name', $params),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $params = [];
 
-        if ($tableName === null) {
-            $sql .= ' tbl.name AS table_name, scm.name AS schema_name,';
-        }
-
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+              SELECT
+                       scm.name AS schema_name,
+                       tbl.name AS table_name,
                        idx.name AS key_name,
                        col.name AS column_name,
                        ~idx.is_unique AS non_unique,
@@ -392,30 +385,27 @@ SQL;
                 JOIN sys.columns AS col
                   ON idxcol.object_id = col.object_id
                  AND idxcol.column_id = col.column_id
-SQL;
-
-        $conditions = [];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = $this->getTableWhereClause($tableName, 'scm.name', 'tbl.name');
-            $sql         .= ' WHERE ' . implode(' AND ', $conditions);
-        }
-
-        $sql .= ' ORDER BY idx.index_id, idxcol.key_ordinal';
+               WHERE %s
+            ORDER BY scm.name,
+                     tbl.name,
+                     idx.index_id,
+                     idxcol.key_ordinal
+SQL,
+            $this->getWhereClause($tableName, 'scm.name', 'tbl.name', $params),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = 'SELECT';
+        $params = [];
 
-        if ($tableName === null) {
-            $sql .= ' OBJECT_NAME(f.parent_object_id) AS table_name, SCHEMA_NAME(f.schema_id) AS schema_name,';
-        }
-
-        $sql .= <<<'SQL'
+        $sql = sprintf(
+            <<<'SQL'
+                SELECT
+                SCHEMA_NAME(f.schema_id) AS schema_name,
+                OBJECT_NAME(f.parent_object_id) AS table_name,
                 f.name AS ForeignKey,
                 COL_NAME(fc.parent_object_id, fc.parent_column_id) AS ColumnName,
                 SCHEMA_NAME(t.schema_id) ReferenceSchemaName,
@@ -425,24 +415,22 @@ SQL;
                 f.update_referential_action_desc
                 FROM sys.foreign_keys AS f
                 INNER JOIN sys.foreign_key_columns AS fc
-                INNER JOIN sys.tables AS t ON t.object_id = fc.referenced_object_id
                 ON f.object_id = fc.constraint_object_id
-SQL;
-
-        $conditions = [];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = $this->getTableWhereClause(
+                INNER JOIN sys.tables AS t
+                ON t.object_id = fc.referenced_object_id
+                WHERE %s
+                ORDER BY 1,
+                         2,
+                         3,
+                         fc.constraint_column_id
+SQL,
+            $this->getWhereClause(
                 $tableName,
                 'SCHEMA_NAME(f.schema_id)',
                 'OBJECT_NAME(f.parent_object_id)',
-            );
-
-            $sql .= ' WHERE ' . implode(' AND ', $conditions);
-        }
-
-        $sql .= ' ORDER BY fc.constraint_column_id';
+                $params,
+            ),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
@@ -452,35 +440,28 @@ SQL;
      */
     protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
     {
-        $sql = <<<'SQL'
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
           SELECT
             tbl.name,
-            p.value AS [table_comment]
+            p.value
           FROM
             sys.tables AS tbl
+            JOIN sys.schemas AS scm
+              ON tbl.schema_id = scm.schema_id
             INNER JOIN sys.extended_properties AS p ON p.major_id=tbl.object_id AND p.minor_id=0 AND p.class=1
-SQL;
-
-        $conditions = ["SCHEMA_NAME(tbl.schema_id) = N'dbo'", "p.name = N'MS_Description'"];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = "tbl.name = N'" . $tableName . "'";
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions);
-
-        /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->connection->executeQuery($sql, $params)
-            ->fetchAllAssociativeIndexed();
+          WHERE
+              p.name = N'MS_Description'
+          AND %s
+SQL,
+            $this->getWhereClause($tableName, 'scm.name', 'tbl.name', $params),
+        );
 
         $tableOptions = [];
-        foreach ($metadata as $table => $data) {
-            $data = array_change_key_case($data, CASE_LOWER);
-
-            $tableOptions[$table] = [
-                'comment' => $data['table_comment'],
-            ];
+        foreach ($this->connection->iterateKeyValue($sql, $params) as $name => $value) {
+            $tableOptions[$name] = ['comment' => $value];
         }
 
         return $tableOptions;
@@ -489,21 +470,36 @@ SQL;
     /**
      * Returns the where clause to filter schema and table name in a query.
      *
-     * @param string $table        The full qualified name of the table.
-     * @param string $schemaColumn The name of the column to compare the schema to in the where clause.
-     * @param string $tableColumn  The name of the column to compare the table to in the where clause.
+     * @param ?string      $tableName    The full qualified name of the table.
+     * @param string       $schemaColumn The name of the column to compare the schema to in the where clause.
+     * @param string       $tableColumn  The name of the column to compare the table to in the where clause.
+     * @param list<string> $params
      */
-    private function getTableWhereClause(string $table, string $schemaColumn, string $tableColumn): string
-    {
-        if (str_contains($table, '.')) {
-            [$schema, $table] = explode('.', $table);
-            $schema           = $this->platform->quoteStringLiteral($schema);
-            $table            = $this->platform->quoteStringLiteral($table);
-        } else {
-            $schema = 'SCHEMA_NAME()';
-            $table  = $this->platform->quoteStringLiteral($table);
+    private function getWhereClause(
+        ?string $tableName,
+        string $schemaColumn,
+        string $tableColumn,
+        array &$params,
+    ): string {
+        $conditions = [];
+
+        if ($tableName !== null) {
+            if (str_contains($tableName, '.')) {
+                [$schemaName, $tableName] = explode('.', $tableName);
+
+                $conditions = [sprintf('%s = ?', $schemaColumn)];
+                $params[]   = $schemaName;
+            } else {
+                $conditions = [sprintf('%s = SCHEMA_NAME()', $schemaColumn)];
+            }
+
+            $conditions[] = sprintf('%s = ?', $tableColumn);
+            $params[]     = $tableName;
         }
 
-        return sprintf('(%s = %s AND %s = %s)', $tableColumn, $table, $schemaColumn, $schema);
+        // The "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
+        $conditions[] = sprintf("%s != 'sysdiagrams'", $tableColumn);
+
+        return implode(' AND ', $conditions);
     }
 }

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -412,23 +412,23 @@ SQL;
         $sql = 'SELECT';
 
         if ($tableName === null) {
-            $sql .= ' OBJECT_NAME (f.parent_object_id) AS table_name, SCHEMA_NAME(f.schema_id) AS schema_name,';
+            $sql .= ' OBJECT_NAME(f.parent_object_id) AS table_name, SCHEMA_NAME(f.schema_id) AS schema_name,';
         }
 
         $sql .= <<<'SQL'
                 f.name AS ForeignKey,
-                SCHEMA_NAME (f.SCHEMA_ID) AS SchemaName,
-                OBJECT_NAME (f.parent_object_id) AS TableName,
-                COL_NAME (fc.parent_object_id,fc.parent_column_id) AS ColumnName,
-                SCHEMA_NAME (t.SCHEMA_ID) ReferenceSchemaName,
-                OBJECT_NAME (f.referenced_object_id) AS ReferenceTableName,
-                COL_NAME(fc.referenced_object_id,fc.referenced_column_id) AS ReferenceColumnName,
+                SCHEMA_NAME(f.schema_id) AS SchemaName,
+                OBJECT_NAME(f.parent_object_id) AS TableName,
+                COL_NAME(fc.parent_object_id, fc.parent_column_id) AS ColumnName,
+                SCHEMA_NAME(t.schema_id) ReferenceSchemaName,
+                OBJECT_NAME(f.referenced_object_id) AS ReferenceTableName,
+                COL_NAME(fc.referenced_object_id, fc.referenced_column_id) AS ReferenceColumnName,
                 f.delete_referential_action_desc,
                 f.update_referential_action_desc
                 FROM sys.foreign_keys AS f
                 INNER JOIN sys.foreign_key_columns AS fc
-                INNER JOIN sys.tables AS t ON t.OBJECT_ID = fc.referenced_object_id
-                ON f.OBJECT_ID = fc.constraint_object_id
+                INNER JOIN sys.tables AS t ON t.object_id = fc.referenced_object_id
+                ON f.object_id = fc.constraint_object_id
 SQL;
 
         $conditions = [];

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -417,8 +417,6 @@ SQL;
 
         $sql .= <<<'SQL'
                 f.name AS ForeignKey,
-                SCHEMA_NAME(f.schema_id) AS SchemaName,
-                OBJECT_NAME(f.parent_object_id) AS TableName,
                 COL_NAME(fc.parent_object_id, fc.parent_column_id) AS ColumnName,
                 SCHEMA_NAME(t.schema_id) ReferenceSchemaName,
                 OBJECT_NAME(f.referenced_object_id) AS ReferenceTableName,

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -27,6 +27,7 @@ use function preg_match_all;
 use function preg_quote;
 use function preg_replace;
 use function rtrim;
+use function sprintf;
 use function str_contains;
 use function str_replace;
 use function str_starts_with;
@@ -424,9 +425,7 @@ SQL
 SELECT name AS table_name
 FROM sqlite_master
 WHERE type = 'table'
-  AND name != 'sqlite_sequence'
-  AND name != 'geometry_columns'
-  AND name != 'spatial_ref_sys'
+  AND name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')
 UNION ALL
 SELECT name
 FROM sqlite_temp_master
@@ -439,77 +438,62 @@ SQL;
 
     protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = <<<'SQL'
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
             SELECT t.name AS table_name,
                    c.*
               FROM sqlite_master t
               JOIN pragma_table_info(t.name) c
-SQL;
-
-        $conditions = [
-            "t.type = 'table'",
-            "t.name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')",
-        ];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = 't.name = ?';
-            $params[]     = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, c.cid';
+             WHERE %s
+          ORDER BY t.name,
+                   c.cid
+SQL,
+            $this->getWhereClause($tableName, $params),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = <<<'SQL'
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
             SELECT t.name AS table_name,
                    i.name,
                    i."unique"
               FROM sqlite_master t
               JOIN pragma_index_list(t.name) i
-SQL;
-
-        $conditions = [
-            "t.type = 'table'",
-            "t.name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')",
-        ];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = 't.name = ?';
-            $params[]     = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, i.seq';
+             WHERE %s
+          ORDER BY t.name, i.seq
+SQL,
+            $this->getWhereClause($tableName, $params),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
     {
-        $sql = <<<'SQL'
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
             SELECT t.name AS table_name,
                    p.*
               FROM sqlite_master t
               JOIN pragma_foreign_key_list(t.name) p
-                ON p."seq" != '-1'
-SQL;
-
-        $conditions = [
-            "t.type = 'table'",
-            "t.name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')",
-        ];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = 't.name = ?';
-            $params[]     = $tableName;
-        }
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, p.id DESC, p.seq';
+                ON p.seq != '-1'
+             WHERE %s
+          ORDER BY t.name,
+                   p.id DESC,
+                   p.seq
+SQL,
+            $this->getWhereClause($tableName, $params),
+        );
 
         return $this->connection->executeQuery($sql, $params);
     }
@@ -615,27 +599,21 @@ SQL;
      */
     private function fetchPrimaryKeyColumns(?string $tableName = null): array
     {
-        $sql = <<<'SQL'
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
             SELECT t.name AS table_name,
                    p.name
               FROM sqlite_master t
               JOIN pragma_table_info(t.name) p
-        SQL;
-
-        $conditions = [
-            "t.type = 'table'",
-            "t.name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')",
-        ];
-        $params     = [];
-
-        if ($tableName !== null) {
-            $conditions[] = 't.name = ?';
-            $params[]     = $tableName;
-        }
-
-        $conditions[] = 'p.pk > 0';
-
-        $sql .= ' WHERE ' . implode(' AND ', $conditions) . ' ORDER BY t.name, p.pk';
+             WHERE %s
+               AND p.pk > 0
+          ORDER BY t.name,
+                   p.pk
+        SQL,
+            $this->getWhereClause($tableName, $params),
+        );
 
         return $this->connection->fetchAllAssociative($sql, $params);
     }
@@ -663,5 +641,21 @@ SQL;
         }
 
         return $tableOptions;
+    }
+
+    /** @param list<string> $params */
+    private function getWhereClause(?string $tableName, array &$params): string
+    {
+        $conditions = [
+            "t.type = 'table'",
+            "t.name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')",
+        ];
+
+        if ($tableName !== null) {
+            $conditions[] = 't.name = ?';
+            $params[]     = $tableName;
+        }
+
+        return implode(' AND ', $conditions);
     }
 }


### PR DESCRIPTION
This refactoring isn't strictly necessary in 4.x but I ended up doing it while working on 5.0, so in order to minimize the difference between the branches, I want to backport it.

The principles are:
1. Try to keep queries as static as possible to make them more readable and possible to analyze by IDEs. Define the body of the query as a template and add dynamic parts via `sprintf()`. As an exception to this rule, consolidate exclusion of special tables in one place (the common dynamic part for all queries).
2. Use more specific fetch methods where possible. For example, where it eliminates the need to lower-case the fetched column names.
3. Bind all parameters instead of using string literals (this could be considered an improvement).
4. Order introspected rows by schema name and table name.