### PR TITLE
Deprecate invalid auto-increment column definitions on SQLite

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
-## Deprecated automatic drop of `auto-increment` column attribute
+## Deprecated invalid auto-increment column definitions on SQLite
+
+The following auto-increment column definitions are deprecated in SQLite:
+
+1. An auto-increment column that is not a primary key.
+2. An auto-increment column that is part of a composite primary key.
+
+## Deprecated automatic drop of auto-increment column attribute on MySQL
 
 Relying on the auto-increment attribute of a MySQL column being automatically dropped once the column is no longer part
 of the primary key constraint is deprecated. Instead, drop the auto-increment attribute explicitly.

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -111,6 +111,14 @@ class AlterTableTest extends FunctionalTestCase
 
     public function testDropNonAutoincrementColumnFromCompositePrimaryKeyWithAutoincrementColumn(): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestSkipped(
+                'SQLite does not support auto-increment columns as part of composite primary key constraint',
+            );
+        }
+
         $this->ensureDroppingPrimaryKeyConstraintIsSupported();
 
         $table = new Table('alter_pk');


### PR DESCRIPTION
This PR deprecates the SQLite table definitions that are valid from DBAL standpoint but aren't valid from SQLite standpoint.

See https://github.com/doctrine/dbal/issues/6847 for more details.