### PR TITLE
Index table-scoped objects by schema and table name separately

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractSchemaManager` methods
+
+The following `AbstractSchemaManager` methods have been removed:
+
+- `AbstractSchemaManager::_getPortableTableDefinition()`
+- `AbstractSchemaManager::_normalizeName()`
+
 ## BC BREAK: Removed `PostgreSQLSchemaManager` methods related to the current schema
 
 The following `PostgreSQLSchemaManager` methods have been removed:
@@ -317,6 +324,8 @@ The `Sequence::isAutoIncrementsFor()` method has been deprecated.
 
 ## Deprecated using invalid database object names
 
+### For schema definition
+
 Using the following objects with an empty name is deprecated: `Table`, `Column`, `Index`, `View`, `Sequence`,
 `Identifier`.
 
@@ -327,6 +336,17 @@ Using the following objects with a name that has more than one qualifier is depr
 The name should be unqualified or contain one qualifier.
 
 The `AbstractAsset` class has been marked as internal.
+
+### For schema introspection
+
+The following `AbstractSchemaManager` methods no longer accept table names that are not valid SQL names:
+
+- `AbstractSchemaManager::introspectTable()`
+- `AbstractSchemaManager::listTableColumns()`
+- `AbstractSchemaManager::listTableIndexes()`
+- `AbstractSchemaManager::listTableForeignKeys()`
+
+The above methods no longer accept qualified table names for the database platforms that don't support schemas.
 
 ## Deprecated configuration-related `Table` methods
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -10,14 +10,15 @@ use Doctrine\DBAL\Exception\DatabaseRequired;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\Deprecations\Deprecation;
-use Throwable;
 
 use function array_filter;
 use function array_intersect;
@@ -36,6 +37,23 @@ use function strtolower;
  */
 abstract class AbstractSchemaManager
 {
+    /**
+     * The value representing the <code>NULL</code> schema key. Should be populated only by the schema managers
+     * corresponding to the database platforms that don't support schemas.
+     */
+    protected const NULL_SCHEMA_KEY = "\x00";
+
+    /**
+     * The name of the column of the schema introspection result set that holds the schema name, if the underlying
+     * platform supports schemas.
+     */
+    protected const SCHEMA_NAME_COLUMN = 'SCHEMA_NAME';
+
+    /**
+     * The name of the column of the schema introspection result set that holds the table name.
+     */
+    protected const TABLE_NAME_COLUMN = 'TABLE_NAME';
+
     /**
      * The current schema name determined from the connection. The <code>null</code> value means that there is no
      * schema currently selected within the connection.
@@ -120,14 +138,13 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableColumns(string $table): array
+    public function listTableColumns(string $tableName): array
     {
-        $this->validateTableName($table, __METHOD__);
-
-        $database = $this->getDatabase(__METHOD__);
-
         return $this->_getPortableTableColumnList(
-            $this->fetchTableColumns($database, $this->normalizeName($table)),
+            $this->fetchTableColumns(
+                $this->getDatabase(__METHOD__),
+                $this->parseOptionallyQualifiedName($tableName),
+            ),
         );
     }
 
@@ -140,15 +157,13 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableIndexes(string $table): array
+    public function listTableIndexes(string $tableName): array
     {
-        $this->validateTableName($table, __METHOD__);
-
-        $database = $this->getDatabase(__METHOD__);
-        $table    = $this->normalizeName($table);
-
         return $this->_getPortableTableIndexesList(
-            $this->fetchIndexColumns($database, $table),
+            $this->fetchIndexColumns(
+                $this->getDatabase(__METHOD__),
+                $this->parseOptionallyQualifiedName($tableName),
+            ),
         );
     }
 
@@ -180,9 +195,18 @@ abstract class AbstractSchemaManager
      */
     public function listTableNames(): array
     {
+        $supportsSchemas   = $this->platform->supportsSchemas();
+        $currentSchemaName = $this->getCurrentSchemaName();
+
         return $this->filterAssetNames(
-            array_map(function (array $row): string {
-                return $this->_getPortableTableDefinition($row);
+            array_map(static function (array $row) use ($supportsSchemas, $currentSchemaName): string {
+                $name = $row[self::TABLE_NAME_COLUMN];
+
+                if ($supportsSchemas && $row[self::SCHEMA_NAME_COLUMN] !== $currentSchemaName) {
+                    $name = $row[self::SCHEMA_NAME_COLUMN] . '.' . $name;
+                }
+
+                return $name;
             }, $this->selectTableNames(
                 $this->getDatabase(__METHOD__),
             )->fetchAllAssociative()),
@@ -220,37 +244,56 @@ abstract class AbstractSchemaManager
         $foreignKeyColumnsByTable = $this->fetchForeignKeyColumnsByTable($database);
         $tableOptionsByTable      = $this->fetchTableOptionsByTable($database);
 
+        $currentSchemaName = $this->getCurrentSchemaName();
+
         $filter = $this->connection->getConfiguration()->getSchemaAssetsFilter();
         $tables = [];
 
         $configuration = $this->createSchemaConfig()
             ->toTableConfiguration();
 
-        foreach ($tableColumnsByTable as $tableName => $tableColumns) {
-            if (! $filter($tableName)) {
-                continue;
+        foreach ($tableColumnsByTable as $schemaNameKey => $schemaTables) {
+            if ($schemaNameKey !== self::NULL_SCHEMA_KEY && $schemaNameKey !== $currentSchemaName) {
+                $qualifier = $schemaNameKey;
+                $prefix    = $schemaNameKey . '.';
+            } else {
+                $qualifier = null;
+                $prefix    = '';
             }
 
-            $editor = Table::editor()
-                ->setName($tableName)
-                ->setColumns($this->_getPortableTableColumnList($tableColumns))
-                ->setIndexes(
-                    $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? []),
-                );
+            foreach ($schemaTables as $unqualifiedName => $tableColumns) {
+                if (! $filter($prefix . $unqualifiedName)) {
+                    continue;
+                }
 
-            if (isset($foreignKeyColumnsByTable[$tableName])) {
-                $editor->setForeignKeyConstraints(
-                    $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName]),
-                );
+                $editor = Table::editor()
+                    ->setName(
+                        OptionallyQualifiedName::quoted($unqualifiedName, $qualifier)
+                            ->toString(),
+                    )
+                    ->setColumns($this->_getPortableTableColumnList($tableColumns))
+                    ->setIndexes(
+                        $this->_getPortableTableIndexesList(
+                            $indexColumnsByTable[$schemaNameKey][$unqualifiedName] ?? [],
+                        ),
+                    );
+
+                if (isset($foreignKeyColumnsByTable[$schemaNameKey][$unqualifiedName])) {
+                    $editor->setForeignKeyConstraints(
+                        $this->_getPortableTableForeignKeysList(
+                            $foreignKeyColumnsByTable[$schemaNameKey][$unqualifiedName],
+                        ),
+                    );
+                }
+
+                if (isset($tableOptionsByTable[$schemaNameKey][$unqualifiedName])) {
+                    $editor->setOptions($tableOptionsByTable[$schemaNameKey][$unqualifiedName]);
+                }
+
+                $tables[] = $editor
+                    ->setConfiguration($configuration)
+                    ->create();
             }
-
-            if (isset($tableOptionsByTable[$tableName])) {
-                $editor->setOptions($tableOptionsByTable[$tableName]);
-            }
-
-            $tables[] = $editor
-                ->setConfiguration($configuration)
-                ->create();
         }
 
         return $tables;
@@ -291,53 +334,10 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * An extension point for those platforms where case sensitivity of the object name depends on whether it's quoted.
-     *
-     * Such platforms should convert a possibly quoted name into a value of the corresponding case.
-     *
-     * @deprecated Use {@see Identifier::toNormalizedValue()} instead.
-     */
-    protected function normalizeName(string $name): string
-    {
-        $identifier = new Identifier($name);
-
-        return $identifier->getName();
-    }
-
-    private function validateTableName(string $input, string $methodName): void
-    {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
-
-        try {
-            $tableName = $parser->parse($input);
-        } catch (Throwable $e) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6768',
-                'Unable to parse table name passed to %s(): %s.',
-                $methodName,
-                $e->getMessage(),
-            );
-
-            return;
-        }
-
-        if ($tableName->getQualifier() === null || $this->platform->supportsSchemas()) {
-            return;
-        }
-
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6768',
-            'Relying on %s() not parsing an unquoted table name containing a dot while working with %s is'
-                . ' deprecated. Pass a quoted name instead.',
-            $methodName,
-            $this->platform::class,
-        );
-    }
-
-    /**
      * Selects names of tables in the specified database.
+     *
+     * Implementations must project the table name as quoted {@see TABLE_NAME_COLUMN}. If the corresponding
+     * database platform supports schemas, the schema name must be projected as quoted {@see SCHEMA_NAME_COLUMN}.
      *
      * @throws Exception
      */
@@ -347,25 +347,46 @@ abstract class AbstractSchemaManager
      * Selects definitions of table columns in the specified database. If the table name is specified, narrows down
      * the selection to this table.
      *
+     * Implementations must project the name of the table the column belongs to as quoted {@see TABLE_NAME_COLUMN}.
+     * If the corresponding database platform supports schemas, the schema name of the column's table should be
+     * projected as quoted {@see SCHEMA_NAME_COLUMN}.
+     *
      * @throws Exception
      */
-    abstract protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result;
+    abstract protected function selectTableColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): Result;
 
     /**
      * Selects definitions of index columns in the specified database. If the table name is specified, narrows down
      * the selection to this table.
      *
+     * Implementations must project the name of the table the index belongs to as quoted {@see TABLE_NAME_COLUMN}.
+     * If the corresponding database platform supports schemas, the schema name of the indexes table should be
+     * projected as quoted {@see SCHEMA_NAME_COLUMN}.
+     *
      * @throws Exception
      */
-    abstract protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result;
+    abstract protected function selectIndexColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): Result;
 
     /**
      * Selects definitions of foreign key columns in the specified database. If the table name is specified,
      * narrows down the selection to this table.
      *
+     * Implementations must project the name of the referencing table of the constraint as quoted
+     * {@see TABLE_NAME_COLUMN}. If the corresponding database platform supports schemas, the schema name of the
+     * referencing table should be projected as quoted {@see SCHEMA_NAME_COLUMN}.
+     *
      * @throws Exception
      */
-    abstract protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result;
+    abstract protected function selectForeignKeyColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): Result;
 
     /**
      * Fetches definitions of table columns in the specified database. If the table name is specified, narrows down
@@ -375,7 +396,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function fetchTableColumns(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         return $this->selectTableColumns($databaseName, $tableName)->fetchAllAssociative();
     }
@@ -388,7 +409,7 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function fetchIndexColumns(string $databaseName, ?string $tableName = null): array
+    protected function fetchIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         return $this->selectIndexColumns($databaseName, $tableName)->fetchAllAssociative();
     }
@@ -401,15 +422,19 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    protected function fetchForeignKeyColumns(string $databaseName, ?string $tableName = null): array
+    protected function fetchForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         return $this->selectForeignKeyColumns($databaseName, $tableName)->fetchAllAssociative();
     }
 
     /**
-     * Fetches definitions of table columns in the specified database and returns them grouped by table name.
+     * Fetches definitions of table columns in the specified database and returns them grouped by schema name and table
+     * name.
      *
-     * @return array<string,list<array<string,mixed>>>
+     * If the corresponding database platform doesn't support schemas, the schema name key will be the
+     * {@see NULL_SCHEMA_KEY}.
+     *
+     * @return array<string,array<string,list<array<string,mixed>>>>
      *
      * @throws Exception
      */
@@ -419,9 +444,13 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * Fetches definitions of index columns in the specified database and returns them grouped by table name.
+     * Fetches definitions of index columns in the specified database and returns them grouped by schema name and table
+     * name.
      *
-     * @return array<string,list<array<string,mixed>>>
+     * If the corresponding database platform doesn't support schemas, the schema name key will be the
+     * {@see NULL_SCHEMA_KEY}.
+     *
+     * @return array<string,array<string,list<array<string,mixed>>>>
      *
      * @throws Exception
      */
@@ -431,9 +460,13 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * Fetches definitions of foreign key columns in the specified database and returns them grouped by table name.
+     * Fetches definitions of foreign key columns in the specified database and returns them grouped by schema name and
+     * table name.
      *
-     * @return array<string, list<array<string, mixed>>>
+     * If the corresponding database platform doesn't support schemas, the schema name key will be the
+     * {@see NULL_SCHEMA_KEY}.
+     *
+     * @return array<string,array<string,list<array<string,mixed>>>>
      *
      * @throws Exception
      */
@@ -443,14 +476,45 @@ abstract class AbstractSchemaManager
     }
 
     /**
-     * Fetches table options for the tables in the specified database and returns them grouped by table name.
-     * If the table name is specified, narrows down the selection to this table.
+     * Fetches table options for the tables in the specified database and returns them grouped by schema name and table
+     * name. If the table name is specified, narrows down the selection to this table.
      *
-     * @return array<string,array<string,mixed>>
+     * If the corresponding database platform doesn't support schemas, the schema name key will be the
+     * {@see NULL_SCHEMA_KEY}.
+     *
+     * @return array<string,array<string,array<string,mixed>>>
      *
      * @throws Exception
      */
-    abstract protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array;
+    abstract protected function fetchTableOptionsByTable(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array;
+
+    final protected function parseOptionallyQualifiedName(string $input): OptionallyQualifiedName
+    {
+        $parser = Parsers::getOptionallyQualifiedNameParser();
+
+        try {
+            return $parser->parse($input);
+        } catch (Parser\Exception $e) {
+            throw InvalidName::fromParserException($input, $e);
+        }
+    }
+
+    /**
+     * Ensures that the given optionally qualified name is in fact unqualified.
+     *
+     * Schema managers for the platforms that don't support schemas, before using the unqualified part of the name,
+     * should use this method to ensure that the name doesn't have a qualifier, which, if it was present, they would be
+     * unable to bind to the schema introspection query.
+     */
+    final protected function ensureUnqualifiedName(OptionallyQualifiedName $name, string $methodName): void
+    {
+        if ($name->getQualifier() !== null) {
+            throw UnsupportedName::fromQualifiedName($name, $methodName);
+        }
+    }
 
     /**
      * Introspects the table with the given name.
@@ -459,6 +523,8 @@ abstract class AbstractSchemaManager
      */
     public function introspectTable(string $name): Table
     {
+        $tableName = $this->parseOptionallyQualifiedName($name);
+
         $columns = $this->listTableColumns($name);
 
         if ($columns === []) {
@@ -470,7 +536,7 @@ abstract class AbstractSchemaManager
             ->setColumns($columns)
             ->setIndexes($this->listTableIndexes($name))
             ->setForeignKeyConstraints($this->listTableForeignKeys($name))
-            ->setOptions($this->getTableOptions($name))
+            ->setOptions($this->getTableOptions($tableName))
             ->create();
     }
 
@@ -499,16 +565,12 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    public function listTableForeignKeys(string $table): array
+    public function listTableForeignKeys(string $tableName): array
     {
-        $this->validateTableName($table, __METHOD__);
-
-        $database = $this->getDatabase(__METHOD__);
-
         return $this->_getPortableTableForeignKeysList(
             $this->fetchForeignKeyColumns(
-                $database,
-                $this->normalizeName($table),
+                $this->getDatabase(__METHOD__),
+                $this->parseOptionallyQualifiedName($tableName),
             ),
         );
     }
@@ -518,16 +580,22 @@ abstract class AbstractSchemaManager
      *
      * @throws Exception
      */
-    private function getTableOptions(string $name): array
+    private function getTableOptions(OptionallyQualifiedName $tableName): array
     {
-        $this->validateTableName($name, __METHOD__);
+        $qualifier = $tableName->getQualifier();
 
-        $normalizedName = $this->normalizeName($name);
+        if ($qualifier !== null) {
+            $schemaNameKey = $qualifier->toNormalizedValue($this->platform);
+        } else {
+            $schemaNameKey = $this->getCurrentSchemaName() ?? self::NULL_SCHEMA_KEY;
+        }
+
+        $unqualifiedTableName = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
 
         return $this->fetchTableOptionsByTable(
             $this->getDatabase(__METHOD__),
-            $normalizedName,
-        )[$normalizedName] ?? [];
+            $tableName,
+        )[$schemaNameKey][$unqualifiedTableName] ?? [];
     }
 
     /* drop*() Methods */
@@ -882,13 +950,6 @@ abstract class AbstractSchemaManager
         return $indexes;
     }
 
-    /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * @param array<string, string> $table
-     */
-    abstract protected function _getPortableTableDefinition(array $table): string;
-
     /** @param array<string, mixed> $view */
     abstract protected function _getPortableViewDefinition(array $view): View;
 
@@ -1038,15 +1099,22 @@ abstract class AbstractSchemaManager
      *
      * @param list<array<string, mixed>> $rows
      *
-     * @return array<string,list<array<string,mixed>>>
+     * @return array<string,array<string,list<array<string,mixed>>>>
      */
     private function groupByTable(array $rows): array
     {
+        $supportsSchemas = $this->platform->supportsSchemas();
+
         $data = [];
 
         foreach ($rows as $row) {
-            $tableName          = $this->_getPortableTableDefinition($row);
-            $data[$tableName][] = $row;
+            if ($supportsSchemas) {
+                $schemaNameKey = $row[self::SCHEMA_NAME_COLUMN];
+            } else {
+                $schemaNameKey = self::NULL_SCHEMA_KEY;
+            }
+
+            $data[$schemaNameKey][$row[self::TABLE_NAME_COLUMN]][] = $row;
         }
 
         return $data;

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
@@ -16,7 +17,6 @@ use function sprintf;
 use function str_replace;
 use function strpos;
 use function strtolower;
-use function strtoupper;
 use function substr;
 
 use const CASE_LOWER;
@@ -104,18 +104,6 @@ class DB2SchemaManager extends AbstractSchemaManager
     }
 
     /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * {@inheritDoc}
-     */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        $table = array_change_key_case($table, CASE_LOWER);
-
-        return $table['name'];
-    }
-
-    /**
      * {@inheritDoc}
      */
     protected function _getPortableTableIndexesList(array $rows): array
@@ -173,40 +161,38 @@ class DB2SchemaManager extends AbstractSchemaManager
         return new View($view['name'], $sql);
     }
 
-    /** @deprecated Use {@see Identifier::toNormalizedValue()} instead. */
-    protected function normalizeName(string $name): string
-    {
-        $identifier = new Identifier($name);
-
-        return $identifier->isQuoted() ? $identifier->getName() : strtoupper($name);
-    }
-
     protected function selectTableNames(string $databaseName): Result
     {
-        $sql = <<<'SQL'
-SELECT TABNAME AS NAME
-FROM SYSCAT.TABLES
-WHERE TYPE = 'T'
-  AND TABSCHEMA = ?
-SQL;
+        $sql = sprintf(
+            <<<'SQL'
+                SELECT TABNAME AS %s
+                FROM SYSCAT.TABLES
+                WHERE TABSCHEMA = ?
+                  AND TYPE = 'T'
+                ORDER BY TABNAME
+                SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+        );
 
         return $this->connection->executeQuery($sql, [$databaseName]);
     }
 
-    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ['C.TABSCHEMA = ?'];
         $params     = [$databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 'C.TABNAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
 SELECT
-       C.TABNAME AS NAME,
+       C.TABNAME AS %s,
        C.COLNAME,
        C.TYPENAME,
        C.CODEPAGE,
@@ -227,26 +213,29 @@ FROM SYSCAT.COLUMNS C
    AND T.TYPE = 'T'
 ORDER BY C.TABNAME, C.COLNO
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ['IDX.TABSCHEMA = ?'];
         $params     = [$databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 'IDX.TABNAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
       SELECT
-             IDX.TABNAME AS NAME,
+             IDX.TABNAME AS %s,
              IDX.INDNAME AS KEY_NAME,
              IDXCOL.COLNAME AS COLUMN_NAME,
              CASE
@@ -268,26 +257,29 @@ SQL,
              IDX.INDNAME,
              IDXCOL.COLSEQ
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ['R.TABSCHEMA = ?'];
         $params     = [$databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 'R.TABNAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
       SELECT
-             R.TABNAME AS NAME,
+             R.TABNAME AS %s,
              FKCOL.COLNAME AS LOCAL_COLUMN,
              R.REFTABNAME AS FOREIGN_TABLE,
              PKCOL.COLNAME AS FOREIGN_COLUMN,
@@ -319,6 +311,7 @@ SQL,
             R.CONSTNAME,
             FKCOL.COLSEQ
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
@@ -328,14 +321,16 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         $conditions = ['TABSCHEMA = ?'];
         $params     = [$databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 'TABNAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
@@ -352,7 +347,7 @@ SQL,
 
         $tableOptions = [];
         foreach ($this->connection->iterateKeyValue($sql, $params) as $table => $remarks) {
-            $tableOptions[$table] = ['comment' => $remarks];
+            $tableOptions[self::NULL_SCHEMA_KEY][$table] = ['comment' => $remarks];
         }
 
         return $tableOptions;

--- a/src/Schema/Exception/UnsupportedName.php
+++ b/src/Schema/Exception/UnsupportedName.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+final class UnsupportedName extends LogicException implements SchemaException
+{
+    public static function fromQualifiedName(
+        OptionallyQualifiedName $name,
+        string $methodName,
+    ): self {
+        return new self(sprintf(
+            "%s() doesn't support introspection of objects with qualified names. %s given.",
+            $methodName,
+            $name->toString(),
+        ));
+    }
+}

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\CachingCollationMeta
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\ConnectionCollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -60,16 +61,6 @@ class MySQLSchemaManager extends AbstractSchemaManager
     ];
 
     private ?DefaultTableOptions $defaultTableOptions = null;
-
-    /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * {@inheritDoc}
-     */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        return $table['TABLE_NAME'];
-    }
 
     /**
      * {@inheritDoc}
@@ -332,18 +323,21 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
     protected function selectTableNames(string $databaseName): Result
     {
-        $sql = <<<'SQL'
-SELECT TABLE_NAME
-FROM information_schema.TABLES
-WHERE TABLE_SCHEMA = ?
-  AND TABLE_TYPE = 'BASE TABLE'
-ORDER BY TABLE_NAME
-SQL;
+        $sql = sprintf(
+            <<<'SQL'
+                SELECT TABLE_NAME AS %s
+                FROM information_schema.TABLES
+                WHERE TABLE_SCHEMA = ?
+                  AND TABLE_TYPE = 'BASE TABLE'
+                ORDER BY TABLE_NAME
+                SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+        );
 
         return $this->connection->executeQuery($sql, [$databaseName]);
     }
 
-    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         // The schema name is passed multiple times as a literal in the WHERE clause instead of using a JOIN condition
         // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
@@ -352,14 +346,16 @@ SQL;
         $params     = [$databaseName, $databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 't.TABLE_NAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
 SELECT
-       c.TABLE_NAME,
+       c.TABLE_NAME         AS %s,
        c.COLUMN_NAME        AS field,
        %s                   AS type,
        c.IS_NULLABLE        AS `null`,
@@ -377,6 +373,7 @@ FROM information_schema.COLUMNS c
 ORDER BY c.TABLE_NAME,
          c.ORDINAL_POSITION
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->platform->getColumnTypeSQLSnippet('c', $databaseName),
             implode(' AND ', $conditions),
         );
@@ -384,20 +381,22 @@ SQL,
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ['TABLE_SCHEMA = ?'];
         $params     = [$databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 'TABLE_NAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
 SELECT
-        TABLE_NAME,
+        TABLE_NAME  AS %s,
         NON_UNIQUE  AS Non_Unique,
         INDEX_NAME  AS Key_name,
         COLUMN_NAME AS Column_Name,
@@ -408,13 +407,14 @@ WHERE %s
 ORDER BY TABLE_NAME,
          SEQ_IN_INDEX
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         // The schema name is passed multiple times in the WHERE clause instead of using a JOIN condition
         // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
@@ -423,14 +423,16 @@ SQL,
         $params     = [$databaseName, $databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 'k.TABLE_NAME = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
 SELECT
-            k.TABLE_NAME,
+            k.TABLE_NAME AS %s,
             k.CONSTRAINT_NAME,
             k.COLUMN_NAME,
             k.REFERENCED_TABLE_NAME,
@@ -448,6 +450,7 @@ ORDER BY k.TABLE_NAME,
          k.CONSTRAINT_NAME,
          k.ORDINAL_POSITION
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
@@ -457,13 +460,15 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         $sql = $this->platform->fetchTableOptionsByTable($tableName !== null);
 
         $params = [$databaseName];
         if ($tableName !== null) {
-            $params[] = $tableName;
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
+            $params[] = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         /** @var array<string,array<string,mixed>> $metadata */
@@ -474,7 +479,7 @@ SQL,
         foreach ($metadata as $table => $data) {
             $data = array_change_key_case($data, CASE_LOWER);
 
-            $tableOptions[$table] = [
+            $tableOptions[self::NULL_SCHEMA_KEY][$table] = [
                 'engine'         => $data['engine'],
                 'collation'      => $data['table_collation'],
                 'charset'        => $data['character_set_name'],

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -21,7 +22,6 @@ use function str_contains;
 use function str_replace;
 use function str_starts_with;
 use function strtolower;
-use function strtoupper;
 use function trim;
 
 use const CASE_LOWER;
@@ -41,18 +41,6 @@ class OracleSchemaManager extends AbstractSchemaManager
         $view = array_change_key_case($view, CASE_LOWER);
 
         return new View($this->getQuotedIdentifierName($view['view_name']), $view['text']);
-    }
-
-    /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * {@inheritDoc}
-     */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        $table = array_change_key_case($table, CASE_LOWER);
-
-        return $this->getQuotedIdentifierName($table['table_name']);
     }
 
     /**
@@ -303,30 +291,35 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     protected function selectTableNames(string $databaseName): Result
     {
-        $sql = <<<'SQL'
-SELECT TABLE_NAME
-FROM ALL_TABLES
-WHERE OWNER = :OWNER
-ORDER BY TABLE_NAME
-SQL;
+        $sql = sprintf(
+            <<<'SQL'
+                SELECT TABLE_NAME AS %s
+                FROM ALL_TABLES
+                WHERE OWNER = :OWNER
+                ORDER BY TABLE_NAME
+                SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+        );
 
         return $this->connection->executeQuery($sql, ['OWNER' => $databaseName]);
     }
 
-    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ['C.OWNER = :OWNER'];
         $params     = ['OWNER' => $databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[]         = 'C.TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
+            $params['TABLE_NAME'] = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
           SELECT
-                 C.TABLE_NAME,
+                 C.TABLE_NAME AS %s,
                  C.COLUMN_NAME,
                  C.DATA_TYPE,
                  C.DATA_DEFAULT,
@@ -347,26 +340,29 @@ SQL;
            WHERE %s
         ORDER BY C.TABLE_NAME, C.COLUMN_ID
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ['IND_COL.INDEX_OWNER = :OWNER'];
         $params     = ['OWNER' => $databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[]         = 'IND_COL.TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
+            $params['TABLE_NAME'] = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
           SELECT
-                 IND_COL.TABLE_NAME,
+                 IND_COL.TABLE_NAME AS %s,
                  IND_COL.INDEX_NAME AS NAME,
                  IND.INDEX_TYPE AS TYPE,
                  DECODE(IND.UNIQUENESS, 'NONUNIQUE', 0, 'UNIQUE', 1) AS IS_UNIQUE,
@@ -385,26 +381,29 @@ SQL,
                  IND_COL.INDEX_NAME,
                  IND_COL.COLUMN_POSITION
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $conditions = ["ALC.CONSTRAINT_TYPE = 'R'", 'COLS.OWNER = :OWNER'];
         $params     = ['OWNER' => $databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[]         = 'COLS.TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
+            $params['TABLE_NAME'] = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
             <<<'SQL'
           SELECT
-                 COLS.TABLE_NAME,
+                 COLS.TABLE_NAME AS %s,
                  ALC.CONSTRAINT_NAME,
                  ALC.DELETE_RULE,
                  ALC.DEFERRABLE,
@@ -422,6 +421,7 @@ SQL,
                  COLS.CONSTRAINT_NAME,
                  COLS.POSITION
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $conditions),
         );
 
@@ -431,14 +431,16 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         $conditions = ['OWNER = :OWNER'];
         $params     = ['OWNER' => $databaseName];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[]         = 'TABLE_NAME = :TABLE_NAME';
-            $params['TABLE_NAME'] = $tableName;
+            $params['TABLE_NAME'] = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $sql = sprintf(
@@ -454,17 +456,9 @@ SQL,
 
         $tableOptions = [];
         foreach ($this->connection->iterateKeyValue($sql, $params) as $table => $comments) {
-            $tableOptions[$table] = ['comment' => $comments];
+            $tableOptions[self::NULL_SCHEMA_KEY][$table] = ['comment' => $comments];
         }
 
         return $tableOptions;
-    }
-
-    /** @deprecated Use {@see Identifier::toNormalizedValue()} instead. */
-    protected function normalizeName(string $name): string
-    {
-        $identifier = new Identifier($name);
-
-        return $identifier->isQuoted() ? $identifier->getName() : strtoupper($name);
     }
 }

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 
@@ -21,7 +22,6 @@ use function in_array;
 use function is_string;
 use function preg_match;
 use function sprintf;
-use function str_contains;
 use function str_replace;
 use function strtolower;
 use function trim;
@@ -132,22 +132,6 @@ SQL,
         }
 
         return parent::_getPortableTableForeignKeysList($list);
-    }
-
-    /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * {@inheritDoc}
-     */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        $currentSchema = $this->getCurrentSchemaName();
-
-        if ($table['schema_name'] === $currentSchema) {
-            return $table['table_name'];
-        }
-
-        return $table['schema_name'] . '.' . $table['table_name'];
     }
 
     /**
@@ -397,30 +381,34 @@ SQL,
 
     protected function selectTableNames(string $databaseName): Result
     {
-        $sql = <<<'SQL'
-SELECT quote_ident(table_name) AS table_name,
-       table_schema AS schema_name
-FROM information_schema.tables
-WHERE table_catalog = ?
-  AND table_schema NOT LIKE 'pg\_%'
-  AND table_schema != 'information_schema'
-  AND table_name != 'geometry_columns'
-  AND table_name != 'spatial_ref_sys'
-  AND table_type = 'BASE TABLE'
-SQL;
+        $sql = sprintf(
+            <<<'SQL'
+                SELECT table_schema AS %s,
+                       table_name AS %s
+                FROM information_schema.tables
+                WHERE table_catalog = ?
+                  AND table_schema NOT LIKE 'pg\_%%'
+                  AND table_schema != 'information_schema'
+                  AND table_name != 'geometry_columns'
+                  AND table_name != 'spatial_ref_sys'
+                  AND table_type = 'BASE TABLE'
+                SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+        );
 
         return $this->connection->executeQuery($sql, [$databaseName]);
     }
 
-    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
             SELECT
-            quote_ident(n.nspname) AS schema_name,
-            quote_ident(c.relname) AS table_name,
+            n.nspname AS %s,
+            c.relname AS %s,
             a.attnum,
             quote_ident(a.attname) AS field,
             t.typname AS type,
@@ -474,21 +462,23 @@ SQL;
                 AND %s
             ORDER BY a.attnum
             SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $this->buildQueryConditions($tableName, $params)),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
             SELECT
-                   quote_ident(tn.nspname) AS schema_name,
-                   quote_ident(tc.relname) AS table_name,
+                   tn.nspname AS %s,
+                   tc.relname AS %s,
                    quote_ident(ic.relname) AS relname,
                    i.indisunique,
                    i.indisprimary,
@@ -506,20 +496,22 @@ SQL;
                 JOIN pg_namespace n ON n.oid = c.relnamespace
                 WHERE %s)
             SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $this->buildQueryConditions($tableName, $params)),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [$this->getMaxIndexKeys()];
 
         $sql = sprintf(
             <<<'SQL'
-        SELECT quote_ident(pkn.nspname) AS schema_name,
-               quote_ident(pkc.relname) AS table_name,
+        SELECT pkn.nspname AS %s,
+               pkc.relname AS %s,
                r.conname,
                pka.attname AS pk_attname,
                fkn.nspname AS fk_nspname,
@@ -552,9 +544,11 @@ SQL;
                               FROM pg_class c
                                 JOIN pg_namespace n
                                     ON n.oid = c.relnamespace
-                              WHERE %s
+                            WHERE %s
                           ) AND r.contype = 'f'
         SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $this->buildQueryConditions($tableName, $params)),
         );
 
@@ -564,32 +558,35 @@ SQL;
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
-            SELECT quote_ident(n.nspname) AS schema_name,
-                   quote_ident(c.relname) AS table_name,
+            SELECT n.nspname AS %s,
+                   c.relname AS %s,
                    CASE c.relpersistence WHEN 'u' THEN true ELSE false END as unlogged,
                    obj_description(c.oid, 'pg_class') AS comment
             FROM pg_class c
                  INNER JOIN pg_namespace n
                      ON n.oid = c.relnamespace
             WHERE
-                  c.relkind = 'r'
+                c.relkind = 'r'
               AND %s
             SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             implode(' AND ', $this->buildQueryConditions($tableName, $params)),
         );
 
-        $tableOptions = [];
-        foreach ($this->connection->iterateAssociative($sql, $params) as $row) {
-            $tableOptions[$this->_getPortableTableDefinition($row)] = $row;
+        $data = [];
+
+        foreach ($this->connection->fetchAllAssociative($sql, $params) as $row) {
+            $data[$row[self::SCHEMA_NAME_COLUMN]][$row[self::TABLE_NAME_COLUMN]] = $row;
         }
 
-        return $tableOptions;
+        return $data;
     }
 
     /**
@@ -597,22 +594,22 @@ SQL;
      *
      * @return non-empty-list<string>
      */
-    private function buildQueryConditions(?string $tableName, array &$params): array
+    private function buildQueryConditions(?OptionallyQualifiedName $tableName, array &$params): array
     {
         $conditions = [];
 
         if ($tableName !== null) {
-            if (str_contains($tableName, '.')) {
-                [$schemaName, $tableName] = explode('.', $tableName);
+            $qualifier = $tableName->getQualifier();
 
+            if ($qualifier !== null) {
                 $conditions[] = 'n.nspname = ?';
-                $params[]     = $schemaName;
+                $params[]     = $qualifier->toNormalizedValue($this->platform);
             } else {
                 $conditions[] = 'n.nspname = ANY(current_schemas(false))';
             }
 
             $conditions[] = 'c.relname = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         $conditions[] = "n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')";

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -8,22 +8,18 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Types\Type;
 
-use function array_change_key_case;
 use function assert;
-use function explode;
 use function func_get_arg;
 use function func_num_args;
 use function implode;
 use function is_string;
 use function preg_match;
 use function sprintf;
-use function str_contains;
 use function str_replace;
 use function strtok;
-
-use const CASE_LOWER;
 
 /**
  * SQL Server Schema Manager.
@@ -225,20 +221,6 @@ SQL,
     }
 
     /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * {@inheritDoc}
-     */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        if ($table['schema_name'] !== $this->getCurrentSchemaName()) {
-            return $table['schema_name'] . '.' . $table['table_name'];
-        }
-
-        return $table['table_name'];
-    }
-
-    /**
      * {@inheritDoc}
      */
     protected function _getPortableDatabaseDefinition(array $database): string
@@ -293,26 +275,30 @@ SQL,
     protected function selectTableNames(string $databaseName): Result
     {
         // The "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams
-        $sql = <<<'SQL'
-SELECT SCHEMA_NAME(schema_id) AS schema_name,
-       name AS table_name
+        $sql = sprintf(
+            <<<'SQL'
+SELECT SCHEMA_NAME(schema_id) AS %s,
+       name AS %s
 FROM sys.tables
 WHERE name != 'sysdiagrams'
 ORDER BY name
-SQL;
+SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+        );
 
         return $this->connection->executeQuery($sql);
     }
 
-    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
                 SELECT
-                          scm.name AS schema_name,
-                          tbl.name AS table_name,
+                          scm.name AS %s,
+                          tbl.name AS %s,
                           col.name,
                           type.name AS type,
                           col.max_length AS length,
@@ -344,21 +330,23 @@ SQL;
                           tbl.name,
                           col.column_id
 SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, 'scm.name', 'tbl.name', $params),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
               SELECT
-                       scm.name AS schema_name,
-                       tbl.name AS table_name,
+                       scm.name AS %s,
+                       tbl.name AS %s,
                        idx.name AS key_name,
                        col.name AS column_name,
                        ~idx.is_unique AS non_unique,
@@ -385,21 +373,23 @@ SQL,
                      idx.index_id,
                      idxcol.key_ordinal
 SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, 'scm.name', 'tbl.name', $params),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
                 SELECT
-                SCHEMA_NAME(f.schema_id) AS schema_name,
-                OBJECT_NAME(f.parent_object_id) AS table_name,
+                SCHEMA_NAME(f.schema_id) AS %s,
+                OBJECT_NAME(f.parent_object_id) AS %s,
                 f.name AS ForeignKey,
                 COL_NAME(fc.parent_object_id, fc.parent_column_id) AS ColumnName,
                 SCHEMA_NAME(t.schema_id) ReferenceSchemaName,
@@ -418,6 +408,8 @@ SQL,
                          3,
                          fc.constraint_column_id
 SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause(
                 $tableName,
                 'SCHEMA_NAME(f.schema_id)',
@@ -432,15 +424,15 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
           SELECT
-            scm.name AS schema_name,
-            tbl.name AS table_name,
+            scm.name AS %s,
+            tbl.name AS %s,
             p.value
           FROM
             sys.tables AS tbl
@@ -451,16 +443,14 @@ SQL,
               p.name = N'MS_Description'
           AND %s
 SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, 'scm.name', 'tbl.name', $params),
         );
 
         $tableOptions = [];
-        foreach ($this->connection->iterateAssociative($sql, $params) as $data) {
-            $data = array_change_key_case($data, CASE_LOWER);
-
-            $tableOptions[$this->_getPortableTableDefinition($data)] = [
-                'comment' => $data['value'],
-            ];
+        foreach ($this->connection->iterateNumeric($sql, $params) as $row) {
+            $tableOptions[$row[0]][$row[1]] = ['comment' => $row[2]];
         }
 
         return $tableOptions;
@@ -469,13 +459,14 @@ SQL,
     /**
      * Returns the where clause to filter schema and table name in a query.
      *
-     * @param ?string      $tableName    The full qualified name of the table.
-     * @param string       $schemaColumn The name of the column to compare the schema to in the where clause.
-     * @param string       $tableColumn  The name of the column to compare the table to in the where clause.
-     * @param list<string> $params
+     * @param ?OptionallyQualifiedName $tableName    The name of the table.
+     * @param string                   $schemaColumn The name of the column to compare the schema to in the where
+     *                                               clause.
+     * @param string                   $tableColumn  The name of the column to compare the table to in the where clause.
+     * @param list<string>             $params
      */
     private function getWhereClause(
-        ?string $tableName,
+        ?OptionallyQualifiedName $tableName,
         string $schemaColumn,
         string $tableColumn,
         array &$params,
@@ -483,17 +474,17 @@ SQL,
         $conditions = [];
 
         if ($tableName !== null) {
-            if (str_contains($tableName, '.')) {
-                [$schemaName, $tableName] = explode('.', $tableName);
+            $qualifier = $tableName->getQualifier();
 
+            if ($qualifier !== null) {
                 $conditions = [sprintf('%s = ?', $schemaColumn)];
-                $params[]   = $schemaName;
+                $params[]   = $qualifier->toNormalizedValue($this->platform);
             } else {
                 $conditions = [sprintf('%s = SCHEMA_NAME()', $schemaColumn)];
             }
 
             $conditions[] = sprintf('%s = ?', $tableColumn);
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         // The "sysdiagrams" table must be ignored as it's internal SQL Server table for Database Diagrams

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Exception\UnsupportedSchema;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
@@ -53,9 +54,12 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     {
         $columnsByTable = parent::fetchForeignKeyColumnsByTable($databaseName);
 
-        if (count($columnsByTable) > 0) {
-            foreach ($columnsByTable as $table => $columns) {
-                $columnsByTable[$table] = $this->addDetailsToTableForeignKeyColumns($table, $columns);
+        foreach ($columnsByTable as $schemaNameKey => $schemaTables) {
+            assert($schemaNameKey === self::NULL_SCHEMA_KEY);
+
+            foreach ($schemaTables as $tableName => $columns) {
+                $columnsByTable[$schemaNameKey][$tableName]
+                    = $this->addDetailsToTableForeignKeyColumns($tableName, $columns);
             }
         }
 
@@ -81,27 +85,22 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     /**
      * {@inheritDoc}
      */
-    public function listTableForeignKeys(string $table): array
+    public function listTableForeignKeys(string $tableName): array
     {
-        $table = $this->normalizeName($table);
+        $tableName = $this->parseOptionallyQualifiedName($tableName);
 
-        $columns = $this->fetchForeignKeyColumns('main', $table);
+        $this->ensureUnqualifiedName($tableName, __METHOD__);
+
+        $columns = $this->fetchForeignKeyColumns('main', $tableName);
 
         if (count($columns) > 0) {
-            $columns = $this->addDetailsToTableForeignKeyColumns($table, $columns);
+            $columns = $this->addDetailsToTableForeignKeyColumns(
+                $tableName->getUnqualifiedName()->toNormalizedValue($this->platform),
+                $columns,
+            );
         }
 
         return $this->_getPortableTableForeignKeysList($columns);
-    }
-
-    /**
-     * @deprecated Use the schema name and the unqualified table name separately instead.
-     *
-     * {@inheritDoc}
-     */
-    protected function _getPortableTableDefinition(array $table): string
-    {
-        return $table['table_name'];
     }
 
     /**
@@ -222,7 +221,9 @@ class SQLiteSchemaManager extends AbstractSchemaManager
 
             // Inferring a shorthand form for the foreign key constraint, where the "to" field is empty.
             // @see https://www.sqlite.org/foreignkeys.html#fk_indexes.
-            $foreignTablePrimaryKeyColumnRows = $this->fetchPrimaryKeyColumns($value['foreignTable']);
+            $foreignTablePrimaryKeyColumnRows = $this->fetchPrimaryKeyColumns(
+                OptionallyQualifiedName::quoted($value['foreignTable']),
+            );
 
             if (count($foreignTablePrimaryKeyColumnRows) < 1) {
                 throw UnsupportedSchema::sqliteMissingForeignKeyConstraintReferencedColumns(
@@ -298,7 +299,7 @@ CREATE\sTABLE' . $this->buildIdentifierPattern($table) . '
     }
 
     /** @throws Exception */
-    private function getCreateTableSQL(string $table): string
+    private function getCreateTableSQL(string $tableName): string
     {
         $sql = $this->connection->fetchOne(
             <<<'SQL'
@@ -314,7 +315,7 @@ WHERE type = 'table'
 AND name = ?
 SQL
             ,
-            [$table],
+            [$tableName],
         );
 
         if ($sql !== false) {
@@ -331,9 +332,9 @@ SQL
      *
      * @throws Exception
      */
-    private function addDetailsToTableForeignKeyColumns(string $table, array $columns): array
+    private function addDetailsToTableForeignKeyColumns(string $tableName, array $columns): array
     {
-        $foreignKeyDetails = $this->getForeignKeyDetails($table);
+        $foreignKeyDetails = $this->getForeignKeyDetails($tableName);
         $foreignKeyCount   = count($foreignKeyDetails);
 
         foreach ($columns as $i => $column) {
@@ -349,9 +350,9 @@ SQL
      *
      * @throws Exception
      */
-    private function getForeignKeyDetails(string $table): array
+    private function getForeignKeyDetails(string $tableName): array
     {
-        $createSql = $this->getCreateTableSQL($table);
+        $createSql = $this->getCreateTableSQL($tableName);
 
         if (
             preg_match_all(
@@ -403,28 +404,31 @@ SQL
 
     protected function selectTableNames(string $databaseName): Result
     {
-        $sql = <<<'SQL'
-SELECT name AS table_name
+        $sql = sprintf(
+            <<<'SQL'
+SELECT name AS %1$s
 FROM sqlite_master
 WHERE type = 'table'
   AND name NOT IN ('geometry_columns', 'spatial_ref_sys', 'sqlite_sequence')
 UNION ALL
-SELECT name
+SELECT name AS %1$s
 FROM sqlite_temp_master
 WHERE type = 'table'
-ORDER BY name
-SQL;
+ORDER BY 1
+SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+        );
 
         return $this->connection->executeQuery($sql);
     }
 
-    protected function selectTableColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
-            SELECT t.name AS table_name,
+            SELECT t.name AS %s,
                    c.*
               FROM sqlite_master t
               JOIN pragma_table_info(t.name) c
@@ -432,19 +436,20 @@ SQL;
           ORDER BY t.name,
                    c.cid
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, $params),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectIndexColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
-            SELECT t.name AS table_name,
+            SELECT t.name AS %s,
                    i.name,
                    i."unique"
               FROM sqlite_master t
@@ -452,19 +457,20 @@ SQL,
              WHERE %s
           ORDER BY t.name, i.seq
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, $params),
         );
 
         return $this->connection->executeQuery($sql, $params);
     }
 
-    protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
+    protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
-            SELECT t.name AS table_name,
+            SELECT t.name AS %s,
                    p.*
               FROM sqlite_master t
               JOIN pragma_foreign_key_list(t.name) p
@@ -474,6 +480,7 @@ SQL,
                    p.id DESC,
                    p.seq
 SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, $params),
         );
 
@@ -483,32 +490,36 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableColumns(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
+        if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+        }
+
         $rows = parent::fetchTableColumns($databaseName, $tableName);
 
         $sqlByTable = $pkColumnNamesByTable = $result = [];
 
         foreach ($rows as $row) {
-            $tableName = $row['table_name'];
+            $unqualifiedTableName = $row[self::TABLE_NAME_COLUMN];
 
-            $sqlByTable[$tableName] ??= $this->getCreateTableSQL($tableName);
+            $sqlByTable[$unqualifiedTableName] ??= $this->getCreateTableSQL($unqualifiedTableName);
 
             if ($row['pk'] === 0 || $row['pk'] === '0' || $row['type'] !== 'INTEGER') {
                 continue;
             }
 
-            $pkColumnNamesByTable[$tableName][] = $row['name'];
+            $pkColumnNamesByTable[$unqualifiedTableName][] = $row['name'];
         }
 
         foreach ($rows as $row) {
-            $tableName  = $row['table_name'];
-            $columnName = $row['name'];
-            $tableSQL   = $sqlByTable[$row['table_name']];
+            $unqualifiedTableName = $row[self::TABLE_NAME_COLUMN];
+            $columnName           = $row['name'];
+            $tableSQL             = $sqlByTable[$row[self::TABLE_NAME_COLUMN]];
 
             $result[] = array_merge($row, [
-                'autoincrement' => isset($pkColumnNamesByTable[$tableName])
-                    && $pkColumnNamesByTable[$tableName] === [$columnName],
+                'autoincrement' => isset($pkColumnNamesByTable[$unqualifiedTableName])
+                    && $pkColumnNamesByTable[$unqualifiedTableName] === [$columnName],
                 'collation' => $this->parseColumnCollationFromSQL($columnName, $tableSQL),
                 'comment' => $this->parseColumnCommentFromSQL($columnName, $tableSQL),
             ]);
@@ -523,7 +534,7 @@ SQL,
      *
      * {@inheritDoc}
      */
-    protected function fetchIndexColumns(string $databaseName, ?string $tableName = null): array
+    protected function fetchIndexColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         $result = [];
 
@@ -531,7 +542,7 @@ SQL,
 
         foreach ($pkColumnNameRows as $pkColumnNameRow) {
             $result[] = [
-                'table_name' => $pkColumnNameRow['table_name'],
+                self::TABLE_NAME_COLUMN => $pkColumnNameRow[self::TABLE_NAME_COLUMN],
                 'key_name' => 'primary',
                 'primary' => true,
                 'non_unique' => false,
@@ -550,7 +561,7 @@ SQL,
             $keyName = $indexColumnRow['name'];
 
             $row = [
-                'table_name' => $indexColumnRow['table_name'],
+                self::TABLE_NAME_COLUMN => $indexColumnRow[self::TABLE_NAME_COLUMN],
                 'key_name'   => $keyName,
                 'primary'    => false,
                 'non_unique' => ! $indexColumnRow['unique'],
@@ -579,13 +590,13 @@ SQL,
      *
      * @throws Exception
      */
-    private function fetchPrimaryKeyColumns(?string $tableName = null): array
+    private function fetchPrimaryKeyColumns(?OptionallyQualifiedName $tableName = null): array
     {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
-            SELECT t.name AS table_name,
+            SELECT t.name AS %s,
                    p.name
               FROM sqlite_master t
               JOIN pragma_table_info(t.name) p
@@ -594,6 +605,7 @@ SQL,
           ORDER BY t.name,
                    p.pk
         SQL,
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, $params),
         );
 
@@ -603,30 +615,35 @@ SQL,
     /**
      * {@inheritDoc}
      */
-    protected function fetchTableOptionsByTable(string $databaseName, ?string $tableName = null): array
+    protected function fetchTableOptionsByTable(string $databaseName, ?OptionallyQualifiedName $tableName = null): array
     {
         if ($tableName === null) {
-            $tables = $this->listTableNames();
+            $tableNames = $this->listTableNames();
         } else {
-            $tables = [$tableName];
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
+            $tableNames = [$tableName->getUnqualifiedName()->toNormalizedValue($this->platform)];
         }
 
         $tableOptions = [];
-        foreach ($tables as $table) {
-            $comment = $this->parseTableCommentFromSQL($table, $this->getCreateTableSQL($table));
+        foreach ($tableNames as $unqualifiedTableName) {
+            $comment = $this->parseTableCommentFromSQL(
+                $unqualifiedTableName,
+                $this->getCreateTableSQL($unqualifiedTableName),
+            );
 
             if ($comment === null) {
                 continue;
             }
 
-            $tableOptions[$table]['comment'] = $comment;
+            $tableOptions[self::NULL_SCHEMA_KEY][$unqualifiedTableName]['comment'] = $comment;
         }
 
         return $tableOptions;
     }
 
     /** @param list<string> $params */
-    private function getWhereClause(?string $tableName, array &$params): string
+    private function getWhereClause(?OptionallyQualifiedName $tableName, array &$params): string
     {
         $conditions = [
             "t.type = 'table'",
@@ -634,8 +651,10 @@ SQL,
         ];
 
         if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
             $conditions[] = 't.name = ?';
-            $params[]     = $tableName;
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue($this->platform);
         }
 
         return implode(' AND ', $conditions);

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -7,16 +7,12 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Exception\InvalidName;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
-use PHPUnit\Framework\Attributes\TestWith;
-
-use function sprintf;
+use Doctrine\DBAL\Types\Types;
 
 final class SchemaManagerTest extends FunctionalTestCase
 {
-    use VerifyDeprecations;
-
     private AbstractSchemaManager $schemaManager;
 
     /** @throws Exception */
@@ -26,35 +22,14 @@ final class SchemaManagerTest extends FunctionalTestCase
     }
 
     /** @throws Exception */
-    #[TestWith([false])]
-    #[TestWith([true])]
-    public function testIntrospectTableWithDotInName(bool $quoted): void
+    public function testIntrospectTableWithDotInName(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
+        $table = new Table('"example.com"');
+        $table->addColumn('id', Types::INTEGER);
 
-        if ($platform->supportsSchemas()) {
-            self::markTestIncomplete('DBAL 4.x will fail to introspect this table on a platform that supports schemas');
-        }
+        $this->dropAndCreateTable($table);
 
-        $name           = 'example.com';
-        $normalizedName = $platform->normalizeUnquotedIdentifier($name);
-        $quotedName     = $this->connection->quoteSingleIdentifier($normalizedName);
-
-        // create the table manually since identifiers with dots are not supported in DBAL 4.x
-        $sql = sprintf('CREATE TABLE %s (s VARCHAR(16))', $quotedName);
-
-        $this->dropTableIfExists($quotedName);
-        $this->connection->executeStatement($sql);
-
-        if ($quoted) {
-            $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6768');
-
-            $table = $this->schemaManager->introspectTable($quotedName);
-        } else {
-            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6768');
-
-            $table = $this->schemaManager->introspectTable($name);
-        }
+        $table = $this->schemaManager->introspectTable('"example.com"');
 
         self::assertCount(1, $table->getColumns());
     }

--- a/tests/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Schema/SQLiteSchemaManagerTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -215,8 +216,10 @@ class SQLiteSchemaManagerTest extends TestCase
         $manager = new class ($conn, new SQLitePlatform()) extends SQLiteSchemaManager {
             public static string $passedDatabaseName;
 
-            protected function selectForeignKeyColumns(string $databaseName, ?string $tableName = null): Result
-            {
+            protected function selectForeignKeyColumns(
+                string $databaseName,
+                ?OptionallyQualifiedName $tableName = null,
+            ): Result {
                 self::$passedDatabaseName = $databaseName;
 
                 return parent::selectForeignKeyColumns($databaseName, $tableName);


### PR DESCRIPTION
This change eliminates the collision caused by the usage of value returned by as the key for grouping table-scoped objects (see https://github.com/doctrine/dbal/pull/6755).

Also, it enables changing the type of the parameter accepted by `TableEditor::setName()` from `string` (currently) to `OptionallyQualifiedName` which now can be built directly from introspected schema: https://github.com/doctrine/dbal/blob/76ab7a377073777a0792771f3a8223a776f9d470/src/Schema/AbstractSchemaManager.php#L268-L272

I will do it in a subsequent PR before `TableEditor::setName()` is released in 4.3.0

## Breaking changes

Besides the breaking changes in the public API, there are more in the protected Schema Manager API for which no upgrade path is being provided:
1. The `select*()` methods that accept a table name (e.g. `selectTableColumns()`) and the corresponding `fetch*()` methods (e.g. `fetchTableColumns()`) now accept the table name as `OptionallyQualifiedName`, not `string`.
2. The above `fetch*()` methods, instead of returning lists of rows grouped by qualified table name, return list of rows grouped by schema name and table name (another level of nesting).

## Improvements

Now, table names containing a dot (e.g. `"example.com"`) can be introspected on the platforms that support schemas without specifying the schema name (see the updated test).

## Future scope

Having the schema managers implement the same API for the database platforms that do and don't support schemas make the code a bit too complex and requiring extra documentation and runtime checks. A better and simpler code could be achieved by using separate APIs for fetching the schema of the databases that do and don't support schemas and an adapter between them, but this would be too much of additional rework at this point.

Fixes: https://github.com/doctrine/dbal/issues/6764.