### PR TITLE
Remove modified foreign keys and indexes from TableDiff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: removed `TableDiff` methods
+
+The `TableDiff::getModifiedForeignKeys()` method has been removed.
+
 ## BC BREAK: changes in `AbstractPlatform` constructor
 
 The `AbstractPlatform` class constructor is now `protected` and requires an `UnquotedIdentifierFolding` instance as its

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ awareness about deprecated code.
 
 ## BC BREAK: removed `TableDiff` methods
 
-The `TableDiff::getModifiedForeignKeys()` method has been removed.
+The `TableDiff::getModifiedForeignKeys()` and `TableDiff::getModifiedIndexes()` methods have been removed.
 
 ## BC BREAK: changes in `AbstractPlatform` constructor
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -22,7 +22,6 @@ use function array_merge;
 use function array_values;
 use function count;
 use function implode;
-use function in_array;
 use function is_array;
 use function is_numeric;
 use function sprintf;
@@ -355,39 +354,19 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 . $this->getColumnDeclarationSQL($newColumnProperties);
         }
 
-        $addedIndexes    = $this->indexAssetsByLowerCaseName($diff->getAddedIndexes());
-        $modifiedIndexes = $this->indexAssetsByLowerCaseName($diff->getModifiedIndexes());
-        $diffModified    = false;
+        $addedIndexes = $this->indexAssetsByLowerCaseName($diff->getAddedIndexes());
 
         if (isset($addedIndexes['primary'])) {
             $keyColumns   = $addedIndexes['primary']->getQuotedColumns($this);
             $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
             unset($addedIndexes['primary']);
-            $diffModified = true;
-        } elseif (isset($modifiedIndexes['primary'])) {
-            $addedColumns = $this->indexAssetsByLowerCaseName($diff->getAddedColumns());
 
-            // Necessary in case the new primary key includes a new auto_increment column
-            foreach ($modifiedIndexes['primary']->getColumns() as $columnName) {
-                if (isset($addedColumns[$columnName]) && $addedColumns[$columnName]->getAutoincrement()) {
-                    $keyColumns   = $modifiedIndexes['primary']->getQuotedColumns($this);
-                    $queryParts[] = 'DROP PRIMARY KEY';
-                    $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
-                    unset($modifiedIndexes['primary']);
-                    $diffModified = true;
-                    break;
-                }
-            }
-        }
-
-        if ($diffModified) {
             $diff = new TableDiff(
                 $diff->getOldTable(),
                 addedColumns: $diff->getAddedColumns(),
                 changedColumns: $diff->getChangedColumns(),
                 droppedColumns: $diff->getDroppedColumns(),
                 addedIndexes: array_values($addedIndexes),
-                modifiedIndexes: array_values($modifiedIndexes),
                 droppedIndexes: $diff->getDroppedIndexes(),
                 renamedIndexes: $diff->getRenamedIndexes(),
                 addedForeignKeys: $diff->getAddedForeignKeys(),
@@ -417,10 +396,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         $sql = [];
 
         $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
-
-        foreach ($diff->getModifiedIndexes() as $changedIndex) {
-            $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $changedIndex));
-        }
 
         foreach ($diff->getDroppedIndexes() as $droppedIndex) {
             $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
@@ -453,7 +428,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
         return array_merge(
             $sql,
-            $this->getPreAlterTableAlterIndexForeignKeySQL($diff),
             parent::getPreAlterTableIndexForeignKeySQL($diff),
             $this->getPreAlterTableRenameIndexForeignKeySQL($diff),
         );
@@ -491,67 +465,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
             // original autoincrement information might be needed later on by other parts of the table alteration
             $column->setAutoincrement(true);
-        }
-
-        return $sql;
-    }
-
-    /**
-     * @param TableDiff $diff The table diff to gather the SQL for.
-     *
-     * @return list<string>
-     */
-    private function getPreAlterTableAlterIndexForeignKeySQL(TableDiff $diff): array
-    {
-        $table = $diff->getOldTable();
-
-        $primaryKey = $table->getPrimaryKey();
-
-        if ($primaryKey === null) {
-            return [];
-        }
-
-        $primaryKeyColumns = [];
-
-        foreach ($primaryKey->getColumns() as $columnName) {
-            if (! $table->hasColumn($columnName)) {
-                continue;
-            }
-
-            $primaryKeyColumns[] = $table->getColumn($columnName);
-        }
-
-        if (count($primaryKeyColumns) === 0) {
-            return [];
-        }
-
-        $sql = [];
-
-        $tableNameSQL = $table->getObjectName()->toSQL($this);
-
-        foreach ($diff->getModifiedIndexes() as $changedIndex) {
-            // Changed primary key
-            if (! $changedIndex->isPrimary()) {
-                continue;
-            }
-
-            foreach ($primaryKeyColumns as $column) {
-                // Check if an autoincrement column was dropped from the primary key.
-                if (! $column->getAutoincrement() || in_array($column->getName(), $changedIndex->getColumns(), true)) {
-                    continue;
-                }
-
-                // The autoincrement attribute needs to be removed from the dropped column
-                // before we can drop and recreate the primary key.
-                $column->setAutoincrement(false);
-
-                $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY ' .
-                    $this->getColumnDeclarationSQL($column->toArray());
-
-                // Restore the autoincrement attribute as it might be needed later on
-                // by other parts of the table alteration.
-                $column->setAutoincrement(true);
-            }
         }
 
         return $sql;

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -391,7 +391,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 droppedIndexes: $diff->getDroppedIndexes(),
                 renamedIndexes: $diff->getRenamedIndexes(),
                 addedForeignKeys: $diff->getAddedForeignKeys(),
-                modifiedForeignKeys: $diff->getModifiedForeignKeys(),
                 droppedForeignKeys: $diff->getDroppedForeignKeys(),
             );
         }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1231,10 +1231,6 @@ abstract class AbstractPlatform
             $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
         }
 
-        foreach ($diff->getModifiedIndexes() as $index) {
-            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
-        }
-
         return $sql;
     }
 
@@ -1250,10 +1246,6 @@ abstract class AbstractPlatform
         }
 
         foreach ($diff->getAddedIndexes() as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
-        }
-
-        foreach ($diff->getModifiedIndexes() as $index) {
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1227,10 +1227,6 @@ abstract class AbstractPlatform
             $sql[] = $this->getDropForeignKeySQL($this->getConstraintName($foreignKey)->toSQL($this), $tableNameSQL);
         }
 
-        foreach ($diff->getModifiedForeignKeys() as $foreignKey) {
-            $sql[] = $this->getDropForeignKeySQL($this->getConstraintName($foreignKey)->toSQL($this), $tableNameSQL);
-        }
-
         foreach ($diff->getDroppedIndexes() as $index) {
             $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
         }
@@ -1250,10 +1246,6 @@ abstract class AbstractPlatform
         $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
 
         foreach ($diff->getAddedForeignKeys() as $foreignKey) {
-            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
-        }
-
-        foreach ($diff->getModifiedForeignKeys() as $foreignKey) {
             $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
         }
 

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -709,7 +709,6 @@ class SQLitePlatform extends AbstractPlatform
             count($diff->getChangedColumns()) > 0
             || count($diff->getDroppedColumns()) > 0
             || count($diff->getAddedIndexes()) > 0
-            || count($diff->getModifiedIndexes()) > 0
             || count($diff->getDroppedIndexes()) > 0
             || count($diff->getRenamedIndexes()) > 0
             || count($diff->getAddedForeignKeys()) > 0
@@ -835,7 +834,6 @@ class SQLitePlatform extends AbstractPlatform
 
         foreach (
             array_merge(
-                $diff->getModifiedIndexes(),
                 $diff->getAddedIndexes(),
                 $diff->getRenamedIndexes(),
             ) as $index

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -713,7 +713,6 @@ class SQLitePlatform extends AbstractPlatform
             || count($diff->getDroppedIndexes()) > 0
             || count($diff->getRenamedIndexes()) > 0
             || count($diff->getAddedForeignKeys()) > 0
-            || count($diff->getModifiedForeignKeys()) > 0
             || count($diff->getDroppedForeignKeys()) > 0
         ) {
             return false;
@@ -899,7 +898,7 @@ class SQLitePlatform extends AbstractPlatform
             unset($foreignKeys[strtolower($constraintName)]);
         }
 
-        foreach (array_merge($diff->getModifiedForeignKeys(), $diff->getAddedForeignKeys()) as $constraint) {
+        foreach ($diff->getAddedForeignKeys() as $constraint) {
             $constraintName = $constraint->getName();
 
             if ($constraintName !== '') {

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -25,7 +25,6 @@ class TableDiff
      * @param array<string, ColumnDiff>   $changedColumns
      * @param array<Column>               $droppedColumns
      * @param array<Index>                $addedIndexes
-     * @param array<Index>                $modifiedIndexes
      * @param array<Index>                $droppedIndexes
      * @param array<string, Index>        $renamedIndexes
      * @param array<ForeignKeyConstraint> $addedForeignKeys
@@ -36,23 +35,11 @@ class TableDiff
         private readonly array $changedColumns = [],
         private readonly array $droppedColumns = [],
         private array $addedIndexes = [],
-        private readonly array $modifiedIndexes = [],
         private array $droppedIndexes = [],
         private readonly array $renamedIndexes = [],
         private readonly array $addedForeignKeys = [],
         private readonly array $droppedForeignKeys = [],
     ) {
-        if (count($this->modifiedIndexes) === 0) {
-            return;
-        }
-
-        Deprecation::trigger(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6831',
-            'Passing a non-empty $modifiedIndexes value to %s() is deprecated. Instead, pass dropped'
-                . ' indexes via $droppedIndexes and added indexes via $addedIndexes.',
-            __METHOD__,
-        );
     }
 
     public function getOldTable(): Table
@@ -144,23 +131,6 @@ class TableDiff
         );
     }
 
-    /**
-     * @deprecated Use {@see getAddedIndexes()} and {@see getDroppedIndexes()} instead.
-     *
-     * @return array<Index>
-     */
-    public function getModifiedIndexes(): array
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6831',
-            '%s() is deprecated, use getAddedIndexes() and getDroppedIndexes() instead.',
-            __METHOD__,
-        );
-
-        return $this->modifiedIndexes;
-    }
-
     /** @return array<Index> */
     public function getDroppedIndexes(): array
     {
@@ -208,7 +178,6 @@ class TableDiff
             && count($this->changedColumns) === 0
             && count($this->droppedColumns) === 0
             && count($this->addedIndexes) === 0
-            && count($this->modifiedIndexes) === 0
             && count($this->droppedIndexes) === 0
             && count($this->renamedIndexes) === 0
             && count($this->addedForeignKeys) === 0

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -29,7 +29,6 @@ class TableDiff
      * @param array<Index>                $droppedIndexes
      * @param array<string, Index>        $renamedIndexes
      * @param array<ForeignKeyConstraint> $addedForeignKeys
-     * @param array<ForeignKeyConstraint> $modifiedForeignKeys
      */
     public function __construct(
         private readonly Table $oldTable,
@@ -41,28 +40,17 @@ class TableDiff
         private array $droppedIndexes = [],
         private readonly array $renamedIndexes = [],
         private readonly array $addedForeignKeys = [],
-        private readonly array $modifiedForeignKeys = [],
         private readonly array $droppedForeignKeys = [],
     ) {
-        if (count($this->modifiedIndexes) !== 0) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6831',
-                'Passing a non-empty $modifiedIndexes value to %s() is deprecated. Instead, pass dropped'
-                    . ' indexes via $droppedIndexes and added indexes via $addedIndexes.',
-                __METHOD__,
-            );
-        }
-
-        if (count($modifiedForeignKeys) === 0) {
+        if (count($this->modifiedIndexes) === 0) {
             return;
         }
 
         Deprecation::trigger(
             'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6827',
-            'Passing a non-empty $modifiedForeignKeys value to %s() is deprecated. Instead, pass dropped'
-                . ' constraints via $droppedForeignKeys and added constraints via $addedForeignKeys.',
+            'https://github.com/doctrine/dbal/pull/6831',
+            'Passing a non-empty $modifiedIndexes value to %s() is deprecated. Instead, pass dropped'
+                . ' indexes via $droppedIndexes and added indexes via $addedIndexes.',
             __METHOD__,
         );
     }
@@ -205,23 +193,6 @@ class TableDiff
         return $this->addedForeignKeys;
     }
 
-    /**
-     * @deprecated Use {@see getAddedForeignKeys()} and {@see getDroppedForeignKeys()} instead.
-     *
-     * @return array<ForeignKeyConstraint>
-     */
-    public function getModifiedForeignKeys(): array
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6827',
-            '%s() is deprecated, use getDroppedForeignKeys() and getAddedForeignKeys() instead.',
-            __METHOD__,
-        );
-
-        return $this->modifiedForeignKeys;
-    }
-
     /** @return array<ForeignKeyConstraint> */
     public function getDroppedForeignKeys(): array
     {
@@ -241,7 +212,6 @@ class TableDiff
             && count($this->droppedIndexes) === 0
             && count($this->renamedIndexes) === 0
             && count($this->addedForeignKeys) === 0
-            && count($this->modifiedForeignKeys) === 0
             && count($this->droppedForeignKeys) === 0;
     }
 }


### PR DESCRIPTION
The methods being removed were deprecated in https://github.com/doctrine/dbal/pull/6827 and https://github.com/doctrine/dbal/pull/6831.

The `AbstractMySQLPlatform` code being removed is covered by `NewPrimaryKeyWithNewAutoIncrementColumnTest`, which still passes.

Prior to the change, the table was altered using the following statement:
```sql
ALTER TABLE dbal2807
    ADD new_id INT AUTO_INCREMENT NOT NULL,
    DROP PRIMARY KEY,
    ADD PRIMARY KEY (new_id);
```

After the change, it is altered like this (the statements are different but semantically equivalent):
```sql
DROP INDEX `primary` ON dbal2807;
ALTER TABLE dbal2807
    ADD new_id INT AUTO_INCREMENT NOT NULL,
    ADD PRIMARY KEY (new_id);
```