### PR TITLE
Do not lose auto-increment when altering primary key

### DIFF
--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -230,6 +230,8 @@ class AlterTableTest extends FunctionalTestCase
         $diff = $schemaManager->createComparator()
             ->compareTables($oldTable, $newTable);
 
+        self::assertFalse($diff->isEmpty());
+
         $schemaManager->alterTable($diff);
 
         $introspectedTable = $schemaManager->introspectTable($newTable->getName());

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -111,13 +111,6 @@ class AlterTableTest extends FunctionalTestCase
 
     public function testDropNonAutoincrementColumnFromCompositePrimaryKeyWithAutoincrementColumn(): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
-            self::markTestIncomplete(
-                'DBAL does not restore the auto-increment attribute after dropping and adding the constraint,'
-                    . ' which is a bug.',
-            );
-        }
-
         $this->ensureDroppingPrimaryKeyConstraintIsSupported();
 
         $table = new Table('alter_pk');
@@ -134,13 +127,6 @@ class AlterTableTest extends FunctionalTestCase
     public function testAddNonAutoincrementColumnToPrimaryKeyWithAutoincrementColumn(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof AbstractMySQLPlatform) {
-            self::markTestIncomplete(
-                'DBAL does not restore the auto-increment attribute after dropping and adding the constraint,'
-                    . ' which is a bug.',
-            );
-        }
 
         if ($platform instanceof SQLitePlatform) {
             self::markTestSkipped(


### PR DESCRIPTION
In MySQL, if a column has the auto-increment attribute, it must be part of the primary key.

Prior to this change, while dropping an old PK and creating a new one, if the old PK included an auto-increment column, before dropping the PK, DBAL would drop the auto-increment attribute on the column in question. The problem is that it wouldn't restore the auto-increment attribute after creating the new PK, which is a bug.

The bug is fixed by combining the `DROP PRIMARY KEY` and `ADD PRIMARY KEY` statements within a single `ALTER TABLE` statement. This way, MySQL is happy because this change is atomic and cannot leave a table in an invalid state, and the auto-increment attribute doesn't need to be temporarily dropped.

Dropping the auto-increment attribute, even temporarily, is a destructive operation since it drops the state of the internal auto-increment counter and should have been avoided.