### PR TITLE
fix: Fix unrecognised functional index defined in MySQL

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -730,6 +730,10 @@ abstract class AbstractSchemaManager
 
         $indexes = [];
         foreach ($result as $indexKey => $data) {
+            if (count($data['columns']) === 0) {
+                continue;
+            }
+
             $indexes[$indexKey] = new Index(
                 $data['name'],
                 $data['columns'],


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #5306

#### Summary

+ The issue leads to crashing dbal.
+ The issue is fixed by skipping adding the columns, returned as null, to the index at the time of the creation of the index
