### PR TITLE
Do not create PK constraint for auto-increment columns on Oracle

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Primary key constraint no longer created for auto-increment columns on Oracle
+
+The primary key constraint is no longer automatically created for auto-increment columns on Oracle. If a primary key
+constraint is required, create it explicitly.
+
 ## BC BREAK: Changes in protected `AbstractPlatform` API
 
 1. The `$options` parameter of the `AbstractPlatform::_getCreateTableSQL()` method is no longer optional and has been

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -359,30 +359,7 @@ class OraclePlatform extends AbstractPlatform
 
         $sql = [];
 
-        $constraintName = $this->generatePrimaryKeyConstraintName($tableName->getUnqualifiedName());
-
-        $index = new Index($constraintName->toString(), [$columnName->toString()], true, true);
-
-        $sql[] = sprintf(
-            <<<'SQL'
-DECLARE
-  CONSTRAINTS_COUNT NUMBER;
-BEGIN
-  SELECT COUNT(CONSTRAINT_NAME) INTO CONSTRAINTS_COUNT
-    FROM USER_CONSTRAINTS
-   WHERE TABLE_NAME = %s
-     AND CONSTRAINT_TYPE = 'P';
-  IF CONSTRAINTS_COUNT = 0 THEN
-    EXECUTE IMMEDIATE %s;
-  END IF;
-END;
-SQL,
-            $this->quoteStringLiteral(
-                $tableName->getUnqualifiedName()->toNormalizedValue($this),
-            ),
-            $this->quoteStringLiteral($this->getCreateIndexSQL($index, $tableName->toSQL($this))),
-        );
-
+        $triggerName  = $this->generateAutoincrementTriggerName($tableName->getUnqualifiedName());
         $sequenceName = $this->generateAutoincrementSequenceName($tableName);
         $sequence     = new Sequence($sequenceName->toString());
         $sql[]        = $this->getCreateSequenceSQL($sequence);
@@ -411,7 +388,7 @@ BEGIN
    END IF;
 END;
 SQL,
-            $constraintName->toSQL($this),
+            $triggerName->toSQL($this),
             $tableName->toSQL($this),
             $columnName->toSQL($this),
             $sequenceName->toSQL($this),
@@ -438,7 +415,7 @@ SQL,
             throw UnsupportedName::fromQualifiedName($tableName, __METHOD__);
         }
 
-        $primaryKeyConstraintName = $this->generatePrimaryKeyConstraintName($tableName->getUnqualifiedName());
+        $primaryKeyConstraintName = $this->generateAutoincrementTriggerName($tableName->getUnqualifiedName());
         $sequenceName             = $this->generateAutoincrementSequenceName($tableName);
 
         return [
@@ -477,12 +454,9 @@ SQL,
     }
 
     /**
-     * Returns the autoincrement primary key constraint name for the given table name.
-     *
-     * Quotes the autoincrement primary key identifier name
-     * if the given table name is quoted by intention.
+     * Returns the autoincrement trigger name for the given table name.
      */
-    private function generatePrimaryKeyConstraintName(Name\Identifier $tableName): Name\Identifier
+    private function generateAutoincrementTriggerName(Name\Identifier $tableName): Name\Identifier
     {
         return $this->addSuffix($tableName, '_AI_PK');
     }

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -164,26 +164,6 @@ class OraclePlatformTest extends AbstractPlatformTestCase
 
         self::assertSame([
             sprintf('CREATE TABLE "%s" ("%s" NUMBER(10) NOT NULL)', $tableName, $columnName),
-            sprintf(
-                <<<'SQL'
-DECLARE
-  CONSTRAINTS_COUNT NUMBER;
-BEGIN
-  SELECT COUNT(CONSTRAINT_NAME) INTO CONSTRAINTS_COUNT
-    FROM USER_CONSTRAINTS
-   WHERE TABLE_NAME = '%s'
-     AND CONSTRAINT_TYPE = 'P';
-  IF CONSTRAINTS_COUNT = 0 THEN
-    EXECUTE IMMEDIATE 'ALTER TABLE "%s" ADD CONSTRAINT "%s_AI_PK" PRIMARY KEY ("%s")';
-  END IF;
-END;
-SQL
-                ,
-                $tableName,
-                $tableName,
-                $tableName,
-                $columnName,
-            ),
             sprintf('CREATE SEQUENCE "%s_SEQ" START WITH 1 MINVALUE 1 INCREMENT BY 1', $tableName),
             sprintf(
                 <<<'SQL'
@@ -494,7 +474,7 @@ SQL
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals('CREATE TABLE "test" ("id" NUMBER(10) NOT NULL)', $sql[0]);
-        self::assertEquals('CREATE SEQUENCE "test_SEQ" START WITH 1 MINVALUE 1 INCREMENT BY 1', $sql[2]);
+        self::assertEquals('CREATE SEQUENCE "test_SEQ" START WITH 1 MINVALUE 1 INCREMENT BY 1', $sql[1]);
         $createTriggerStatement = <<<'EOD'
 CREATE TRIGGER "test_AI_PK"
    BEFORE INSERT
@@ -519,7 +499,7 @@ BEGIN
 END;
 EOD;
 
-        self::assertEquals($createTriggerStatement, $sql[3]);
+        self::assertEquals($createTriggerStatement, $sql[2]);
     }
 
     protected function getQuotesReservedKeywordInIndexDeclarationSQL(): string


### PR DESCRIPTION
## Background

DBAL, in order to emulate auto-increment behavior on Oracle, creates a sequence and a trigger that uses the value from the sequence if the inserted value is empty.

Additionally, together with the trigger, for some reason it creates a primary key constraint. The trigger doesn't require a primary key constraint to function properly (mentioned earlier in https://github.com/doctrine/dbal/pull/6810). This can be confirmed by removing the following line and running the test: https://github.com/doctrine/dbal/blob/95d093a306e3cd059a5ddf2e461c24c6fddf5a4f/tests/Functional/AutoIncrementColumnTest.php#L20

## The problem

First, this code needs to be maintained and updated, especially in during the rework of object names. Second, this automatically created PK would most likely cause a false-positive diff, if a table was defined without a PK and then introspected with one.

## Deprecation

Relying on the current behavior cannot be deprecated because there's no way to tell whether the library consumer really relies on it. Even if the auto-increment column isn't part of the PK, it doesn't mean that the consumer needs it and should create explicitly.