### PR TITLE
Update DriverException.php: Adding SQL to error message

### DIFF
--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -24,7 +24,7 @@ class DriverException extends \Exception implements Exception, Driver\Exception
         private readonly ?Query $query,
     ) {
         if ($query !== null) {
-            $message = 'An exception occurred while executing a query: ' . $driverException->getMessage();
+            $message = 'An exception occurred while executing a query: ' . $driverException->getMessage() . ' | SQL: ' . $query->getSQL() . ' | Params: ' . $query->getParams();
         } else {
             $message = 'An exception occurred in the driver: ' . $driverException->getMessage();
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Reason: When a value is too long, all I'm getting in Symfony is:
> An exception occurred while executing a query: SQLSTATE[22001]: String data, right truncated: 7 ERROR:  value too long for type character varying(255)

This is repeated over and over in the exception message, but I still have **no clue**:
* Which table we're talking about
* Which column
* Which value
