### PR TITLE
Revert IBM Db2 health check improvement

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -521,17 +521,15 @@ jobs:
           LICENSE: "accept"
           DBNAME: "doctrine"
 
-        options: >-
-          --health-cmd "su - ${DB2INSTANCE} -c \"db2 -t CONNECT TO ${DBNAME};\""
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 5
-          --privileged
+        options: "--privileged"
 
         ports:
           - "50000:50000"
 
     steps:
+      - name: "Perform healthcheck"
+        run: "docker logs -f ${{ job.services.ibm_db2.id }} | sed '/(*) Setup has completed./ q'"
+
       - name: "Create temporary tablespace"
         run: "docker exec ${{ job.services.ibm_db2.id }} su - db2inst1 -c 'db2 -t CONNECT TO doctrine; db2 -t CREATE USER TEMPORARY TABLESPACE doctrine_tbsp PAGESIZE 4 K;'"
 


### PR DESCRIPTION
This PR reverts the changes implemented in https://github.com/doctrine/dbal/pull/6159 by @phansys.

The current implementation is prone to sporadic [build failures](https://github.com/doctrine/dbal/actions/runs/13926758669/job/38973277985) like this:
```
docker exec 0b61e1f48228591144597cf40f0dba30336d278be7cfca95a8ae82b78381a36f su - db2inst1 -c 'db2 -t CONNECT TO doctrine; db2 -t CREATE USER TEMPORARY TABLESPACE doctrine_tbsp PAGESIZE 4 K;'
SQL6036N  START or STOP DATABASE MANAGER command is already in progress.
DB21034E  The command was processed as an SQL statement because it was not a 
valid Command Line Processor command.  During SQL processing it returned:
SQL1024N  A database connection does not exist.  SQLSTATE=08003
Error: Process completed with exit code 4.
```
In my experiense of the past couple of months, it fails like this in ~30% of the cases and requires a manual restart of the build.

I did some research and couldn't find a better approach. It looks like by the time when the `db2 -t CONNECT TO <database>` succeeds, the database is ready to accept connections but isn't yet ready to create the tablespace. There must be a better way to implement the health check using the Docker API, but it would require more research.

Another alternative could be, instead of executing the script that creates the tablespace after the health check, to mount it to the service's container under the `/var/custom/` path, so that service executes it whenever it's ready.