### PR TITLE
Rework SQLite auto-increment introspection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: `INTEGER PRIMARY KEY` columns are no longer introspected as auto-incremented on SQLite
+
+Even though `INTEGER PRIMARY KEY` columns are effectively auto-incremented on SQLite, DBAL no longer introspects them as
+such. Only if the column is declared as `INTEGER PRIMARY KEY AUTOINCREMENT`, it will be introspected as
+auto-incremented.
+
 ## BC BREAK: removed support for invalid auto-increment column definitions on SQLite
 
 The following auto-increment column definitions are no longer supported on SQLite:

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -237,6 +237,14 @@ class SQLiteSchemaManager extends AbstractSchemaManager
         return parent::_getPortableTableForeignKeysList($list);
     }
 
+    /** @link https://www.sqlite.org/autoinc.html#the_autoincrement_keyword */
+    private function parseColumnAutoIncrementFromSQL(string $column, string $sql): bool
+    {
+        $pattern = '/' . $this->buildIdentifierPattern($column) . 'INTEGER\s+PRIMARY\s+KEY\s+AUTOINCREMENT/i';
+
+        return preg_match($pattern, $sql) === 1;
+    }
+
     private function parseColumnCollationFromSQL(string $column, string $sql): ?string
     {
         $pattern = '{' . $this->buildIdentifierPattern($column)
@@ -497,28 +505,16 @@ SQL,
 
         $rows = parent::fetchTableColumns($databaseName, $tableName);
 
-        $sqlByTable = $pkColumnNamesByTable = $result = [];
-
-        foreach ($rows as $row) {
-            $unqualifiedTableName = $row[self::TABLE_NAME_COLUMN];
-
-            $sqlByTable[$unqualifiedTableName] ??= $this->getCreateTableSQL($unqualifiedTableName);
-
-            if ($row['pk'] === 0 || $row['pk'] === '0' || $row['type'] !== 'INTEGER') {
-                continue;
-            }
-
-            $pkColumnNamesByTable[$unqualifiedTableName][] = $row['name'];
-        }
+        $sqlByTable = $result = [];
 
         foreach ($rows as $row) {
             $unqualifiedTableName = $row[self::TABLE_NAME_COLUMN];
             $columnName           = $row['name'];
-            $tableSQL             = $sqlByTable[$row[self::TABLE_NAME_COLUMN]];
+
+            $tableSQL = $sqlByTable[$unqualifiedTableName] ??= $this->getCreateTableSQL($unqualifiedTableName);
 
             $result[] = array_merge($row, [
-                'autoincrement' => isset($pkColumnNamesByTable[$unqualifiedTableName])
-                    && $pkColumnNamesByTable[$unqualifiedTableName] === [$columnName],
+                'autoincrement' => $this->parseColumnAutoIncrementFromSQL($columnName, $tableSQL),
                 'collation' => $this->parseColumnCollationFromSQL($columnName, $tableSQL),
                 'comment' => $this->parseColumnCommentFromSQL($columnName, $tableSQL),
             ]);

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -17,13 +17,6 @@ class AlterTableTest extends FunctionalTestCase
 {
     public function testAddPrimaryKeyOnExistingColumn(): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof SQLitePlatform) {
-            self::markTestSkipped(
-                'SQLite will automatically set up auto-increment behavior on the primary key column, which this test'
-                    . ' does not expect.',
-            );
-        }
-
         $table = new Table('alter_pk');
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('val', Types::INTEGER);

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -118,10 +118,6 @@ final class SchemaManagerTest extends FunctionalTestCase
             self::markTestSkipped('This test is only supported on platforms that have autoincrement');
         }
 
-        if (! $autoincrement && $platform instanceof SQLitePlatform) {
-            self::markTestIncomplete('See https://github.com/doctrine/dbal/issues/6844');
-        }
-
         $table = new Table('test_autoincrement');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => $autoincrement]);
         $table->setPrimaryKey(['id']);


### PR DESCRIPTION
With this change, only `INTEGER PRIMARY KEY AUTOINCREMENT` SQLite columns will be introspected as auto-incremented. The `INTEGER PRIMARY KEY` ones won't. This way, the logic of introspection will be consistent with the logic of declaring the schema.

Fixes https://github.com/doctrine/dbal/issues/6844.