### PR TITLE
PostgreSQL: Add schema name to DROP INDEX when table not in default schema

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -833,6 +833,16 @@ SQL
             return $this->getDropConstraintSQL($constraintName, $table);
         }
 
+        if ($table !== null) {
+            $indexName = $index instanceof Index ? $index->getQuotedName($this) : $index;
+            $tableName = $table instanceof Table ? $table->getQuotedName($this) : $table;
+
+            if (strpos($tableName, '.') !== false) {
+                [$schema] = explode('.', $tableName);
+                $index    = $schema . '.' . $indexName;
+            }
+        }
+
         return parent::getDropIndexSQL($index, $table);
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

For indexes created on tables not in default search path schemas (like `myschema.mytable`) , PostgreSQL also needs the schema name along the index name in the `DROP INDEX` query.

Consider the following index:
```sql
CREATE INDEX myindex ON myschema.mytable (mycolumn);
```

When the index is removed from mappings/metadata, the following SQL command is generated by the Comparator, but will fail when executed (and potentially dangerous, as it will drop the indexes in the default schemas, if they exist) :
```
DROP INDEX myindex;

[42704] ERROR: index "myindex" does not exist
```

To drop the index, the SQL query needs to be:
```
DROP INDEX myschema.myindex;

completed in 19 ms
```


