### PR TITLE
Fix false-positive primary key column length deprecation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,6 +17,7 @@ The following `Index` usage scenarios have been deprecated:
 3. Using qualified or otherwise invalid column names in index columns
 4. Using other values than positive integers as index column lengths
 5. Using nullable columns in a primary key index
+6. Extending the `Index` class has been deprecated. Use the `Index` class directly.
 
 ## Deprecated passing unquoted names containing dots for table introspection on platforms that don't support schemas
 

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -38,7 +38,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * @deprecated
      *
-     * @var array<string, Identifier>
+     * @var non-empty-array<string, Identifier>
      */
     protected array $_localColumnNames;
 
@@ -54,7 +54,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * @deprecated
      *
-     * @var array<string, Identifier>
+     * @var non-empty-array<string, Identifier>
      */
     protected array $_foreignColumnNames;
 
@@ -276,9 +276,9 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     }
 
     /**
-     * @param array<int, string> $names
+     * @param non-empty-array<int, string> $names
      *
-     * @return array<string, Identifier>
+     * @return non-empty-array<string, Identifier>
      */
     private function createIdentifierMap(array $names): array
     {
@@ -297,7 +297,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * @deprecated Use {@see getReferencingColumnNames()} instead.
      *
-     * @return array<int, string>
+     * @return non-empty-list<string>
      */
     public function getLocalColumns(): array
     {
@@ -323,7 +323,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * @param AbstractPlatform $platform The platform to use for quotation.
      *
-     * @return array<int, string>
+     * @return non-empty-array<int, string>
      */
     public function getQuotedLocalColumns(AbstractPlatform $platform): array
     {
@@ -348,7 +348,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * Returns unquoted representation of local table column names for comparison with other FK
      *
-     * @return array<int, string>
+     * @return non-empty-array<int, string>
      */
     public function getUnquotedLocalColumns(): array
     {
@@ -367,7 +367,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * Returns unquoted representation of foreign table column names for comparison with other FK
      *
-     * @return array<int, string>
+     * @return non-empty-array<int, string>
      */
     public function getUnquotedForeignColumns(): array
     {
@@ -457,7 +457,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      * Returns the names of the referenced table columns
      * the foreign key constraint is associated with.
      *
-     * @return array<int, string>
+     * @return non-empty-array<int, string>
      */
     public function getForeignColumns(): array
     {
@@ -483,7 +483,7 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      *
      * @param AbstractPlatform $platform The platform to use for quotation.
      *
-     * @return array<int, string>
+     * @return non-empty-array<int, string>
      */
     public function getQuotedForeignColumns(AbstractPlatform $platform): array
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -139,7 +139,7 @@ class Table extends AbstractNamedObject
     /**
      * Sets the Primary Key.
      *
-     * @param array<int, string> $columnNames
+     * @param non-empty-list<string> $columnNames
      */
     public function setPrimaryKey(array $columnNames, ?string $indexName = null): self
     {
@@ -187,9 +187,9 @@ class Table extends AbstractNamedObject
     }
 
     /**
-     * @param array<int, string>   $columnNames
-     * @param array<int, string>   $flags
-     * @param array<string, mixed> $options
+     * @param non-empty-list<string> $columnNames
+     * @param array<int, string>     $flags
+     * @param array<string, mixed>   $options
      */
     public function addIndex(
         array $columnNames,
@@ -234,8 +234,8 @@ class Table extends AbstractNamedObject
     }
 
     /**
-     * @param array<int, string>   $columnNames
-     * @param array<string, mixed> $options
+     * @param non-empty-list<string> $columnNames
+     * @param array<string, mixed>   $options
      */
     public function addUniqueIndex(array $columnNames, ?string $indexName = null, array $options = []): self
     {
@@ -915,9 +915,9 @@ class Table extends AbstractNamedObject
     }
 
     /**
-     * @param array<int, string>   $columns
-     * @param array<int, string>   $flags
-     * @param array<string, mixed> $options
+     * @param non-empty-list<string> $columns
+     * @param array<int, string>     $flags
+     * @param array<string, mixed>   $options
      */
     private function _createIndex(
         array $columns,

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -120,7 +120,7 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
     /**
      * @deprecated Use {@see getColumnNames()} instead.
      *
-     * @return list<string>
+     * @return non-empty-list<string>
      */
     public function getColumns(): array
     {
@@ -131,6 +131,7 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
             __METHOD__,
         );
 
+        /** @phpstan-ignore return.type */
         return array_keys($this->columns);
     }
 

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -22,18 +22,13 @@ class ForeignKeyConstraintTest extends TestCase
 {
     use VerifyDeprecations;
 
-    /** @param string[] $indexColumns */
+    /** @param non-empty-list<string> $indexColumns */
     #[DataProvider('getIntersectsIndexColumnsData')]
     public function testIntersectsIndexColumns(array $indexColumns, bool $expectedResult): void
     {
         $foreignKey = new ForeignKeyConstraint(['foo', 'bar'], 'foreign_table', ['fk_foo', 'fk_bar']);
 
-        $index = $this->getMockBuilder(Index::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $index->expects(self::once())
-            ->method('getColumns')
-            ->willReturn($indexColumns);
+        $index = new Index('foo', $indexColumns);
 
         self::assertSame($expectedResult, $foreignKey->intersectsIndexColumns($index));
     }

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -111,9 +111,9 @@ class IndexTest extends TestCase
     }
 
     /**
-     * @param string[]     $columns
-     * @param int[]|null[] $lengths1
-     * @param int[]|null[] $lengths2
+     * @param non-empty-list<string> $columns
+     * @param list<?int>             $lengths1
+     * @param list<?int>             $lengths2
      */
     #[DataProvider('indexLengthProvider')]
     public function testFulfilledWithLength(array $columns, array $lengths1, array $lengths2, bool $expected): void
@@ -204,6 +204,7 @@ class IndexTest extends TestCase
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6787');
 
+        /** @phpstan-ignore argument.type */
         $index = new Index('idx_user_name', []);
 
         $this->expectException(InvalidState::class);
@@ -226,7 +227,18 @@ class IndexTest extends TestCase
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6787');
 
-        new Index('primary', ['id'], false, true, [], ['lengths' => [32]]);
+        $index = new Index('primary', ['id'], false, true, [], ['lengths' => [32]]);
+
+        $this->expectException(InvalidState::class);
+
+        $index->getIndexedColumns();
+    }
+
+    public function testPrimaryKeyWithNullColumnLength(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6787');
+
+        new Index('primary', ['id'], false, true, [], ['lengths' => [null]]);
     }
 
     public function testNonIntegerColumnLength(): void


### PR DESCRIPTION
This PR fixes false-positive primary key column length deprecation introduced in https://github.com/doctrine/dbal/pull/6787. Originally, it would trigger if the array of column lengths passed to a primary key index is not empty. This is too strict since during introspection lengths are populated with null values by default: https://github.com/doctrine/dbal/blob/113744f954fed54bd4c3616692ee199b7a671fbb/src/Schema/AbstractSchemaManager.php#L857

Instead, we want to trigger the deprecation only if a non-null length would be associated with an indexed column.

Additionally, I want to introduce two more deprecation-related changes:
1. Deprecate extending the `Index` class similar to `UniqueConstraint` and `ForeignKeyConstraint`.
2. Annotate all methods accepting a list of index columns as accepting a non-empty list.

I had to add a couple of `@phpstan-ignore`s because even though `Index` and `UniqueConstraint` accept a non-empty list of column names, they initialize their corresponding properties with an empty array and then populate them by calling a protected method. So this property has to be initialized with an empty array and thus cannot be guaranteed to be non-empty.