### PR TITLE
Remove support for auto-dropping auto-increment with PK

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -15,9 +15,7 @@ use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 
-use function array_diff;
 use function array_map;
 use function array_merge;
 use function count;
@@ -357,47 +355,20 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         $droppedIndexes = $this->indexIndexesByLowerCaseName($diff->getDroppedIndexes());
         $addedIndexes   = $this->indexIndexesByLowerCaseName($diff->getAddedIndexes());
 
-        $noLongerPrimaryKeyColumns = [];
-
         if (isset($droppedIndexes['primary'])) {
             $queryParts[] = 'DROP PRIMARY KEY';
 
-            $noLongerPrimaryKeyColumns = $droppedIndexes['primary']->getColumns();
+            $diff->unsetDroppedIndex($droppedIndexes['primary']);
         }
 
         if (isset($addedIndexes['primary'])) {
             $keyColumns   = $addedIndexes['primary']->getQuotedColumns($this);
             $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
 
-            $noLongerPrimaryKeyColumns = array_diff(
-                $noLongerPrimaryKeyColumns,
-                $addedIndexes['primary']->getColumns(),
-            );
-
             $diff->unsetAddedIndex($addedIndexes['primary']);
         }
 
         $tableSql = [];
-
-        if (isset($droppedIndexes['primary'])) {
-            $oldTable = $diff->getOldTable();
-            foreach ($noLongerPrimaryKeyColumns as $columnName) {
-                if (! $oldTable->hasColumn($columnName)) {
-                    continue;
-                }
-
-                $column = $oldTable->getColumn($columnName);
-                if ($column->getAutoincrement()) {
-                    $tableSql = array_merge(
-                        $tableSql,
-                        $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndexes['primary']),
-                    );
-                    break;
-                }
-            }
-
-            $diff->unsetDroppedIndex($droppedIndexes['primary']);
-        }
 
         if (count($queryParts) > 0) {
             $tableSql[] = 'ALTER TABLE ' . $diff->getOldTable()->getObjectName()->toSQL($this) . ' '
@@ -421,8 +392,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
 
         foreach ($diff->getDroppedIndexes() as $droppedIndex) {
-            $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
-
             foreach ($diff->getAddedIndexes() as $addedIndex) {
                 if ($droppedIndex->getColumns() !== $addedIndex->getColumns()) {
                     continue;
@@ -449,66 +418,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             }
         }
 
-        return array_merge(
-            $sql,
-            parent::getPreAlterTableIndexForeignKeySQL($diff),
-            $this->getPreAlterTableRenameIndexForeignKeySQL($diff),
-        );
-    }
-
-    /** @return list<string> */
-    private function getPreAlterTableAlterPrimaryKeySQL(TableDiff $diff, Index $index): array
-    {
-        if (! $index->isPrimary()) {
-            return [];
-        }
-
-        $table = $diff->getOldTable();
-
-        $sql = [];
-
-        $tableNameSQL = $table->getObjectName()->toSQL($this);
-
-        // Dropping primary keys requires to unset autoincrement attribute on the particular column first.
-        foreach ($index->getColumns() as $columnName) {
-            if (! $table->hasColumn($columnName)) {
-                continue;
-            }
-
-            $column = $table->getColumn($columnName);
-
-            if (! $column->getAutoincrement()) {
-                continue;
-            }
-
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6841',
-                'Relying on the auto-increment attribute of a column being automatically dropped once a column'
-                    . ' is no longer part of the primary key constraint is deprecated. Instead, drop the auto-increment'
-                    . ' attribute explicitly.',
-            );
-
-            $column->setAutoincrement(false);
-
-            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY ' .
-                $this->getColumnDeclarationSQL($column->toArray());
-
-            // original autoincrement information might be needed later on by other parts of the table alteration
-            $column->setAutoincrement(true);
-        }
-
-        return $sql;
-    }
-
-    /**
-     * @param TableDiff $diff The table diff to gather the SQL for.
-     *
-     * @return list<string>
-     */
-    protected function getPreAlterTableRenameIndexForeignKeySQL(TableDiff $diff): array
-    {
-        return [];
+        return array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
     }
 
     protected function getCreateIndexSQLFlags(Index $index): string

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -55,9 +55,8 @@ class AlterTableTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if ($platform instanceof AbstractMySQLPlatform) {
-            self::markTestIncomplete(
-                'DBAL should not allow this migration on MySQL because an auto-increment column must be part of the'
-                    . ' primary key constraint.',
+            self::markTestSkipped(
+                'MySQL does not support auto-increment columns that are not part of the primary key constraint',
             );
         }
 
@@ -85,9 +84,8 @@ class AlterTableTest extends FunctionalTestCase
         $platform = $this->connection->getDatabasePlatform();
 
         if ($platform instanceof AbstractMySQLPlatform) {
-            self::markTestIncomplete(
-                'DBAL should not allow this migration on MySQL because an auto-increment column must be part of the'
-                    . ' primary key constraint.',
+            self::markTestSkipped(
+                'MySQL does not support auto-increment columns that are not part of the primary key constraint',
             );
         }
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -137,32 +137,6 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertNotNull($table->getPrimaryKey());
     }
 
-    public function testDropPrimaryKeyWithAutoincrementColumn(): void
-    {
-        $table = new Table('drop_primary_key');
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->addColumn('foo', Types::INTEGER);
-        $table->setPrimaryKey(['id', 'foo']);
-
-        $this->dropAndCreateTable($table);
-
-        $diffTable = clone $table;
-
-        $diffTable->dropPrimaryKey();
-
-        $diff = $this->schemaManager->createComparator()
-            ->compareTables($table, $diffTable);
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6841');
-
-        $this->schemaManager->alterTable($diff);
-
-        $table = $this->schemaManager->introspectTable('drop_primary_key');
-
-        self::assertNull($table->getPrimaryKey());
-        self::assertFalse($table->getColumn('id')->getAutoincrement());
-    }
-
     public function testDoesNotPropagateDefaultValuesForUnsupportedColumnTypes(): void
     {
         if ($this->connection->getDatabasePlatform() instanceof MariaDBPlatform) {


### PR DESCRIPTION
The affected behavior was deprecated in https://github.com/doctrine/dbal/pull/6841.

Fixes https://github.com/doctrine/dbal/issues/6840.