### PR TITLE
Convert driver exceptions when starting transactions

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1027,7 +1027,11 @@ class Connection implements ServerVersionProvider
         ++$this->transactionNestingLevel;
 
         if ($this->transactionNestingLevel === 1) {
-            $connection->beginTransaction();
+            try {
+                $connection->beginTransaction();
+            } catch (Driver\Exception $e) {
+                throw $this->convertException($e);
+            }
         } else {
             $this->createSavepoint($this->_getNestedTransactionSavePointName());
         }

--- a/src/Driver/API/PostgreSQL/ExceptionConverter.php
+++ b/src/Driver/API/PostgreSQL/ExceptionConverter.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Driver\API\PostgreSQL;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
+use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Exception\DatabaseDoesNotExist;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
@@ -75,6 +76,10 @@ final class ExceptionConverter implements ExceptionConverterInterface
 
             case '08006':
                 return new ConnectionException($exception, $query);
+        }
+
+        if (str_contains($exception->getMessage(), 'terminating connection')) {
+            return new ConnectionLost($exception, $query);
         }
 
         return new DriverException($exception, $query);

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -80,7 +80,9 @@ final class Connection implements ConnectionInterface
 
     public function beginTransaction(): void
     {
-        $this->connection->begin_transaction();
+        if (! $this->connection->begin_transaction()) {
+            throw ConnectionError::new($this->connection);
+        }
     }
 
     public function commit(): void

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -20,8 +20,17 @@ use const E_WARNING;
 
 class TransactionTest extends FunctionalTestCase
 {
+    public function testBeginTransactionFailure(): void
+    {
+        $this->expectConnectionLoss(static function (Connection $connection): void {
+            $connection->beginTransaction();
+        });
+    }
+
     public function testCommitFailure(): void
     {
+        $this->connection->beginTransaction();
+
         $this->expectConnectionLoss(static function (Connection $connection): void {
             $connection->commit();
         });
@@ -29,6 +38,8 @@ class TransactionTest extends FunctionalTestCase
 
     public function testRollbackFailure(): void
     {
+        $this->connection->beginTransaction();
+
         $this->expectConnectionLoss(static function (Connection $connection): void {
             $connection->rollBack();
         });
@@ -36,7 +47,6 @@ class TransactionTest extends FunctionalTestCase
 
     private function expectConnectionLoss(callable $scenario): void
     {
-        $this->connection->beginTransaction();
         $this->killCurrentSession();
         $this->expectException(ConnectionLost::class);
 

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -74,7 +75,14 @@ class TransactionTest extends FunctionalTestCase
         $databasePlatform = $this->connection->getDatabasePlatform();
 
         [$currentProcessQuery, $killProcessStatement] = match (true) {
-            $databasePlatform instanceof AbstractMySqlPlatform => ['SELECT CONNECTION_ID()', 'KILL ?'],
+            $databasePlatform instanceof AbstractMySqlPlatform => [
+                'SELECT CONNECTION_ID()',
+                'KILL ?',
+            ],
+            $databasePlatform instanceof PostgreSQLPlatform => [
+                'SELECT pg_backend_pid()',
+                'SELECT pg_terminate_backend(?)',
+            ],
             default => self::markTestSkipped('Unsupported test platform.'),
         };
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

The wrapped connection may no longer be valid for long-running processes, and starting a transaction will cause driver exceptions.

DBAL Connection wasn't converting these, leaking internal details of the platform and not providing a consistent API (all other methods would throw a `ConnectionLost` exception for the scenario above).

This ensures we do have the expected behaviour for this edge case.
