### PR TITLE
Remove duplicate schema manager tests

### DIFF
--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -35,29 +35,6 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         return $platform instanceof AbstractMySQLPlatform;
     }
 
-    public function testSwitchPrimaryKeyColumns(): void
-    {
-        $tableOld = new Table('switch_primary_key_columns');
-        $tableOld->addColumn('foo_id', Types::INTEGER);
-        $tableOld->addColumn('bar_id', Types::INTEGER);
-
-        $this->schemaManager->createTable($tableOld);
-        $tableFetched = $this->schemaManager->introspectTable('switch_primary_key_columns');
-        $tableNew     = clone $tableFetched;
-        $tableNew->setPrimaryKey(['bar_id', 'foo_id']);
-
-        $diff = $this->schemaManager->createComparator()
-            ->compareTables($tableFetched, $tableNew);
-
-        $this->schemaManager->alterTable($diff);
-
-        $table = $this->schemaManager->introspectTable('switch_primary_key_columns');
-
-        $primaryKey = $table->getPrimaryKey();
-        self::assertNotNull($primaryKey);
-        self::assertSame(['bar_id', 'foo_id'], $primaryKey->getColumns());
-    }
-
     public function testFulltextIndex(): void
     {
         $table = new Table('fulltext_index');
@@ -107,31 +84,6 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $indexes = $this->schemaManager->listTableIndexes('index_length');
         self::assertArrayHasKey('text_index', $indexes);
         self::assertSame([128], $indexes['text_index']->getOption('lengths'));
-    }
-
-    public function testAlterTableAddPrimaryKey(): void
-    {
-        $table = new Table('alter_table_add_pk');
-        $table->addColumn('id', Types::INTEGER);
-        $table->addColumn('foo', Types::INTEGER);
-        $table->addIndex(['id'], 'idx_id');
-
-        $this->schemaManager->createTable($table);
-
-        $diffTable = clone $table;
-
-        $diffTable->dropIndex('idx_id');
-        $diffTable->setPrimaryKey(['id']);
-
-        $diff = $this->schemaManager->createComparator()
-            ->compareTables($table, $diffTable);
-
-        $this->schemaManager->alterTable($diff);
-
-        $table = $this->schemaManager->introspectTable('alter_table_add_pk');
-
-        self::assertFalse($table->hasIndex('idx_id'));
-        self::assertNotNull($table->getPrimaryKey());
     }
 
     public function testDropPrimaryKeyWithAutoincrementColumn(): void


### PR DESCRIPTION
Removed tests:
1. `testSwitchPrimaryKeyColumns()` duplicates `SchemaManagerFunctionalTestCase#testSwitchPrimaryKeyOrder()`
2. `testAlterTableAddPrimaryKey()` duplicates `AlterTableTest#testAddPrimaryKeyOnExistingColumn()`

Not removed tests:
1. `MySQLSchemaManagerTest#testDropPrimaryKeyWithAutoincrementColumn()` duplicates `AlterTableTest#testDropPrimaryKeyWithAutoincrementColumn()`, but the latter is skipped on MySQL because its assertion would fail due to https://github.com/doctrine/dbal/issues/6840. This test is removed in https://github.com/doctrine/dbal/pull/6843.