### PR TITLE
Enable PHPStan checks for exceptions

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,8 +7,22 @@ parameters:
         - tests
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+        uncheckedExceptionClasses:
+            - ErrorException
+            - LogicException
+            - RuntimeException
     ignoreErrors:
         - identifier: missingType.generics
+
+        # Ignore missing declarations of checked exceptions in tests
+        -
+            identifier: missingType.checkedException
+            paths:
+                - static-analysis
+                - tests
 
         # https://github.com/phpstan/phpstan-strict-rules/issues/103
         -

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -269,8 +269,7 @@ class Connection implements ServerVersionProvider
      *
      * @see isAutoCommit
      *
-     * @throws ConnectionException
-     * @throws DriverException
+     * @throws Exception
      */
     public function setAutoCommit(bool $autoCommit): void
     {
@@ -558,6 +557,8 @@ class Connection implements ServerVersionProvider
      * @param string $identifier The identifier to be quoted.
      *
      * @return string The quoted identifier.
+     *
+     * @throws Exception
      */
     public function quoteIdentifier(string $identifier): string
     {
@@ -587,6 +588,8 @@ class Connection implements ServerVersionProvider
     /**
      * The usage of this method is discouraged. Use prepared statements
      * or {@see AbstractPlatform::quoteStringLiteral()} instead.
+     *
+     * @throws Exception
      */
     public function quote(string $value): string
     {
@@ -833,6 +836,7 @@ class Connection implements ServerVersionProvider
 
         [$cacheKey, $realKey] = $qcp->generateCacheKeys($sql, $params, $types, $connectionParams);
 
+        // @phpstan-ignore missingType.checkedException
         $item = $resultCache->getItem($cacheKey);
 
         if ($item->isHit()) {
@@ -1088,6 +1092,7 @@ class Connection implements ServerVersionProvider
         }
     }
 
+    /** @throws Exception */
     private function updateTransactionStateAfterCommit(): void
     {
         if ($this->transactionNestingLevel !== 0) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1314,7 +1314,11 @@ class Connection implements ServerVersionProvider
                     $bindingType = ParameterType::STRING;
                 }
 
-                $stmt->bindValue($bindIndex, $value, $bindingType);
+                try {
+                    $stmt->bindValue($bindIndex, $value, $bindingType);
+                } catch (Driver\Exception $e) {
+                    throw $this->convertException($e);
+                }
 
                 ++$bindIndex;
             }
@@ -1328,7 +1332,11 @@ class Connection implements ServerVersionProvider
                     $bindingType = ParameterType::STRING;
                 }
 
-                $stmt->bindValue($name, $value, $bindingType);
+                try {
+                    $stmt->bindValue($name, $value, $bindingType);
+                } catch (Driver\Exception $e) {
+                    throw $this->convertException($e);
+                }
             }
         }
     }

--- a/src/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Connections/PrimaryReadReplicaConnection.php
@@ -141,6 +141,7 @@ class PrimaryReadReplicaConnection extends Connection
         return $this->performConnect();
     }
 
+    /** @throws Exception */
     protected function performConnect(?string $connectionName = null): DriverConnection
     {
         $requestedConnectionChange = ($connectionName !== null);
@@ -192,6 +193,8 @@ class PrimaryReadReplicaConnection extends Connection
      * Connects to the primary node of the database cluster.
      *
      * All following statements after this will be executed against the primary node.
+     *
+     * @throws Exception
      */
     public function ensureConnectedToPrimary(): void
     {
@@ -204,6 +207,8 @@ class PrimaryReadReplicaConnection extends Connection
      * All following statements after this will be executed against the replica node,
      * unless the keepReplica option is set to false and a primary connection
      * was already opened.
+     *
+     * @throws Exception
      */
     public function ensureConnectedToReplica(): void
     {

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Exception\PlatformException;
 use SensitiveParameter;
 
 /**
@@ -38,6 +39,8 @@ interface Driver
      * the platform this driver connects to.
      *
      * @return AbstractPlatform The database platform.
+     *
+     * @throws PlatformException
      */
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): AbstractPlatform;
 

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -75,6 +75,7 @@ final class Result implements ResultInterface
         }
     }
 
+    /** @throws Exception */
     public function getColumnName(int $index): string
     {
         try {

--- a/src/Driver/PgSQL/Connection.php
+++ b/src/Driver/PgSQL/Connection.php
@@ -41,6 +41,8 @@ final class Connection implements ConnectionInterface
     public function prepare(string $sql): Statement
     {
         $visitor = new ConvertParameters();
+
+        /** @phpstan-ignore missingType.checkedException */
         $this->parser->parse($sql, $visitor);
 
         $statementName = uniqid('dbal', true);

--- a/src/Exception/ParseError.php
+++ b/src/Exception/ParseError.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\SQL\Parser;
+
+/** @internal */
+final class ParseError extends \Exception implements Exception
+{
+    public static function fromParserException(Parser\Exception $exception): self
+    {
+        return new self('Unable to parse query.', 0, $exception);
+    }
+}

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
@@ -481,11 +480,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         );
     }
 
-    /**
-     * @return list<string>
-     *
-     * @throws Exception
-     */
+    /** @return list<string> */
     private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index): array
     {
         if (! $index->isPrimary()) {
@@ -526,8 +521,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      * @param TableDiff $diff The table diff to gather the SQL for.
      *
      * @return list<string>
-     *
-     * @throws Exception
      */
     private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff): array
     {

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -37,6 +37,7 @@ use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 
@@ -161,6 +162,8 @@ abstract class AbstractPlatform
     /**
      * Initializes Doctrine Type Mappings with the platform defaults
      * and with all additional type mappings.
+     *
+     * @throws TypesException
      */
     private function initializeAllDoctrineTypeMappings(): void
     {
@@ -372,6 +375,8 @@ abstract class AbstractPlatform
 
     /**
      * Gets the Doctrine type that is mapped for the given database column type.
+     *
+     * @throws TypesException
      */
     public function getDoctrineTypeMapping(string $dbType): string
     {
@@ -394,6 +399,8 @@ abstract class AbstractPlatform
 
     /**
      * Checks if a database type is currently supported by this platform.
+     *
+     * @throws TypesException
      */
     public function hasDoctrineTypeMappingFor(string $dbType): bool
     {

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\SQLiteKeywords;
@@ -704,8 +703,6 @@ class SQLitePlatform extends AbstractPlatform
      * @param array<string,Column> $columns
      *
      * @return array<string,Column>
-     *
-     * @throws Exception
      */
     private function replaceColumn(string $tableName, array $columns, string $columnName, Column $column): array
     {
@@ -724,11 +721,7 @@ class SQLitePlatform extends AbstractPlatform
         return array_combine($keys, $values);
     }
 
-    /**
-     * @return list<string>|false
-     *
-     * @throws Exception
-     */
+    /** @return list<string>|false */
     private function getSimpleAlterTableSQL(TableDiff $diff): array|false
     {
         if (

--- a/src/Portability/Driver.php
+++ b/src/Portability/Driver.php
@@ -7,7 +7,9 @@ namespace Doctrine\DBAL\Portability;
 use Doctrine\DBAL\ColumnCase;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Doctrine\DBAL\Platforms\Exception\PlatformException;
 use PDO;
 use SensitiveParameter;
 
@@ -26,6 +28,9 @@ final class Driver extends AbstractDriverMiddleware
 
     /**
      * {@inheritDoc}
+     *
+     * @throws PlatformException
+     * @throws Exception
      */
     public function connect(
         #[SensitiveParameter]

--- a/src/Query/CommonTableExpression.php
+++ b/src/Query/CommonTableExpression.php
@@ -10,7 +10,11 @@ use function sprintf;
 /** @internal */
 final class CommonTableExpression
 {
-    /** @param string[]|null $columns */
+    /**
+     * @param string[]|null $columns
+     *
+     * @throws QueryException
+     */
     public function __construct(
         public readonly string $name,
         public readonly string|QueryBuilder $query,

--- a/src/Query/Expression/ExpressionBuilder.php
+++ b/src/Query/Expression/ExpressionBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query\Expression;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 
 use function implode;
 use function sprintf;
@@ -236,6 +237,8 @@ class ExpressionBuilder
      *
      * The usage of this method is discouraged. Use prepared statements
      * or {@see AbstractPlatform::quoteStringLiteral()} instead.
+     *
+     * @throws Exception
      */
     public function literal(string $input): string
     {

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -345,6 +345,8 @@ class QueryBuilder
      * </code>
      *
      * @return string The SQL query string.
+     *
+     * @throws Exception
      */
     public function getSQL(): string
     {
@@ -551,6 +553,8 @@ class QueryBuilder
      * </code>
      *
      * @return $this
+     *
+     * @throws QueryException
      */
     public function addUnion(string|QueryBuilder $part, UnionType $type = UnionType::DISTINCT): self
     {
@@ -1417,6 +1421,8 @@ class QueryBuilder
 
     /**
      * Converts this instance into a UNION string in SQL.
+     *
+     * @throws Exception
      */
     private function getSQLForUnion(): string
     {
@@ -1444,6 +1450,8 @@ class QueryBuilder
      * the final SQL query being constructed.
      *
      * @return string The string representation of this QueryBuilder.
+     *
+     * @throws Exception
      */
     public function __toString(): string
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
 use Doctrine\DBAL\Schema\Name\Parsers;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
@@ -795,6 +796,8 @@ abstract class AbstractSchemaManager
      * @param array<array<string, mixed>> $rows
      *
      * @return array<string, Column>
+     *
+     * @throws TypesException
      */
     protected function _getPortableTableColumnList(string $table, string $database, array $rows): array
     {
@@ -813,6 +816,8 @@ abstract class AbstractSchemaManager
      * Gets Table Column Definition.
      *
      * @param array<string, mixed> $tableColumn
+     *
+     * @throws TypesException
      */
     abstract protected function _getPortableTableColumnDefinition(array $tableColumn): Column;
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -166,6 +166,7 @@ abstract class AbstractSchemaManager
         return count($names) === count(array_intersect($names, array_map('strtolower', $this->listTableNames())));
     }
 
+    /** @throws Exception */
     public function tableExists(string $tableName): bool
     {
         return $this->tablesExist([$tableName]);

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -648,6 +648,11 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     {
         if (isset($options['match'])) {
             try {
+                /**
+                 * This looks like a PHPStan bug.
+                 *
+                 * @phpstan-ignore missingType.checkedException
+                 */
                 return MatchType::from(strtoupper($options['match']));
             } catch (ValueError $e) {
                 Deprecation::trigger(
@@ -669,6 +674,11 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     {
         if (isset($options[$option])) {
             try {
+                /**
+                 * This looks like a PHPStan bug.
+                 *
+                 * @phpstan-ignore missingType.checkedException
+                 */
                 return ReferentialAction::from(strtoupper($options[$option]));
             } catch (ValueError $e) {
                 Deprecation::trigger(

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -147,6 +147,7 @@ SQL,
      */
     protected function _getPortableTableDefinition(array $table): string
     {
+        // @phpstan-ignore missingType.checkedException
         $currentSchema = $this->getCurrentSchema();
 
         if ($table['schema_name'] === $currentSchema) {
@@ -177,6 +178,7 @@ SQL,
                 implode(', ', $colNumbers),
             );
 
+            // @phpstan-ignore missingType.checkedException
             $indexColumns = $this->connection->fetchAllAssociative($columnNameSql);
 
             // required for getting the order of the columns right.

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -190,6 +190,7 @@ SQL,
             if (! isset($foreignKeys[$name])) {
                 $referencedTableName = $row['ReferenceTableName'];
 
+                // @phpstan-ignore missingType.checkedException
                 if ($row['ReferenceSchemaName'] !== $this->getCurrentSchemaName()) {
                     $referencedTableName = $row['ReferenceSchemaName'] . '.' . $referencedTableName;
                 }
@@ -248,6 +249,7 @@ SQL,
      */
     protected function _getPortableTableDefinition(array $table): string
     {
+        // @phpstan-ignore missingType.checkedException
         if ($table['schema_name'] !== $this->getCurrentSchemaName()) {
             return $table['schema_name'] . '.' . $table['table_name'];
         }

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -228,6 +228,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
 
             // Inferring a shorthand form for the foreign key constraint, where the "to" field is empty.
             // @see https://www.sqlite.org/foreignkeys.html#fk_indexes.
+            // @phpstan-ignore missingType.checkedException
             $foreignTablePrimaryKeyColumnRows = $this->fetchPrimaryKeyColumns($value['foreignTable']);
 
             if (count($foreignTablePrimaryKeyColumnRows) < 1) {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
@@ -314,7 +315,11 @@ class Table extends AbstractNamedObject
         return false;
     }
 
-    /** @param array<string, mixed> $options */
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @throws TypesException
+     */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {
         $column = new Column($name, Type::getType($typeName), $options);

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Types\Exception\TypeAlreadyRegistered;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
 use Doctrine\DBAL\Types\Exception\TypesAlreadyExists;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 
 use function spl_object_id;
@@ -23,7 +24,11 @@ final class TypeRegistry
     /** @var array<int, string> */
     private array $instancesReverseIndex;
 
-    /** @param array<string, Type> $instances */
+    /**
+     * @param array<string, Type> $instances
+     *
+     * @throws TypesException
+     */
     public function __construct(array $instances = [])
     {
         $this->instances             = [];
@@ -36,7 +41,7 @@ final class TypeRegistry
     /**
      * Finds a type by the given name.
      *
-     * @throws Exception
+     * @throws TypesException
      */
     public function get(string $name): Type
     {
@@ -51,7 +56,7 @@ final class TypeRegistry
     /**
      * Finds a name for the given type.
      *
-     * @throws Exception
+     * @throws TypesException
      */
     public function lookupName(Type $type): string
     {
@@ -75,7 +80,7 @@ final class TypeRegistry
     /**
      * Registers a custom type to the type map.
      *
-     * @throws Exception
+     * @throws TypesException
      */
     public function register(string $name, Type $type): void
     {


### PR DESCRIPTION
This PR enables PHPStan checks for checked exception (the unchecked exceptions are listed in the PHPStan configuration).

All exceptions annotated with `@phpstan-ignore` are either something that looks like a PHPStan bug (I didn't bother drilling in, since this code is removed in 5.0.x) or issues in our code:
1. Lack of error handling.
2. Hacks where a certain method implementation performs the operations that it's not supposed to perform by the API contract.

This automation will provide the following benefits:
1. Force us to maintain better phpDocs and implement better error handling (see intermediate commits).
3. Make us strive for a better exception type system.
4. Prevent us from blindly making bad design decisions. My favorite one is lazy platform loading where a call to something that shouldn't have any side effects (e.g. quoting an identifier) may trigger a database connection.