### PR TITLE
Do not over increment identitiy sequence on Oracle

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -397,7 +397,6 @@ BEGIN
       WHILE (last_InsertID > last_Sequence) LOOP
          SELECT ' . $sequenceName . '.NEXTVAL INTO last_Sequence FROM DUAL;
       END LOOP;
-      SELECT ' . $sequenceName . '.NEXTVAL INTO last_Sequence FROM DUAL;
    END IF;
 END;';
 

--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional;
 
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -13,32 +16,66 @@ class AutoIncrementColumnTest extends FunctionalTestCase
 {
     private bool $shouldDisableIdentityInsert = false;
 
+    /** @throws Exception */
     protected function setUp(): void
     {
         $table = new Table('auto_increment_table');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('val', Types::INTEGER);
         $table->setPrimaryKey(['id']);
 
         $this->dropAndCreateTable($table);
     }
 
+    /** @throws Exception */
     protected function tearDown(): void
     {
         if (! $this->shouldDisableIdentityInsert) {
             return;
         }
 
-        $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table OFF');
+        $this->setIdentityInsert('OFF');
     }
 
+    /** @throws Exception */
+    public function testInsertAutoGeneratesValue(): void
+    {
+        $this->connection->insert('auto_increment_table', ['val' => 0]);
+        self::assertEquals(1, $this->connection->fetchOne('SELECT MAX(id) FROM auto_increment_table'));
+    }
+
+    /** @throws Exception */
     public function testInsertIdentityValue(): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
-            $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table ON');
+        $platform    = $this->connection->getDatabasePlatform();
+        $isSQLServer = $platform instanceof SQLServerPlatform;
+
+        if ($isSQLServer) {
+            $this->setIdentityInsert('ON');
             $this->shouldDisableIdentityInsert = true;
         }
 
-        $this->connection->insert('auto_increment_table', ['id' => 2]);
-        self::assertEquals(2, $this->connection->fetchOne('SELECT id FROM auto_increment_table'));
+        $this->connection->insert('auto_increment_table', ['id' => 2, 'val' => 0]);
+        self::assertEquals(2, $this->connection->fetchOne('SELECT MAX(id) FROM auto_increment_table'));
+
+        if ($isSQLServer) {
+            $this->setIdentityInsert('OFF');
+            $this->shouldDisableIdentityInsert = false;
+        }
+
+        // using an explicit value for an autoincrement column does not affect the next value
+        // on the following platforms
+        if ($platform instanceof PostgreSqlPlatform || $platform instanceof DB2Platform) {
+            return;
+        }
+
+        $this->connection->insert('auto_increment_table', ['val' => 0]);
+        self::assertEquals(3, $this->connection->fetchOne('SELECT MAX(id) FROM auto_increment_table'));
+    }
+
+    /** @throws Exception */
+    private function setIdentityInsert(string $value): void
+    {
+        $this->connection->executeStatement('SET IDENTITY_INSERT auto_increment_table ' . $value);
     }
 }

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -231,7 +231,6 @@ BEGIN
       WHILE (last_InsertID > last_Sequence) LOOP
          SELECT %s_SEQ.NEXTVAL INTO last_Sequence FROM DUAL;
       END LOOP;
-      SELECT %s_SEQ.NEXTVAL INTO last_Sequence FROM DUAL;
    END IF;
 END;
 SQL
@@ -244,7 +243,6 @@ SQL
                 $columnName,
                 $tableName,
                 $columnName,
-                $tableName,
                 $tableName,
             ),
         ], $this->platform->getCreateTableSQL($table));
@@ -540,7 +538,6 @@ BEGIN
       WHILE (last_InsertID > last_Sequence) LOOP
          SELECT "test_SEQ".NEXTVAL INTO last_Sequence FROM DUAL;
       END LOOP;
-      SELECT "test_SEQ".NEXTVAL INTO last_Sequence FROM DUAL;
    END IF;
 END;
 EOD;


### PR DESCRIPTION
This isn't really a bug bug, but something that could be improved. If an explicit value is inserted into an auto-increment column on Oracle, the next auto-increment value will be not +1 but +2.

Apparently, such a case doesn't affect the internal auto-increment sequence on Postgres and DB2 at all, but there's nothing we can do here.