### PR TITLE
Accept OptionallyQualifiedName in TableEditor::setName()

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -230,26 +230,15 @@ abstract class AbstractSchemaManager
                 continue;
             }
 
-            $editor = Table::editor()
-                ->setName($tableName)
-                ->setColumns($this->_getPortableTableColumnList($tableName, $database, $tableColumns))
-                ->setIndexes(
-                    $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? [], $tableName),
-                );
-
-            if (isset($foreignKeyColumnsByTable[$tableName])) {
-                $editor->setForeignKeyConstraints(
-                    $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName]),
-                );
-            }
-
-            if (isset($tableOptionsByTable[$tableName])) {
-                $editor->setOptions($tableOptionsByTable[$tableName]);
-            }
-
-            $tables[] = $editor
-                ->setConfiguration($configuration)
-                ->create();
+            $tables[] = new Table(
+                $tableName,
+                $this->_getPortableTableColumnList($tableName, $database, $tableColumns),
+                $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? [], $tableName),
+                [],
+                $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName] ?? []),
+                $tableOptionsByTable[$tableName] ?? [],
+                $configuration,
+            );
         }
 
         return $tables;
@@ -464,13 +453,14 @@ abstract class AbstractSchemaManager
             throw TableDoesNotExist::new($name);
         }
 
-        return Table::editor()
-            ->setName($name)
-            ->setColumns($columns)
-            ->setIndexes($this->listTableIndexes($name))
-            ->setForeignKeyConstraints($this->listTableForeignKeys($name))
-            ->setOptions($this->getTableOptions($name))
-            ->create();
+        return new Table(
+            $name,
+            $columns,
+            $this->listTableIndexes($name),
+            [],
+            $this->listTableForeignKeys($name),
+            $this->getTableOptions($name),
+        );
     }
 
     /**

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -371,13 +371,12 @@ class Schema extends AbstractAsset
      */
     public function createTable(string $name): Table
     {
-        $table = Table::editor()
-            ->setName($name)
-            ->setOptions($this->_schemaConfig->getDefaultTableOptions())
-            ->setConfiguration($this->_schemaConfig->toTableConfiguration())
-            ->create();
-
+        $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
         $this->_addTable($table);
+
+        foreach ($this->_schemaConfig->getDefaultTableOptions() as $option => $value) {
+            $table->addOption($option, $value);
+        }
 
         return $table;
     }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -72,9 +72,6 @@ class Table extends AbstractNamedObject
     private int $maxIdentifierLength;
 
     /**
-     * @internal Use {@link Table::editor()} to instantiate an editor and {@link TableEditor::create()}
-     *           to create a table.
-     *
      * @param array<Column>               $columns
      * @param array<Index>                $indexes
      * @param array<UniqueConstraint>     $uniqueConstraints
@@ -873,7 +870,7 @@ class Table extends AbstractNamedObject
     public function edit(): TableEditor
     {
         return self::editor()
-            ->setName($this->getObjectName()->toString())
+            ->setName($this->getObjectName())
             ->setColumns($this->_columns)
             ->setIndexes($this->_indexes)
             ->setUniqueConstraints($this->uniqueConstraints)

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 
 final class TableEditor
 {
-    private ?string $name = null;
+    private ?OptionallyQualifiedName $name = null;
 
     /** @var array<Column> */
     private array $columns = [];
@@ -32,7 +33,7 @@ final class TableEditor
     {
     }
 
-    public function setName(string $name): self
+    public function setName(OptionallyQualifiedName $name): self
     {
         $this->name = $name;
 
@@ -93,7 +94,7 @@ final class TableEditor
         }
 
         return new Table(
-            $this->name,
+            $this->name->toString(),
             $this->columns,
             $this->indexes,
             $this->uniqueConstraints,

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\TestCase;
 
@@ -12,12 +13,14 @@ class TableEditorTest extends TestCase
 {
     public function testSetName(): void
     {
+        $name = OptionallyQualifiedName::unquoted('contacts');
+
         $table = (new Table('accounts'))
             ->edit()
-            ->setName('contacts')
+            ->setName($name)
             ->create();
 
-        self::assertSame('contacts', $table->getName());
+        self::assertEquals($name, $table->getObjectName());
     }
 
     public function testNameNotSet(): void


### PR DESCRIPTION
### Background

`TableEditor` was the first object editor introduced (https://github.com/doctrine/dbal/pull/6660). Later, it was followed by `UniqueConstraintEditor` (https://github.com/doctrine/dbal/pull/6685) and `ForeignKeyConstraintEditor` (https://github.com/doctrine/dbal/pull/6728).

The API of `TableEditor` was designed to closely mimic the `Table` constructor. Specifically, `setName()` accepts `string`. The other two were designed to provide an upgrade path to 5.0 where we eventually want to express object names as `Name` instances.

In order to unify the API of the editors and avoid an unnecessary BC break in the future, I want `TableEditor#setName()` to also accept a `Name`.

### Implementation details

In order to accommodate this API change, we need to revert the introduction of the usage of `TableEditor` in all existing code, because a `Table` in 4.x is not guaranteed to have a valid (in terms of the SQL syntax) name. During the merge up, all those reverts will be discarded, so the 5.0.x code will keep using the editor.

Additionally, I'm unmarking the `Table` constructor as `@internal` for now. Unlike the `UniqueConstraint` and `ForeignKeyConstraint` editors, the existing `Table` editor hasn't fully replaced the usage of the constructor in 5.0, so expecting the end users to be able to not use the constructor is unrealistic. _In its current state_, it will lead to a worse user experience.