### PR TITLE
Deprecate auto-increment being dropped with the PK on MySQL

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated automatic drop of `auto-increment` column attribute
+
+Relying on the auto-increment attribute of a MySQL column being automatically dropped once the column is no longer part
+of the primary key constraint is deprecated. Instead, drop the auto-increment attribute explicitly.
+
 ## Deprecated handling of modified indexes in `TableDiff`
 
 Passing a non-empty `$modifiedIndexes` value to the `TableDiff` constructor is deprecated. Instead, pass dropped

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -396,8 +396,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 $addedIndexes['primary']->getColumns(),
             );
 
-            unset($addedIndexes['primary']);
-            $diffModified = true;
+            $diff->unsetAddedIndex($addedIndexes['primary']);
         }
 
         $tableSql = [];
@@ -419,23 +418,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 }
             }
 
-            unset($droppedIndexes['primary']);
-            $diffModified = true;
-        }
-
-        if ($diffModified) {
-            $diff = new TableDiff(
-                $diff->getOldTable(),
-                addedColumns: $diff->getAddedColumns(),
-                changedColumns: $diff->getChangedColumns(),
-                droppedColumns: $diff->getDroppedColumns(),
-                addedIndexes: array_values($addedIndexes),
-                droppedIndexes: array_values($droppedIndexes),
-                renamedIndexes: $diff->getRenamedIndexes(),
-                addedForeignKeys: $diff->getAddedForeignKeys(),
-                modifiedForeignKeys: $diff->getModifiedForeignKeys(),
-                droppedForeignKeys: $diff->getDroppedForeignKeys(),
-            );
+            $diff->unsetDroppedIndex($droppedIndexes['primary']);
         }
 
         if (count($queryParts) > 0) {
@@ -524,6 +507,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             if (! $column->getAutoincrement()) {
                 continue;
             }
+
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6841',
+                'Relying on the auto-increment attribute of a column being automatically dropped once a column'
+                    . ' is no longer part of the primary key constraint is deprecated. Instead, drop the auto-increment'
+                    . ' attribute explicitly.',
+            );
 
             $column->setAutoincrement(false);
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -20,11 +20,14 @@ use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\SmallFloatType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 use function array_keys;
 
 class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     public static function setUpBeforeClass(): void
     {
         Type::addType('point', PointType::class);
@@ -149,6 +152,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $diff = $this->schemaManager->createComparator()
             ->compareTables($table, $diffTable);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6841');
 
         $this->schemaManager->alterTable($diff);
 


### PR DESCRIPTION
Silently dropping auto-increment on a column while dropping the primary key is a destructive operation which the user didn't request.

See https://github.com/doctrine/dbal/issues/6840 for more details.