### PR TITLE
Clean up schema introspection parsing code

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -72,6 +72,10 @@ Passing names that are not valid SQL to the schema introspection methods is also
 The following platform and schema manager methods are considered implementation details and have been marked as
 internal:
 
+- `AbstractMySQLPlatform::getColumnTypeSQLSnippet()`
+- `AbstractMySQLPlatform::fetchTableOptionsByTable()`
+- `MariaDB1010Platform::fetchTableOptionsByTable()`
+- `MariaDBPlatform::getColumnTypeSQLSnippet()`
 - `OraclePlatform::getCreateAutoincrementSql()`
 - `OraclePlatform::getIdentitySequenceName()`
 - `OracleSchemaManager::dropAutoincrement()`

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -229,6 +229,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      * The SQL snippet required to elucidate a column type
      *
      * Returns a column type SELECT snippet string
+     *
+     * @internal The method should be only used from within the {@see MySQLSchemaManager} class hierarchy.
      */
     public function getColumnTypeSQLSnippet(string $tableAlias, string $databaseName): string
     {
@@ -870,6 +872,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return $result;
     }
 
+    /** @internal The method should be only used from within the {@see MySQLSchemaManager} class hierarchy. */
     public function fetchTableOptionsByTable(bool $includeTableName): string
     {
         $sql = <<<'SQL'

--- a/src/Platforms/MariaDB1010Platform.php
+++ b/src/Platforms/MariaDB1010Platform.php
@@ -18,6 +18,7 @@ class MariaDB1010Platform extends MariaDB1060Platform
         return AbstractPlatform::createSelectSQLBuilder();
     }
 
+    /** @internal The method should be only used from within the {@see MySQLSchemaManager} class hierarchy. */
     public function fetchTableOptionsByTable(bool $includeTableName): string
     {
         // MariaDB-10.10.1 added FULL_COLLATION_NAME to the information_schema.COLLATION_CHARACTER_SET_APPLICABILITY.

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -29,6 +29,8 @@ class MariaDBPlatform extends AbstractMySQLPlatform
      * as JSON where it was originally specified as such instead of LONGTEXT.
      *
      * The CHECK constraints are stored in information_schema.CHECK_CONSTRAINTS so query that table.
+     *
+     * @internal The method should be only used from within the {@see MySQLSchemaManager} class hierarchy.
      */
     public function getColumnTypeSQLSnippet(string $tableAlias, string $databaseName): string
     {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -83,15 +83,13 @@ class DB2SchemaManager extends AbstractSchemaManager
 
         $options = [
             'length'          => $length,
-            'unsigned'        => false,
             'fixed'           => $fixed,
             'default'         => $default,
             'autoincrement'   => (bool) $tableColumn['autoincrement'],
             'notnull'         => $tableColumn['nulls'] === 'N',
-            'platformOptions' => [],
         ];
 
-        if (isset($tableColumn['comment'])) {
+        if ($tableColumn['comment'] !== null) {
             $options['comment'] = $tableColumn['comment'];
         }
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -86,11 +86,8 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         foreach ($rows as $i => $row) {
             $row = array_change_key_case($row, CASE_LOWER);
-            if ($row['key_name'] === 'PRIMARY') {
-                $row['primary'] = true;
-            } else {
-                $row['primary'] = false;
-            }
+
+            $row['primary'] = $row['key_name'] === 'PRIMARY';
 
             if (str_contains($row['index_type'], 'FULLTEXT')) {
                 $row['flags'] = ['FULLTEXT'];
@@ -131,10 +128,6 @@ class MySQLSchemaManager extends AbstractSchemaManager
         $length = $tableColumn['length'] ?? strtok('(), ');
 
         $fixed = false;
-
-        if (! isset($tableColumn['name'])) {
-            $tableColumn['name'] = '';
-        }
 
         $scale     = 0;
         $precision = null;
@@ -225,19 +218,13 @@ class MySQLSchemaManager extends AbstractSchemaManager
             'values'        => $values,
         ];
 
-        if (isset($tableColumn['comment'])) {
+        if ($tableColumn['comment'] !== null) {
             $options['comment'] = $tableColumn['comment'];
         }
 
         $column = new Column($tableColumn['field'], Type::getType($type), $options);
-
-        if (isset($tableColumn['characterset'])) {
-            $column->setPlatformOption('charset', $tableColumn['characterset']);
-        }
-
-        if (isset($tableColumn['collation'])) {
-            $column->setPlatformOption('collation', $tableColumn['collation']);
-        }
+        $column->setPlatformOption('charset', $tableColumn['characterset']);
+        $column->setPlatformOption('collation', $tableColumn['collation']);
 
         return $column;
     }

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -64,19 +64,18 @@ class OracleSchemaManager extends AbstractSchemaManager
         foreach ($rows as $row) {
             $row = array_change_key_case($row, CASE_LOWER);
 
-            $keyName = strtolower($row['name']);
-            $buffer  = [];
+            $buffer = [];
 
             if ($row['is_primary'] === 'P') {
-                $keyName              = 'primary';
+                $buffer['key_name']   = 'primary';
                 $buffer['primary']    = true;
                 $buffer['non_unique'] = false;
             } else {
+                $buffer['key_name']   = strtolower($row['name']);
                 $buffer['primary']    = false;
                 $buffer['non_unique'] = ! $row['is_unique'];
             }
 
-            $buffer['key_name']    = $keyName;
             $buffer['column_name'] = $this->getQuotedIdentifierName($row['column_name']);
             $indexBuffer[]         = $buffer;
         }
@@ -103,10 +102,6 @@ class OracleSchemaManager extends AbstractSchemaManager
         $length = $precision = null;
         $scale  = 0;
         $fixed  = false;
-
-        if (! isset($tableColumn['column_name'])) {
-            $tableColumn['column_name'] = '';
-        }
 
         assert(array_key_exists('data_default', $tableColumn));
 
@@ -184,7 +179,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             'scale'      => $scale,
         ];
 
-        if (isset($tableColumn['comments'])) {
+        if ($tableColumn['comments'] !== null) {
             $options['comment'] = $tableColumn['comments'];
         }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -374,7 +374,7 @@ SQL,
             'autoincrement' => $autoincrement,
         ];
 
-        if (isset($tableColumn['comment'])) {
+        if ($tableColumn['comment'] !== null) {
             $options['comment'] = $tableColumn['comment'];
         }
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -129,7 +129,7 @@ SQL,
             'autoincrement' => (bool) $tableColumn['autoincrement'],
         ];
 
-        if (isset($tableColumn['comment'])) {
+        if ($tableColumn['comment'] !== null) {
             $options['comment'] = $tableColumn['comment'];
         }
 
@@ -149,9 +149,7 @@ SQL,
             );
         }
 
-        if (isset($tableColumn['collation']) && $tableColumn['collation'] !== 'NULL') {
-            $column->setPlatformOption('collation', $tableColumn['collation']);
-        }
+        $column->setPlatformOption('collation', $tableColumn['collation']);
 
         return $column;
     }

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -145,10 +145,6 @@ class SQLiteSchemaManager extends AbstractSchemaManager
 
         $notnull = (bool) $tableColumn['notnull'];
 
-        if (! isset($tableColumn['name'])) {
-            $tableColumn['name'] = '';
-        }
-
         if ($dbType === 'char') {
             $fixed = true;
         }

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -223,7 +223,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns('test_collation');
 
-        self::assertArrayNotHasKey('collation', $columns['id']->getPlatformOptions());
+        self::assertFalse($columns['id']->hasPlatformOption('collation'));
         self::assertEquals('latin1_swedish_ci', $columns['text']->getPlatformOption('collation'));
         self::assertEquals('latin1_swedish_ci', $columns['foo']->getPlatformOption('collation'));
         self::assertEquals('utf8mb4_general_ci', $columns['bar']->getPlatformOption('collation'));

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -32,6 +32,7 @@ class DBAL461Test extends TestCase
             'precision' => 0,
             'autoincrement' => false,
             'collation' => 'foo',
+            'comment' => null,
         ]);
 
         self::assertInstanceOf(DecimalType::class, $column->getType());


### PR DESCRIPTION
Just a bit backward-compatible schema introspection code cleanup.

1. Mark some `AbstractMySQLPlatform` methods as internal. This is similar to https://github.com/doctrine/dbal/pull/6788.
2. Remove redundant defaults when constructing `Column` in `DB2SchemaManager#_getPortableTableColumnDefinition()`.
3. Remove or rework conditions like `if (isset($tableColumn[<some-column>>]))`, since all columns are unconditionally selected during introspection.