### PR TITLE
Rework code for working with extended properties

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -143,4 +143,9 @@
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName">
         <exclude-pattern>src/ParameterType.php</exclude-pattern>
     </rule>
+
+    <!-- PHP_CodeSniffer doesn't seem to understand splat operator with associative arrays -->
+    <rule ref="Squiz.Arrays.ArrayDeclaration.KeySpecified">
+        <exclude-pattern>src/Platforms/SQLServerPlatform.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -344,12 +344,8 @@ class OraclePlatform extends AbstractPlatform
         return 'SELECT view_name, text FROM sys.user_views';
     }
 
-    /**
-     * @internal The method should be only used by the {@see OraclePlatform} class.
-     *
-     * @return array<int, string>
-     */
-    protected function getCreateAutoincrementSql(string $name, string $table, int $start = 1): array
+    /** @return list<string> */
+    private function getCreateAutoincrementSql(string $name, string $table, int $start = 1): array
     {
         $tableIdentifier   = $this->normalizeIdentifier($table);
         $quotedTableName   = $tableIdentifier->getObjectName()->toSQL($this);
@@ -672,8 +668,7 @@ END;';
         return ['ALTER INDEX ' . $oldIndexName . ' RENAME TO ' . $index->getObjectName()->toSQL($this)];
     }
 
-    /** @internal The method should be only used by the {@see OraclePlatform} class. */
-    protected function getIdentitySequenceName(string $tableName): string
+    private function getIdentitySequenceName(string $tableName): string
     {
         $table = new Identifier($tableName);
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -275,13 +275,11 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to create the comment for.
      * @param string $comment    The column's comment.
      */
-    protected function getCreateColumnCommentSQL(string $tableName, string $columnName, string $comment): string
+    private function getCreateColumnCommentSQL(string $tableName, string $columnName, string $comment): string
     {
         if (str_contains($tableName, '.')) {
             [$schemaName, $tableName] = explode('.', $tableName);
@@ -304,11 +302,9 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL snippet for declaring a default constraint.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @param mixed[] $column Column definition.
      */
-    protected function getDefaultConstraintDeclarationSQL(array $column): string
+    private function getDefaultConstraintDeclarationSQL(array $column): string
     {
         if (! isset($column['default'])) {
             throw new InvalidArgumentException('Incomplete column definition. "default" required.');
@@ -571,13 +567,11 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to alter the comment for.
      * @param string $comment    The column's comment.
      */
-    protected function getAlterColumnCommentSQL(string $tableName, string $columnName, string $comment): string
+    private function getAlterColumnCommentSQL(string $tableName, string $columnName, string $comment): string
     {
         if (str_contains($tableName, '.')) {
             [$schemaName, $tableName] = explode('.', $tableName);
@@ -608,12 +602,10 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to drop the comment for.
      */
-    protected function getDropColumnCommentSQL(string $tableName, string $columnName): string
+    private function getDropColumnCommentSQL(string $tableName, string $columnName): string
     {
         if (str_contains($tableName, '.')) {
             [$schemaName, $tableName] = explode('.', $tableName);
@@ -667,8 +659,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for adding an extended property to a database object.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @link http://msdn.microsoft.com/en-us/library/ms180047%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to add.
@@ -680,7 +670,7 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
      */
-    protected function getAddExtendedPropertySQL(
+    private function getAddExtendedPropertySQL(
         string $name,
         ?string $value = null,
         ?string $level0Type = null,
@@ -710,8 +700,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for dropping an extended property from a database object.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @link http://technet.microsoft.com/en-gb/library/ms178595%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to drop.
@@ -722,7 +710,7 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
      */
-    protected function getDropExtendedPropertySQL(
+    private function getDropExtendedPropertySQL(
         string $name,
         ?string $level0Type = null,
         ?string $level0Name = null,
@@ -750,8 +738,6 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * Returns the SQL statement for updating an extended property of a database object.
      *
-     * @internal The method should be only used by the {@see SQLServerPlatform} class.
-     *
      * @link http://msdn.microsoft.com/en-us/library/ms186885%28v=sql.90%29.aspx
      *
      * @param string      $name       The name of the property to update.
@@ -763,7 +749,7 @@ class SQLServerPlatform extends AbstractPlatform
      * @param string|null $level2Type The type of the object at level 2 the property belongs to.
      * @param string|null $level2Name The name of the object at level 2 the property belongs to.
      */
-    protected function getUpdateExtendedPropertySQL(
+    private function getUpdateExtendedPropertySQL(
         string $name,
         ?string $value = null,
         ?string $level0Type = null,

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -275,27 +275,22 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
+     * @link https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql
+     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to create the comment for.
      * @param string $comment    The column's comment.
      */
     private function getCreateColumnCommentSQL(string $tableName, string $columnName, string $comment): string
     {
-        if (str_contains($tableName, '.')) {
-            [$schemaName, $tableName] = explode('.', $tableName);
-        } else {
-            $schemaName = 'dbo';
-        }
-
-        return $this->getAddExtendedPropertySQL(
-            'MS_Description',
-            $comment,
-            'SCHEMA',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($schemaName)),
-            'TABLE',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($tableName)),
-            'COLUMN',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($columnName)),
+        return $this->getExecSQL(
+            'sp_addextendedproperty',
+            $this->quoteNationalStringLiteral('MS_Description'),
+            $this->quoteNationalStringLiteral($comment),
+            ...$this->getArgumentsForExtendedProperties([
+                ...$this->getExtendedPropertiesForTable($tableName),
+                'COLUMN' => $this->quoteStringLiteral($this->unquoteSingleIdentifier($columnName)),
+            ]),
         );
     }
 
@@ -567,27 +562,22 @@ class SQLServerPlatform extends AbstractPlatform
      * as column comments are stored in the same property there when
      * specifying a column's "Description" attribute.
      *
+     * @link https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-updateextendedproperty-transact-sql
+     *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to alter the comment for.
      * @param string $comment    The column's comment.
      */
     private function getAlterColumnCommentSQL(string $tableName, string $columnName, string $comment): string
     {
-        if (str_contains($tableName, '.')) {
-            [$schemaName, $tableName] = explode('.', $tableName);
-        } else {
-            $schemaName = 'dbo';
-        }
-
-        return $this->getUpdateExtendedPropertySQL(
-            'MS_Description',
-            $comment,
-            'SCHEMA',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($schemaName)),
-            'TABLE',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($tableName)),
-            'COLUMN',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($columnName)),
+        return $this->getExecSQL(
+            'sp_updateextendedproperty',
+            $this->quoteNationalStringLiteral('MS_Description'),
+            $this->quoteNationalStringLiteral($comment),
+            ...$this->getArgumentsForExtendedProperties([
+                ...$this->getExtendedPropertiesForTable($tableName),
+                'COLUMN' => $this->quoteStringLiteral($this->unquoteSingleIdentifier($columnName)),
+            ]),
         );
     }
 
@@ -604,23 +594,18 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @param string $tableName  The quoted table name to which the column belongs.
      * @param string $columnName The quoted column name to drop the comment for.
+     *
+     * https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-dropextendedproperty-transact-sql
      */
     private function getDropColumnCommentSQL(string $tableName, string $columnName): string
     {
-        if (str_contains($tableName, '.')) {
-            [$schemaName, $tableName] = explode('.', $tableName);
-        } else {
-            $schemaName = 'dbo';
-        }
-
-        return $this->getDropExtendedPropertySQL(
-            'MS_Description',
-            'SCHEMA',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($schemaName)),
-            'TABLE',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($tableName)),
-            'COLUMN',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($columnName)),
+        return $this->getExecSQL(
+            'sp_dropextendedproperty',
+            $this->quoteNationalStringLiteral('MS_Description'),
+            ...$this->getArgumentsForExtendedProperties([
+                ...$this->getExtendedPropertiesForTable($tableName),
+                'COLUMN' => $this->quoteStringLiteral($this->unquoteSingleIdentifier($columnName)),
+            ]),
         );
     }
 
@@ -648,132 +633,14 @@ class SQLServerPlatform extends AbstractPlatform
 
     /**
      * Returns the SQL statement that will execute sp_rename with the given arguments.
+     *
+     * @param string ...$arguments The literal values of the arguments to pass to the <code>sp_rename</code> procedure.
      */
     private function getRenameSQL(string ...$arguments): string
     {
         return $this->getExecSQL('sp_rename', ...array_map(function (string $argument): string {
             return $this->quoteNationalStringLiteral($argument);
         }, $arguments));
-    }
-
-    /**
-     * Returns the SQL statement for adding an extended property to a database object.
-     *
-     * @link http://msdn.microsoft.com/en-us/library/ms180047%28v=sql.90%29.aspx
-     *
-     * @param string      $name       The name of the property to add.
-     * @param string|null $value      The value of the property to add.
-     * @param string|null $level0Type The type of the object at level 0 the property belongs to.
-     * @param string|null $level0Name The name of the object at level 0 the property belongs to.
-     * @param string|null $level1Type The type of the object at level 1 the property belongs to.
-     * @param string|null $level1Name The name of the object at level 1 the property belongs to.
-     * @param string|null $level2Type The type of the object at level 2 the property belongs to.
-     * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     */
-    private function getAddExtendedPropertySQL(
-        string $name,
-        ?string $value = null,
-        ?string $level0Type = null,
-        ?string $level0Name = null,
-        ?string $level1Type = null,
-        ?string $level1Name = null,
-        ?string $level2Type = null,
-        ?string $level2Name = null,
-    ): string {
-        $arguments = [
-            $this->quoteNationalStringLiteral($name),
-            $this->quoteNationalStringLiteral($value ?? ''),
-            $this->quoteNationalStringLiteral($level0Type ?? ''),
-            $level0Name ?? '',
-            $this->quoteNationalStringLiteral($level1Type ?? ''),
-            $level1Name ?? '',
-        ];
-
-        if ($level2Type !== null || $level2Name !== null) {
-            $arguments[] = $this->quoteNationalStringLiteral($level2Type ?? '');
-            $arguments[] = $level2Name ?? '';
-        }
-
-        return $this->getExecSQL('sp_addextendedproperty', ...$arguments);
-    }
-
-    /**
-     * Returns the SQL statement for dropping an extended property from a database object.
-     *
-     * @link http://technet.microsoft.com/en-gb/library/ms178595%28v=sql.90%29.aspx
-     *
-     * @param string      $name       The name of the property to drop.
-     * @param string|null $level0Type The type of the object at level 0 the property belongs to.
-     * @param string|null $level0Name The name of the object at level 0 the property belongs to.
-     * @param string|null $level1Type The type of the object at level 1 the property belongs to.
-     * @param string|null $level1Name The name of the object at level 1 the property belongs to.
-     * @param string|null $level2Type The type of the object at level 2 the property belongs to.
-     * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     */
-    private function getDropExtendedPropertySQL(
-        string $name,
-        ?string $level0Type = null,
-        ?string $level0Name = null,
-        ?string $level1Type = null,
-        ?string $level1Name = null,
-        ?string $level2Type = null,
-        ?string $level2Name = null,
-    ): string {
-        $arguments = [
-            $this->quoteNationalStringLiteral($name),
-            $this->quoteNationalStringLiteral($level0Type ?? ''),
-            $level0Name ?? '',
-            $this->quoteNationalStringLiteral($level1Type ?? ''),
-            $level1Name ?? '',
-        ];
-
-        if ($level2Type !== null || $level2Name !== null) {
-            $arguments[] = $this->quoteNationalStringLiteral($level2Type ?? '');
-            $arguments[] = $level2Name ?? '';
-        }
-
-        return $this->getExecSQL('sp_dropextendedproperty', ...$arguments);
-    }
-
-    /**
-     * Returns the SQL statement for updating an extended property of a database object.
-     *
-     * @link http://msdn.microsoft.com/en-us/library/ms186885%28v=sql.90%29.aspx
-     *
-     * @param string      $name       The name of the property to update.
-     * @param string|null $value      The value of the property to update.
-     * @param string|null $level0Type The type of the object at level 0 the property belongs to.
-     * @param string|null $level0Name The name of the object at level 0 the property belongs to.
-     * @param string|null $level1Type The type of the object at level 1 the property belongs to.
-     * @param string|null $level1Name The name of the object at level 1 the property belongs to.
-     * @param string|null $level2Type The type of the object at level 2 the property belongs to.
-     * @param string|null $level2Name The name of the object at level 2 the property belongs to.
-     */
-    private function getUpdateExtendedPropertySQL(
-        string $name,
-        ?string $value = null,
-        ?string $level0Type = null,
-        ?string $level0Name = null,
-        ?string $level1Type = null,
-        ?string $level1Name = null,
-        ?string $level2Type = null,
-        ?string $level2Name = null,
-    ): string {
-        $arguments = [
-            $this->quoteNationalStringLiteral($name),
-            $this->quoteNationalStringLiteral($value ?? ''),
-            $this->quoteNationalStringLiteral($level0Type ?? ''),
-            $level0Name ?? '',
-            $this->quoteNationalStringLiteral($level1Type ?? ''),
-            $level1Name ?? '',
-        ];
-
-        if ($level2Type !== null || $level2Name !== null) {
-            $arguments[] = $this->quoteNationalStringLiteral($level2Type ?? '');
-            $arguments[] = $level2Name ?? '';
-        }
-
-        return $this->getExecSQL('sp_updateextendedproperty', ...$arguments);
     }
 
     /**
@@ -790,6 +657,50 @@ class SQLServerPlatform extends AbstractPlatform
     private function quoteNationalStringLiteral(string $value): string
     {
         return 'N' . $this->quoteStringLiteral($value);
+    }
+
+    /**
+     * Returns the stored procedure arguments for the extended properties.
+     *
+     * The keys of the properties array are property name literals, and the values are SQL fragments representing the
+     * values.
+     *
+     * @param array<string,string> $properties
+     *
+     * @return list<string>
+     */
+    private function getArgumentsForExtendedProperties(array $properties): array
+    {
+        $arguments = [];
+
+        foreach ($properties as $name => $value) {
+            $arguments[] = $this->quoteNationalStringLiteral($name);
+            $arguments[] = $value;
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Returns extended properties representing the given table.
+     *
+     * The keys of the returned array are property name literals, and the values are SQL fragments representing the
+     * values.
+     *
+     * @return array<string,string>
+     */
+    private function getExtendedPropertiesForTable(string $tableName): array
+    {
+        if (str_contains($tableName, '.')) {
+            [$schemaName, $tableName] = explode('.', $tableName);
+        } else {
+            $schemaName = 'dbo';
+        }
+
+        return [
+            'SCHEMA' => $this->quoteStringLiteral($this->unquoteSingleIdentifier($schemaName)),
+            'TABLE' => $this->quoteStringLiteral($this->unquoteSingleIdentifier($tableName)),
+        ];
     }
 
     public function getEmptyIdentityInsertSQL(string $quotedTableName, string $quotedIdentifierColumnName): string
@@ -1224,21 +1135,16 @@ class SQLServerPlatform extends AbstractPlatform
         return parent::getLikeWildcardCharacters() . '[]^';
     }
 
+    /** @link https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql */
     protected function getCommentOnTableSQL(string $tableName, string $comment): string
     {
-        if (str_contains($tableName, '.')) {
-            [$schemaName, $tableName] = explode('.', $tableName);
-        } else {
-            $schemaName = 'dbo';
-        }
-
-        return $this->getAddExtendedPropertySQL(
-            'MS_Description',
-            $comment,
-            'SCHEMA',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($schemaName)),
-            'TABLE',
-            $this->quoteStringLiteral($this->unquoteSingleIdentifier($tableName)),
+        return $this->getExecSQL(
+            'sp_addextendedproperty',
+            $this->quoteNationalStringLiteral('MS_Description'),
+            $this->quoteNationalStringLiteral($comment),
+            ...$this->getArgumentsForExtendedProperties(
+                $this->getExtendedPropertiesForTable($tableName),
+            ),
         );
     }
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -253,19 +253,13 @@ class OracleSchemaManager extends AbstractSchemaManager
         $this->connection->executeStatement($statement);
     }
 
-    /**
-     * @internal The method should be only used by the {@see OracleSchemaManager} class.
-     *
-     * @throws Exception
-     */
-    protected function dropAutoincrement(string $table): bool
+    /** @throws Exception */
+    private function dropAutoincrement(string $table): void
     {
         $sql = $this->platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {
             $this->connection->executeStatement($query);
         }
-
-        return true;
     }
 
     public function dropTable(string $name): void


### PR DESCRIPTION
This PR refactors the code that invokes the stored procedures that work with SQL Server extended properties. It removes `SQLServerPlatform#getAddExtendedPropertySQL()` and other similar methods in favor of using `SQLServerPlatform#getExecSQL()` and building the procedure parameters individually for each call.

It also generalizes the logic of deriving the `SCHEMA` and `TABLE` properties from the table name. We will be able to modify it in a single place once the table name becomes represented with `OptionallyQualifiedName` instead of `string`.

Additionally, it marks all methods declared as internal in https://github.com/doctrine/dbal/pull/6788 as private.