### PR TITLE
Mark protected platform and schema manager methods as internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,22 @@ table name contains a dot or other special characters, it should be quoted.
 
 Passing names that are not valid SQL to the schema introspection methods is also deprecated.
 
+## Platform and schema manager methods marked as internal
+
+The following platform and schema manager methods are considered implementation details and have been marked as
+internal:
+
+- `OraclePlatform::getCreateAutoincrementSql()`
+- `OraclePlatform::getIdentitySequenceName()`
+- `OracleSchemaManager::dropAutoincrement()`
+- `SQLServerPlatform::getCreateColumnCommentSQL()`
+- `SQLServerPlatform::getDefaultConstraintDeclarationSQL()`
+- `SQLServerPlatform::getAlterColumnCommentSQL()`
+- `SQLServerPlatform::getDropColumnCommentSQL()`
+- `SQLServerPlatform::getAddExtendedPropertySQL()`
+- `SQLServerPlatform::getDropExtendedPropertySQL()`
+- `SQLServerPlatform::getUpdateExtendedPropertySQL()`
+
 ## Deprecated `AbstractSchemaManager::_normalizeName()`
 
 The `AbstractSchemaManager::_normalizeName()` method has been deprecated. Use `Identifier::toNormalizedValue()` to

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -345,7 +345,11 @@ class OraclePlatform extends AbstractPlatform
         return 'SELECT view_name, text FROM sys.user_views';
     }
 
-    /** @return array<int, string> */
+    /**
+     * @internal The method should be only used by the {@see OraclePlatform} class.
+     *
+     * @return array<int, string>
+     */
     protected function getCreateAutoincrementSql(string $name, string $table, int $start = 1): array
     {
         $tableIdentifier   = $this->normalizeIdentifier($table);
@@ -684,6 +688,7 @@ END;';
         return ['ALTER INDEX ' . $oldIndexName . ' RENAME TO ' . $index->getQuotedName($this)];
     }
 
+    /** @internal The method should be only used by the {@see OraclePlatform} class. */
     protected function getIdentitySequenceName(string $tableName): string
     {
         $table = new Identifier($tableName);

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -279,6 +279,8 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
+     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to create the comment for.
      * @param string $comment    The column's comment.
@@ -305,6 +307,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * Returns the SQL snippet for declaring a default constraint.
+     *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
      *
      * @param mixed[] $column Column definition.
      */
@@ -568,6 +572,8 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
+     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to alter the comment for.
      * @param string $comment    The column's comment.
@@ -602,6 +608,8 @@ class SQLServerPlatform extends AbstractPlatform
      * which provides compatibility with SQL Server Management Studio,
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
+     *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
      *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to drop the comment for.
@@ -661,6 +669,8 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for adding an extended property to a database object.
      *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
+     *
      * @link http://msdn.microsoft.com/en-us/library/ms180047%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to add.
@@ -695,6 +705,8 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for dropping an extended property from a database object.
      *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
+     *
      * @link http://technet.microsoft.com/en-gb/library/ms178595%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to drop.
@@ -726,6 +738,8 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * Returns the SQL statement for updating an extended property of a database object.
+     *
+     * @internal The method should be only used by the {@see SQLServerPlatform} class.
      *
      * @link http://msdn.microsoft.com/en-us/library/ms186885%28v=sql.90%29.aspx
      *

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -283,7 +283,11 @@ class OracleSchemaManager extends AbstractSchemaManager
         $this->connection->executeStatement($statement);
     }
 
-    /** @throws Exception */
+    /**
+     * @internal The method should be only used by the {@see OracleSchemaManager} class.
+     *
+     * @throws Exception
+     */
     protected function dropAutoincrement(string $table): bool
     {
         $sql = $this->platform->getDropAutoincrementSql($table);


### PR DESCRIPTION
Every protected method of a platform or schema manager class that doesn't override a method from its abstract is an implementation detail (not part of the corresponding API) and should not be used outside the library. We want to be able to modify these methods without waiting for the next major release.