### PR TITLE
Fix SchemaManagerFunctionalTestCase::testSwitchPrimaryKeyOrder()

### DIFF
--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1462,8 +1462,21 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertTrue($child->hasIndex('idx_2'));
     }
 
+    /** @throws Exception */
     public function testSwitchPrimaryKeyOrder(): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (
+            $platform instanceof DB2Platform
+            || $platform instanceof OraclePlatform
+            || $platform instanceof SQLServerPlatform
+        ) {
+            self::markTestIncomplete(
+                'Dropping primary key constraint on the currently used database platform is not implemented.',
+            );
+        }
+
         $prototype = new Table('test_switch_pk_order');
         $prototype->addColumn('foo_id', Types::INTEGER);
         $prototype->addColumn('bar_id', Types::INTEGER);
@@ -1481,11 +1494,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             $schemaManager->introspectTable('test_switch_pk_order'),
             $table,
         );
+        self::assertFalse($diff->isEmpty());
+        $schemaManager->alterTable($diff);
 
         $table      = $schemaManager->introspectTable('test_switch_pk_order');
         $primaryKey = $table->getPrimaryKey();
         self::assertNotNull($primaryKey);
-        self::assertSame(['foo_id', 'bar_id'], array_map('strtolower', $primaryKey->getColumns()));
+        self::assertSame(['bar_id', 'foo_id'], array_map('strtolower', $primaryKey->getColumns()));
     }
 
     public function testDropColumnWithDefault(): void


### PR DESCRIPTION
The original test was reworked in #5714 (3.5.x). Prior to the rework, the final assertion would look like this (which was correct): https://github.com/doctrine/dbal/blob/35741d682240193b4403e3e1e6bad3cfeffa055e/tests/Schema/Platforms/MySQLSchemaTest.php#L38-L44

After the rework, the assertion started looking like this (incorrect, note the column order): https://github.com/doctrine/dbal/blob/a4a9b1799c1227ce308e1e64ca8448b50a0ceec6/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php#L1774

The version of the test after the rework produces the `$diff` but doesn't use it for anything (it's an unused variable). The diff was supposed to be applied to the database schema, and then the assertion should have been made that the new column order is now effective.

## Skipping the test

The test passes on MySQL and SQLite because the corresponding DBALs APIs were designed after MySQL. Specifically, `DROP INDEX PRIMARY` on MySQL (and, for some reason, on SQLite) drops the primary key. The Postgres implementation gets away with a hack – instead of dropping the index, it generates the PK name and drops the constraint: https://github.com/doctrine/dbal/blob/369ab24fc865939ff451c5214742cebac052f2f1/src/Platforms/PostgreSQLPlatform.php#L368-L375

This hack is not implemented for other platforms, so they don't support dropping the PK and fail with a SQL error, which is a bug. This hack cannot be ported to the other platforms easily, because the auto-generated name there is less predictable. This issue could be addressed by replacing the "primary index" with `PrimaryKeyConstraint`, which, once introspected from the database, would hold the actual constraint name.