### PR TITLE
Do not drop PK constraint when dropping auto-increment on Oracle

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -422,13 +422,12 @@ SQL,
             throw UnsupportedName::fromQualifiedName($tableName, __METHOD__);
         }
 
-        $primaryKeyConstraintName = $this->generateAutoincrementTriggerName($tableName->getUnqualifiedName());
-        $sequenceName             = $this->generateAutoincrementSequenceName($tableName);
+        $triggerName  = $this->generateAutoincrementTriggerName($tableName->getUnqualifiedName());
+        $sequenceName = $this->generateAutoincrementSequenceName($tableName);
 
         return [
-            'DROP TRIGGER ' . $primaryKeyConstraintName->toSQL($this),
+            'DROP TRIGGER ' . $triggerName->toSQL($this),
             $this->getDropSequenceSQL($sequenceName->toSQL($this)),
-            $this->getDropConstraintSQL($primaryKeyConstraintName->toSQL($this), $tableName->toSQL($this)),
         ];
     }
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -412,7 +412,6 @@ SQL
                 [
                     'DROP TRIGGER "MYTABLE_AI_PK"',
                     'DROP SEQUENCE "MYTABLE_SEQ"',
-                    'ALTER TABLE "MYTABLE" DROP CONSTRAINT "MYTABLE_AI_PK"',
                 ],
             ],
             [
@@ -420,7 +419,6 @@ SQL
                 [
                     'DROP TRIGGER "myTable_AI_PK"',
                     'DROP SEQUENCE "myTable_SEQ"',
-                    'ALTER TABLE "myTable" DROP CONSTRAINT "myTable_AI_PK"',
                 ],
             ],
             [
@@ -428,7 +426,6 @@ SQL
                 [
                     'DROP TRIGGER "TABLE_AI_PK"',
                     'DROP SEQUENCE "TABLE_SEQ"',
-                    'ALTER TABLE "TABLE" DROP CONSTRAINT "TABLE_AI_PK"',
                 ],
             ],
         ];


### PR DESCRIPTION
As of https://github.com/doctrine/dbal/pull/6817, DBAL doesn't add a primary key constraint to the table when declaring a column as auto-incremented on Oracle. It shouldn't drop the PK when dropping the auto-increment either.

Technically, this is not a bug because DBAL doesn't support adding auto-increment to or dropping it from an existing column. This code is invoked only when the table is dropped, and there's no harm in dropping the PK in this case. It's just unnecessary.