### PR TITLE
Deprecate modified foreign keys in TableDiff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated handling of modified foreign keys in `TableDiff`
+
+Passing a non-empty `$modifiedForeignKeys` value to the `TableDiff` constructor is deprecated. Instead, pass dropped
+constraints via `$droppedForeignKeys` and added constraints via `$addedForeignKeys`.
+
+The `TableDiff::getModifiedForeignKeys()` method has been deprecated. The old version of the foreign key constraint is
+included in the return value of `TableDiff::getDroppedForeignKeys()`, the new version is included in the return value of
+`TableDiff::getModifiedForeignKeys()`.
+
 ## Deprecated not passing `$options` to `AbstractPlatform::_getCreateTableSQL()`
 
 Not passing the `$options` argument or any of its following keys to the `AbstractPlatform::_getCreateTableSQL()` method

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -145,16 +145,15 @@ class Comparator
      */
     public function compareTables(Table $oldTable, Table $newTable): TableDiff
     {
-        $addedColumns        = [];
-        $modifiedColumns     = [];
-        $droppedColumns      = [];
-        $addedIndexes        = [];
-        $modifiedIndexes     = [];
-        $droppedIndexes      = [];
-        $renamedIndexes      = [];
-        $addedForeignKeys    = [];
-        $modifiedForeignKeys = [];
-        $droppedForeignKeys  = [];
+        $addedColumns       = [];
+        $modifiedColumns    = [];
+        $droppedColumns     = [];
+        $addedIndexes       = [];
+        $modifiedIndexes    = [];
+        $droppedIndexes     = [];
+        $renamedIndexes     = [];
+        $addedForeignKeys   = [];
+        $droppedForeignKeys = [];
 
         $oldColumns = $oldTable->getColumns();
         $newColumns = $newTable->getColumns();
@@ -262,7 +261,8 @@ class Comparator
                     unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
                 } else {
                     if (strtolower($oldForeignKey->getName()) === strtolower($newForeignKey->getName())) {
-                        $modifiedForeignKeys[] = $newForeignKey;
+                        $droppedForeignKeys[$oldKey] = $oldForeignKey;
+                        $addedForeignKeys[$newKey]   = $newForeignKey;
 
                         unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
                     }
@@ -288,7 +288,6 @@ class Comparator
             droppedIndexes: $droppedIndexes,
             renamedIndexes: $renamedIndexes,
             addedForeignKeys: $addedForeignKeys,
-            modifiedForeignKeys: $modifiedForeignKeys,
             droppedForeignKeys: $droppedForeignKeys,
         );
     }

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -64,7 +64,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
     {
         $table = $this->introspectTable($table);
 
-        $this->alterTable(new TableDiff($table, modifiedForeignKeys: [$foreignKey]));
+        $this->alterTable(new TableDiff($table, addedForeignKeys: [$foreignKey]));
     }
 
     public function dropForeignKey(string $name, string $table): void

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -44,6 +44,17 @@ class TableDiff
         private readonly array $modifiedForeignKeys = [],
         private readonly array $droppedForeignKeys = [],
     ) {
+        if (count($modifiedForeignKeys) === 0) {
+            return;
+        }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6827',
+            'Passing a non-empty $modifiedForeignKeys value to %s() is deprecated. Instead, pass dropped'
+                . ' constraints via $droppedForeignKeys and added constraints via $addedForeignKeys.',
+            __METHOD__,
+        );
     }
 
     public function getOldTable(): Table
@@ -173,9 +184,20 @@ class TableDiff
         return $this->addedForeignKeys;
     }
 
-    /** @return array<ForeignKeyConstraint> */
+    /**
+     * @deprecated Use {@see getAddedForeignKeys()} and {@see getDroppedForeignKeys()} instead.
+     *
+     * @return array<ForeignKeyConstraint>
+     */
     public function getModifiedForeignKeys(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6827',
+            '%s() is deprecated, use getDroppedForeignKeys() and getAddedForeignKeys() instead.',
+            __METHOD__,
+        );
+
         return $this->modifiedForeignKeys;
     }
 

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -279,7 +279,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($table1, $table2);
 
-        self::assertCount(1, $tableDiff->getModifiedForeignKeys());
+        self::assertCount(1, $tableDiff->getDroppedForeignKeys());
+        self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 
     public function testMovedForeignKeyForeignTable(): void
@@ -300,7 +301,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($table1, $table2);
 
-        self::assertCount(1, $tableDiff->getModifiedForeignKeys());
+        self::assertCount(1, $tableDiff->getDroppedForeignKeys());
+        self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 
     public function testTablesCaseInsensitive(): void


### PR DESCRIPTION
Constraints cannot be modified neither in the DBAL Schema API, nor in databases – they can be dropped and added. However, `Comparator` and `TableDiff` represent non-equal foreign key constraints with the same name as "modified".

This requires the consumer of the diff to implement additional processing of the "modified foreign keys" alongside the dropped and added ones: 
https://github.com/doctrine/dbal/blob/b2ac865facda5c6480970387848352920ad94626/src/Platforms/AbstractPlatform.php#L1310-L1312 https://github.com/doctrine/dbal/blob/b2ac865facda5c6480970387848352920ad94626/src/Platforms/AbstractPlatform.php#L1336-L1338 https://github.com/doctrine/dbal/blob/b2ac865facda5c6480970387848352920ad94626/src/Platforms/SQLitePlatform.php#L923

## The changes
As part of the deprecation, the `Comparator` will stop passing `$modifiedForeignKeys` to the `TableDiff` constructor and instead will start including the dropped and added constraint to `$droppedForeignKeys` and `$addedForeignKeys` respectively. I don't think that this is a breaking change assuming that the consumer of the diff processes it in full (not just the modified keys).

I coulnd't find any Doctrine (other than DBAL) and other open-source code that would use `TableDiff#getModifiedForeignKeys()` at all.

If we believe the shape of the diff should remain intact, then instead of deprecating the method, we need to introduce a comparator configuration parameter for producing the diff the new way and then deprecating it. This would be overkill.