### PR TITLE
Remove support for invalid auto-increment column definitions on SQLite

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: removed support for invalid auto-increment column definitions on SQLite
+
+The following auto-increment column definitions are no longer supported on SQLite:
+
+1. An auto-increment column that is not a primary key.
+2. An auto-increment column that is part of a composite primary key.
+
 ## BC BREAK: removed `TableDiff` methods
 
 The `TableDiff::getModifiedForeignKeys()` and `TableDiff::getModifiedIndexes()` methods have been removed.

--- a/src/Platforms/Exception/UnsupportedTableDefinition.php
+++ b/src/Platforms/Exception/UnsupportedTableDefinition.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\Exception;
+
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class UnsupportedTableDefinition extends InvalidArgumentException implements PlatformException
+{
+    public static function autoIncrementColumnNotPartOfPrimaryKey(UnqualifiedName $columnName): self
+    {
+        return new self(sprintf(
+            'Auto-increment column %s must be a primary key column.',
+            $columnName->toString(),
+        ));
+    }
+
+    public static function autoIncrementColumnPartOfCompositePrimaryKey(UnqualifiedName $columnName): self
+    {
+        return new self(sprintf(
+            'Auto-increment column %s cannot be part of a composite primary key.',
+            $columnName->toString(),
+        ));
+    }
+}

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
+use Doctrine\DBAL\Platforms\Exception\UnsupportedTableDefinition;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -22,7 +23,6 @@ use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_combine;
@@ -345,17 +345,11 @@ class SQLitePlatform extends AbstractPlatform
                 ->toNormalizedValue($folding);
 
             if (! isset($primaryKeyColumnNames[$columnName])) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/6849',
-                    'Declaring a column that is not part of the primary key as auto-increment is deprecated.',
-                );
-            } elseif (count($primaryKeyColumnNames) > 1) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/6849',
-                    'Declaring a column that is part of a composite primary key as auto-increment is deprecated.',
-                );
+                throw UnsupportedTableDefinition::autoIncrementColumnNotPartOfPrimaryKey($column['name']);
+            }
+
+            if (count($primaryKeyColumnNames) > 1) {
+                throw UnsupportedTableDefinition::autoIncrementColumnPartOfCompositePrimaryKey($column['name']);
             }
 
             return true;

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Exception\UnsupportedTableDefinition;
 use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -18,15 +19,12 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 
 use function implode;
 
 /** @extends AbstractPlatformTestCase<SQLitePlatform> */
 class SQLitePlatformTest extends AbstractPlatformTestCase
 {
-    use VerifyDeprecations;
-
     public function createPlatform(): AbstractPlatform
     {
         return new SQLitePlatform();
@@ -646,7 +644,7 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table = new Table('test_autoincrement');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6849');
+        $this->expectException(UnsupportedTableDefinition::class);
         $this->platform->getCreateTableSQL($table);
     }
 
@@ -657,7 +655,7 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table->addColumn('id2', Types::INTEGER);
         $table->setPrimaryKey(['id1', 'id2']);
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6849');
+        $this->expectException(UnsupportedTableDefinition::class);
         $this->platform->getCreateTableSQL($table);
     }
 }


### PR DESCRIPTION
Using invalid auto-increment column definitions on SQLite was deprecated in https://github.com/doctrine/dbal/pull/6849.

Fixes https://github.com/doctrine/dbal/issues/6847.