### PR TITLE
Clean up schema introspection queries and parsing code

### DIFF
--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -85,12 +85,12 @@ class DB2SchemaManager extends AbstractSchemaManager
             'length'          => $length,
             'fixed'           => $fixed,
             'default'         => $default,
-            'autoincrement'   => (bool) $tableColumn['autoincrement'],
+            'autoincrement'   => $tableColumn['generated'] === 'D',
             'notnull'         => $tableColumn['nulls'] === 'N',
         ];
 
-        if ($tableColumn['comment'] !== null) {
-            $options['comment'] = $tableColumn['comment'];
+        if ($tableColumn['remarks'] !== null) {
+            $options['comment'] = $tableColumn['remarks'];
         }
 
         if ($scale !== null && $precision !== null) {
@@ -107,8 +107,11 @@ class DB2SchemaManager extends AbstractSchemaManager
     protected function _getPortableTableIndexesList(array $rows): array
     {
         foreach ($rows as &$row) {
-            $row            = array_change_key_case($row, CASE_LOWER);
-            $row['primary'] = (bool) $row['primary'];
+            $row = array_change_key_case($row, CASE_LOWER);
+
+            $row['column_name'] = $row['colname'];
+            $row['primary']     = $row['uniquerule'] === 'P';
+            $row['non_unique']  = $row['uniquerule'] === 'D';
         }
 
         return parent::_getPortableTableIndexesList($rows);
@@ -124,18 +127,26 @@ class DB2SchemaManager extends AbstractSchemaManager
         foreach ($rows as $tableForeignKey) {
             $tableForeignKey = array_change_key_case($tableForeignKey, CASE_LOWER);
 
-            if (! isset($foreignKeys[$tableForeignKey['index_name']])) {
-                $foreignKeys[$tableForeignKey['index_name']] = [
+            if (! isset($foreignKeys[$tableForeignKey['constname']])) {
+                $foreignKeys[$tableForeignKey['constname']] = [
                     'local' => [$tableForeignKey['local_column']],
-                    'foreignTable' => $tableForeignKey['foreign_table'],
+                    'foreignTable' => $tableForeignKey['reftabname'],
                     'foreign' => [$tableForeignKey['foreign_column']],
-                    'name' => $tableForeignKey['index_name'],
-                    'onUpdate' => $tableForeignKey['on_update'],
-                    'onDelete' => $tableForeignKey['on_delete'],
+                    'name' => $tableForeignKey['constname'],
+                    'onUpdate' => match ($tableForeignKey['updaterule']) {
+                        'R' => 'RESTRICT',
+                        default => null,
+                    },
+                    'onDelete' => match ($tableForeignKey['deleterule']) {
+                        'C' => 'CASCADE',
+                        'N' => 'SET NULL',
+                        'R' => 'RESTRICT',
+                        default => null,
+                    },
                 ];
             } else {
-                $foreignKeys[$tableForeignKey['index_name']]['local'][]   = $tableForeignKey['local_column'];
-                $foreignKeys[$tableForeignKey['index_name']]['foreign'][] = $tableForeignKey['foreign_column'];
+                $foreignKeys[$tableForeignKey['constname']]['local'][]   = $tableForeignKey['local_column'];
+                $foreignKeys[$tableForeignKey['constname']]['foreign'][] = $tableForeignKey['foreign_column'];
             }
         }
 
@@ -199,11 +210,8 @@ SELECT
        C.NULLS,
        C.LENGTH,
        C.SCALE,
-       C.REMARKS AS COMMENT,
-       CASE
-           WHEN C.GENERATED = 'D' THEN 1
-           ELSE 0
-           END   AS AUTOINCREMENT,
+       C.REMARKS,
+       C.GENERATED,
        C.DEFAULT
 FROM SYSCAT.COLUMNS C
          JOIN SYSCAT.TABLES AS T
@@ -239,15 +247,8 @@ SQL,
       SELECT
              IDX.TABNAME AS %s,
              IDX.INDNAME AS KEY_NAME,
-             IDXCOL.COLNAME AS COLUMN_NAME,
-             CASE
-                 WHEN IDX.UNIQUERULE = 'P' THEN 1
-                 ELSE 0
-             END AS PRIMARY,
-             CASE
-                 WHEN IDX.UNIQUERULE = 'D' THEN 1
-                 ELSE 0
-             END AS NON_UNIQUE
+             IDXCOL.COLNAME,
+             IDX.UNIQUERULE
         FROM SYSCAT.INDEXES AS IDX
         JOIN SYSCAT.TABLES AS T
           ON IDX.TABSCHEMA = T.TABSCHEMA AND IDX.TABNAME = T.TABNAME
@@ -285,17 +286,11 @@ SQL,
       SELECT
              R.TABNAME AS %s,
              FKCOL.COLNAME AS LOCAL_COLUMN,
-             R.REFTABNAME AS FOREIGN_TABLE,
+             R.REFTABNAME,
              PKCOL.COLNAME AS FOREIGN_COLUMN,
-             R.CONSTNAME AS INDEX_NAME,
-             CASE
-                 WHEN R.UPDATERULE = 'R' THEN 'RESTRICT'
-             END AS ON_UPDATE,
-             CASE
-                 WHEN R.DELETERULE = 'C' THEN 'CASCADE'
-                 WHEN R.DELETERULE = 'N' THEN 'SET NULL'
-                 WHEN R.DELETERULE = 'R' THEN 'RESTRICT'
-             END AS ON_DELETE
+             R.CONSTNAME,
+             R.UPDATERULE,
+             R.DELETERULE
         FROM SYSCAT.REFERENCES AS R
          JOIN SYSCAT.TABLES AS T
               ON T.TABSCHEMA = R.TABSCHEMA

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -112,7 +112,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        $dbType = strtolower($tableColumn['type']);
+        $dbType = strtolower($tableColumn['column_type']);
         $dbType = strtok($dbType, '(), ');
         assert(is_string($dbType));
 
@@ -141,7 +141,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
                 if (
                     preg_match(
                         '([A-Za-z]+\(([0-9]+),([0-9]+)\))',
-                        $tableColumn['type'],
+                        $tableColumn['column_type'],
                         $match,
                     ) === 1
                 ) {
@@ -187,35 +187,35 @@ class MySQLSchemaManager extends AbstractSchemaManager
                 break;
 
             case 'enum':
-                $values = $this->parseEnumExpression($tableColumn['type']);
+                $values = $this->parseEnumExpression($tableColumn['column_type']);
                 break;
         }
 
         if ($this->platform instanceof MariaDBPlatform) {
-            $columnDefault = $this->getMariaDBColumnDefault($this->platform, $tableColumn['default']);
+            $columnDefault = $this->getMariaDBColumnDefault($this->platform, $tableColumn['column_default']);
         } else {
-            $columnDefault = $tableColumn['default'];
+            $columnDefault = $tableColumn['column_default'];
         }
 
         $options = [
             'length'        => $length !== null ? (int) $length : null,
-            'unsigned'      => str_contains($tableColumn['type'], 'unsigned'),
+            'unsigned'      => str_contains($tableColumn['column_type'], 'unsigned'),
             'fixed'         => $fixed,
             'default'       => $columnDefault,
-            'notnull'       => $tableColumn['null'] !== 'YES',
+            'notnull'       => $tableColumn['is_nullable'] !== 'YES',
             'scale'         => $scale,
             'precision'     => $precision,
             'autoincrement' => str_contains($tableColumn['extra'], 'auto_increment'),
             'values'        => $values,
         ];
 
-        if ($tableColumn['comment'] !== null) {
-            $options['comment'] = $tableColumn['comment'];
+        if ($tableColumn['column_comment'] !== null) {
+            $options['comment'] = $tableColumn['column_comment'];
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
-        $column->setPlatformOption('charset', $tableColumn['characterset']);
-        $column->setPlatformOption('collation', $tableColumn['collation']);
+        $column = new Column($tableColumn['column_name'], Type::getType($type), $options);
+        $column->setPlatformOption('charset', $tableColumn['character_set_name']);
+        $column->setPlatformOption('collation', $tableColumn['collation_name']);
 
         return $column;
     }
@@ -344,16 +344,15 @@ class MySQLSchemaManager extends AbstractSchemaManager
         $sql = sprintf(
             <<<'SQL'
 SELECT
-       c.TABLE_NAME         AS %s,
-       c.COLUMN_NAME        AS field,
-       %s                   AS type,
-       c.IS_NULLABLE        AS `null`,
-       c.COLUMN_KEY         AS `key`,
-       c.COLUMN_DEFAULT     AS `default`,
+       c.TABLE_NAME AS %s,
+       c.COLUMN_NAME,
+       %s AS COLUMN_TYPE,
+       c.IS_NULLABLE,
+       c.COLUMN_DEFAULT,
        c.EXTRA,
-       c.COLUMN_COMMENT     AS comment,
-       c.CHARACTER_SET_NAME AS characterset,
-       c.COLLATION_NAME     AS collation
+       c.COLUMN_COMMENT,
+       c.CHARACTER_SET_NAME,
+       c.COLLATION_NAME
 FROM information_schema.COLUMNS c
     INNER JOIN information_schema.TABLES t
         ON t.TABLE_NAME = c.TABLE_NAME
@@ -387,12 +386,12 @@ SQL,
         $sql = sprintf(
             <<<'SQL'
 SELECT
-        TABLE_NAME  AS %s,
-        NON_UNIQUE  AS Non_Unique,
-        INDEX_NAME  AS Key_name,
-        COLUMN_NAME AS Column_Name,
-        SUB_PART    AS Sub_Part,
-        INDEX_TYPE  AS Index_Type
+        TABLE_NAME AS %s,
+        NON_UNIQUE,
+        INDEX_NAME AS Key_name,
+        COLUMN_NAME,
+        SUB_PART,
+        INDEX_TYPE
 FROM information_schema.STATISTICS
 WHERE %s
 ORDER BY TABLE_NAME,

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -57,14 +57,14 @@ class OracleSchemaManager extends AbstractSchemaManager
 
             $buffer = [];
 
-            if ($row['is_primary'] === 'P') {
+            if ($row['constraint_type'] === 'P') {
                 $buffer['key_name']   = 'primary';
                 $buffer['primary']    = true;
                 $buffer['non_unique'] = false;
             } else {
-                $buffer['key_name']   = strtolower($row['name']);
+                $buffer['key_name']   = strtolower($row['index_name']);
                 $buffer['primary']    = false;
-                $buffer['non_unique'] = ! $row['is_unique'];
+                $buffer['non_unique'] = $row['uniqueness'] !== 'UNIQUE';
             }
 
             $buffer['column_name'] = $this->getQuotedIdentifierName($row['column_name']);
@@ -371,12 +371,10 @@ SQL,
             <<<'SQL'
           SELECT
                  IND_COL.TABLE_NAME AS %s,
-                 IND_COL.INDEX_NAME AS NAME,
-                 IND.INDEX_TYPE AS TYPE,
-                 DECODE(IND.UNIQUENESS, 'NONUNIQUE', 0, 'UNIQUE', 1) AS IS_UNIQUE,
+                 IND_COL.INDEX_NAME,
+                 IND.UNIQUENESS,
                  IND_COL.COLUMN_NAME,
-                 IND_COL.COLUMN_POSITION AS COLUMN_POS,
-                 CON.CONSTRAINT_TYPE AS IS_PRIMARY
+                 CON.CONSTRAINT_TYPE
             FROM ALL_IND_COLUMNS IND_COL
        LEFT JOIN ALL_INDEXES IND
               ON IND.OWNER = IND_COL.INDEX_OWNER

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -214,7 +214,7 @@ SQL,
         $length = null;
 
         if (
-            in_array(strtolower($tableColumn['type']), ['varchar', 'bpchar'], true)
+            in_array(strtolower($tableColumn['typname']), ['varchar', 'bpchar'], true)
             && preg_match('/\((\d*)\)/', $tableColumn['complete_type'], $matches) === 1
         ) {
             $length = (int) $matches[1];
@@ -253,11 +253,11 @@ SQL,
         $scale     = 0;
         $jsonb     = null;
 
-        $dbType = strtolower($tableColumn['type']);
+        $dbType = strtolower($tableColumn['typname']);
         if (
             $tableColumn['domain_type'] !== null
             && $tableColumn['domain_type'] !== ''
-            && ! $this->platform->hasDoctrineTypeMappingFor($tableColumn['type'])
+            && ! $this->platform->hasDoctrineTypeMappingFor($tableColumn['typname'])
         ) {
             $dbType                       = strtolower($tableColumn['domain_type']);
             $tableColumn['complete_type'] = $tableColumn['domain_complete_type'];
@@ -358,7 +358,7 @@ SQL,
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['attname'], Type::getType($type), $options);
 
         if (! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);
@@ -414,8 +414,8 @@ SQL,
             n.nspname AS %s,
             c.relname AS %s,
             a.attnum,
-            quote_ident(a.attname) AS field,
-            t.typname AS type,
+            quote_ident(a.attname) AS attname,
+            t.typname,
             format_type(a.atttypid, a.atttypmod) AS complete_type,
             (
                 SELECT CASE

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -119,10 +119,10 @@ SQL,
 
         $options = [
             'fixed'         => $fixed,
-            'notnull'       => (bool) $tableColumn['notnull'],
+            'notnull'       => ! $tableColumn['is_nullable'],
             'scale'         => $scale,
             'precision'     => $precision,
-            'autoincrement' => (bool) $tableColumn['autoincrement'],
+            'autoincrement' => (bool) $tableColumn['is_identity'],
         ];
 
         if ($tableColumn['comment'] !== null) {
@@ -145,7 +145,7 @@ SQL,
             );
         }
 
-        $column->setPlatformOption('collation', $tableColumn['collation']);
+        $column->setPlatformOption('collation', $tableColumn['collation_name']);
 
         return $column;
     }
@@ -211,9 +211,13 @@ SQL,
     protected function _getPortableTableIndexesList(array $rows): array
     {
         foreach ($rows as &$row) {
-            $row['non_unique'] = (bool) $row['non_unique'];
-            $row['primary']    = (bool) $row['primary'];
-            $row['flags']      = $row['flags'] ? [$row['flags']] : null;
+            $row['non_unique'] = ! $row['is_unique'];
+            $row['primary']    = (bool) $row['is_primary_key'];
+            $row['flags']      = match ($row['type']) {
+                1 => ['clustered'],
+                2 => ['nonclustered'],
+                default => null,
+            };
         }
 
         return parent::_getPortableTableIndexesList($rows);
@@ -301,13 +305,13 @@ SQL,
                           col.name,
                           type.name AS type,
                           col.max_length AS length,
-                          ~col.is_nullable AS notnull,
+                          col.is_nullable,
                           def.definition AS [default],
                           def.name AS df_name,
                           col.scale,
                           col.precision,
-                          col.is_identity AS autoincrement,
-                          col.collation_name AS collation,
+                          col.is_identity,
+                          col.collation_name,
                           -- CAST avoids driver error for sql_variant type
                           CAST(prop.value AS NVARCHAR(MAX)) AS comment
                 FROM      sys.columns AS col
@@ -348,13 +352,9 @@ SQL,
                        tbl.name AS %s,
                        idx.name AS key_name,
                        col.name AS column_name,
-                       ~idx.is_unique AS non_unique,
-                       idx.is_primary_key AS [primary],
-                       CASE idx.type
-                           WHEN '1' THEN 'clustered'
-                           WHEN '2' THEN 'nonclustered'
-                           ELSE NULL
-                       END AS flags
+                       idx.is_unique,
+                       idx.is_primary_key,
+                       idx.type
                 FROM sys.tables AS tbl
                 JOIN sys.schemas AS scm
                   ON tbl.schema_id = scm.schema_id

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -28,11 +28,11 @@ class DBAL461Test extends TestCase
             'type' => 'numeric(18,0)',
             'length' => null,
             'default' => null,
-            'notnull' => false,
+            'is_nullable' => true,
             'scale' => 18,
             'precision' => 0,
-            'autoincrement' => false,
-            'collation' => 'foo',
+            'is_identity' => false,
+            'collation_name' => 'foo',
             'comment' => null,
         ]);
 


### PR DESCRIPTION
This code is still insane in terms of type safety and indirection, but the following changes can be made without changing the design:
1. Remove redundant aliases for the columns that are queried and processed by the same class (it's an unnecessary level of indirection).
   - We keep the `Key_name` alias for all queries because this column is processed in the `AbstractManager`, not in the platform-specific ones.
3. Move the logic of processing a given column value  (e.g. negation or matching against a certain value) from SQL to `_getPortable*Definition()` methods.

Ideally, the logic of building the query and processing the results should be in the same method, so its implementation can change w/o any external side effects but I still cannot wrap my head around what this design should look like.