### PR TITLE
Rework creation of autoincrement objects on Oracle

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,6 +19,8 @@ awareness about deprecated code.
    `$name`. The column name is sourced from the `$column` parameter.
 5. The `CreateTableParameters` array no longer includes the `primary` key. Primary key columns should be sourced from
    the `primary_index` element.
+6. The type of the `$name` parameter of the `AbstractPlatform::_getCreateTableSQL()` method has changed from `string`
+   to `OptionallyQualifiedName`. Now the parameter is named `$tableName`.
 
 Additionally, the column names of the primary key index are no longer deduplicated.
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
@@ -226,7 +227,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $elements = [];
 
@@ -255,7 +256,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             $sql[] = 'TEMPORARY';
         }
 
-        $sql[] = 'TABLE ' . $name . ' (' . implode(', ', $elements) . ')';
+        $sql[] = 'TABLE ' . $tableName->toSQL($this) . ' (' . implode(', ', $elements) . ')';
 
         $tableOptions = $this->buildTableOptions($parameters);
 
@@ -271,7 +272,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
         if (isset($parameters['foreignKeys'])) {
             foreach ($parameters['foreignKeys'] as $definition) {
-                $sql[] = $this->getCreateForeignKeySQL($definition, $name);
+                $sql[] = $this->getCreateForeignKeySQL($definition, $tableName->toSQL($this));
             }
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
@@ -813,7 +814,7 @@ abstract class AbstractPlatform
             throw NoColumnsSpecifiedForTable::new($table->getName());
         }
 
-        $tableName                       = $table->getObjectName()->toSQL($this);
+        $tableName                       = $table->getObjectName();
         $parameters                      = $table->getOptions();
         $parameters['indexes']           = [];
         $parameters['uniqueConstraints'] = [];
@@ -849,7 +850,7 @@ abstract class AbstractPlatform
 
         if ($this->supportsCommentOnStatement()) {
             if ($table->hasOption('comment')) {
-                $sql[] = $this->getCommentOnTableSQL($tableName, $table->getOption('comment'));
+                $sql[] = $this->getCommentOnTableSQL($tableName->toSQL($this), $table->getOption('comment'));
             }
 
             foreach ($table->getColumns() as $column) {
@@ -859,7 +860,11 @@ abstract class AbstractPlatform
                     continue;
                 }
 
-                $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getObjectName()->toSQL($this), $comment);
+                $sql[] = $this->getCommentOnColumnSQL(
+                    $tableName->toSQL($this),
+                    $column->getObjectName()->toSQL($this),
+                    $comment,
+                );
             }
         }
 
@@ -960,7 +965,7 @@ abstract class AbstractPlatform
      *
      * @return list<string>
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $elements = [];
 
@@ -985,12 +990,12 @@ abstract class AbstractPlatform
 
         $elements = array_merge($elements, $this->getCheckDeclarationSQL($columns));
 
-        $query = 'CREATE TABLE ' . $name . ' (' . implode(', ', $elements) . ')';
+        $query = 'CREATE TABLE ' . $tableName->toSQL($this) . ' (' . implode(', ', $elements) . ')';
 
         $sql = [$query];
 
         foreach ($parameters['foreignKeys'] as $definition) {
-            $sql[] = $this->getCreateForeignKeySQL($definition, $name);
+            $sql[] = $this->getCreateForeignKeySQL($definition, $tableName->toSQL($this));
         }
 
         return $sql;

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
@@ -234,16 +235,16 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $indexes = $parameters['indexes'];
 
         $parameters['indexes'] = [];
 
-        $sqls = parent::_getCreateTableSQL($name, $columns, $parameters);
+        $sqls = parent::_getCreateTableSQL($tableName, $columns, $parameters);
 
         foreach ($indexes as $definition) {
-            $sqls[] = $this->getCreateIndexSQL($definition, $name);
+            $sqls[] = $this->getCreateIndexSQL($definition, $tableName->toSQL($this));
         }
 
         return $sqls;

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -6,11 +6,14 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnLengthRequired;
+use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
@@ -312,13 +315,13 @@ class OraclePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $indexes = $parameters['indexes'];
 
         $parameters['indexes'] = [];
 
-        $sql = parent::_getCreateTableSQL($name, $columns, $parameters);
+        $sql = parent::_getCreateTableSQL($tableName, $columns, $parameters);
 
         foreach ($columns as $column) {
             if (isset($column['sequence'])) {
@@ -331,11 +334,11 @@ class OraclePlatform extends AbstractPlatform
                 continue;
             }
 
-            $sql = array_merge($sql, $this->getCreateAutoincrementSql($column['name'], $name));
+            $sql = array_merge($sql, $this->getCreateAutoincrementSql($tableName, $column['name']));
         }
 
         foreach ($indexes as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $name);
+            $sql[] = $this->getCreateIndexSQL($index, $tableName->toSQL($this));
         }
 
         return $sql;
@@ -348,17 +351,17 @@ class OraclePlatform extends AbstractPlatform
     }
 
     /** @return list<string> */
-    private function getCreateAutoincrementSql(UnqualifiedName $name, string $table, int $start = 1): array
+    private function getCreateAutoincrementSql(OptionallyQualifiedName $tableName, UnqualifiedName $columnName): array
     {
-        $tableIdentifier   = $this->normalizeIdentifier($table);
-        $quotedTableName   = $tableIdentifier->getObjectName()->toSQL($this);
-        $unquotedTableName = $tableIdentifier->getName();
+        if ($tableName->getQualifier() !== null) {
+            throw UnsupportedName::fromQualifiedName($tableName, __METHOD__);
+        }
 
         $sql = [];
 
-        $autoincrementIdentifierName = $this->getAutoincrementIdentifierName($tableIdentifier);
+        $constraintName = $this->generatePrimaryKeyConstraintName($tableName->getUnqualifiedName());
 
-        $idx = new Index($autoincrementIdentifierName, [$name->toString()], true, true);
+        $index = new Index($constraintName->toString(), [$columnName->toString()], true, true);
 
         $sql[] = sprintf(
             <<<'SQL'
@@ -374,14 +377,14 @@ BEGIN
   END IF;
 END;
 SQL,
-            $this->quoteStringLiteral($unquotedTableName),
-            $this->quoteStringLiteral($this->getCreateIndexSQL($idx, $quotedTableName)),
+            $this->quoteStringLiteral(
+                $tableName->getUnqualifiedName()->toNormalizedValue($this),
+            ),
+            $this->quoteStringLiteral($this->getCreateIndexSQL($index, $tableName->toSQL($this))),
         );
 
-        $sequenceName = $this->getIdentitySequenceName(
-            $tableIdentifier->isQuoted() ? $quotedTableName : $unquotedTableName,
-        );
-        $sequence     = new Sequence($sequenceName, $start);
+        $sequenceName = $this->generateAutoincrementSequenceName($tableName);
+        $sequence     = new Sequence($sequenceName->toString());
         $sql[]        = $this->getCreateSequenceSQL($sequence);
 
         $sql[] = sprintf(
@@ -408,11 +411,13 @@ BEGIN
    END IF;
 END;
 SQL,
-            $autoincrementIdentifierName,
-            $quotedTableName,
-            $name->toSQL($this),
-            $sequenceName,
-            $this->quoteStringLiteral($sequence->getName()),
+            $constraintName->toSQL($this),
+            $tableName->toSQL($this),
+            $columnName->toSQL($this),
+            $sequenceName->toSQL($this),
+            $this->quoteStringLiteral(
+                $sequenceName->getUnqualifiedName()->toNormalizedValue($this),
+            ),
         );
 
         return $sql;
@@ -423,22 +428,23 @@ SQL,
      *
      * Returns the SQL statements to drop the autoincrement for the given table name.
      *
-     * @param string $table The table name to drop the autoincrement for.
+     * @param OptionallyQualifiedName $tableName The table name to drop the autoincrement for.
      *
      * @return string[]
      */
-    public function getDropAutoincrementSql(string $table): array
+    public function getDropAutoincrementSql(OptionallyQualifiedName $tableName): array
     {
-        $table                       = $this->normalizeIdentifier($table);
-        $autoincrementIdentifierName = $this->getAutoincrementIdentifierName($table);
-        $identitySequenceName        = $this->getIdentitySequenceName(
-            $table->isQuoted() ? $table->getObjectName()->toSQL($this) : $table->getName(),
-        );
+        if ($tableName->getQualifier() !== null) {
+            throw UnsupportedName::fromQualifiedName($tableName, __METHOD__);
+        }
+
+        $primaryKeyConstraintName = $this->generatePrimaryKeyConstraintName($tableName->getUnqualifiedName());
+        $sequenceName             = $this->generateAutoincrementSequenceName($tableName);
 
         return [
-            'DROP TRIGGER ' . $autoincrementIdentifierName,
-            $this->getDropSequenceSQL($identitySequenceName),
-            $this->getDropConstraintSQL($autoincrementIdentifierName, $table->getObjectName()->toSQL($this)),
+            'DROP TRIGGER ' . $primaryKeyConstraintName->toSQL($this),
+            $this->getDropSequenceSQL($sequenceName->toSQL($this)),
+            $this->getDropConstraintSQL($primaryKeyConstraintName->toSQL($this), $tableName->toSQL($this)),
         ];
     }
 
@@ -463,29 +469,22 @@ SQL,
      * if the new string exceeds max identifier length,
      * keeps $suffix, cuts from $identifier as much as the part exceeding.
      */
-    private function addSuffix(string $identifier, string $suffix): string
+    private function addSuffix(Name\Identifier $identifier, string $suffix): Name\Identifier
     {
-        $maxPossibleLengthWithoutSuffix = $this->getMaxIdentifierLength() - strlen($suffix);
-        if (strlen($identifier) > $maxPossibleLengthWithoutSuffix) {
-            $identifier = substr($identifier, 0, $maxPossibleLengthWithoutSuffix);
-        }
+        $prefix = substr($identifier->toNormalizedValue($this), 0, $this->getMaxIdentifierLength() - strlen($suffix));
 
-        return $identifier . $suffix;
+        return Name\Identifier::quoted($prefix . $suffix);
     }
 
     /**
-     * Returns the autoincrement primary key identifier name for the given table identifier.
+     * Returns the autoincrement primary key constraint name for the given table name.
      *
      * Quotes the autoincrement primary key identifier name
      * if the given table name is quoted by intention.
      */
-    private function getAutoincrementIdentifierName(Identifier $table): string
+    private function generatePrimaryKeyConstraintName(Name\Identifier $tableName): Name\Identifier
     {
-        $identifierName = $this->addSuffix($table->getName(), '_AI_PK');
-
-        return $table->isQuoted()
-            ? $this->quoteSingleIdentifier($identifierName)
-            : $identifierName;
+        return $this->addSuffix($tableName, '_AI_PK');
     }
 
     public function getDropForeignKeySQL(string $foreignKey, string $table): string
@@ -679,20 +678,12 @@ SQL,
         return ['ALTER INDEX ' . $oldIndexName . ' RENAME TO ' . $index->getObjectName()->toSQL($this)];
     }
 
-    private function getIdentitySequenceName(string $tableName): string
+    private function generateAutoincrementSequenceName(OptionallyQualifiedName $tableName): OptionallyQualifiedName
     {
-        $table = new Identifier($tableName);
-
-        // No usage of column name to preserve BC compatibility with <2.5
-        $identitySequenceName = $this->addSuffix($table->getName(), '_SEQ');
-
-        if ($table->isQuoted()) {
-            $identitySequenceName = '"' . $identitySequenceName . '"';
-        }
-
-        $identitySequenceIdentifier = $this->normalizeIdentifier($identitySequenceName);
-
-        return $identitySequenceIdentifier->getObjectName()->toSQL($this);
+        return new OptionallyQualifiedName(
+            $this->addSuffix($tableName->getUnqualifiedName(), '_SEQ'),
+            $tableName->getQualifier(),
+        );
     }
 
     protected function supportsCommentOnStatement(): bool

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -370,7 +371,7 @@ class PostgreSQLPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $elements = [];
 
@@ -387,20 +388,20 @@ class PostgreSQLPlatform extends AbstractPlatform
 
         $unlogged = isset($parameters['unlogged']) && $parameters['unlogged'] === true ? ' UNLOGGED' : '';
 
-        $query = 'CREATE' . $unlogged . ' TABLE ' . $name . ' (' . implode(', ', $elements) . ')';
+        $query = 'CREATE' . $unlogged . ' TABLE ' . $tableName->toSQL($this) . ' (' . implode(', ', $elements) . ')';
 
         $sql = [$query];
 
         foreach ($parameters['indexes'] as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $name);
+            $sql[] = $this->getCreateIndexSQL($index, $tableName->toSQL($this));
         }
 
         foreach ($parameters['uniqueConstraints'] as $uniqueConstraint) {
-            $sql[] = $this->getCreateUniqueConstraintSQL($uniqueConstraint, $name);
+            $sql[] = $this->getCreateUniqueConstraintSQL($uniqueConstraint, $tableName->toSQL($this));
         }
 
         foreach ($parameters['foreignKeys'] as $definition) {
-            $sql[] = $this->getCreateForeignKeySQL($definition, $name);
+            $sql[] = $this->getCreateForeignKeySQL($definition, $tableName->toSQL($this));
         }
 
         return $sql;

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
@@ -173,19 +174,19 @@ class SQLServerPlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $defaultConstraintsSql = [];
         $commentsSql           = [];
 
         $tableComment = $parameters['comment'] ?? null;
         if ($tableComment !== null) {
-            $commentsSql[] = $this->getCommentOnTableSQL($name, $tableComment);
+            $commentsSql[] = $this->getCommentOnTableSQL($tableName->toSQL($this), $tableComment);
         }
 
         foreach ($columns as $column) {
             if (isset($column['default'])) {
-                $defaultConstraintsSql[] = 'ALTER TABLE ' . $name .
+                $defaultConstraintsSql[] = 'ALTER TABLE ' . $tableName->toSQL($this) .
                     ' ADD' . $this->getDefaultConstraintDeclarationSQL($column);
             }
 
@@ -193,7 +194,11 @@ class SQLServerPlatform extends AbstractPlatform
                 continue;
             }
 
-            $commentsSql[] = $this->getCreateColumnCommentSQL($name, $column['name'], $column['comment']);
+            $commentsSql[] = $this->getCreateColumnCommentSQL(
+                $tableName->toSQL($this),
+                $column['name'],
+                $column['comment'],
+            );
         }
 
         $elements = [];
@@ -223,16 +228,16 @@ class SQLServerPlatform extends AbstractPlatform
 
         $elements = array_merge($elements, $this->getCheckDeclarationSQL($columns));
 
-        $query = 'CREATE TABLE ' . $name . ' (' . implode(', ', $elements) . ')';
+        $query = 'CREATE TABLE ' . $tableName->toSQL($this) . ' (' . implode(', ', $elements) . ')';
 
         $sql = [$query];
 
         foreach ($parameters['indexes'] as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $name);
+            $sql[] = $this->getCreateIndexSQL($index, $tableName->toSQL($this));
         }
 
         foreach ($parameters['foreignKeys'] as $definition) {
-            $sql[] = $this->getCreateForeignKeySQL($definition, $name);
+            $sql[] = $this->getCreateForeignKeySQL($definition, $tableName->toSQL($this));
         }
 
         return array_merge($sql, $commentsSql, $defaultConstraintsSql);

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
 use Doctrine\DBAL\Schema\Table;
@@ -258,7 +259,7 @@ class SQLitePlatform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function _getCreateTableSQL(string $name, array $columns, array $parameters): array
+    protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         $elements = [];
 
@@ -292,14 +293,16 @@ class SQLitePlatform extends AbstractPlatform
             $tableComment = $this->getInlineTableCommentSQL($comment);
         }
 
-        $query = ['CREATE TABLE ' . $name . ' ' . $tableComment . '(' . implode(', ', $elements) . ')'];
+        $query = [
+            'CREATE TABLE ' . $tableName->toSQL($this) . ' ' . $tableComment . '(' . implode(', ', $elements) . ')',
+        ];
 
         if (isset($parameters['alter']) && $parameters['alter'] === true) {
             return $query;
         }
 
         foreach ($parameters['indexes'] as $indexDef) {
-            $query[] = $this->getCreateIndexSQL($indexDef, $name);
+            $query[] = $this->getCreateIndexSQL($indexDef, $tableName->toSQL($this));
         }
 
         return $query;

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -8,7 +8,10 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\Parser;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -254,7 +257,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     }
 
     /** @throws Exception */
-    private function dropAutoincrement(string $table): void
+    private function dropAutoincrement(OptionallyQualifiedName $table): void
     {
         $sql = $this->platform->getDropAutoincrementSql($table);
         foreach ($sql as $query) {
@@ -264,8 +267,16 @@ class OracleSchemaManager extends AbstractSchemaManager
 
     public function dropTable(string $name): void
     {
+        $parser = Parsers::getOptionallyQualifiedNameParser();
+
         try {
-            $this->dropAutoincrement($name);
+            $tableName = $parser->parse($name);
+        } catch (Parser\Exception $e) {
+            throw InvalidName::fromParserException($name, $e);
+        }
+
+        try {
+            $this->dropAutoincrement($tableName);
         } catch (DatabaseObjectNotFoundException) {
         }
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -419,25 +420,25 @@ SQL
 
     /** @param string[] $expectedSql */
     #[DataProvider('getReturnsDropAutoincrementSQL')]
-    public function testReturnsDropAutoincrementSQL(string $table, array $expectedSql): void
+    public function testReturnsDropAutoincrementSQL(OptionallyQualifiedName $table, array $expectedSql): void
     {
         self::assertSame($expectedSql, $this->platform->getDropAutoincrementSql($table));
     }
 
-    /** @return mixed[][] */
+    /** @return iterable<array{OptionallyQualifiedName, list<string>}> */
     public static function getReturnsDropAutoincrementSQL(): iterable
     {
         return [
             [
-                'myTable',
+                OptionallyQualifiedName::unquoted('myTable'),
                 [
-                    'DROP TRIGGER MYTABLE_AI_PK',
+                    'DROP TRIGGER "MYTABLE_AI_PK"',
                     'DROP SEQUENCE "MYTABLE_SEQ"',
-                    'ALTER TABLE "MYTABLE" DROP CONSTRAINT MYTABLE_AI_PK',
+                    'ALTER TABLE "MYTABLE" DROP CONSTRAINT "MYTABLE_AI_PK"',
                 ],
             ],
             [
-                '"myTable"',
+                OptionallyQualifiedName::quoted('myTable'),
                 [
                     'DROP TRIGGER "myTable_AI_PK"',
                     'DROP SEQUENCE "myTable_SEQ"',
@@ -445,11 +446,11 @@ SQL
                 ],
             ],
             [
-                'table',
+                OptionallyQualifiedName::unquoted('table'),
                 [
-                    'DROP TRIGGER TABLE_AI_PK',
+                    'DROP TRIGGER "TABLE_AI_PK"',
                     'DROP SEQUENCE "TABLE_SEQ"',
-                    'ALTER TABLE "TABLE" DROP CONSTRAINT TABLE_AI_PK',
+                    'ALTER TABLE "TABLE" DROP CONSTRAINT "TABLE_AI_PK"',
                 ],
             ],
         ];


### PR DESCRIPTION
This PR reworks the code that auto-generates the names of the Oracle objects that implement the auto-increment behavior (the primary key constraint, the trigger and the sequence). It pursuits two goals:
1. Eliminate some usages of the `Schema\Identifier` class, which is deprecated and has to be eventually removed.
2. It lays the groundwork for the replacement of the "primary key index" with `PrimaryKeyConstraint`, which is to be introduced later.

P.S. I just realized that we don't really have to create a PK as part of setting up auto-increment. For instance, MySQL requires an auto-increment column to be part of the PK, so we can expect the user to explicitly created the PK on Oracle as well. But even if we make this change, the work in this PR won't be thrown away, it will still be relevant for the sequence and the trigger.