### PR TITLE
Deprecate modified indexes in TableDiff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated handling of modified indexes in `TableDiff`
+
+Passing a non-empty `$modifiedIndexes` value to the `TableDiff` constructor is deprecated. Instead, pass dropped
+indexes via `$droppedIndexes` and added indexes via `$addedIndexes`.
+
+The `TableDiff::getModifiedIndexes()` method has been deprecated. The old version of the index is included in the return
+value of `TableDiff::getDroppedIndexes()`, the new version is included in the return value of
+`TableDiff::getAddedIndexes()`.
+
 ## Deprecated handling of modified foreign keys in `TableDiff`
 
 Passing a non-empty `$modifiedForeignKeys` value to the `TableDiff` constructor is deprecated. Instead, pass dropped
@@ -15,7 +24,7 @@ constraints via `$droppedForeignKeys` and added constraints via `$addedForeignKe
 
 The `TableDiff::getModifiedForeignKeys()` method has been deprecated. The old version of the foreign key constraint is
 included in the return value of `TableDiff::getDroppedForeignKeys()`, the new version is included in the return value of
-`TableDiff::getModifiedForeignKeys()`.
+`TableDiff::getAddedForeignKeys()`.
 
 ## Deprecated not passing `$options` to `AbstractPlatform::_getCreateTableSQL()`
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
@@ -481,11 +480,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         );
     }
 
-    /**
-     * @return list<string>
-     *
-     * @throws Exception
-     */
+    /** @return list<string> */
     private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index): array
     {
         if (! $index->isPrimary()) {
@@ -526,8 +521,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      * @param TableDiff $diff The table diff to gather the SQL for.
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff): array
     {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -364,14 +364,14 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     public function getDropIndexSQL(string $name, string $table): string
     {
-        if ($name === '"primary"') {
-            if (str_ends_with($table, '"')) {
-                $constraintName = substr($table, 0, -1) . '_pkey"';
-            } else {
-                $constraintName = $table . '_pkey';
-            }
+        if (str_ends_with($table, '"')) {
+            $primaryKeyName = substr($table, 0, -1) . '_pkey"';
+        } else {
+            $primaryKeyName = $table . '_pkey';
+        }
 
-            return $this->getDropConstraintSQL($constraintName, $table);
+        if ($name === '"primary"' || $name === $primaryKeyName) {
+            return $this->getDropConstraintSQL($primaryKeyName, $table);
         }
 
         if (str_contains($table, '.')) {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -149,7 +149,6 @@ class Comparator
         $modifiedColumns    = [];
         $droppedColumns     = [];
         $addedIndexes       = [];
-        $modifiedIndexes    = [];
         $droppedIndexes     = [];
         $renamedIndexes     = [];
         $addedForeignKeys   = [];
@@ -245,7 +244,8 @@ class Comparator
                 continue;
             }
 
-            $modifiedIndexes[] = $newIndex;
+            $droppedIndexes[$oldIndexName] = $oldIndex;
+            $addedIndexes[$oldIndexName]   = $newIndex;
         }
 
         if ($this->config->getDetectRenamedIndexes()) {
@@ -284,7 +284,6 @@ class Comparator
             changedColumns: $modifiedColumns,
             droppedColumns: $droppedColumns,
             addedIndexes: $addedIndexes,
-            modifiedIndexes: $modifiedIndexes,
             droppedIndexes: $droppedIndexes,
             renamedIndexes: $renamedIndexes,
             addedForeignKeys: $addedForeignKeys,

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -44,6 +44,16 @@ class TableDiff
         private readonly array $modifiedForeignKeys = [],
         private readonly array $droppedForeignKeys = [],
     ) {
+        if (count($this->modifiedIndexes) !== 0) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6831',
+                'Passing a non-empty $modifiedIndexes value to %s() is deprecated. Instead, pass dropped'
+                    . ' indexes via $droppedIndexes and added indexes via $addedIndexes.',
+                __METHOD__,
+            );
+        }
+
         if (count($modifiedForeignKeys) === 0) {
             return;
         }
@@ -146,9 +156,20 @@ class TableDiff
         );
     }
 
-    /** @return array<Index> */
+    /**
+     * @deprecated Use {@see getAddedIndexes()} and {@see getDroppedIndexes()} instead.
+     *
+     * @return array<Index>
+     */
     public function getModifiedIndexes(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6831',
+            '%s() is deprecated, use getAddedIndexes() and getDroppedIndexes() instead.',
+            __METHOD__,
+        );
+
         return $this->modifiedIndexes;
     }
 


### PR DESCRIPTION
The same reasoning applies as in https://github.com/doctrine/dbal/pull/6827.

The `@throws Exception` annotations being removed from `AbstractMySQLPlatform` seem to have been mistakenly introduced as a result of conflict resolution during a merge up (2.11.x → 3.0.x).

See the details about the changes in `PostgreSQLPlatform` inline.