### PR TITLE
Deprecate introspection of unquoted table names with dot

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated passing unquoted names containing dots for table introspection on platforms that don't support schemas
+
+Relying on table names containing dots not being parsed on platforms that don't support schemas is deprecated. If a
+table name contains a dot or other special characters, it should be quoted.
+
+Passing names that are not valid SQL to the schema introspection methods is also deprecated.
+
 ## Deprecated `AbstractSchemaManager::_normalizeName()`
 
 The `AbstractSchemaManager::_normalizeName()` method has been deprecated. Use `Identifier::toNormalizedValue()` to

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\Attributes\TestWith;
+
+use function sprintf;
+
+final class SchemaManagerTest extends FunctionalTestCase
+{
+    use VerifyDeprecations;
+
+    private AbstractSchemaManager $schemaManager;
+
+    /** @throws Exception */
+    protected function setUp(): void
+    {
+        $this->schemaManager = $this->connection->createSchemaManager();
+    }
+
+    /** @throws Exception */
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testIntrospectTableWithDotInName(bool $quoted): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform->supportsSchemas()) {
+            self::markTestIncomplete('DBAL 4.x will fail to introspect this table on a platform that supports schemas');
+        }
+
+        $name           = 'example.com';
+        $normalizedName = $platform->normalizeUnquotedIdentifier($name);
+        $quotedName     = $this->connection->quoteSingleIdentifier($normalizedName);
+
+        // create the table manually since identifiers with dots are not supported in DBAL 4.x
+        $sql = sprintf('CREATE TABLE %s (s VARCHAR(16))', $quotedName);
+
+        $this->dropTableIfExists($quotedName);
+        $this->connection->executeStatement($sql);
+
+        if ($quoted) {
+            $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6768');
+
+            $table = $this->schemaManager->introspectTable($quotedName);
+        } else {
+            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6768');
+
+            $table = $this->schemaManager->introspectTable($name);
+        }
+
+        self::assertCount(1, $table->getColumns());
+    }
+
+    /** @throws Exception */
+    public function testIntrospectTableWithInvalidName(): void
+    {
+        $table = new Table('"example"');
+        $table->addColumn('id', 'integer');
+
+        $this->dropAndCreateTable($table);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6768');
+
+        $table = $this->schemaManager->introspectTable('"example');
+        self::assertCount(1, $table->getColumns());
+    }
+}


### PR DESCRIPTION
Currently, the semantics of the "table name" parameter of the schema introspection methods are undefined and depend on whether the target database platform supports schemas.

Take the following call for example:
```php
$schemaManager->introspectTable('example.com');
```

If the DBAL doesn't support schemas on target platform (e.g. MySQL), the schema manager will try to introspect the table named `"example.com"` (the dot is part of the name): https://github.com/doctrine/dbal/blob/9aff49dfc2f73ad79fc578053a9b4e0c862d007e/src/Schema/MySQLSchemaManager.php#L379-L382 This behavior doesn't depend on whether the name is quoted (see the new test for more details).

If the DBAL does support schemas on target platform (e.g. PostgreSQL), the schema manager will interpret the dot as part of the SQL syntax and will try to introspect the table named `"com"` in the schema named `"example"`: https://github.com/doctrine/dbal/blob/851e6be197dd0f4cd6a0c22182caa1f8f6aa0178/src/Schema/PostgreSQLSchemaManager.php#L587-L588

It is impossible to introspect a table with a dot in the name w/o explicitly mentioning the schema, and this behavior also doesn't depend on whether the name is quoted.

In DBAL 5, this behavior will be consistent and predictable:
1. The name will be parsed according to the SQL syntax. The dot will be interpreted unless the name is quoted.
2. An attempt to introspect a table with a name that has a qualifier (e.g. `inventory.products`) on a platform that doesn't support schemas (e.g. MySQL) will result in an error.
3. It will be possible to introspect tables with a dot in the name w/o explicitly specifying the schema on the platforms that support schemas.

### A side note on the new test

I find the current `SchemaManagerFunctionalTestCase` design with an abstract class and one concrete class per platform quite unfortunate. If I want to test a new case, I will create a test method in the base class, and it will get inherited by each subclass. When running the test suite, all subclasses except for the one corresponding to the current platform will skip it and only one will run it. This design doesn't have any advantages and adds the following disadvantages:
1. It produces skipped tests, even if a given method is meant to pass on all platforms.
2. It makes it easier to write tests that work inconsistently across platforms by overriding test methods in sub-classes. On the contrary, if a case cannot be consistently implemented across platform, it should be clear from the test (e.g. from an `if` statement).

I want to stop adding new tests to the existing `SchemaManagerFunctionalTestCase` and at some point break it down into regular test classes w/o using inheritance.