### PR TITLE
Trim quotes in unqualified foreign table names when diffing foreign keys

### DIFF
--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -251,6 +251,10 @@ class ForeignKeyConstraint extends AbstractAsset implements Constraint
             $name = substr($name, $position + 1);
         }
 
+        if ($this->isIdentifierQuoted($name)) {
+            $name = $this->trimQuotes($name);
+        }
+
         return strtolower($name);
     }
 

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+use function array_merge;
+
+final class SchemaManagerTest extends FunctionalTestCase
+{
+    private AbstractSchemaManager $schemaManager;
+
+    /** @throws Exception */
+    protected function setUp(): void
+    {
+        $this->schemaManager = $this->connection->createSchemaManager();
+    }
+
+    /**
+     * @param callable(AbstractSchemaManager):Comparator $comparatorFactory
+     *
+     * @dataProvider dataEmptyDiffRegardlessOfForeignTableQuotes
+     */
+    public function testEmptyDiffRegardlessOfForeignTableQuotes(
+        callable $comparatorFactory,
+        string $foreignTableName
+    ): void {
+        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
+            self::markTestSkipped('Platform does not support schemas.');
+        }
+
+        $this->dropTableIfExists('other_schema.other_table');
+        $this->dropTableIfExists('other_schema."user"');
+        $this->dropSchemaIfExists('other_schema');
+
+        $tableForeign = new Table($foreignTableName);
+        $tableForeign->addColumn('id', 'integer');
+        $tableForeign->setPrimaryKey(['id']);
+
+        $tableTo = new Table('other_schema.other_table');
+        $tableTo->addColumn('id', 'integer');
+        $tableTo->addColumn('user_id', 'integer');
+        $tableTo->setPrimaryKey(['id']);
+        $tableTo->addForeignKeyConstraint($tableForeign, ['user_id'], ['id'], []);
+
+        $schemaTo = new Schema([$tableForeign, $tableTo]);
+        $this->schemaManager->createSchemaObjects($schemaTo);
+
+        $schemaFrom = $this->schemaManager->introspectSchema();
+        $tableFrom  = $schemaFrom->getTable('other_schema.other_table');
+
+        $diff = $comparatorFactory($this->schemaManager)->compareTables($tableFrom, $tableTo);
+        self::assertTrue($diff->isEmpty());
+    }
+
+    /** @return iterable<mixed[]> */
+    public static function dataEmptyDiffRegardlessOfForeignTableQuotes(): iterable
+    {
+        foreach (ComparatorTestUtils::comparatorProvider() as $comparatorArguments) {
+            foreach (
+                [
+                    'unquoted' => ['other_schema.user'],
+                    'partially quoted' => ['other_schema."user"'],
+                    'fully quoted' => ['"other_schema"."user"'],
+                ] as $testArguments
+            ) {
+                yield array_merge($comparatorArguments, $testArguments);
+            }
+        }
+    }
+}

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -98,4 +98,19 @@ abstract class FunctionalTestCase extends TestCase
         $this->dropTableIfExists($tableName);
         $schemaManager->createTable($table);
     }
+
+    /**
+     * Drops the schema with the specified name, if it exists.
+     *
+     * @throws Exception
+     */
+    public function dropSchemaIfExists(string $name): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        try {
+            $schemaManager->dropSchema($name);
+        } catch (DatabaseObjectNotFoundException $e) {
+        }
+    }
 }

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -72,8 +72,12 @@ class ForeignKeyConstraintTest extends TestCase
     {
         return [
             ['schema.foreign_table', 'foreign_table'],
+            ['schema."foreign_table"', 'foreign_table'],
+            ['"schema"."foreign_table"', 'foreign_table'],
             ['foreign_table', 'foreign_table'],
             [new Table('schema.foreign_table'), 'foreign_table'],
+            [new Table('schema."foreign_table"'), 'foreign_table'],
+            [new Table('"schema"."foreign_table"'), 'foreign_table'],
             [new Table('foreign_table'), 'foreign_table'],
         ];
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6772

#### Summary

Trims the quotes in `ForeignKeyConstraint::getUnqualifiedForeignTableName`, only if quoted. Used in `Comparator::diffForeignKey` when comparing foreign keys for changes. Fixes dropping and re-adding of foreign keys when foreign table name is simultaneously a reserved word (quoted) and in a non-default schema (not in [default search path schemas](https://www.postgresql.org/docs/16/ddl-schemas.html#DDL-SCHEMAS-PATH)).
