### PR TITLE
Only trim the leading slash from the DSN if a host is also available

### DIFF
--- a/src/Tools/DsnParser.php
+++ b/src/Tools/DsnParser.php
@@ -109,7 +109,11 @@ final class DsnParser
             return $params;
         }
 
-        $url['path'] = $this->normalizeDatabaseUrlPath($url['path']);
+        if (isset($params['host'])) {
+            // Only normalize the path if a host is also available. Otherwise we might trim leading slashes
+            // from a pure dbname.
+            $url['path'] = $this->normalizeDatabaseUrlPath($url['path']);
+        }
 
         // If we do not have a known DBAL driver, we do not know any connection URL path semantics to evaluate
         // and therefore treat the path as a regular DBAL connection URL path.
@@ -132,7 +136,11 @@ final class DsnParser
     private function normalizeDatabaseUrlPath(string $urlPath): string
     {
         // Trim leading slash from URL path.
-        return substr($urlPath, 1);
+        if ($urlPath[0] === '/') {
+            return substr($urlPath, 1);
+        }
+
+        return $urlPath;
     }
 
     /**

--- a/src/Tools/DsnParser.php
+++ b/src/Tools/DsnParser.php
@@ -135,12 +135,10 @@ final class DsnParser
      */
     private function normalizeDatabaseUrlPath(string $urlPath): string
     {
-        // Trim leading slash from URL path.
-        if ($urlPath[0] === '/') {
-            return substr($urlPath, 1);
-        }
+        assert($urlPath[0] === '/');
 
-        return $urlPath;
+        // Trim leading slash from URL path.
+        return substr($urlPath, 1);
     }
 
     /**

--- a/tests/Tools/DsnParserTest.php
+++ b/tests/Tools/DsnParserTest.php
@@ -172,6 +172,14 @@ final class DsnParserTest extends TestCase
                     'dbname'   => 'baz',
                 ],
             ],
+            'quoted URL' => [
+                '"sqlite:////tmp/dbname.sqlite"',
+                ['dbname' => '"sqlite:////tmp/dbname.sqlite"'],
+            ],
+            'absolute path' => [
+                '/tmp/dbname.sqlite',
+                ['dbname' => '/tmp/dbname.sqlite'],
+            ],
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6789

#### Summary

Previously the DsnParser unconditionally removed the first character from the path, without verifying that it is actually a slash and that it is dealing with a reasonably well-formed URI. This causes confusing behavior when a malformed URI that survives `parse_url()` is passed to `parse()`, since DsnParser would return the input as the `dbname`, but with the first character missing.

This can lead to hard-to-debug situations when the DSN is coming from an environment variable, where quoting characters are accidentally included in the value itself, instead of being interpreted by the tool setting the env, since the `dbname` almost looks like the intended input (but still having the trailing quote).

see doctrine/dbal#6789
