### PR TITLE
Introduce IndexedColumn

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `Index` usage scenarios
+
+The following `Index` usage scenarios have been deprecated:
+
+1. Instantiation of an index with empty columns
+2. Instantiation of a primary key index with column lengths specified
+3. Using qualified or otherwise invalid column names in index columns
+4. Using other values than positive integers as index column lengths
+5. Using nullable columns in a primary key index
+
 ## Deprecated passing unquoted names containing dots for table introspection on platforms that don't support schemas
 
 Relying on table names containing dots not being parsed on platforms that don't support schemas is deprecated. If a

--- a/src/Schema/Exception/InvalidState.php
+++ b/src/Schema/Exception/InvalidState.php
@@ -16,10 +16,15 @@ final class InvalidState extends LogicException implements SchemaException
         return new self('Object name has not been initialized.');
     }
 
+    public static function indexHasInvalidColumns(string $indexName): self
+    {
+        return new self(sprintf('Index "%s" has invalid columns.', $indexName));
+    }
+
     public static function foreignKeyConstraintHasInvalidReferencedTableName(string $constraintName): self
     {
         return new self(sprintf(
-            'Foreign key constraint "%s" has invalid referenced table names.',
+            'Foreign key constraint "%s" has invalid referenced table name.',
             $constraintName,
         ));
     }

--- a/src/Schema/Index/IndexedColumn.php
+++ b/src/Schema/Index/IndexedColumn.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Index;
+
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+final class IndexedColumn
+{
+    /**
+     * @internal
+     *
+     * @param ?positive-int $length
+     */
+    public function __construct(private readonly UnqualifiedName $columnName, private readonly ?int $length)
+    {
+    }
+
+    public function getColumnName(): UnqualifiedName
+    {
+        return $this->columnName;
+    }
+
+    public function getLength(): ?int
+    {
+        return $this->length;
+    }
+}

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -151,6 +151,15 @@ class Table extends AbstractNamedObject
 
         foreach ($columnNames as $columnName) {
             $column = $this->getColumn($columnName);
+
+            if (! $column->getNotnull()) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6787',
+                    'Using nullable columns in a primary key index is deprecated.',
+                );
+            }
+
             $column->setNotnull(true);
         }
 

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -293,6 +293,8 @@ class TableTest extends TestCase
 
     public function testBuilderSetPrimaryKey(): void
     {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6787');
+
         $table = new Table('foo');
 
         $table->addColumn('bar', Types::INTEGER);
@@ -302,6 +304,20 @@ class TableTest extends TestCase
         self::assertInstanceOf(Index::class, $table->getPrimaryKey());
         self::assertTrue($table->getIndex('primary')->isUnique());
         self::assertTrue($table->getIndex('primary')->isPrimary());
+    }
+
+    public function testSetPrimaryKeyOnANullableColumn(): void
+    {
+        $table = new Table('users');
+
+        $id = $table->addColumn('id', Types::INTEGER)
+            ->setNotnull(false);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6787');
+
+        $table->setPrimaryKey(['id']);
+
+        self::assertTrue($id->getNotnull());
     }
 
     public function testBuilderAddUniqueIndex(): void


### PR DESCRIPTION
Before reworking `Index` similarly to `UniqueConstraint` and `ForeignKeyConstraint`, I want to introduce `PrimaryKeyConstraint`. Currently, they are represented as indexes with the "is primary" attribute set to `true`, but there's no such thing as "primary index". On all supported platforms, a primary index is implemented as a `PRIMARY KEY` constraint.

Besides introducing such a class, I want to provide an upgrade path and implement a new API (e.g. `Table#getPrimaryKeyConstraint()`) which would be state-compatible with the existing API. For instance, a user should be able to create a primary index and then access the primary key constraint.

For that, I want to deprecate all invalid states that an index may currently have. The `IndexedColumn` class, particularly, will provide some guarantees for indexed column names and their lengths. Also, it will combine the name and the length together, which should be easier to use.

Additionally, even though it currently works correctly, I'm deprecating using nullable columns in a primary index. The reasons are:
1. It's a made-up requirement. Columns in DBAL are non-nullable by default, so someone has to manually to declare it as nullable for that feature to be relevant. Implicitly overriding the definition that the user has explicitly provided looks shady.
2. It mutates the column, while we're moving towards immutable types.