### PR TITLE
Clean up OraclePlatform auto-increment code

### DIFF
--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -193,13 +193,13 @@ class OraclePlatformTest extends AbstractPlatformTestCase
             sprintf(
                 <<<'SQL'
 DECLARE
-  constraints_Count NUMBER;
+  CONSTRAINTS_COUNT NUMBER;
 BEGIN
-  SELECT COUNT(CONSTRAINT_NAME) INTO constraints_Count
+  SELECT COUNT(CONSTRAINT_NAME) INTO CONSTRAINTS_COUNT
     FROM USER_CONSTRAINTS
    WHERE TABLE_NAME = '%s'
      AND CONSTRAINT_TYPE = 'P';
-  IF constraints_Count = 0 OR constraints_Count = '' THEN
+  IF CONSTRAINTS_COUNT = 0 THEN
     EXECUTE IMMEDIATE 'ALTER TABLE %s ADD CONSTRAINT %s_AI_PK PRIMARY KEY (%s)';
   END IF;
 END;
@@ -225,7 +225,7 @@ BEGIN
       SELECT %s_SEQ.NEXTVAL INTO :NEW.%s FROM DUAL;
    ELSE
       SELECT NVL(Last_Number, 0) INTO last_Sequence
-        FROM User_Sequences
+        FROM USER_SEQUENCES
        WHERE Sequence_Name = '%s_SEQ';
       SELECT :NEW.%s INTO last_InsertID FROM DUAL;
       WHILE (last_InsertID > last_Sequence) LOOP
@@ -534,7 +534,7 @@ BEGIN
       SELECT "test_SEQ".NEXTVAL INTO :NEW."id" FROM DUAL;
    ELSE
       SELECT NVL(Last_Number, 0) INTO last_Sequence
-        FROM User_Sequences
+        FROM USER_SEQUENCES
        WHERE Sequence_Name = 'test_SEQ';
       SELECT :NEW."id" INTO last_InsertID FROM DUAL;
       WHILE (last_InsertID > last_Sequence) LOOP


### PR DESCRIPTION
Before reworking this code to use names as objects and `PrimaryKeyConstraint` instead of `Index` in 5.0.x, I want to clean it up and use `sprintf()` instead of concatenation. This way, each variable is used in the `sprintf()` call only once, which will minimize the amount of changes to be made to this this code.

Additionally:
1. An unused variable has been removed.
2. The variable name and the view names in the SQL expression have been upper-cased, which is the natural case for Oracle.
3. The condition `OR constraints_Count = ''` has been removed because the variable is of the type `NUMBER`, so it's never true.