### PR TITLE
Prevent LockMode\NoneTest from blocking on SQL Server

### DIFF
--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -71,7 +71,9 @@ class NoneTest extends FunctionalTestCase
         }
 
         $db = $this->connection->getDatabase();
-        $this->connection->executeStatement('ALTER DATABASE ' . $db . ' SET READ_COMMITTED_SNAPSHOT OFF');
+        $this->connection->executeStatement(
+            'ALTER DATABASE ' . $db . ' SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE',
+        );
     }
 
     public function testLockModeNoneDoesNotBreakTransactionIsolation(): void


### PR DESCRIPTION
This issue doesn't happen on CI but happens for me locally on macOS (it passes locally on Linux). The test in question blocks indefinitely while performing the following query on teardown: https://github.com/doctrine/dbal/blob/02025a95211a706f6461e63250264f7aa942f9e4/tests/Functional/LockMode/NoneTest.php#L74

The reason seems to be the same as here, but I don't fully understand what it is: https://github.com/doctrine/dbal/blob/02025a95211a706f6461e63250264f7aa942f9e4/tests/Functional/LockMode/NoneTest.php#L28-L29

The solution is to force `SINGLE_USER` for the `SET READ_COMMITTED_SNAPSHOT OFF` query as well.

Note that the "when not running this test in isolation" clause isn't true in my case since the test blocks even if running in isolation, so I removed it.