### PR TITLE
Remove outdated MySQL platform test assertions

### DIFF
--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -593,12 +593,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
      */
     protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
     {
-        return [
-            'ALTER TABLE `mytable` DROP FOREIGN KEY fk_foo',
-            'DROP INDEX `idx_foo` ON `mytable`',
-            'CREATE INDEX `idx_foo_renamed` ON mytable (foo)',
-            'ALTER TABLE `mytable` ADD CONSTRAINT `fk_foo` FOREIGN KEY (`foo`) REFERENCES foreign_table (id)',
-        ];
+        return ['ALTER TABLE `mytable` RENAME INDEX `idx_foo` TO `idx_foo_renamed`'];
     }
 
     /**

--- a/tests/Platforms/MariaDBPlatformTest.php
+++ b/tests/Platforms/MariaDBPlatformTest.php
@@ -46,14 +46,6 @@ class MariaDBPlatformTest extends AbstractMySQLPlatformTestCase
     }
 
     /**
-     * {@inheritDoc}
-     */
-    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
-    {
-        return ['ALTER TABLE `mytable` RENAME INDEX `idx_foo` TO `idx_foo_renamed`'];
-    }
-
-    /**
      * From MariaDB 10.2.7, JSON type is an alias to LONGTEXT however from 10.4.3 setting a column
      * as JSON adds additional functionality so use JSON.
      *

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -58,14 +58,6 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array
-    {
-        return ['ALTER TABLE `mytable` RENAME INDEX `idx_foo` TO `idx_foo_renamed`'];
-    }
-
     public function testHasCorrectDefaultTransactionIsolationLevel(): void
     {
         self::assertEquals(


### PR DESCRIPTION
The expected migration that contains `DROP FOREIGN KEY` is only relevant for DBAL 4 which supports MySQL older than 5.7 and MariaDB older than 10.5.2. In DBAL 5, the code that would generate this DDL no longer exists.

This change might be included into https://github.com/doctrine/dbal/pull/6346.