### PR TITLE
:bug: Oracle: fix comment retrieval on table with reserved keyword name

### DIFF
--- a/docs/en/reference/testing.rst
+++ b/docs/en/reference/testing.rst
@@ -79,7 +79,7 @@ then run the following command:
 
 .. code-block:: console
 
-    $ phpunit -c ci/github/pdo_mysql.xml
+    $ phpunit -c ci/github/phpunit/pdo_mysql.xml
 
 We do not currently have specific instructions on how to run a Database
 server, but we do recommend Docker as a convenient way to do so.

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -249,11 +249,12 @@ abstract class AbstractSchemaManager
             );
         }
 
+        $normalizedTable = $this->normalizeName($table);
+
         return $this->_getPortableTableColumnList(
-            $table,
+            $normalizedTable,
             $database,
-            $this->selectTableColumns($database, $this->normalizeName($table))
-                ->fetchAllAssociative(),
+            $this->selectTableColumns($database, $normalizedTable)->fetchAllAssociative(),
         );
     }
 
@@ -486,7 +487,7 @@ abstract class AbstractSchemaManager
             $this->listTableIndexes($name),
             [],
             $foreignKeys,
-            $tableOptionsByTable[$normalizedName] ?? [],
+            $tableOptionsByTable[$name] ?? [],
         );
     }
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -512,13 +512,13 @@ SQL;
 
         $sql .= ' FROM ALL_TAB_COMMENTS WHERE ' . implode(' AND ', $conditions);
 
-        /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->_conn->executeQuery($sql, $params)
-            ->fetchAllAssociativeIndexed();
+        /** @var array<array{TABLE_NAME: string, COMMENTS: string|null}> $metadata */
+        $metadata = $this->_conn->executeQuery($sql, $params)->fetchAllAssociative();
 
         $tableOptions = [];
-        foreach ($metadata as $table => $data) {
-            $data = array_change_key_case($data, CASE_LOWER);
+        foreach ($metadata as $data) {
+            $data  = array_change_key_case($data, CASE_LOWER);
+            $table = $this->_getPortableTableDefinition($data);
 
             $tableOptions[$table] = [
                 'comment' => $data['comments'],

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1676,10 +1676,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $this->createReservedKeywordTables();
 
-        $user = $this->schemaManager->introspectTable('"user"');
-        self::assertCount(2, $user->getColumns());
-        self::assertCount(2, $user->getIndexes());
-        self::assertCount(1, $user->getForeignKeys());
+        $select = $this->schemaManager->introspectTable('"select"');
+        self::assertCount(3, $select->getColumns());
+        self::assertCount(2, $select->getIndexes());
+        self::assertCount(1, $select->getForeignKeys());
+        self::assertSame('table comment', $select->getComment());
+        self::assertSame('column comment', $select->getColumn('select')->getComment());
     }
 
     public function testIntrospectReservedKeywordTableViaListTables(): void
@@ -1688,24 +1690,28 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tables = $this->schemaManager->listTables();
 
-        $user = $this->findTableByName($tables, 'user');
-        self::assertNotNull($user);
-        self::assertCount(2, $user->getColumns());
-        self::assertCount(2, $user->getIndexes());
-        self::assertCount(1, $user->getForeignKeys());
+        $select = $this->findTableByName($tables, 'select');
+        self::assertNotNull($select);
+        self::assertCount(3, $select->getColumns());
+        self::assertCount(2, $select->getIndexes());
+        self::assertCount(1, $select->getForeignKeys());
+        self::assertSame('table comment', $select->getComment());
+        self::assertSame('column comment', $select->getColumn('select')->getComment());
     }
 
     private function createReservedKeywordTables(): void
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        $this->dropTableIfExists($platform->quoteIdentifier('user'));
+        $this->dropTableIfExists($platform->quoteIdentifier('select'));
         $this->dropTableIfExists($platform->quoteIdentifier('group'));
 
         $schema = new Schema();
 
-        $user = $schema->createTable('user');
+        $user = $schema->createTable('select');
+        $user->setComment('table comment');
         $user->addColumn('id', Types::INTEGER);
+        $user->addColumn('select', Types::INTEGER)->setComment('column comment');
         $user->addColumn('group_id', Types::INTEGER);
         $user->setPrimaryKey(['id']);
         $user->addForeignKeyConstraint('group', ['group_id'], ['id']);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6764

:warning: This targets the `3.9.x` branch as requested in https://github.com/doctrine/dbal/pull/6765#issuecomment-2633994265

#### Summary

Use `\Doctrine\DBAL\Schema\OracleSchemaManager::_getPortableTableDefinition` in `\Doctrine\DBAL\Schema\OracleSchemaManager::fetchTableOptionsByTable` to be consistent with `\Doctrine\DBAL\Schema\AbstractSchemaManager::fetchAllAssociativeGrouped` which calls `\Doctrine\DBAL\Schema\OracleSchemaManager::_getPortableTableDefinition`

This also fixes an issue in SQLite due to the fact that the name passed to `_getPortableTableColumnList` was not always normalized.