### PR TITLE
Deprecate `AbstractSchemaManager::_getPortableTableDefinition()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractSchemaManager::_getPortableTableDefinition()`
+
+The `AbstractSchemaManager::_getPortableTableDefinition()` method has been deprecated. Use the schema name and the
+unqualified table name separately instead.
+
 ## Deprecated `PostgreSQLSchemaManager` methods related to the current schema
 
 The following `PostgreSQLSchemaManager` methods have been deprecated:

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -837,7 +837,11 @@ abstract class AbstractSchemaManager
         return $indexes;
     }
 
-    /** @param array<string, string> $table */
+    /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
+     * @param array<string, string> $table
+     */
     abstract protected function _getPortableTableDefinition(array $table): string;
 
     /** @param array<string, mixed> $view */

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -101,6 +101,8 @@ class DB2SchemaManager extends AbstractSchemaManager
     }
 
     /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
      * {@inheritDoc}
      */
     protected function _getPortableTableDefinition(array $table): string

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -61,6 +61,8 @@ class MySQLSchemaManager extends AbstractSchemaManager
     private ?DefaultTableOptions $defaultTableOptions = null;
 
     /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
      * {@inheritDoc}
      */
     protected function _getPortableTableDefinition(array $table): string

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -43,6 +43,8 @@ class OracleSchemaManager extends AbstractSchemaManager
     }
 
     /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
      * {@inheritDoc}
      */
     protected function _getPortableTableDefinition(array $table): string

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -142,6 +142,8 @@ SQL,
     }
 
     /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
      * {@inheritDoc}
      */
     protected function _getPortableTableDefinition(array $table): string

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -236,6 +236,8 @@ SQL,
     }
 
     /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
      * {@inheritDoc}
      */
     protected function _getPortableTableDefinition(array $table): string

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -92,6 +92,8 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     }
 
     /**
+     * @deprecated Use the schema name and the unqualified table name separately instead.
+     *
      * {@inheritDoc}
      */
     protected function _getPortableTableDefinition(array $table): string


### PR DESCRIPTION
The approach of indexing table-scoped objects (e.g. columns) and filtering tables by simple concatenation of the schema name and unqualified table name is prone to collisions.

For example, on PostgreSQL:
```php
$connection->executeStatement('CREATE SCHEMA a');
$connection->executeStatement('CREATE SCHEMA "a.b"');
$connection->executeStatement('CREATE TABLE a."b.c" (id1 int)');
$connection->executeStatement('CREATE TABLE "a.b".c (id2 int)');

$tables = $schemaManager->listTables();
echo count($tables), PHP_EOL; // 1

echo implode(', ', array_map(
    static fn (Column $column) => $column->getName(),
    $tables[0]->getColumns()),
), PHP_EOL; // id1, id2
```

The susceptibility to collisions could be addressed by quoting the identifiers within the qualified name but it would be a BC break. In 5.0, the schema name and unqualified table name will be used for indexing table-scoped objects separately.