### PR TITLE
feat: support non-libc collations in postgres

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -220,6 +220,8 @@ jobs:
       matrix:
         php-version:
           - "8.4"
+        postgres-locale-provider:
+            - "libc"
         postgres-version:
           - "10"
           - "16"
@@ -240,11 +242,16 @@ jobs:
           - php-version: "8.5"
             postgres-version: "17"
             extension: "pdo_pgsql"
+          - php-version: "8.4"
+            postgres-version: "15"
+            extension: "pdo_pgsql"
+            postgres-locale-provider: "icu"
 
     services:
       postgres:
         image: "postgres:${{ matrix.postgres-version }}"
         env:
+          POSTGRES_INITDB_ARGS: ${{ matrix.postgres-locale-provider == 'icu' && '--locale-provider=icu --icu-locale=en-US' || '' }}
           POSTGRES_PASSWORD: "postgres"
 
         options: >-
@@ -278,7 +285,7 @@ jobs:
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "${{ github.job }}-${{ matrix.postgres-version }}-${{ matrix.extension }}-${{ matrix.php-version }}.coverage"
+          name: "${{ github.job }}-${{ matrix.postgres-version }}-${{ matrix.extension }}-${{ matrix.php-version }}-${{ matrix.postgres-locale-provider }}.coverage"
           path: "coverage.xml"
 
   phpunit-mariadb:

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -431,7 +431,14 @@ SQL;
             quote_ident(a.attname) AS field,
             t.typname AS type,
             format_type(a.atttypid, a.atttypmod) AS complete_type,
-            (SELECT tc.collcollate FROM pg_catalog.pg_collation tc WHERE tc.oid = a.attcollation) AS collation,
+            (
+                SELECT CASE
+                    WHEN collprovider = 'c' THEN tc.collcollate
+                    WHEN collprovider = 'd' THEN null
+                    ELSE tc.collname
+                END
+                FROM pg_catalog.pg_collation tc WHERE tc.oid = a.attcollation
+            ) AS collation,
             (SELECT t1.typname FROM pg_catalog.pg_type t1 WHERE t1.oid = t.typbasetype) AS domain_type,
             (SELECT format_type(t2.typbasetype, t2.typtypmod) FROM
               pg_catalog.pg_type t2 WHERE t2.typtype = 'd' AND t2.oid = a.atttypid) AS domain_complete_type,

--- a/tests/Functional/Platform/AlterColumnTest.php
+++ b/tests/Functional/Platform/AlterColumnTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Platform;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -35,5 +36,55 @@ class AlterColumnTest extends FunctionalTestCase
         self::assertCount(2, $columns);
         self::assertEqualsIgnoringCase('c1', $columns[0]->getName());
         self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
+    }
+
+    public function testSupportsCollations(): void
+    {
+        if (! $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('This test covers PostgreSQL-specific schema comparison scenarios.');
+        }
+
+        $table = new Table('test_alter');
+
+        $columnUft8EnUs = $table->addColumn('c1', Types::STRING);
+        $columnUft8EnUs->setPlatformOption('collation', 'en_US.utf8');
+
+        $table->addColumn('c2', Types::STRING);
+
+        $this->dropAndCreateTable($table);
+
+        $sm   = $this->connection->createSchemaManager();
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('test_alter'), $table);
+
+        self::assertTrue($diff->isEmpty());
+    }
+
+    public function testSupportsIcuCollationProviders(): void
+    {
+        if (! $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('This test covers PostgreSQL-specific schema comparison scenarios.');
+        }
+
+        $hasIcuCollations = $this->connection->fetchOne(
+            "SELECT 1 FROM pg_collation WHERE collprovider = 'icu'",
+        ) !== false;
+
+        if (! $hasIcuCollations) {
+            self::markTestSkipped('This test requires ICU collations to be available.');
+        }
+
+        $table = new Table('test_alter');
+
+        $columnIcu = $table->addColumn('c1', Types::STRING);
+        $columnIcu->setPlatformOption('collation', 'en-US-x-icu');
+
+        $this->dropAndCreateTable($table);
+
+        $sm   = $this->connection->createSchemaManager();
+        $diff = $sm->createComparator()
+            ->compareTables($sm->introspectTable('test_alter'), $table);
+
+        self::assertTrue($diff->isEmpty());
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | 

#### Summary

Collation registry (pg_catalog.pg_collation) may contain null values in `collcollate` column. Libc collations have the column set but other collations have `collname` set instead.

In CI force install ICU locales via initdb.

-------------

For libc we have to keep using `collcollate`:
<img width="493" alt="image" src="https://github.com/user-attachments/assets/40d0e3ad-327d-4e57-b761-5c23603b4c6a" />

Since there may be differences in `collcollate` and `collname` and we don't want BC break:

<img width="659" alt="image" src="https://github.com/user-attachments/assets/40922752-3091-4b90-8376-cf3310d5d371" />

----------

For default provider use `null`:

<img width="644" alt="image" src="https://github.com/user-attachments/assets/138a41e2-fe81-4a18-822b-e77aac00d8f1" />

-----------

For icu use `collname` (not `colliculocale` so user can reference [custom collations](https://www.postgresql.org/docs/14/collation.html#COLLATION-CREATE)):

<img width="727" alt="image" src="https://github.com/user-attachments/assets/b7613a63-6416-4374-a04a-f06bd5183458" />

------------

_Catalog ref: https://www.postgresql.org/docs/current/catalog-pg-collation.html#CATALOG-PG-COLLATION_

