### PR TITLE
Merge 4.2.x up into 4.3.x

### DIFF
--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -230,6 +230,8 @@ class AlterTableTest extends FunctionalTestCase
         $diff = $schemaManager->createComparator()
             ->compareTables($oldTable, $newTable);
 
+        self::assertFalse($diff->isEmpty());
+
         $schemaManager->alterTable($diff);
 
         $introspectedTable = $schemaManager->introspectTable($newTable->getName());

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -111,13 +111,6 @@ class AlterTableTest extends FunctionalTestCase
 
     public function testDropNonAutoincrementColumnFromCompositePrimaryKeyWithAutoincrementColumn(): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
-            self::markTestIncomplete(
-                'DBAL does not restore the auto-increment attribute after dropping and adding the constraint,'
-                    . ' which is a bug.',
-            );
-        }
-
         $this->ensureDroppingPrimaryKeyConstraintIsSupported();
 
         $table = new Table('alter_pk');
@@ -134,13 +127,6 @@ class AlterTableTest extends FunctionalTestCase
     public function testAddNonAutoincrementColumnToPrimaryKeyWithAutoincrementColumn(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof AbstractMySQLPlatform) {
-            self::markTestIncomplete(
-                'DBAL does not restore the auto-increment attribute after dropping and adding the constraint,'
-                    . ' which is a bug.',
-            );
-        }
 
         if ($platform instanceof SQLitePlatform) {
             self::markTestSkipped(


### PR DESCRIPTION
This is a very ugly merge up which, on the one hand, is absolutely free of Git conflicts, but on the other, requires quite some code changes to keep the build green. It might have been avoided if the conflicting changes below were implemented in the reverse order or in the same branch.

The conflicting changes are  https://github.com/doctrine/dbal/pull/6831 (a deprecation from `4.3.x`) and https://github.com/doctrine/dbal/pull/6836 (a bug fix from `4.2.x`).

### Background

In MySQL, if a column has the auto-increment attribute, it must be part of the primary key.

To enable altering the primary keys that contain an auto-increment column, DBAL drops the auto-increment attribute on that column. It does it:
1. When the column is still part of the PK (a bug fixed in https://github.com/doctrine/dbal/pull/6836).
2. When the column is no longer part of the PK (which is a legitimized bug covered by `MySQLSchemaManagerTest#testDropPrimaryKeyWithAutoincrementColumn()`, see https://github.com/doctrine/dbal/issues/6840).

There is the code in the MySQL platform in 4.2.x. that inlines the `DROP PRIMARY KEY` and `ADD PRIMARY KEY` statements for a modified PK into a single statement and preserves the auto-increment on a column if it can be preserved: https://github.com/doctrine/dbal/blob/87c7b4d51249e4cb57a314a2fed7f3da47827604/src/Platforms/AbstractMySQLPlatform.php#L378-L381

### The nature of the conflict

1. The `testDropPrimaryKeyWithAutoincrementColumn()` test drops a PK.
2. On `4.2.x`, the "inlining" code is triggered only by a "modified" PK, so it's not executed by the test, and the test passes.
4. On `4.3.x`, the "inlining" code is triggered by a dropped PK, not modified PK, so it removes the dropped PK from the diff and doesn't let the downstream code drop the auto-increment attribute.

### The solution

As part of "inlining", we detect, if an auto-increment column is no longer part of the PK, and if that's the case, call `getPreAlterTableAlterPrimaryKeySQL()` which will drop the auto-increment attribute.

### Next steps

His is a hack that is needed to support another existing hack. Once this behavior of silently dropping auto-increment as part of dropping the PK is deprecated, all this hackery will be removed from the codebase.