### PR TITLE
Extract UnquotedIdentifierFolding from AbstractPlatform

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
@@ -45,6 +46,11 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     final public const LENGTH_LIMIT_TINYBLOB   = 255;
     final public const LENGTH_LIMIT_BLOB       = 65535;
     final public const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
+
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::NONE);
+    }
 
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string
     {
@@ -886,10 +892,5 @@ SQL;
         $conditions[] = "t.TABLE_TYPE = 'BASE TABLE'";
 
         return $sql . ' WHERE ' . implode(' AND ', $conditions);
-    }
-
-    public function normalizeUnquotedIdentifier(string $identifier): string
-    {
-        return $identifier;
     }
 }

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
@@ -33,6 +34,11 @@ use function str_contains;
  */
 class DB2Platform extends AbstractPlatform
 {
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::UPPER);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\Keywords\OracleKeywords;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -35,6 +36,11 @@ use function substr;
  */
 class OraclePlatform extends AbstractPlatform
 {
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::UPPER);
+    }
+
     public function getSubstringExpression(string $string, string $start, ?string $length = null): string
     {
         if ($length === null) {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\Keywords\PostgreSQLKeywords;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -62,6 +63,11 @@ class PostgreSQLPlatform extends AbstractPlatform
             '0',
         ],
     ];
+
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::LOWER);
+    }
 
     /**
      * PostgreSQL has different behavior with some drivers
@@ -800,10 +806,5 @@ class PostgreSQLPlatform extends AbstractPlatform
     public function createSchemaManager(Connection $connection): PostgreSQLSchemaManager
     {
         return new PostgreSQLSchemaManager($connection, $this);
-    }
-
-    public function normalizeUnquotedIdentifier(string $identifier): string
-    {
-        return strtolower($identifier);
     }
 }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\SQLServerSchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -53,6 +54,11 @@ class SQLServerPlatform extends AbstractPlatform
 {
     /** @internal Should be used only from within the {@see AbstractSchemaManager} class hierarchy. */
     public const OPTION_DEFAULT_CONSTRAINT_NAME = 'default_constraint_name';
+
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::NONE);
+    }
 
     public function createSelectSQLBuilder(): SelectSQLBuilder
     {
@@ -1316,10 +1322,5 @@ class SQLServerPlatform extends AbstractPlatform
     public function createSchemaManager(Connection $connection): SQLServerSchemaManager
     {
         return new SQLServerSchemaManager($connection, $this);
-    }
-
-    public function normalizeUnquotedIdentifier(string $identifier): string
-    {
-        return $identifier;
     }
 }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -46,6 +47,11 @@ use function trim;
  */
 class SQLitePlatform extends AbstractPlatform
 {
+    public function __construct()
+    {
+        parent::__construct(UnquotedIdentifierFolding::NONE);
+    }
+
     public function getCreateDatabaseSQL(string $name): string
     {
         throw NotSupported::new(__METHOD__);
@@ -960,10 +966,5 @@ class SQLitePlatform extends AbstractPlatform
     public function getUnionSelectPartSQL(string $subQuery): string
     {
         return $subQuery;
-    }
-
-    public function normalizeUnquotedIdentifier(string $identifier): string
-    {
-        return $identifier;
     }
 }

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -353,6 +353,7 @@ abstract class AbstractAsset
         );
 
         $keywords = $platform->getReservedKeywordsList();
+        $folding  = $platform->getUnquotedIdentifierFolding();
         $parts    = $normalizedParts = [];
 
         foreach (explode('.', $this->getName()) as $identifier) {
@@ -360,7 +361,7 @@ abstract class AbstractAsset
 
             if (! $isQuoted) {
                 $parts[]           = $identifier;
-                $normalizedParts[] = $platform->normalizeUnquotedIdentifier($identifier);
+                $normalizedParts[] = $folding->foldUnquotedIdentifier($identifier);
             } else {
                 $parts[]           = $platform->quoteSingleIdentifier($identifier);
                 $normalizedParts[] = $identifier;
@@ -370,11 +371,11 @@ abstract class AbstractAsset
         $name = implode('.', $parts);
 
         if ($this->validateFuture) {
-            $futureParts = array_map(static function (Identifier $identifier) use ($platform): string {
+            $futureParts = array_map(static function (Identifier $identifier) use ($folding): string {
                 $value = $identifier->getValue();
 
                 if (! $identifier->isQuoted()) {
-                    $value = $platform->normalizeUnquotedIdentifier($value);
+                    $value = $folding->foldUnquotedIdentifier($value);
                 }
 
                 return $value;

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -38,7 +38,7 @@ final class Identifier
     public function toSQL(AbstractPlatform $platform): string
     {
         return $platform->quoteSingleIdentifier(
-            $this->toNormalizedValue($platform),
+            $this->toNormalizedValue($platform->getUnquotedIdentifierFolding()),
         );
     }
 
@@ -47,10 +47,10 @@ final class Identifier
      *
      * Consumers should use the normalized value for schema comparison and referencing the objects to be introspected.
      */
-    public function toNormalizedValue(AbstractPlatform $platform): string
+    public function toNormalizedValue(UnquotedIdentifierFolding $folding): string
     {
         if (! $this->isQuoted) {
-            return $platform->normalizeUnquotedIdentifier($this->value);
+            return $folding->foldUnquotedIdentifier($this->value);
         }
 
         return $this->value;

--- a/src/Schema/Name/UnquotedIdentifierFolding.php
+++ b/src/Schema/Name/UnquotedIdentifierFolding.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Name;
+
+use function strtolower;
+use function strtoupper;
+
+/**
+ * Defines how a database platform folds the case of unquoted identifiers.
+ */
+enum UnquotedIdentifierFolding
+{
+    /**
+     * Represents upper-case folding of unquoted identifiers.
+     */
+    case UPPER;
+
+    /**
+     * Represents lower-case folding of unquoted identifiers.
+     */
+    case LOWER;
+
+    /**
+     * Represents no folding of unquoted identifiers.
+     */
+    case NONE;
+
+    /**
+     * Applies case folding to an unquoted identifier as a database platform would when processing an SQL statement.
+     */
+    public function foldUnquotedIdentifier(string $value): string
+    {
+        return match ($this) {
+            self::UPPER => strtoupper($value),
+            self::LOWER => strtolower($value),
+            self::NONE => $value,
+        };
+    }
+}

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -123,7 +123,7 @@ final class SchemaManagerTest extends FunctionalTestCase
         }
 
         $name           = 'example.com';
-        $normalizedName = $platform->normalizeUnquotedIdentifier($name);
+        $normalizedName = $platform->getUnquotedIdentifierFolding()->foldUnquotedIdentifier($name);
         $quotedName     = $this->connection->quoteSingleIdentifier($normalizedName);
 
         // create the table manually since identifiers with dots are not supported in DBAL 4.x

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -124,8 +124,10 @@ abstract class FunctionalTestCase extends TestCase
             throw NotSupported::new(__METHOD__);
         }
 
+        $folding = $platform->getUnquotedIdentifierFolding();
+
         $normalizedSchemaName = $schemaName->getIdentifier()
-            ->toNormalizedValue($platform);
+            ->toNormalizedValue($folding);
 
         $schemaManager  = $this->connection->createSchemaManager();
         $databaseSchema = $schemaManager->introspectSchema();
@@ -135,7 +137,7 @@ abstract class FunctionalTestCase extends TestCase
             $qualifier = $sequence->getObjectName()
                 ->getQualifier();
 
-            if ($qualifier === null || $qualifier->toNormalizedValue($platform) !== $normalizedSchemaName) {
+            if ($qualifier === null || $qualifier->toNormalizedValue($folding) !== $normalizedSchemaName) {
                 continue;
             }
 
@@ -147,7 +149,7 @@ abstract class FunctionalTestCase extends TestCase
             $qualifier = $table->getObjectName()
                 ->getQualifier();
 
-            if ($qualifier === null || $qualifier->toNormalizedValue($platform) !== $normalizedSchemaName) {
+            if ($qualifier === null || $qualifier->toNormalizedValue($folding) !== $normalizedSchemaName) {
                 continue;
             }
 
@@ -321,7 +323,8 @@ abstract class FunctionalTestCase extends TestCase
 
         return Identifier::quoted(
             $this->connection->getDatabasePlatform()
-                ->normalizeUnquotedIdentifier($identifier->getValue()),
+                ->getUnquotedIdentifierFolding()
+                ->foldUnquotedIdentifier($identifier->getValue()),
         );
     }
 }

--- a/tests/Platforms/AbstractPlatformExtensionTest.php
+++ b/tests/Platforms/AbstractPlatformExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractPlatformExtensionTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    /**
+     * This test uses deprecated PHPUnit features and can be removed during the PHPUnit upgrade.
+     */
+    public function testNotPassingUnquotedIdentifierFolding(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6823');
+
+        $this->getMockForAbstractClass(AbstractPlatform::class);
+    }
+
+    /**
+     * This test uses deprecated PHPUnit features and can be removed during the PHPUnit upgrade.
+     */
+    public function testNotCallingParentConstructor(): void
+    {
+        $platform = $this->getMockForAbstractClass(AbstractPlatform::class, [], '', false);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6823');
+
+        $platform->getUnquotedIdentifierFolding();
+    }
+}


### PR DESCRIPTION
## Background

As of https://github.com/doctrine/dbal/pull/6592 (not yet released), `AbstractPlatform` has been responsible for normalizing (e.g. upper-casing or lower-casing) unquoted identifiers. This is needed in the following cases:
1. Quoting identifiers (it has to be normalized before quoting)
2. Schema introspection (unlike SQL which may upper-case or lower-case unquoted identifiers, schema introspection queries are case-sensitive and expect the parameters in their actual case).

In both of those cases, a platform instance is available, so the current design is fine.

## Current limitations

When it comes to representing database objects in DBAL, e.g. columns or indexes in a `Table`, tables in a `Schema`, etc., nested objects are referenced by their lower-case names. Because of that, for example, it's impossible to introspect a table that contains columns `ID` and `id` on Oracle (see https://github.com/doctrine/dbal/issues/4357#issuecomment-911123014).

For that to be possible, we need to be able to use the "normalization" behavior that corresponds to a platform in the model layer. E.g. it should be possible to "represent a table introspected from Oracle" or "define a table that can be correctly deployed to MySQL and Postgres".

Adding a dependency of say `Table` on the `AbstractPlatform` class itself wouldn't be right because:
1. This is a too big of a dependency to add.
2. The model layer shouldn't depend on infrastructure.

Instead, we can extract the "normalization" behavior into a separate component.

Similar to the introduction of SQL builders, this is another tiny step towards `AbstractPlatform` decluttering and modularization.

## Terminology

The proposed term for the behavior of upper-casing or lower-casing unquoted identifiers is "folding". This term is not used in the SQL standard but is used in [Postgres](https://www.postgresql.org/docs/current/sql-syntax-lexical.html) and [IBM DB2](https://www.ibm.com/docs/en/db2-for-zos/13?topic=elements-identifiers) documentation.

Alternatively, this could be named "identifier normalization mode", "unquoted identifier semantics" or "unquoted identifier case".

## Technicalities
### Enum vs. interface

Originally, I started with declaring `UnquotedIdentifierFolding` as an interface, but then decided to replace it and all implementations with an enum.

The major reason is that I want to achieve the behavior where a user can tell that their schema should be compatible with say MySQL, SQL Server and SQLite, and DBAL will know that they all use the same approach to folding unquoted identifiers (none) and use a single implementation for all of them (it is easy to tell if they all return the same enum value).

The downside of using an enum is that it's hard to extend, but I don't think any platform we will support in the future will require a new folding behavior.

### Introduction of the `AbstractPlatform` constructor

`AbstractPlatform::$unquotedIdentifierFolding` is private and is accepted as a constructor parameter. Compared to declaring as a protected property, it has the following advantages:
1. Each platform will have to explicitly declare its folding. There will be no default, because there is no specific value that would make enough sense as the default.
4. It will be possible to declare it as readonly.

### Testing runtime deprecations

Testing runtime deprecations requires mocking an abstract class, which PHPUnit has deprecated long ago (https://github.com/sebastianbergmann/phpunit/issues/5305). Furthermore, PHPUnit cannot call a protected constructor in order to test not passing a constructor argument.

Unless there's a way to test it in a reasonable way, I think we can leave these deprecation untested.