### PR TITLE
Unmark Index as final

### DIFF
--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -28,7 +28,7 @@ use function strtolower;
  * @final
  * @extends AbstractNamedObject<UnqualifiedName>
  */
-final class Index extends AbstractNamedObject
+class Index extends AbstractNamedObject
 {
     /**
      * Asset identifier instances of the column names the index is associated with.


### PR DESCRIPTION
I mistakenly marked `Index` as `final` in https://github.com/doctrine/dbal/pull/6799. The intention was to mark it with the `@final` phpDoc but I was cherry-picking this and other changes from 5.0.x-based branch back to 4.3.x and forgot to remove the keyword.