### PR TITLE
Rework auto-increment introspection tests

### DIFF
--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -59,17 +59,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertInstanceOf(MoneyType::class, $table->getColumn('value')->getType());
     }
 
-    public function testDetectsAutoIncrement(): void
-    {
-        $autoincTable = new Table('autoinc_table');
-        $column       = $autoincTable->addColumn('id', Types::INTEGER);
-        $column->setAutoincrement(true);
-        $this->dropAndCreateTable($autoincTable);
-        $autoincTable = $this->schemaManager->introspectTable('autoinc_table');
-
-        self::assertTrue($autoincTable->getColumn('id')->getAutoincrement());
-    }
-
     public function testAlterTableAutoIncrementAdd(): void
     {
         $tableFrom = new Table('autoinc_table_add');

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -693,43 +693,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertStringContainsString('view_test_table', $filtered[0]->getSql());
     }
 
-    public function testAutoincrementDetection(): void
-    {
-        if (! $this->connection->getDatabasePlatform()->supportsIdentityColumns()) {
-            self::markTestSkipped('This test is only supported on platforms that have autoincrement');
-        }
-
-        $table = new Table('test_autoincrement');
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
-
-        $this->schemaManager->createTable($table);
-
-        $inferredTable = $this->schemaManager->introspectTable('test_autoincrement');
-        self::assertTrue($inferredTable->hasColumn('id'));
-        self::assertTrue($inferredTable->getColumn('id')->getAutoincrement());
-    }
-
-    public function testAutoincrementDetectionMulticolumns(): void
-    {
-        if (! $this->connection->getDatabasePlatform()->supportsIdentityColumns()) {
-            self::markTestSkipped('This test is only supported on platforms that have autoincrement');
-        }
-
-        $table = new Table('test_not_autoincrement');
-        $table->setSchemaConfig($this->schemaManager->createSchemaConfig());
-        $table->addColumn('id', Types::INTEGER);
-        $table->addColumn('other_id', Types::INTEGER);
-        $table->setPrimaryKey(['id', 'other_id']);
-
-        $this->schemaManager->createTable($table);
-
-        $inferredTable = $this->schemaManager->introspectTable('test_not_autoincrement');
-        self::assertTrue($inferredTable->hasColumn('id'));
-        self::assertFalse($inferredTable->getColumn('id')->getAutoincrement());
-    }
-
     public function testUpdateSchemaWithForeignKeyRenaming(): void
     {
         $table = new Table('test_fk_base');

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\TestWith;
 
 final class SchemaManagerTest extends FunctionalTestCase
 {
@@ -94,5 +96,57 @@ final class SchemaManagerTest extends FunctionalTestCase
             'quoted schema' => ['"other_schema".some_table'],
             'reserved schema' => ['case.some_table'],
         ];
+    }
+
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testAutoIncrementColumnIntrospection(bool $autoincrement): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsIdentityColumns()) {
+            self::markTestSkipped('This test is only supported on platforms that have autoincrement');
+        }
+
+        if (! $autoincrement && $platform instanceof SQLitePlatform) {
+            self::markTestIncomplete('See https://github.com/doctrine/dbal/issues/6844');
+        }
+
+        $table = new Table('test_autoincrement');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => $autoincrement]);
+        $table->setPrimaryKey(['id']);
+        $this->dropAndCreateTable($table);
+
+        $table = $this->schemaManager->introspectTable('test_autoincrement');
+
+        self::assertSame($autoincrement, $table->getColumn('id')->getAutoincrement());
+    }
+
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testAutoIncrementColumnInCompositePrimaryKeyIntrospection(bool $autoincrement): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform->supportsIdentityColumns()) {
+            self::markTestSkipped('This test is only supported on platforms that have autoincrement');
+        }
+
+        if ($autoincrement && $platform instanceof SQLitePlatform) {
+            self::markTestSkipped(
+                'SQLite does not support auto-increment columns as part of composite primary key constraint',
+            );
+        }
+
+        $table = new Table('test_autoincrement');
+        $table->addColumn('id1', Types::INTEGER, ['autoincrement' => $autoincrement]);
+        $table->addColumn('id2', Types::INTEGER);
+        $table->setPrimaryKey(['id1', 'id2']);
+        $this->dropAndCreateTable($table);
+
+        $table = $this->schemaManager->introspectTable('test_autoincrement');
+
+        self::assertSame($autoincrement, $table->getColumn('id1')->getAutoincrement());
+        self::assertFalse($table->getColumn('id2')->getAutoincrement());
     }
 }


### PR DESCRIPTION
There are multiple auto-increment introspection tests scattered across the test suite, but they don't cover some edge cases (e.g. https://github.com/doctrine/dbal/issues/6844 and https://github.com/doctrine/dbal/issues/6847). So I want to consolidate them.