### PR TITLE
Introduce equals() for names and foreign key constraints

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
-use function array_map;
 use function assert;
 use function count;
 use function strtolower;
@@ -238,10 +236,11 @@ class Comparator
 
         $oldForeignKeys = $oldTable->getForeignKeys();
         $newForeignKeys = $newTable->getForeignKeys();
+        $folding        = $this->platform->getUnquotedIdentifierFolding();
 
         foreach ($oldForeignKeys as $oldKey => $oldForeignKey) {
             foreach ($newForeignKeys as $newKey => $newForeignKey) {
-                if ($this->diffForeignKey($oldForeignKey, $newForeignKey) === false) {
+                if ($newForeignKey->equals($oldForeignKey, $folding)) {
                     unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
                 } else {
                     if (strtolower($oldForeignKey->getName()) === strtolower($newForeignKey->getName())) {
@@ -374,54 +373,6 @@ class Comparator
         }
 
         return $renamedIndexes;
-    }
-
-    protected function diffForeignKey(ForeignKeyConstraint $key1, ForeignKeyConstraint $key2): bool
-    {
-        if (
-            $this->normalizeColumnNames($key1->getReferencingColumnNames())
-            !==
-            $this->normalizeColumnNames($key2->getReferencingColumnNames())
-        ) {
-            return true;
-        }
-
-        if (
-            $this->normalizeColumnNames($key1->getReferencedColumnNames())
-            !==
-            $this->normalizeColumnNames($key2->getReferencedColumnNames())
-        ) {
-            return true;
-        }
-
-        if (
-            strtolower($key1->getReferencedTableName()->getUnqualifiedName()->getValue())
-                !== strtolower($key2->getReferencedTableName()->getUnqualifiedName()->getValue())
-        ) {
-            return true;
-        }
-
-        if ($key1->getOnUpdateAction() !== $key2->getOnUpdateAction()) {
-            return true;
-        }
-
-        return $key1->getOnDeleteAction() !== $key2->getOnDeleteAction();
-    }
-
-    /**
-     * Normalizes column names for comparison. Historically, it lower-cases the names regardless of the target database
-     * platform and whether the names are quoted. This isn't correct, but it is what it is for the time being.
-     *
-     * @param list<UnqualifiedName> $columnNames
-     *
-     * @return ($columnNames is non-empty-list ? non-empty-list<string> : list<string>)
-     */
-    private function normalizeColumnNames(array $columnNames): array
-    {
-        return array_map(
-            static fn (UnqualifiedName $columnName) => strtolower($columnName->getIdentifier()->getValue()),
-            $columnNames,
-        );
     }
 
     /**

--- a/src/Schema/Exception/IncomparableNames.php
+++ b/src/Schema/Exception/IncomparableNames.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+final class IncomparableNames extends LogicException implements SchemaException
+{
+    public static function fromOptionallyQualifiedNames(
+        OptionallyQualifiedName $name1,
+        OptionallyQualifiedName $name2,
+    ): self {
+        return new self(sprintf(
+            'Non-equally qualified names are incomparable: %s, %s.',
+            $name1->toString(),
+            $name2->toString(),
+        ));
+    }
+}

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 
 use function count;
 
@@ -135,6 +136,67 @@ final class ForeignKeyConstraint extends AbstractOptionallyNamedObject
     public function getDeferrability(): Deferrability
     {
         return $this->deferrability;
+    }
+
+    /**
+     * Returns whether this foreign key constraint is equal to the other.
+     *
+     * For the constraints to be comparable, both must either reference a table by the name with a qualifier or by the
+     * name with no qualifier.
+     */
+    public function equals(self $other, UnquotedIdentifierFolding $folding): bool
+    {
+        if ($this === $other) {
+            return true;
+        }
+
+        if (! $this->referencedTableName->equals($other->referencedTableName, $folding)) {
+            return false;
+        }
+
+        if (! $this->columnsNamesEqual($this->referencingColumnNames, $other->referencingColumnNames, $folding)) {
+            return false;
+        }
+
+        if (! $this->columnsNamesEqual($this->referencedColumnNames, $other->referencedColumnNames, $folding)) {
+            return false;
+        }
+
+        if ($this->matchType !== $other->matchType) {
+            return false;
+        }
+
+        if ($this->onUpdateAction !== $other->onUpdateAction) {
+            return false;
+        }
+
+        if ($this->onDeleteAction !== $other->onDeleteAction) {
+            return false;
+        }
+
+        return $this->deferrability === $other->deferrability;
+    }
+
+    /**
+     * @param list<UnqualifiedName> $thisNames
+     * @param list<UnqualifiedName> $otherNames
+     */
+    private function columnsNamesEqual(
+        array $thisNames,
+        array $otherNames,
+        UnquotedIdentifierFolding $folding,
+    ): bool {
+        if (count($thisNames) !== count($otherNames)) {
+            return false;
+        }
+
+        for ($i = 0, $count = count($thisNames); $i < $count; $i++) {
+            if (! $thisNames[$i]->equals($otherNames[$i], $folding)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -35,6 +35,18 @@ final class Identifier
         return $this->isQuoted;
     }
 
+    /**
+     * Returns whether this identifier is equal to the other.
+     */
+    public function equals(self $other, UnquotedIdentifierFolding $folding): bool
+    {
+        if ($this === $other) {
+            return true;
+        }
+
+        return $this->toNormalizedValue($folding) === $other->toNormalizedValue($folding);
+    }
+
     public function toSQL(AbstractPlatform $platform): string
     {
         return $platform->quoteSingleIdentifier(

--- a/src/Schema/Name/OptionallyQualifiedName.php
+++ b/src/Schema/Name/OptionallyQualifiedName.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema\Name;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Exception\IncomparableNames;
 use Doctrine\DBAL\Schema\Name;
 
 /**
@@ -46,6 +47,30 @@ final class OptionallyQualifiedName implements Name
         }
 
         return $this->qualifier->toString() . '.' . $unqualifiedName;
+    }
+
+    /**
+     * Returns whether this optionally qualified name is equal to the other.
+     *
+     * To be comparable, both names must either have a qualifier or have no qualifier.
+     */
+    public function equals(self $other, UnquotedIdentifierFolding $folding): bool
+    {
+        if ($this === $other) {
+            return true;
+        }
+
+        if (($this->qualifier === null) !== ($other->qualifier === null)) {
+            throw IncomparableNames::fromOptionallyQualifiedNames($this, $other);
+        }
+
+        if (! $this->unqualifiedName->equals($other->getUnqualifiedName(), $folding)) {
+            return false;
+        }
+
+        return $this->qualifier === null
+            || $other->qualifier === null
+            || $this->qualifier->equals($other->qualifier, $folding);
     }
 
     /**

--- a/src/Schema/Name/UnqualifiedName.php
+++ b/src/Schema/Name/UnqualifiedName.php
@@ -32,6 +32,18 @@ final class UnqualifiedName implements Name
     }
 
     /**
+     * Returns whether this unqualified name is equal to the other.
+     */
+    public function equals(self $other, UnquotedIdentifierFolding $folding): bool
+    {
+        if ($this === $other) {
+            return true;
+        }
+
+        return $this->identifier->equals($other->getIdentifier(), $folding);
+    }
+
+    /**
      * Creates a quoted unqualified name.
      */
     public static function quoted(string $value): self

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ForeignKeyConstraintTest extends TestCase
@@ -60,5 +62,134 @@ class ForeignKeyConstraintTest extends TestCase
         $this->expectException(InvalidForeignKeyConstraintDefinition::class);
 
         $editor->create();
+    }
+
+    public function testEqualsToSelf(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames(
+                UnqualifiedName::unquoted('user_id'),
+            )
+            ->setReferencedTableName(OptionallyQualifiedName::unquoted('users'))
+            ->setReferencedColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->create();
+
+        self::assertTrue($constraint->equals($constraint, UnquotedIdentifierFolding::NONE));
+    }
+
+    public function testEqualConstraints(): void
+    {
+        $constraint1 = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames(
+                UnqualifiedName::unquoted('user_id'),
+            )
+            ->setReferencedTableName(OptionallyQualifiedName::unquoted('users'))
+            ->setReferencedColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->create();
+
+        $constraint2 = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames(
+                UnqualifiedName::unquoted('user_id'),
+            )
+            ->setReferencedTableName(OptionallyQualifiedName::unquoted('users'))
+            ->setReferencedColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->create();
+
+        self::assertTrue($constraint1->equals($constraint2, UnquotedIdentifierFolding::NONE));
+        self::assertTrue($constraint2->equals($constraint1, UnquotedIdentifierFolding::NONE));
+    }
+
+    #[DataProvider('unequalConstraintProvider')]
+    public function testUnequalConstraints(ForeignKeyConstraint $constraint1, ForeignKeyConstraint $constraint2): void
+    {
+        self::assertFalse($constraint1->equals($constraint2, UnquotedIdentifierFolding::NONE));
+        self::assertFalse($constraint2->equals($constraint1, UnquotedIdentifierFolding::NONE));
+    }
+
+    /** @return iterable<array{ForeignKeyConstraint, ForeignKeyConstraint}> */
+    public static function unequalConstraintProvider(): iterable
+    {
+        $prototype = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames(
+                UnqualifiedName::unquoted('user_id'),
+            )
+            ->setReferencedTableName(OptionallyQualifiedName::unquoted('users'))
+            ->setReferencedColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->create();
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setReferencedTableName(OptionallyQualifiedName::unquoted('orders'))
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setReferencingColumnNames(
+                    UnqualifiedName::unquoted('user_name'),
+                )
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setReferencedColumnNames(
+                    UnqualifiedName::unquoted('name'),
+                )
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setReferencingColumnNames(
+                    UnqualifiedName::unquoted('user_id'),
+                    UnqualifiedName::unquoted('user_name'),
+                )
+                ->setReferencedColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                    UnqualifiedName::unquoted('name'),
+                )
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setMatchType(MatchType::FULL)
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setOnUpdateAction(ReferentialAction::CASCADE)
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setOnDeleteAction(ReferentialAction::SET_NULL)
+                ->create(),
+        ];
+
+        yield [
+            $prototype,
+            $prototype->edit()
+                ->setDeferrability(Deferrability::DEFERRED)
+                ->create(),
+        ];
     }
 }

--- a/tests/Schema/Name/IdentifierTest.php
+++ b/tests/Schema/Name/IdentifierTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Schema\Name;
 
 use Doctrine\DBAL\Schema\Exception\InvalidIdentifier;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -30,5 +31,88 @@ class IdentifierTest extends TestCase
         yield [Identifier::unquoted('id'), 'id'];
         yield [Identifier::quoted('name'), '"name"'];
         yield [Identifier::quoted('"value"'), '"""value"""'];
+    }
+
+    public function testEqualsToSelf(): void
+    {
+        $identifier = Identifier::unquoted('id');
+
+        self::assertTrue($identifier->equals($identifier, UnquotedIdentifierFolding::NONE));
+    }
+
+    #[DataProvider('equalIdentifierProvider')]
+    public function testEqualsToOther(
+        Identifier $identifier1,
+        Identifier $identifier2,
+        UnquotedIdentifierFolding $folding,
+    ): void {
+        self::assertTrue($identifier1->equals($identifier2, $folding));
+        self::assertTrue($identifier2->equals($identifier1, $folding));
+    }
+
+    /** @return iterable<array{Identifier, Identifier, UnquotedIdentifierFolding}> */
+    public static function equalIdentifierProvider(): iterable
+    {
+        yield [
+            Identifier::unquoted('id'),
+            Identifier::unquoted('id'),
+            UnquotedIdentifierFolding::NONE,
+        ];
+
+        yield [
+            Identifier::quoted('id'),
+            Identifier::quoted('id'),
+            UnquotedIdentifierFolding::NONE,
+        ];
+
+        yield [
+            Identifier::quoted('id'),
+            Identifier::unquoted('ID'),
+            UnquotedIdentifierFolding::LOWER,
+        ];
+
+        yield [
+            Identifier::quoted('ID'),
+            Identifier::unquoted('id'),
+            UnquotedIdentifierFolding::UPPER,
+        ];
+    }
+
+    #[DataProvider('unequalIdentifierProvider')]
+    public function testNonEqualsToOther(
+        Identifier $identifier1,
+        Identifier $identifier2,
+        UnquotedIdentifierFolding $folding,
+    ): void {
+        self::assertFalse($identifier1->equals($identifier2, $folding));
+        self::assertFalse($identifier2->equals($identifier1, $folding));
+    }
+
+    /** @return iterable<array{Identifier, Identifier, UnquotedIdentifierFolding}> */
+    public static function unequalIdentifierProvider(): iterable
+    {
+        yield [
+            Identifier::unquoted('foo'),
+            Identifier::unquoted('bar'),
+            UnquotedIdentifierFolding::NONE,
+        ];
+
+        yield [
+            Identifier::unquoted('id'),
+            Identifier::unquoted('ID'),
+            UnquotedIdentifierFolding::NONE,
+        ];
+
+        yield [
+            Identifier::quoted('id'),
+            Identifier::quoted('ID'),
+            UnquotedIdentifierFolding::LOWER,
+        ];
+
+        yield [
+            Identifier::quoted('ID'),
+            Identifier::quoted('id'),
+            UnquotedIdentifierFolding::UPPER,
+        ];
     }
 }

--- a/tests/Schema/Name/OptionallyQualifiedNameTest.php
+++ b/tests/Schema/Name/OptionallyQualifiedNameTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema\Name;
 
+use Doctrine\DBAL\Schema\Exception\IncomparableNames;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class OptionallyQualifiedNameTest extends TestCase
@@ -65,5 +68,80 @@ class OptionallyQualifiedNameTest extends TestCase
         self::assertNull($name->getQualifier());
 
         self::assertSame('customers', $name->toString());
+    }
+
+    public function testEqualsToSelf(): void
+    {
+        $name = OptionallyQualifiedName::unquoted('user.id');
+
+        self::assertTrue($name->equals($name, UnquotedIdentifierFolding::NONE));
+    }
+
+    #[DataProvider('equalNameProvider')]
+    public function testEqualsNames(OptionallyQualifiedName $name1, OptionallyQualifiedName $name2): void
+    {
+        self::assertTrue($name2->equals($name1, UnquotedIdentifierFolding::NONE));
+        self::assertTrue($name1->equals($name2, UnquotedIdentifierFolding::NONE));
+    }
+
+    /** @return iterable<array{OptionallyQualifiedName, OptionallyQualifiedName}> */
+    public static function equalNameProvider(): iterable
+    {
+        yield [
+            OptionallyQualifiedName::unquoted('id'),
+            OptionallyQualifiedName::unquoted('id'),
+        ];
+
+        yield [
+            OptionallyQualifiedName::unquoted('id', 'user'),
+            OptionallyQualifiedName::unquoted('id', 'user'),
+        ];
+    }
+
+    #[DataProvider('unequalNameProvider')]
+    public function testUnequalsNames(OptionallyQualifiedName $name1, OptionallyQualifiedName $name2): void
+    {
+        self::assertFalse($name1->equals($name2, UnquotedIdentifierFolding::NONE));
+        self::assertFalse($name2->equals($name1, UnquotedIdentifierFolding::NONE));
+    }
+
+    /** @return iterable<array{OptionallyQualifiedName, OptionallyQualifiedName}> */
+    public static function unequalNameProvider(): iterable
+    {
+        yield [
+            OptionallyQualifiedName::unquoted('id'),
+            OptionallyQualifiedName::unquoted('name'),
+        ];
+
+        yield [
+            OptionallyQualifiedName::unquoted('id', 'user'),
+            OptionallyQualifiedName::unquoted('name', 'user'),
+        ];
+
+        yield [
+            OptionallyQualifiedName::unquoted('id', 'user'),
+            OptionallyQualifiedName::unquoted('id', 'order'),
+        ];
+    }
+
+    #[DataProvider('incomparableNameProvider')]
+    public function testIncomparableNames(OptionallyQualifiedName $name1, OptionallyQualifiedName $name2): void
+    {
+        $this->expectException(IncomparableNames::class);
+        $name1->equals($name2, UnquotedIdentifierFolding::NONE);
+    }
+
+    /** @return iterable<array{OptionallyQualifiedName, OptionallyQualifiedName}> */
+    public static function incomparableNameProvider(): iterable
+    {
+        yield [
+            OptionallyQualifiedName::unquoted('id'),
+            OptionallyQualifiedName::unquoted('id', 'user'),
+        ];
+
+        yield [
+            OptionallyQualifiedName::unquoted('id', 'user'),
+            OptionallyQualifiedName::unquoted('id'),
+        ];
     }
 }

--- a/tests/Schema/Name/UnqualifiedNameTest.php
+++ b/tests/Schema/Name/UnqualifiedNameTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema\Name;
 
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use PHPUnit\Framework\TestCase;
 
 class UnqualifiedNameTest extends TestCase
@@ -31,5 +32,30 @@ class UnqualifiedNameTest extends TestCase
         self::assertEquals('id', $identifier->getValue());
 
         self::assertSame('id', $name->toString());
+    }
+
+    public function testEqualsToSelf(): void
+    {
+        $name = UnqualifiedName::unquoted('id');
+
+        self::assertTrue($name->equals($name, UnquotedIdentifierFolding::NONE));
+    }
+
+    public function testEqualsToOther(): void
+    {
+        $name1 = UnqualifiedName::unquoted('id');
+        $name2 = UnqualifiedName::unquoted('id');
+
+        self::assertTrue($name1->equals($name2, UnquotedIdentifierFolding::NONE));
+        self::assertTrue($name2->equals($name1, UnquotedIdentifierFolding::NONE));
+    }
+
+    public function testNotEqualsToOther(): void
+    {
+        $name1 = UnqualifiedName::unquoted('id');
+        $name2 = UnqualifiedName::unquoted('name');
+
+        self::assertFalse($name1->equals($name2, UnquotedIdentifierFolding::NONE));
+        self::assertFalse($name2->equals($name1, UnquotedIdentifierFolding::NONE));
     }
 }


### PR DESCRIPTION
This is a step towards comparing schema objects using an API specifically designed for that instead of using ad-hoc implementations (e.g. `strtolower($name)` for names) all over the place.

This PR introduces an `equals()` method for `Name` implementations and `ForeignKeyConstraint`. It moves the logic of comparing foreign key constraints from `Comparator` to the `ForeignKeyConstraint` class itself.

Currently, `ForeignKeyConstraint#equals()` doesn't compare constraint names because `Comparator` doesn't do that. Adding comparison of the names as part of constraint comparison will require adding the logic that will account for the fact that a name omitted in the application-side constraint definition may be auto-generated in the database.

In subsequent PRs, the `PrimaryKeyConstraint` class will be introduced and a similar `equals()` method will be added.

## Additional notes

These methods could be introduced in 4.3.x instead of here but I'm deliberately not doing that:
1. It is not guaranteed there that all schema objects have valid names, so it will be impossible to use them in the actual library code.
2. Releasing this code as part of 4.3.0 will make it impossible to introduce breaking changes to this code, even though the library itself won't use it. For example, https://github.com/doctrine/dbal/pull/6823 was possible only because it modified a not yet released API. We can always backport it, if there are good reasons for that.