### PR TITLE
Refactor SQL Server code for calling stored procedures

### DIFF
--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -657,7 +657,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
         $expectedSql = [
             'CREATE TABLE testschema.test (id INT NOT NULL, PRIMARY KEY (id))',
-            "EXEC sp_addextendedproperty N'MS_Description', N'This is a comment', "
+            "EXEC [sp_addextendedproperty] N'MS_Description', N'This is a comment', "
                 . "N'SCHEMA', 'testschema', N'TABLE', 'test', N'COLUMN', 'id'",
         ];
 
@@ -678,7 +678,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
         $expectedSql = [
             'ALTER TABLE testschema.mytable ADD quota INT NOT NULL',
-            "EXEC sp_addextendedproperty N'MS_Description', N'A comment', "
+            "EXEC [sp_addextendedproperty] N'MS_Description', N'A comment', "
                 . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
@@ -697,7 +697,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         ]);
 
         $expectedSql = [
-            "EXEC sp_dropextendedproperty N'MS_Description'"
+            "EXEC [sp_dropextendedproperty] N'MS_Description'"
                 . ", N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
@@ -715,7 +715,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             ),
         ]);
 
-        $expectedSql = ["EXEC sp_updateextendedproperty N'MS_Description', N'B comment', "
+        $expectedSql = ["EXEC [sp_updateextendedproperty] N'MS_Description', N'B comment', "
                 . "N'SCHEMA', 'testschema', N'TABLE', 'mytable', N'COLUMN', 'quota'",
         ];
 
@@ -840,7 +840,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
      */
     protected function getAlterTableRenameIndexSQL(): array
     {
-        return ["EXEC sp_rename N'mytable.idx_foo', N'idx_bar', N'INDEX'"];
+        return ["EXEC [sp_rename] N'mytable.idx_foo', N'idx_bar', N'INDEX'"];
     }
 
     /**
@@ -849,8 +849,8 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     protected function getQuotedAlterTableRenameIndexSQL(): array
     {
         return [
-            "EXEC sp_rename N'[table].[create]', N'select', N'INDEX'",
-            "EXEC sp_rename N'[table].[foo]', N'bar', N'INDEX'",
+            "EXEC [sp_rename] N'[table].[create]', N'select', N'INDEX'",
+            "EXEC [sp_rename] N'[table].[foo]', N'bar', N'INDEX'",
         ];
     }
 
@@ -859,7 +859,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
      */
     protected function getAlterTableRenameIndexInSchemaSQL(): array
     {
-        return ["EXEC sp_rename N'myschema.mytable.idx_foo', N'idx_bar', N'INDEX'"];
+        return ["EXEC [sp_rename] N'myschema.mytable.idx_foo', N'idx_bar', N'INDEX'"];
     }
 
     /**
@@ -868,8 +868,8 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
     {
         return [
-            "EXEC sp_rename N'[schema].[table].[create]', N'select', N'INDEX'",
-            "EXEC sp_rename N'[schema].[table].[foo]', N'bar', N'INDEX'",
+            "EXEC [sp_rename] N'[schema].[table].[create]', N'select', N'INDEX'",
+            "EXEC [sp_rename] N'[schema].[table].[foo]', N'bar', N'INDEX'",
         ];
     }
 
@@ -933,7 +933,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
      */
     protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
     {
-        return ["EXEC sp_rename N'mytable.idx_foo', N'idx_foo_renamed', N'INDEX'"];
+        return ["EXEC [sp_rename] N'mytable.idx_foo', N'idx_foo_renamed', N'INDEX'"];
     }
 
     protected function getLimitOffsetCastToIntExpectedQuery(): string


### PR DESCRIPTION
I want to unify the SQL Server platform code for calling stored procedures. This is a backport of the backward-compatible part of the changes that I'm planning for 5.0.x:
1. Instead of using string concatenation in every method that needs to execute a stored procedure, use `SQLServerPlatform#getExecSQL()`.
2. Instead of manually prepending `N` to national string literals, use `SQLServerPlatform#quoteNationalStringLiteral()`.

Eventually, it will allow to get rid of the methods with the signatures like this: https://github.com/doctrine/dbal/blob/c17f856205fd73e5d4f626165d774a35275569cc/src/Platforms/SQLServerPlatform.php#L675-L693

They are just boilerplate that mimics the signatures of the corresponding stored procedures. They don't enforce the contract that the arguments need to be passed in pairs and can generate syntactically invalid SQL. For instance, here, if `$level2Type` is not `null` but `$level2Name` is: https://github.com/doctrine/dbal/blob/a030c1e2c5c7a9ad98e360a4bd1ea316c13c4821/src/Platforms/SQLServerPlatform.php#L699-L702