### PR TITLE
Introduce Identifier::toNormalizedValue(), deprecate AbstractSchemaManager::_normalizeName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `AbstractSchemaManager::_normalizeName()`
+
+The `AbstractSchemaManager::_normalizeName()` method has been deprecated. Use `Identifier::toNormalizedValue()` to
+obtain the value of the identifier normalized according to the rules of the target database platform.
+
 ## Deprecated `AbstractSchemaManager::_getPortableTableDefinition()`
 
 The `AbstractSchemaManager::_getPortableTableDefinition()` method has been deprecated. Use the schema name and the

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -286,6 +286,8 @@ abstract class AbstractSchemaManager
      * An extension point for those platforms where case sensitivity of the object name depends on whether it's quoted.
      *
      * Such platforms should convert a possibly quoted name into a value of the corresponding case.
+     *
+     * @deprecated Use {@see Identifier::toNormalizedValue()} instead.
      */
     protected function normalizeName(string $name): string
     {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -189,6 +189,7 @@ class DB2SchemaManager extends AbstractSchemaManager
         return new View($view['name'], $sql);
     }
 
+    /** @deprecated Use {@see Identifier::toNormalizedValue()} instead. */
     protected function normalizeName(string $name): string
     {
         $identifier = new Identifier($name);

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -37,13 +37,23 @@ final class Identifier
 
     public function toSQL(AbstractPlatform $platform): string
     {
+        return $platform->quoteSingleIdentifier(
+            $this->toNormalizedValue($platform),
+        );
+    }
+
+    /**
+     * Returns the literal value of the identifier normalized according to the rules of the given database platform.
+     *
+     * Consumers should use the normalized value for schema comparison and referencing the objects to be introspected.
+     */
+    public function toNormalizedValue(AbstractPlatform $platform): string
+    {
         if (! $this->isQuoted) {
-            $value = $platform->normalizeUnquotedIdentifier($this->value);
-        } else {
-            $value = $this->value;
+            return $platform->normalizeUnquotedIdentifier($this->value);
         }
 
-        return $platform->quoteSingleIdentifier($value);
+        return $this->value;
     }
 
     public function toString(): string

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -479,6 +479,7 @@ SQL,
         return $tableOptions;
     }
 
+    /** @deprecated Use {@see Identifier::toNormalizedValue()} instead. */
     protected function normalizeName(string $name): string
     {
         $identifier = new Identifier($name);


### PR DESCRIPTION
`AbstractSchemaManager::_normalizeName()` would normalize the name in the all-or-nothing way. If the schema name is is quoted but the table name is not, it won't normalize either of them. This is incorrect. Normalization should be done at the identifier level, which is now done by `Identifier::toNormalizedValue()`.

The new method isn't really a drop-in replacement for the old one, but I just need to deprecate the old one (to be removed in 5.0) and introduce the new one (to be used in 5.0).