### PR TITLE
Remove support for primary indexes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,19 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Changes in features related to primary key constraints
+
+1. The `Index` class can no longer represent a primary key constraint. As a result:
+    1. The `Table::getIndexes()` and `AbstractSchemaManager::listTableIndexes()` methods no longer return the index that  
+       backs the primary key constraint.
+    2. The index that backs the primary key constraint is no longer considered during implicit index management.
+2. The `Table::getPrimaryKey()` and `Table::setPrimaryKey()` methods have been removed.
+3. The `Table::renameIndex()` method can no longer be used to rename a primary key constraint.
+4. The `AbstractPlatform::getCreatePrimaryKeySQL()` method has been removed.
+5. The `PostgreSQLPlatform::getDropIndexSQL()` method no longer builds SQL for dropping a primary key constraint. As a
+   result, dropping a primary key constraint on Postgres is now only possible if the constraint name is known (e.g. in
+   the result of database schema introspection).
+
 ## BC BREAK: `INTEGER PRIMARY KEY` columns are no longer introspected as auto-incremented on SQLite
 
 Even though `INTEGER PRIMARY KEY` columns are effectively auto-incremented on SQLite, DBAL no longer introspects them as

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -25,7 +25,6 @@ use function is_array;
 use function is_numeric;
 use function sprintf;
 use function str_replace;
-use function strtolower;
 
 /**
  * Provides the base implementation for the lowest versions of supported MySQL-like database platforms.
@@ -352,20 +351,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 . $this->getColumnDeclarationSQL($newColumnProperties);
         }
 
-        $droppedIndexes = $this->indexIndexesByLowerCaseName($diff->getDroppedIndexes());
-        $addedIndexes   = $this->indexIndexesByLowerCaseName($diff->getAddedIndexes());
-
-        if (isset($droppedIndexes['primary'])) {
+        if ($diff->getDroppedPrimaryKeyConstraint() !== null) {
             $queryParts[] = 'DROP PRIMARY KEY';
-
-            $diff->unsetDroppedIndex($droppedIndexes['primary']);
         }
 
-        if (isset($addedIndexes['primary'])) {
-            $keyColumns   = $addedIndexes['primary']->getQuotedColumns($this);
-            $queryParts[] = 'ADD PRIMARY KEY (' . implode(', ', $keyColumns) . ')';
+        $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
 
-            $diff->unsetAddedIndex($addedIndexes['primary']);
+        if ($addedPrimaryKeyConstraint !== null) {
+            $queryParts[] = 'ADD ' . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
         $tableSql = [];
@@ -397,19 +390,23 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                     continue;
                 }
 
-                $indexClause = 'INDEX ' . $addedIndex->getName();
+                $indexClause = 'INDEX ' . $addedIndex->getObjectName()->toSQL($this);
 
                 if ($addedIndex->isPrimary()) {
-                    $indexClause = 'PRIMARY KEY';
-                } elseif ($addedIndex->isUnique()) {
-                    $indexClause = 'UNIQUE INDEX ' . $addedIndex->getName();
+                    continue;
                 }
 
-                $query  = 'ALTER TABLE ' . $tableNameSQL . ' DROP INDEX ' . $droppedIndex->getName() . ', ';
-                $query .= 'ADD ' . $indexClause;
-                $query .= ' (' . implode(', ', $addedIndex->getQuotedColumns($this)) . ')';
+                if ($addedIndex->isUnique()) {
+                    $indexClause = 'UNIQUE ' . $indexClause;
+                }
 
-                $sql[] = $query;
+                $sql[] = sprintf(
+                    'ALTER TABLE %s DROP INDEX %s, ADD %s (%s)',
+                    $tableNameSQL,
+                    $droppedIndex->getObjectName()->toSQL($this),
+                    $indexClause,
+                    implode(', ', $addedIndex->getQuotedColumns($this)),
+                );
 
                 $diff->unsetAddedIndex($addedIndex);
                 $diff->unsetDroppedIndex($droppedIndex);
@@ -669,22 +666,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     public function createSchemaManager(Connection $connection): MySQLSchemaManager
     {
         return new MySQLSchemaManager($connection, $this);
-    }
-
-    /**
-     * @param array<Index> $indexes
-     *
-     * @return array<string,Index>
-     */
-    private function indexIndexesByLowerCaseName(array $indexes): array
-    {
-        $result = [];
-
-        foreach ($indexes as $index) {
-            $result[strtolower($index->getName())] = $index;
-        }
-
-        return $result;
     }
 
     /** @internal The method should be only used from within the {@see MySQLSchemaManager} class hierarchy. */

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
@@ -247,11 +248,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             $elements[] = $this->getIndexDeclarationSQL($definition);
         }
 
-        if (isset($parameters['primary_index'])) {
-            $elements[] = sprintf(
-                'PRIMARY KEY (%s)',
-                implode(', ', $parameters['primary_index']->getQuotedColumns($this)),
-            );
+        if (isset($parameters['primaryKey'])) {
+            $elements[] = $this->getPrimaryKeyConstraintDeclarationSQL($parameters['primaryKey']);
         }
 
         $sql = ['CREATE'];
@@ -527,6 +525,14 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     protected function getColumnCharsetDeclarationSQL(string $charset): string
     {
         return 'CHARACTER SET ' . $charset;
+    }
+
+    protected function getPrimaryKeyConstraintDeclarationSQL(PrimaryKeyConstraint $constraint): string
+    {
+        $this->ensurePrimaryKeyConstraintIsNotNamed($constraint);
+        $this->ensurePrimaryKeyConstraintIsClustered($constraint);
+
+        return parent::getPrimaryKeyConstraintDeclarationSQL($constraint);
     }
 
     protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -392,10 +392,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
 
                 $indexClause = 'INDEX ' . $addedIndex->getObjectName()->toSQL($this);
 
-                if ($addedIndex->isPrimary()) {
-                    continue;
-                }
-
                 if ($addedIndex->isUnique()) {
                     $indexClause = 'UNIQUE ' . $indexClause;
                 }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\Exception\NoColumnsSpecifiedForTable;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
+use Doctrine\DBAL\Platforms\Exception\UnsupportedPrimaryKeyConstraintDefinition;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\UnspecifiedConstraintName;
@@ -26,6 +27,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
@@ -71,8 +73,8 @@ use function strtolower;
  *
  * @phpstan-import-type ColumnProperties from Column
  * @phpstan-type CreateTableParameters = array{
- *    primary_index?: Index,
  *    indexes: list<Index>,
+ *    primaryKey: ?PrimaryKeyConstraint,
  *    uniqueConstraints: list<UniqueConstraint>,
  *    foreignKeys: list<ForeignKeyConstraint>,
  *    comment?: string,
@@ -834,18 +836,17 @@ abstract class AbstractPlatform
 
         $tableName                       = $table->getObjectName();
         $parameters                      = $table->getOptions();
+        $parameters['primaryKey']        = $table->getPrimaryKeyConstraint();
         $parameters['indexes']           = [];
         $parameters['uniqueConstraints'] = [];
         $parameters['foreignKeys']       = [];
 
         foreach ($table->getIndexes() as $index) {
-            if (! $index->isPrimary()) {
-                $parameters['indexes'][] = $index;
-
+            if ($index->isPrimary()) {
                 continue;
             }
 
-            $parameters['primary_index'] = $index;
+            $parameters['indexes'][] = $index;
         }
 
         foreach ($table->getUniqueConstraints() as $uniqueConstraint) {
@@ -995,11 +996,8 @@ abstract class AbstractPlatform
             $elements[] = $this->getUniqueConstraintDeclarationSQL($definition);
         }
 
-        if (isset($parameters['primary_index'])) {
-            $elements[] = sprintf(
-                'PRIMARY KEY (%s)',
-                implode(', ', $parameters['primary_index']->getQuotedColumns($this)),
-            );
+        if (isset($parameters['primaryKey'])) {
+            $elements[] = $this->getPrimaryKeyConstraintDeclarationSQL($parameters['primaryKey']);
         }
 
         foreach ($parameters['indexes'] as $definition) {
@@ -1501,6 +1499,48 @@ abstract class AbstractPlatform
     public function getTemporaryTableName(string $tableName): string
     {
         return $tableName;
+    }
+
+    /**
+     * Returns declaration of a primary key constraint.
+     */
+    protected function getPrimaryKeyConstraintDeclarationSQL(PrimaryKeyConstraint $constraint): string
+    {
+        $chunks = [];
+
+        $name = $constraint->getObjectName();
+        if ($name !== null) {
+            $chunks[] = 'CONSTRAINT';
+            $chunks[] = $name->toSQL($this);
+        }
+
+        $chunks[] = 'PRIMARY KEY';
+
+        if (! $constraint->isClustered()) {
+            $chunks[] = 'NONCLUSTERED';
+        }
+
+        $chunks[] = $this->buildUnqualifiedNameListSQL($constraint->getColumnNames());
+
+        return implode(' ', $chunks);
+    }
+
+    final protected function ensurePrimaryKeyConstraintIsNotNamed(PrimaryKeyConstraint $constraint): void
+    {
+        if ($constraint->getObjectName() === null) {
+            return;
+        }
+
+        throw UnsupportedPrimaryKeyConstraintDefinition::fromNamedConstraint(static::class);
+    }
+
+    final protected function ensurePrimaryKeyConstraintIsClustered(PrimaryKeyConstraint $constraint): void
+    {
+        if ($constraint->isClustered()) {
+            return;
+        }
+
+        throw UnsupportedPrimaryKeyConstraintDefinition::fromNonClusteredConstraint(static::class);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1470,10 +1470,7 @@ abstract class AbstractPlatform
             $chunks[] = 'CLUSTERED';
         }
 
-        $chunks[] = sprintf('(%s)', implode(', ', array_map(
-            fn (UnqualifiedName $columnName) => $columnName->toSQL($this),
-            $constraint->getColumnNames(),
-        )));
+        $chunks[] = $this->buildUnqualifiedNameListSQL($constraint->getColumnNames());
 
         return implode(' ', $chunks);
     }
@@ -1560,25 +1557,21 @@ abstract class AbstractPlatform
      */
     protected function getForeignKeyBaseDeclarationSQL(ForeignKeyConstraint $foreignKey): string
     {
-        $name = $foreignKey->getObjectName();
+        $chunks = [];
 
-        $sql = '';
+        $name = $foreignKey->getObjectName();
         if ($name !== null) {
-            $sql .= 'CONSTRAINT ' . $name->toSQL($this) . ' ';
+            $chunks[] = 'CONSTRAINT';
+            $chunks[] = $name->toSQL($this);
         }
 
-        return $sql . sprintf(
-            'FOREIGN KEY (%s) REFERENCES %s (%s)',
-            implode(', ', array_map(
-                fn (UnqualifiedName $columnName) => $columnName->toSQL($this),
-                $foreignKey->getReferencingColumnNames(),
-            )),
-            $foreignKey->getReferencedTableName()->toSQL($this),
-            implode(', ', array_map(
-                fn (UnqualifiedName $columnName) => $columnName->toSQL($this),
-                $foreignKey->getReferencedColumnNames(),
-            )),
-        );
+        $chunks[] = 'FOREIGN KEY';
+        $chunks[] = $this->buildUnqualifiedNameListSQL($foreignKey->getReferencingColumnNames());
+        $chunks[] = 'REFERENCES';
+        $chunks[] = $foreignKey->getReferencedTableName()->toSQL($this);
+        $chunks[] = $this->buildUnqualifiedNameListSQL($foreignKey->getReferencedColumnNames());
+
+        return implode(' ', $chunks);
     }
 
     /**
@@ -1607,6 +1600,15 @@ abstract class AbstractPlatform
     protected function getColumnCollationDeclarationSQL(string $collation): string
     {
         return $this->supportsColumnCollation() ? 'COLLATE ' . $this->quoteSingleIdentifier($collation) : '';
+    }
+
+    /** @param non-empty-list<UnqualifiedName> $names */
+    private function buildUnqualifiedNameListSQL(array $names): string
+    {
+        return sprintf('(%s)', implode(', ', array_map(
+            fn (UnqualifiedName $columnName) => $columnName->toSQL($this),
+            $names,
+        )));
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -44,7 +44,6 @@ use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function addcslashes;
 use function array_map;
@@ -842,10 +841,6 @@ abstract class AbstractPlatform
         $parameters['foreignKeys']       = [];
 
         foreach ($table->getIndexes() as $index) {
-            if ($index->isPrimary()) {
-                continue;
-            }
-
             $parameters['indexes'][] = $index;
         }
 
@@ -1112,10 +1107,6 @@ abstract class AbstractPlatform
             ));
         }
 
-        if ($index->isPrimary()) {
-            return $this->getCreatePrimaryKeySQL($index, $table);
-        }
-
         $query  = 'CREATE ' . $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name . ' ON ' . $table;
         $query .= ' (' . implode(', ', $index->getQuotedColumns($this)) . ')' . $this->getPartialIndexSQL($index);
 
@@ -1140,23 +1131,6 @@ abstract class AbstractPlatform
     protected function getCreateIndexSQLFlags(Index $index): string
     {
         return $index->isUnique() ? 'UNIQUE ' : '';
-    }
-
-    /**
-     * Returns the SQL to create an unnamed primary key constraint.
-     *
-     * @deprecated
-     */
-    public function getCreatePrimaryKeySQL(Index $index, string $table): string
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6867',
-            '%s() is deprecated.',
-            __METHOD__,
-        );
-
-        return 'ALTER TABLE ' . $table . ' ADD PRIMARY KEY (' . implode(', ', $index->getQuotedColumns($this)) . ')';
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
@@ -210,6 +211,13 @@ class DB2Platform extends AbstractPlatform
     public function getListViewsSQL(string $database): string
     {
         return 'SELECT NAME, TEXT FROM SYSIBM.SYSVIEWS';
+    }
+
+    protected function getPrimaryKeyConstraintDeclarationSQL(PrimaryKeyConstraint $constraint): string
+    {
+        $this->ensurePrimaryKeyConstraintIsClustered($constraint);
+
+        return parent::getPrimaryKeyConstraintDeclarationSQL($constraint);
     }
 
     protected function supportsCommentOnStatement(): bool

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
+use Doctrine\DBAL\Schema\Exception\UnspecifiedConstraintName;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
@@ -272,7 +273,20 @@ class DB2Platform extends AbstractPlatform
         $sql         = [];
         $commentsSQL = [];
 
-        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
+        $tableName    = $diff->getOldTable()->getObjectName();
+        $tableNameSQL = $tableName->toSQL($this);
+
+        $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
+
+        if ($droppedPrimaryKeyConstraint !== null) {
+            $constraintName = $droppedPrimaryKeyConstraint->getObjectName();
+
+            if ($constraintName === null) {
+                throw UnspecifiedConstraintName::new();
+            }
+
+            $sql[] = $this->getDropConstraintSQL($constraintName->toSQL($this), $tableNameSQL);
+        }
 
         $queryParts = [];
         foreach ($diff->getAddedColumns() as $column) {
@@ -330,6 +344,13 @@ class DB2Platform extends AbstractPlatform
 
         if (count($queryParts) > 0) {
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . implode(' ', $queryParts);
+        }
+
+        $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
+
+        if ($addedPrimaryKeyConstraint !== null) {
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ADD '
+                . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
         // Some table alteration operations require a table reorganization.
@@ -462,9 +483,7 @@ class DB2Platform extends AbstractPlatform
                     continue;
                 }
 
-                if ($droppedIndex->isPrimary()) {
-                    $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP PRIMARY KEY';
-                } elseif ($droppedIndex->isUnique()) {
+                if ($droppedIndex->isUnique()) {
                     $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP UNIQUE '
                         . $droppedIndex->getObjectName()->toSQL($this);
                 } else {

--- a/src/Platforms/Exception/UnsupportedPrimaryKeyConstraintDefinition.php
+++ b/src/Platforms/Exception/UnsupportedPrimaryKeyConstraintDefinition.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\Exception;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class UnsupportedPrimaryKeyConstraintDefinition extends InvalidArgumentException implements PlatformException
+{
+    /** @param class-string<AbstractPlatform> $platformClassName */
+    public static function fromNamedConstraint(string $platformClassName): self
+    {
+        return new self(sprintf(
+            'Database platform %s does not support named primary key constraints.',
+            $platformClassName,
+        ));
+    }
+
+    /** @param class-string<AbstractPlatform> $platformClassName */
+    public static function fromNonClusteredConstraint(string $platformClassName): self
+    {
+        return new self(sprintf(
+            'Database platform %s supports only clustered primary key constraints.',
+            $platformClassName,
+        ));
+    }
+}

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\OracleSchemaManager;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -485,6 +486,13 @@ SQL,
     public function getDropForeignKeySQL(string $foreignKey, string $table): string
     {
         return $this->getDropConstraintSQL($foreignKey, $table);
+    }
+
+    protected function getPrimaryKeyConstraintDeclarationSQL(PrimaryKeyConstraint $constraint): string
+    {
+        $this->ensurePrimaryKeyConstraintIsClustered($constraint);
+
+        return parent::getPrimaryKeyConstraintDeclarationSQL($constraint);
     }
 
     protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -24,7 +24,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_merge;
@@ -132,20 +131,6 @@ class OraclePlatform extends AbstractPlatform
         return '(' . $value1 . '-' .
                 $this->getBitAndComparisonExpression($value1, $value2)
                 . '+' . $value2 . ')';
-    }
-
-    /** @deprecated */
-    public function getCreatePrimaryKeySQL(Index $index, string $table): string
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6867',
-            '%s() is deprecated.',
-            __METHOD__,
-        );
-
-        return 'ALTER TABLE ' . $table . ' ADD CONSTRAINT ' . $index->getObjectName()->toSQL($this)
-            . ' PRIMARY KEY (' . implode(', ', $index->getQuotedColumns($this)) . ')';
     }
 
     /**

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnLengthRequired;
+use Doctrine\DBAL\Schema\Exception\UnspecifiedConstraintName;
 use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
@@ -478,9 +479,9 @@ SQL,
     /**
      * Returns the autoincrement trigger name for the given table name.
      */
-    private function generateAutoincrementTriggerName(Name\Identifier $tableName): Name\Identifier
+    private function generateAutoincrementTriggerName(Name\Identifier $tableName): UnqualifiedName
     {
-        return $this->addSuffix($tableName, '_AI_PK');
+        return new UnqualifiedName($this->addSuffix($tableName, '_AI_PK'));
     }
 
     public function getDropForeignKeySQL(string $foreignKey, string $table): string
@@ -542,7 +543,20 @@ SQL,
         $commentsSQL  = [];
         $addColumnSQL = [];
 
-        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
+        $tableName    = $diff->getOldTable()->getObjectName();
+        $tableNameSQL = $tableName->toSQL($this);
+
+        $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
+
+        if ($droppedPrimaryKeyConstraint !== null) {
+            $constraintName = $droppedPrimaryKeyConstraint->getObjectName();
+
+            if ($constraintName === null) {
+                throw UnspecifiedConstraintName::new();
+            }
+
+            $sql[] = $this->getDropConstraintSQL($constraintName->toSQL($this), $tableNameSQL);
+        }
 
         foreach ($diff->getAddedColumns() as $column) {
             $addColumnSQL[] = $this->getColumnDeclarationSQL($column->toArray());
@@ -635,6 +649,13 @@ SQL,
 
         if (count($dropColumnSQL) > 0) {
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP (' . implode(', ', $dropColumnSQL) . ')';
+        }
+
+        $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
+
+        if ($addedPrimaryKeyConstraint !== null) {
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ADD '
+                . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
         return array_merge(

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
@@ -172,6 +173,13 @@ class PostgreSQLPlatform extends AbstractPlatform
                        view_definition AS definition
                 FROM   information_schema.views
                 WHERE  view_definition IS NOT NULL';
+    }
+
+    protected function getPrimaryKeyConstraintDeclarationSQL(PrimaryKeyConstraint $constraint): string
+    {
+        $this->ensurePrimaryKeyConstraintIsClustered($constraint);
+
+        return parent::getPrimaryKeyConstraintDeclarationSQL($constraint);
     }
 
     protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string
@@ -394,11 +402,8 @@ class PostgreSQLPlatform extends AbstractPlatform
             $elements[] = $this->getColumnDeclarationSQL($column);
         }
 
-        if (isset($parameters['primary_index'])) {
-            $elements[] = sprintf(
-                'PRIMARY KEY (%s)',
-                implode(', ', $parameters['primary_index']->getQuotedColumns($this)),
-            );
+        if (isset($parameters['primaryKey'])) {
+            $elements[] = $this->getPrimaryKeyConstraintDeclarationSQL($parameters['primaryKey']);
         }
 
         $unlogged = isset($parameters['unlogged']) && $parameters['unlogged'] === true ? ' UNLOGGED' : '';

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Exception\UnspecifiedConstraintName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
@@ -209,9 +210,21 @@ class PostgreSQLPlatform extends AbstractPlatform
         $sql         = [];
         $commentsSQL = [];
 
-        $table = $diff->getOldTable();
+        $table        = $diff->getOldTable();
+        $tableName    = $table->getObjectName();
+        $tableNameSQL = $tableName->toSQL($this);
 
-        $tableNameSQL = $table->getObjectName()->toSQL($this);
+        $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
+
+        if ($droppedPrimaryKeyConstraint !== null) {
+            $constraintName = $droppedPrimaryKeyConstraint->getObjectName();
+
+            if ($constraintName === null) {
+                throw UnspecifiedConstraintName::new();
+            }
+
+            $sql[] = $this->getDropConstraintSQL($constraintName->toSQL($this), $tableNameSQL);
+        }
 
         foreach ($diff->getAddedColumns() as $addedColumn) {
             $query = 'ADD ' . $this->getColumnDeclarationSQL($addedColumn->toArray());
@@ -302,6 +315,13 @@ class PostgreSQLPlatform extends AbstractPlatform
                 $newColumn->getObjectName()->toSQL($this),
                 $newColumn->getComment(),
             );
+        }
+
+        $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
+
+        if ($addedPrimaryKeyConstraint !== null) {
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ADD '
+                . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
         return array_merge(

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -32,9 +31,7 @@ use function is_numeric;
 use function is_string;
 use function sprintf;
 use function str_contains;
-use function str_ends_with;
 use function strtolower;
-use function substr;
 use function trim;
 
 /**
@@ -385,24 +382,6 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     public function getDropIndexSQL(string $name, string $table): string
     {
-        if (str_ends_with($table, '"')) {
-            $primaryKeyName = substr($table, 0, -1) . '_pkey"';
-        } else {
-            $primaryKeyName = $table . '_pkey';
-        }
-
-        if ($name === '"primary"' || $name === $primaryKeyName) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6867',
-                'Building the SQL for dropping primary key constraint via %s() is deprecated. Use'
-                    . ' getDropConstraintSQL() instead.',
-                __METHOD__,
-            );
-
-            return $this->getDropConstraintSQL($primaryKeyName, $table);
-        }
-
         if (str_contains($table, '.')) {
             [$schema] = explode('.', $table);
             $name     = $schema . '.' . $name;

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -218,19 +218,8 @@ class SQLServerPlatform extends AbstractPlatform
             $elements[] = $this->getUniqueConstraintDeclarationSQL($definition);
         }
 
-        if (isset($parameters['primary_index'])) {
-            $primaryKeySQL = 'PRIMARY KEY';
-
-            if ($parameters['primary_index']->hasFlag('nonclustered')) {
-                $primaryKeySQL .= ' NONCLUSTERED';
-            }
-
-            $primaryKeySQL .= sprintf(
-                ' (%s)',
-                implode(', ', $parameters['primary_index']->getQuotedColumns($this)),
-            );
-
-            $elements[] = $primaryKeySQL;
+        if (isset($parameters['primaryKey'])) {
+            $elements[] = $this->getPrimaryKeyConstraintDeclarationSQL($parameters['primaryKey']);
         }
 
         $elements = array_merge($elements, $this->getCheckDeclarationSQL($columns));

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\SQLServer\SQL\Builder\SQLServerSelectSQLBuilder;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Exception\UnspecifiedConstraintName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -317,7 +318,7 @@ class SQLServerPlatform extends AbstractPlatform
     {
         $constraint = parent::getCreateIndexSQL($index, $table);
 
-        if ($index->isUnique() && ! $index->isPrimary()) {
+        if ($index->isUnique()) {
             $constraint = $this->_appendUniqueConstraintDefinition($constraint, $index);
         }
 
@@ -366,6 +367,18 @@ class SQLServerPlatform extends AbstractPlatform
         $table = $diff->getOldTable();
 
         $tableName = $table->getName();
+
+        $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
+
+        if ($droppedPrimaryKeyConstraint !== null) {
+            $constraintName = $droppedPrimaryKeyConstraint->getObjectName();
+
+            if ($constraintName === null) {
+                throw UnspecifiedConstraintName::new();
+            }
+
+            $sql[] = $this->getDropConstraintSQL($constraintName->toSQL($this), $table->getObjectName()->toSQL($this));
+        }
 
         foreach ($diff->getAddedColumns() as $column) {
             $columnProperties = $column->toArray();
@@ -444,8 +457,6 @@ class SQLServerPlatform extends AbstractPlatform
                 );
             }
 
-            $columnNameSQL = $newColumn->getObjectName()->toSQL($this);
-
             $newDeclarationSQL     = $this->getColumnDeclarationSQL($newColumn->toArray());
             $oldDeclarationSQL     = $this->getColumnDeclarationSQL($oldColumn->toArray());
             $declarationSQLChanged = $newDeclarationSQL !== $oldDeclarationSQL;
@@ -474,6 +485,12 @@ class SQLServerPlatform extends AbstractPlatform
             }
 
             $queryParts[] = $this->getAlterTableAddDefaultConstraintClause($tableName, $newColumn);
+        }
+
+        $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
+
+        if ($addedPrimaryKeyConstraint !== null) {
+            $queryParts[] = 'ADD ' . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
         foreach ($queryParts as $query) {

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -23,7 +23,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
 
 use function array_map;
@@ -238,25 +237,6 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         return array_merge($sql, $commentsSql, $defaultConstraintsSql);
-    }
-
-    /** @deprecated */
-    public function getCreatePrimaryKeySQL(Index $index, string $table): string
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6867',
-            '%s() is deprecated.',
-            __METHOD__,
-        );
-
-        $sql = 'ALTER TABLE ' . $table . ' ADD PRIMARY KEY';
-
-        if ($index->hasFlag('nonclustered')) {
-            $sql .= ' NONCLUSTERED';
-        }
-
-        return $sql . ' (' . implode(', ', $index->getQuotedColumns($this)) . ')';
     }
 
     private function unquoteSingleIdentifier(string $possiblyQuotedName): string

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -820,7 +820,7 @@ class SQLitePlatform extends AbstractPlatform
 
             $changed      = false;
             $indexColumns = [];
-            foreach ($index->getColumns() as $columnName) {
+            foreach ($index->getUnquotedColumns() as $columnName) {
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($indexes[$key]);

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -268,7 +269,7 @@ class SQLitePlatform extends AbstractPlatform
     protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
         if ($this->hasAutoIncrementColumn($columns, $parameters)) {
-            unset($parameters['primary_index']);
+            unset($parameters['primaryKey']);
         }
 
         $elements = [];
@@ -281,13 +282,8 @@ class SQLitePlatform extends AbstractPlatform
             $elements[] = $this->getUniqueConstraintDeclarationSQL($definition);
         }
 
-        if (isset($parameters['primary_index'])) {
-            $primaryKeyColumns = $parameters['primary_index']->getQuotedColumns($this);
-
-            $elements[] = sprintf(
-                'PRIMARY KEY (%s)',
-                implode(', ', $primaryKeyColumns),
-            );
+        if (isset($parameters['primaryKey'])) {
+            $elements[] = $this->getPrimaryKeyConstraintDeclarationSQL($parameters['primaryKey']);
         }
 
         foreach ($parameters['foreignKeys'] as $foreignKey) {
@@ -326,10 +322,9 @@ class SQLitePlatform extends AbstractPlatform
 
         $folding = $this->getUnquotedIdentifierFolding();
 
-        if (isset($parameters['primary_index'])) {
-            foreach ($parameters['primary_index']->getIndexedColumns() as $indexedColumn) {
-                $columnName = $indexedColumn->getColumnName()
-                    ->getIdentifier()
+        if (isset($parameters['primaryKey'])) {
+            foreach ($parameters['primaryKey']->getColumnNames() as $columnName) {
+                $columnName = $columnName->getIdentifier()
                     ->toNormalizedValue($folding);
 
                 $primaryKeyColumnNames[$columnName] = true;
@@ -391,6 +386,14 @@ class SQLitePlatform extends AbstractPlatform
     public function getListViewsSQL(string $database): string
     {
         return "SELECT name, sql FROM sqlite_master WHERE type='view' AND sql NOT NULL";
+    }
+
+    protected function getPrimaryKeyConstraintDeclarationSQL(PrimaryKeyConstraint $constraint): string
+    {
+        $this->ensurePrimaryKeyConstraintIsNotNamed($constraint);
+        $this->ensurePrimaryKeyConstraintIsClustered($constraint);
+
+        return parent::getPrimaryKeyConstraintDeclarationSQL($constraint);
     }
 
     protected function getAdvancedForeignKeyOptionsSQL(ForeignKeyConstraint $foreignKey): string

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -502,10 +502,6 @@ class SQLitePlatform extends AbstractPlatform
         $sql = [];
 
         foreach ($this->getIndexesInAlteredTable($diff) as $index) {
-            if ($index->isPrimary()) {
-                continue;
-            }
-
             $sql[] = $this->getCreateIndexSQL($index, $table->getObjectName()->toSQL($this));
         }
 
@@ -562,10 +558,6 @@ class SQLitePlatform extends AbstractPlatform
             ));
         }
 
-        if ($index->isPrimary()) {
-            return $this->getCreatePrimaryKeySQL($index, $table);
-        }
-
         if (strpos($table, '.') !== false) {
             [$schema, $table] = explode('.', $table);
             $name             = $schema . '.' . $name;
@@ -589,12 +581,6 @@ class SQLitePlatform extends AbstractPlatform
         }
 
         return $sql;
-    }
-
-    /** @deprecated */
-    public function getCreatePrimaryKeySQL(Index $index, string $table): string
-    {
-        throw NotSupported::new(__METHOD__);
     }
 
     public function getCreateForeignKeySQL(ForeignKeyConstraint $foreignKey, string $table): string
@@ -850,7 +836,7 @@ class SQLitePlatform extends AbstractPlatform
                 $index->getName(),
                 $indexColumns,
                 $index->isUnique(),
-                $index->isPrimary(),
+                false,
                 $index->getFlags(),
             );
         }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -675,10 +675,12 @@ class SQLitePlatform extends AbstractPlatform
         $newTable = new Table(
             $table->getObjectName()->toSQL($this),
             $columns,
-            $this->getPrimaryIndexInAlteredTable($diff),
+            [],
             [],
             $this->getForeignKeysInAlteredTable($diff),
             $table->getOptions(),
+            null,
+            $this->getPrimaryKeyConstraintInAlteredTable($diff, $table),
         );
 
         $newTable->addOption('alter', true);
@@ -741,6 +743,8 @@ class SQLitePlatform extends AbstractPlatform
             || count($diff->getRenamedIndexes()) > 0
             || count($diff->getAddedForeignKeys()) > 0
             || count($diff->getDroppedForeignKeys()) > 0
+            || $diff->getDroppedPrimaryKeyConstraint() !== null
+            || $diff->getAddedPrimaryKeyConstraint() !== null
         ) {
             return false;
         }
@@ -939,20 +943,52 @@ class SQLitePlatform extends AbstractPlatform
         return $foreignKeys;
     }
 
-    /** @return array<string, Index> */
-    private function getPrimaryIndexInAlteredTable(TableDiff $diff): array
+    private function getPrimaryKeyConstraintInAlteredTable(TableDiff $diff, Table $oldTable): ?PrimaryKeyConstraint
     {
-        $primaryIndex = [];
+        $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
 
-        foreach ($this->getIndexesInAlteredTable($diff) as $index) {
-            if (! $index->isPrimary()) {
+        if ($addedPrimaryKeyConstraint !== null) {
+            return $addedPrimaryKeyConstraint;
+        }
+
+        if ($diff->getDroppedPrimaryKeyConstraint() !== null) {
+            return null;
+        }
+
+        $primaryKeyConstraint = $oldTable->getPrimaryKeyConstraint();
+
+        if ($primaryKeyConstraint === null) {
+            return null;
+        }
+
+        $nameMap = $this->getDiffColumnNameMap($diff);
+
+        $changed = false;
+
+        $columnNames = [];
+        foreach ($primaryKeyConstraint->getColumnNames() as $columnName) {
+            $originalColumnName   = $columnName->getIdentifier()->getValue();
+            $normalizedColumnName = strtolower($originalColumnName);
+            if (! isset($nameMap[$normalizedColumnName])) {
+                return null;
+            }
+
+            $columnNames[] = UnqualifiedName::unquoted($nameMap[$normalizedColumnName]);
+
+            if ($originalColumnName === $nameMap[$normalizedColumnName]) {
                 continue;
             }
 
-            $primaryIndex = [$index->getName() => $index];
+            $changed = true;
         }
 
-        return $primaryIndex;
+        if (! $changed) {
+            return $primaryKeyConstraint;
+        }
+
+        return $primaryKeyConstraint->edit()
+            ->setColumnNames(...$columnNames)
+            ->create();
     }
 
     public function createSchemaManager(Connection $connection): SQLiteSchemaManager

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -21,10 +21,12 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 
+use function array_change_key_case;
 use function array_filter;
 use function array_intersect;
 use function array_map;
 use function array_values;
+use function assert;
 use function count;
 use function func_get_arg;
 use function func_num_args;
@@ -169,6 +171,21 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * Returns the primary key constraint definition for a given table.
+     *
+     * @throws Exception
+     */
+    public function getTablePrimaryKeyConstraint(string $tableName): ?PrimaryKeyConstraint
+    {
+        return $this->parsePrimaryKeyConstraint(
+            $this->fetchPrimaryKeyConstraintColumns(
+                $this->getDatabase(__METHOD__),
+                $this->parseOptionallyQualifiedName($tableName),
+            ),
+        );
+    }
+
+    /**
      * Returns true if all the given tables exist.
      *
      * @param array<int, string> $names
@@ -244,6 +261,7 @@ abstract class AbstractSchemaManager
         $tableColumnsByTable      = $this->fetchTableColumnsByTable($database);
         $indexColumnsByTable      = $this->fetchIndexColumnsByTable($database);
         $foreignKeyColumnsByTable = $this->fetchForeignKeyColumnsByTable($database);
+        $primaryKeyColumnsByTable = $this->fetchPrimaryKeyConstraintColumnsByTable($database);
         $tableOptionsByTable      = $this->fetchTableOptionsByTable($database);
 
         $currentSchemaName = $this->getCurrentSchemaName();
@@ -278,6 +296,14 @@ abstract class AbstractSchemaManager
                             $indexColumnsByTable[$schemaNameKey][$unqualifiedName] ?? [],
                         ),
                     );
+
+                if (isset($primaryKeyColumnsByTable[$schemaNameKey][$unqualifiedName])) {
+                    $editor->setPrimaryKeyConstraint(
+                        $this->parsePrimaryKeyConstraint(
+                            $primaryKeyColumnsByTable[$schemaNameKey][$unqualifiedName],
+                        ),
+                    );
+                }
 
                 if (isset($foreignKeyColumnsByTable[$schemaNameKey][$unqualifiedName])) {
                     $editor->setForeignKeyConstraints(
@@ -416,6 +442,21 @@ abstract class AbstractSchemaManager
     }
 
     /**
+     * Fetches definitions of primary key columns in the specified database. If the table name is specified, narrows
+     * down the selection to this table.
+     *
+     * @return list<array<string, mixed>>
+     *
+     * @throws Exception
+     */
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
      * Fetches definitions of foreign key columns in the specified database. If the table name is specified,
      * narrows down the selection to this table.
      *
@@ -458,6 +499,22 @@ abstract class AbstractSchemaManager
     protected function fetchIndexColumnsByTable(string $databaseName): array
     {
         return $this->groupByTable($this->fetchIndexColumns($databaseName));
+    }
+
+    /**
+     * Fetches definitions of primary key constraint columns in the specified database and returns them grouped by
+     * schema name and table name.
+     *
+     * If the corresponding database platform doesn't support schemas, the schema name key will be the
+     * {@see NULL_SCHEMA_KEY}.
+     *
+     * @return array<string,array<string,list<array<string,mixed>>>>
+     *
+     * @throws Exception
+     */
+    protected function fetchPrimaryKeyConstraintColumnsByTable(string $databaseName): array
+    {
+        return $this->groupByTable($this->fetchPrimaryKeyConstraintColumns($databaseName));
     }
 
     /**
@@ -535,6 +592,7 @@ abstract class AbstractSchemaManager
         return Table::editor()
             ->setName($tableName)
             ->setColumns($columns)
+            ->setPrimaryKeyConstraint($this->getTablePrimaryKeyConstraint($name))
             ->setIndexes($this->listTableIndexes($name))
             ->setForeignKeyConstraints($this->listTableForeignKeys($name))
             ->setOptions($this->getTableOptions($tableName))
@@ -891,6 +949,47 @@ abstract class AbstractSchemaManager
         return $list;
     }
 
+    /** @param list<array<string, mixed>> $rows */
+    protected function parsePrimaryKeyConstraint(array $rows): ?PrimaryKeyConstraint
+    {
+        if (count($rows) < 1) {
+            return null;
+        }
+
+        $constraintName = null;
+        $isClustered    = true;
+        $columnNames    = [];
+
+        foreach ($rows as $i => $row) {
+            $row = array_change_key_case($row);
+
+            if ($i === 0) {
+                $constraintName = $row['constraint_name'];
+
+                if (isset($row['is_clustered'])) {
+                    $isClustered = $row['is_clustered'];
+                }
+            } else {
+                assert($row['constraint_name'] === $constraintName);
+            }
+
+            $columnNames[] = UnqualifiedName::quoted($row['column_name']);
+        }
+
+         $editor = PrimaryKeyConstraint::editor();
+
+        if ($constraintName !== null) {
+            $editor->setName(
+                UnqualifiedName::quoted($constraintName),
+            );
+        }
+
+        return $editor
+            ->setColumnNames(...$columnNames)
+            ->setIsClustered($isClustered)
+            ->create();
+    }
+
     /**
      * Gets Table Column Definition.
      *
@@ -911,12 +1010,8 @@ abstract class AbstractSchemaManager
     {
         $result = [];
         foreach ($rows as $row) {
-            $indexName = $keyName = $row['key_name'];
-            if ($row['primary']) {
-                $keyName = 'primary';
-            }
-
-            $keyName = strtolower($keyName);
+            $indexName = $row['key_name'];
+            $keyName   = strtolower($indexName);
 
             if (! isset($result[$keyName])) {
                 $options = [
@@ -931,7 +1026,6 @@ abstract class AbstractSchemaManager
                     'name' => $indexName,
                     'columns' => [],
                     'unique' => ! $row['non_unique'],
-                    'primary' => $row['primary'],
                     'flags' => $row['flags'] ?? [],
                     'options' => $options,
                 ];
@@ -947,7 +1041,7 @@ abstract class AbstractSchemaManager
                 $data['name'],
                 $data['columns'],
                 $data['unique'],
-                $data['primary'],
+                false,
                 $data['flags'],
                 $data['options'],
             );

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -208,10 +208,6 @@ class Comparator
 
         // See if all the indexes from the old table exist in the new one
         foreach ($newIndexes as $newIndexName => $newIndex) {
-            if ($newIndex->isPrimary()) {
-                continue;
-            }
-
             if ($oldTable->hasIndex($newIndexName)) {
                 continue;
             }
@@ -221,10 +217,6 @@ class Comparator
 
         // See if there are any removed indexes in the new table
         foreach ($oldIndexes as $oldIndexName => $oldIndex) {
-            if ($oldIndex->isPrimary()) {
-                continue;
-            }
-
             if (! $newTable->hasIndex($oldIndexName)) {
                 $droppedIndexes[$oldIndexName] = $oldIndex;
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-use function assert;
 use function count;
 use function strtolower;
 
@@ -127,14 +126,16 @@ class Comparator
      */
     public function compareTables(Table $oldTable, Table $newTable): TableDiff
     {
-        $addedColumns       = [];
-        $modifiedColumns    = [];
-        $droppedColumns     = [];
-        $addedIndexes       = [];
-        $droppedIndexes     = [];
-        $renamedIndexes     = [];
-        $addedForeignKeys   = [];
-        $droppedForeignKeys = [];
+        $addedColumns                = [];
+        $modifiedColumns             = [];
+        $droppedColumns              = [];
+        $addedIndexes                = [];
+        $droppedIndexes              = [];
+        $renamedIndexes              = [];
+        $addedForeignKeys            = [];
+        $droppedForeignKeys          = [];
+        $addedPrimaryKeyConstraint   = null;
+        $droppedPrimaryKeyConstraint = null;
 
         $oldColumns = $oldTable->getColumns();
         $newColumns = $newTable->getColumns();
@@ -194,12 +195,24 @@ class Comparator
             $this->detectRenamedColumns($modifiedColumns, $addedColumns, $droppedColumns);
         }
 
+        $oldPrimaryKeyConstraint = $oldTable->getPrimaryKeyConstraint();
+        $newPrimaryKeyConstraint = $newTable->getPrimaryKeyConstraint();
+
+        if (! $this->primaryKeyConstraintsEqual($oldPrimaryKeyConstraint, $newPrimaryKeyConstraint)) {
+            $droppedPrimaryKeyConstraint = $oldPrimaryKeyConstraint;
+            $addedPrimaryKeyConstraint   = $newPrimaryKeyConstraint;
+        }
+
         $oldIndexes = $oldTable->getIndexes();
         $newIndexes = $newTable->getIndexes();
 
         // See if all the indexes from the old table exist in the new one
         foreach ($newIndexes as $newIndexName => $newIndex) {
-            if (($newIndex->isPrimary() && $oldTable->getPrimaryKey() !== null) || $oldTable->hasIndex($newIndexName)) {
+            if ($newIndex->isPrimary()) {
+                continue;
+            }
+
+            if ($oldTable->hasIndex($newIndexName)) {
                 continue;
             }
 
@@ -208,19 +221,18 @@ class Comparator
 
         // See if there are any removed indexes in the new table
         foreach ($oldIndexes as $oldIndexName => $oldIndex) {
-            // See if the index is removed in the new table.
-            if (
-                ($oldIndex->isPrimary() && $newTable->getPrimaryKey() === null) ||
-                ! $oldIndex->isPrimary() && ! $newTable->hasIndex($oldIndexName)
-            ) {
+            if ($oldIndex->isPrimary()) {
+                continue;
+            }
+
+            if (! $newTable->hasIndex($oldIndexName)) {
                 $droppedIndexes[$oldIndexName] = $oldIndex;
 
                 continue;
             }
 
             // See if index has changed in the new table.
-            $newIndex = $oldIndex->isPrimary() ? $newTable->getPrimaryKey() : $newTable->getIndex($oldIndexName);
-            assert($newIndex instanceof Index);
+            $newIndex = $newTable->getIndex($oldIndexName);
 
             if (! $this->diffIndex($oldIndex, $newIndex)) {
                 continue;
@@ -271,6 +283,8 @@ class Comparator
             renamedIndexes: $renamedIndexes,
             addedForeignKeys: $addedForeignKeys,
             droppedForeignKeys: $droppedForeignKeys,
+            addedPrimaryKeyConstraint: $addedPrimaryKeyConstraint,
+            droppedPrimaryKeyConstraint: $droppedPrimaryKeyConstraint,
         );
     }
 
@@ -319,6 +333,20 @@ class Comparator
                 $removedColumns[$oldColumnName],
             );
         }
+    }
+
+    private function primaryKeyConstraintsEqual(
+        ?PrimaryKeyConstraint $oldPrimaryKeyConstraint,
+        ?PrimaryKeyConstraint $newPrimaryKeyConstraint,
+    ): bool {
+        if ($oldPrimaryKeyConstraint !== null && $newPrimaryKeyConstraint !== null) {
+            return $oldPrimaryKeyConstraint->equals(
+                $newPrimaryKeyConstraint,
+                $this->platform->getUnquotedIdentifierFolding(),
+            );
+        }
+
+        return $oldPrimaryKeyConstraint === null && $newPrimaryKeyConstraint === null;
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -256,6 +256,7 @@ SQL,
           ON IDX.INDSCHEMA = IDXCOL.INDSCHEMA AND IDX.INDNAME = IDXCOL.INDNAME
        WHERE %s
          AND T.TYPE = 'T'
+         AND IDX.UNIQUERULE != 'P'
     ORDER BY IDX.TABNAME,
              IDX.INDNAME,
              IDXCOL.COLSEQ
@@ -265,6 +266,49 @@ SQL,
         );
 
         return $this->connection->executeQuery($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
+        $conditions = ['TC.TABSCHEMA = ?'];
+        $params     = [$databaseName];
+
+        if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
+            $conditions[] = 'TC.TABNAME = ?';
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue(
+                $this->platform->getUnquotedIdentifierFolding(),
+            );
+        }
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+                TC.TABNAME AS TABLE_NAME,
+                TC.CONSTNAME AS CONSTRAINT_NAME,
+                KCU.COLNAME AS COLUMN_NAME
+            FROM
+                SYSCAT.TABCONST TC
+            INNER JOIN
+                SYSCAT.KEYCOLUSE KCU
+                ON KCU.TABSCHEMA = TC.TABSCHEMA
+               AND KCU.TABNAME = TC.TABNAME
+               AND KCU.CONSTNAME = TC.CONSTNAME
+            WHERE %s
+              AND TC.TYPE = 'P'
+         ORDER BY TABLE_NAME,
+                  KCU.COLSEQ
+SQL,
+            implode(' AND ', $conditions),
+        );
+
+        return $this->connection->fetchAllAssociative($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result

--- a/src/Schema/Exception/InvalidIndexDefinition.php
+++ b/src/Schema/Exception/InvalidIndexDefinition.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Exception;
 
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\SchemaException;
 use LogicException;
 
@@ -19,24 +18,16 @@ final class InvalidIndexDefinition extends LogicException implements SchemaExcep
         return new self('Index column names are not set.');
     }
 
-    public static function primaryKeyIndexHasColumnLengths(): self
-    {
-        return new self('Primary key index cannot have column lengths.');
-    }
-
-    public static function primaryKeyIndexOnANullableColumn(UnqualifiedName $columnName): self
-    {
-        return new self(sprintf(
-            'Primary key index cannot use nullable column %s.',
-            $columnName->toString(),
-        ));
-    }
-
     public static function invalidColumnLength(mixed $length): self
     {
         return new self(sprintf(
             'Indexed column length must be an integer, %s given.',
             is_object($length) ? $length::class : gettype($length),
         ));
+    }
+
+    public static function fromPrimaryIndex(): self
+    {
+        return new self('Primary indexes are not supported.');
     }
 }

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_keys;
@@ -34,9 +33,6 @@ final class Index extends AbstractNamedObject
     private readonly array $_columns;
 
     private readonly bool $_isUnique;
-
-    /** @deprecated Use {@see PrimaryKeyConstraint()} instead. */
-    private readonly bool $_isPrimary;
 
     /**
      * Platform specific flags for indexes.
@@ -72,15 +68,10 @@ final class Index extends AbstractNamedObject
         }
 
         if ($isPrimary) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6867',
-                'Declaring an index as primary is deprecated. Use PrimaryKeyConstraint instead.',
-            );
+            throw InvalidIndexDefinition::fromPrimaryIndex();
         }
 
-        $this->_isUnique  = $isUnique || $isPrimary;
-        $this->_isPrimary = $isPrimary;
+        $this->_isUnique = $isUnique;
 
         $identifiers = [];
         foreach ($columns as $column) {
@@ -93,7 +84,7 @@ final class Index extends AbstractNamedObject
             $this->addFlag($flag);
         }
 
-        $this->columns = $this->parseColumns($isPrimary, $columns, $options['lengths'] ?? []);
+        $this->columns = $this->parseColumns($columns, $options['lengths'] ?? []);
     }
 
     protected function getNameParser(): UnqualifiedNameParser
@@ -165,24 +156,12 @@ final class Index extends AbstractNamedObject
      */
     public function isSimpleIndex(): bool
     {
-        return ! $this->_isPrimary && ! $this->_isUnique;
+        return ! $this->_isUnique;
     }
 
     public function isUnique(): bool
     {
         return $this->_isUnique;
-    }
-
-    /** @deprecated Use {@see PrimaryKeyConstraint()} instead. */
-    public function isPrimary(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6867',
-            'Checking whether an index is primary is deprecated. Use PrimaryKeyConstraint instead.',
-        );
-
-        return $this->_isPrimary;
     }
 
     public function hasColumnAtPosition(string $name, int $pos = 0): bool
@@ -241,16 +220,11 @@ final class Index extends AbstractNamedObject
                 return false;
             }
 
-            if (! $this->isUnique() && ! $this->isPrimary()) {
-                // this is a special case: If the current key is neither primary or unique, any unique or
-                // primary key will always have the same effect for the index and there cannot be any constraint
-                // overlaps. This means a primary or unique index can always fulfill the requirements of just an
-                // index that has no constraints.
+            if (! $this->isUnique()) {
+                // this is a special case: If the current index is not unique, any unique index key will always have the
+                // same effect for the index and there cannot be any constraint overlaps. This means a unique index can
+                // always fulfill the requirements of just an index that has no constraints.
                 return true;
-            }
-
-            if ($other->isPrimary() !== $this->isPrimary()) {
-                return false;
             }
 
             return $other->isUnique() === $this->isUnique();
@@ -264,16 +238,12 @@ final class Index extends AbstractNamedObject
      */
     public function overrules(Index $other): bool
     {
-        if ($other->isPrimary()) {
-            return false;
-        }
-
         if ($this->isSimpleIndex() && $other->isUnique()) {
             return false;
         }
 
         return $this->spansColumns($other->getColumns())
-            && ($this->isPrimary() || $this->isUnique())
+            && $this->isUnique()
             && $this->samePartialIndex($other);
     }
 
@@ -337,7 +307,7 @@ final class Index extends AbstractNamedObject
      *
      * @return non-empty-list<IndexedColumn>
      */
-    private function parseColumns(bool $isPrimary, array $columnNames, array $lengths): array
+    private function parseColumns(array $columnNames, array $lengths): array
     {
         $columns = [];
 
@@ -352,14 +322,8 @@ final class Index extends AbstractNamedObject
 
             $length = array_shift($lengths);
 
-            if ($length !== null) {
-                if ($isPrimary) {
-                    throw InvalidIndexDefinition::primaryKeyIndexHasColumnLengths();
-                }
-
-                if (! is_int($length) || $length < 1) {
-                    throw InvalidIndexDefinition::invalidColumnLength($length);
-                }
+            if ($length !== null && (! is_int($length) || $length < 1)) {
+                throw InvalidIndexDefinition::invalidColumnLength($length);
             }
 
             $columns[] = new IndexedColumn($parsedName, $length);

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -77,9 +77,6 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         foreach ($rows as $i => $row) {
             $row = array_change_key_case($row, CASE_LOWER);
-
-            $row['primary'] = $row['key_name'] === 'PRIMARY';
-
             if (str_contains($row['index_type'], 'FULLTEXT')) {
                 $row['flags'] = ['FULLTEXT'];
             } elseif (str_contains($row['index_type'], 'SPATIAL')) {
@@ -394,6 +391,7 @@ SELECT
         INDEX_TYPE
 FROM information_schema.STATISTICS
 WHERE %s
+AND INDEX_NAME != 'PRIMARY'
 ORDER BY TABLE_NAME,
          SEQ_IN_INDEX
 SQL,
@@ -402,6 +400,49 @@ SQL,
         );
 
         return $this->connection->executeQuery($sql, $params);
+    }
+
+    /** {@inheritDoc} */
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
+        // The schema name is passed multiple times as a literal in the WHERE clause instead of using a JOIN condition
+        // in order to avoid performance issues on MySQL older than 8.0 and the corresponding MariaDB versions
+        // caused by https://bugs.mysql.com/bug.php?id=81347
+        $conditions = ['tc.TABLE_SCHEMA = ?', 'kcu.TABLE_SCHEMA = ?'];
+        $params     = [$databaseName, $databaseName];
+
+        if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
+            $conditions[] = 'tc.TABLE_NAME = ?';
+            $params[]     = $tableName->getUnqualifiedName()->toNormalizedValue(
+                $this->platform->getUnquotedIdentifierFolding(),
+            );
+        }
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+                tc.TABLE_NAME,
+                tc.CONSTRAINT_NAME,
+                kcu.COLUMN_NAME
+            FROM
+                information_schema.TABLE_CONSTRAINTS tc
+            INNER JOIN
+                information_schema.KEY_COLUMN_USAGE kcu
+                ON kcu.TABLE_NAME = tc.TABLE_NAME
+               AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+            WHERE %s
+              AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
+            ORDER BY TABLE_NAME,
+                     kcu.ORDINAL_POSITION;
+            SQL,
+            implode(' AND ', $conditions),
+        );
+
+        return $this->connection->fetchAllAssociative($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -57,16 +57,9 @@ class OracleSchemaManager extends AbstractSchemaManager
 
             $buffer = [];
 
-            if ($row['constraint_type'] === 'P') {
-                $buffer['key_name']   = 'primary';
-                $buffer['primary']    = true;
-                $buffer['non_unique'] = false;
-            } else {
-                $buffer['key_name']   = strtolower($row['index_name']);
-                $buffer['primary']    = false;
-                $buffer['non_unique'] = $row['uniqueness'] !== 'UNIQUE';
-            }
-
+            $buffer['key_name']    = strtolower($row['index_name']);
+            $buffer['primary']     = false;
+            $buffer['non_unique']  = $row['uniqueness'] !== 'UNIQUE';
             $buffer['column_name'] = $this->getQuotedIdentifierName($row['column_name']);
             $indexBuffer[]         = $buffer;
         }
@@ -383,6 +376,7 @@ SQL,
               ON CON.OWNER = IND_COL.INDEX_OWNER
              AND CON.INDEX_NAME = IND_COL.INDEX_NAME
            WHERE %s
+             AND (CON.CONSTRAINT_TYPE IS NULL OR CON.CONSTRAINT_TYPE != 'P')
         ORDER BY IND_COL.TABLE_NAME,
                  IND_COL.INDEX_NAME,
                  IND_COL.COLUMN_POSITION
@@ -392,6 +386,49 @@ SQL,
         );
 
         return $this->connection->executeQuery($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
+        $conditions = ['AC.OWNER = :OWNER'];
+        $params     = ['OWNER' => $databaseName];
+
+        if ($tableName !== null) {
+            $this->ensureUnqualifiedName($tableName, __METHOD__);
+
+            $conditions[]         = 'AC.TABLE_NAME = :TABLE_NAME';
+            $params['TABLE_NAME'] = $tableName->getUnqualifiedName()->toNormalizedValue(
+                $this->platform->getUnquotedIdentifierFolding(),
+            );
+        }
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+                AC.TABLE_NAME,
+                AC.CONSTRAINT_NAME,
+                ACC.COLUMN_NAME
+            FROM
+                ALL_CONSTRAINTS AC
+            INNER JOIN
+                ALL_CONS_COLUMNS ACC
+                ON ACC.OWNER = AC.OWNER
+               AND ACC.TABLE_NAME = AC.TABLE_NAME
+               AND ACC.CONSTRAINT_NAME = AC.CONSTRAINT_NAME
+            WHERE %s
+              AND AC.CONSTRAINT_TYPE = 'P'
+            ORDER BY TABLE_NAME,
+                     ACC.POSITION
+SQL,
+            implode(' AND ', $conditions),
+        );
+
+        return $this->connection->fetchAllAssociative($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -171,7 +171,6 @@ SQL,
                         'key_name' => $row['relname'],
                         'column_name' => trim($colRow['attname']),
                         'non_unique' => ! $row['indisunique'],
-                        'primary' => $row['indisprimary'],
                         'where' => $row['where'],
                     ];
                 }
@@ -492,7 +491,6 @@ SQL,
                    tc.relname AS %s,
                    quote_ident(ic.relname) AS relname,
                    i.indisunique,
-                   i.indisprimary,
                    i.indkey,
                    i.indrelid,
                    pg_get_expr(indpred, indrelid) AS "where"
@@ -506,6 +504,7 @@ SQL,
                 JOIN pg_class AS c ON c.oid = i.indrelid
                 JOIN pg_namespace n ON n.oid = c.relnamespace
                 WHERE %s)
+            AND i.indisprimary = false
             SQL,
             $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
             $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
@@ -513,6 +512,50 @@ SQL,
         );
 
         return $this->connection->executeQuery($sql, $params);
+    }
+
+    /** {@inheritDoc} */
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT n.nspname AS %s,
+                   c.relname AS %s,
+                   ct.conname AS constraint_name,
+                   a.attname AS column_name
+            FROM 
+                pg_namespace n
+            INNER JOIN
+                pg_class c
+                    ON c.relnamespace = n.oid
+            INNER JOIN
+                pg_constraint ct
+                    ON ct.conrelid = c.oid
+            INNER JOIN
+                pg_index i
+                    ON i.indrelid = c.oid
+                   AND i.indexrelid = ct.conindid
+            INNER JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS keys(attnum, ord)
+                   ON true
+            INNER JOIN
+                pg_attribute a
+                    ON a.attrelid = c.oid
+                   AND a.attnum = keys.attnum
+            WHERE %s
+              AND ct.contype = 'p'
+            ORDER BY 
+                1, 2, keys.ord;
+            SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+            implode(' AND ', $this->buildQueryConditions($tableName, $params)),
+        );
+
+        return $this->connection->fetchAllAssociative($sql, $params);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result

--- a/src/Schema/PrimaryKeyConstraint.php
+++ b/src/Schema/PrimaryKeyConstraint.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Schema\Exception\InvalidPrimaryKeyConstraintDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 
 use function count;
 
@@ -53,6 +54,24 @@ final class PrimaryKeyConstraint implements OptionallyNamedObject
     public function isClustered(): bool
     {
         return $this->isClustered;
+    }
+
+    /**
+     * Returns whether this primary key constraint is equal to the other.
+     */
+    public function equals(self $other, UnquotedIdentifierFolding $folding): bool
+    {
+        if (count($this->columnNames) !== count($other->columnNames)) {
+            return false;
+        }
+
+        for ($i = 0, $count = count($this->columnNames); $i < $count; $i++) {
+            if (! $this->columnNames[$i]->equals($other->columnNames[$i], $folding)) {
+                return false;
+            }
+        }
+
+        return $this->isClustered === $other->isClustered;
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -212,7 +212,6 @@ SQL,
     {
         foreach ($rows as &$row) {
             $row['non_unique'] = ! $row['is_unique'];
-            $row['primary']    = (bool) $row['is_primary_key'];
             $row['flags']      = match ($row['type']) {
                 1 => ['clustered'],
                 2 => ['nonclustered'],
@@ -353,7 +352,6 @@ SQL,
                        idx.name AS key_name,
                        col.name AS column_name,
                        idx.is_unique,
-                       idx.is_primary_key,
                        idx.type
                 FROM sys.tables AS tbl
                 JOIN sys.schemas AS scm
@@ -367,6 +365,7 @@ SQL,
                   ON idxcol.object_id = col.object_id
                  AND idxcol.column_id = col.column_id
                WHERE %s
+                 AND idx.is_primary_key = 0
             ORDER BY scm.name,
                      tbl.name,
                      idx.index_id,
@@ -378,6 +377,64 @@ SQL,
         );
 
         return $this->connection->executeQuery($sql, $params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
+        $params = [];
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+                s.name AS %s,
+                t.name AS %s,
+                i.name AS constraint_name,
+                c.name AS column_name,
+                i.type
+            FROM
+                sys.schemas s
+            INNER JOIN
+                sys.tables t
+                ON t.schema_id = s.schema_id
+            INNER JOIN
+                sys.indexes i
+                ON i.object_id = t.object_id
+               AND i.is_primary_key = 1
+            INNER JOIN
+                sys.index_columns ic
+                ON ic.object_id = t.object_id
+               AND ic.index_id = i.index_id
+            INNER JOIN
+                sys.columns c
+                ON c.object_id = t.object_id
+               AND c.column_id = ic.column_id
+            WHERE %s
+            ORDER BY s.name,
+                     t.name,
+                     ic.key_ordinal;
+            SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
+            $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
+            $this->getWhereClause($tableName, 's.name', 't.name', $params),
+        );
+
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /** @param list<array<string, mixed>> $rows */
+    protected function parsePrimaryKeyConstraint(array $rows): ?PrimaryKeyConstraint
+    {
+        foreach ($rows as &$row) {
+            $row['is_clustered'] = (int) $row['type'] === 1;
+            unset($row['type']);
+        }
+
+        return parent::parsePrimaryKeyConstraint($rows);
     }
 
     protected function selectForeignKeyColumns(string $databaseName, ?OptionallyQualifiedName $tableName = null): Result

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -220,7 +220,8 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             // Inferring a shorthand form for the foreign key constraint, where the "to" field is empty.
             // @see https://www.sqlite.org/foreignkeys.html#fk_indexes.
             // @phpstan-ignore missingType.checkedException
-            $foreignTablePrimaryKeyColumnRows = $this->fetchPrimaryKeyColumns(
+            $foreignTablePrimaryKeyColumnRows = $this->fetchPrimaryKeyConstraintColumns(
+                '',
                 OptionallyQualifiedName::quoted($value['foreignTable']),
             );
 
@@ -231,7 +232,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
                 );
             }
 
-            $list[$id]['foreign'] = array_column($foreignTablePrimaryKeyColumnRows, 'name');
+            $list[$id]['foreign'] = array_column($foreignTablePrimaryKeyColumnRows, 'column_name');
         }
 
         return parent::_getPortableTableForeignKeysList($list);
@@ -533,18 +534,6 @@ SQL,
     {
         $result = [];
 
-        $pkColumnNameRows = $this->fetchPrimaryKeyColumns($tableName);
-
-        foreach ($pkColumnNameRows as $pkColumnNameRow) {
-            $result[] = [
-                self::TABLE_NAME_COLUMN => $pkColumnNameRow[self::TABLE_NAME_COLUMN],
-                'key_name' => 'primary',
-                'primary' => true,
-                'non_unique' => false,
-                'column_name' => $pkColumnNameRow['name'],
-            ];
-        }
-
         $indexColumnRows = parent::fetchIndexColumns($databaseName, $tableName);
 
         foreach ($indexColumnRows as $indexColumnRow) {
@@ -558,7 +547,6 @@ SQL,
             $row = [
                 self::TABLE_NAME_COLUMN => $indexColumnRow[self::TABLE_NAME_COLUMN],
                 'key_name'   => $keyName,
-                'primary'    => false,
                 'non_unique' => ! $indexColumnRow['unique'],
             ];
 
@@ -577,22 +565,22 @@ SQL,
     }
 
     /**
-     * Fetches names of primary key columns. If the table name is specified, narrows down the selection to this table.
+     * {@inheritDoc}
      *
      * @link https://www.sqlite.org/pragma.html#pragma_table_info
-     *
-     * @return list<array<string, mixed>>
-     *
-     * @throws Exception
      */
-    private function fetchPrimaryKeyColumns(?OptionallyQualifiedName $tableName = null): array
-    {
+    protected function fetchPrimaryKeyConstraintColumns(
+        string $databaseName,
+        ?OptionallyQualifiedName $tableName = null,
+    ): array {
         $params = [];
 
         $sql = sprintf(
             <<<'SQL'
-            SELECT t.name AS %s,
-                   p.name
+            SELECT NULL AS %s,
+                   t.name AS %s,
+                   NULL AS constraint_name,
+                   p.name AS column_name
               FROM sqlite_master t
               JOIN pragma_table_info(t.name) p
              WHERE %s
@@ -600,6 +588,7 @@ SQL,
           ORDER BY t.name,
                    p.pk
         SQL,
+            $this->platform->quoteSingleIdentifier(self::SCHEMA_NAME_COLUMN),
             $this->platform->quoteSingleIdentifier(self::TABLE_NAME_COLUMN),
             $this->getWhereClause($tableName, $params),
         );

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -11,9 +11,7 @@ use Doctrine\DBAL\Schema\Exception\IndexAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\IndexDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\IndexNameInvalid;
 use Doctrine\DBAL\Schema\Exception\InvalidForeignKeyConstraintDefinition;
-use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
 use Doctrine\DBAL\Schema\Exception\InvalidName;
-use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\Exception\InvalidTableName;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
@@ -65,9 +63,6 @@ class Table extends AbstractNamedObject
      */
     private array $implicitIndexNames = [];
 
-    /** @deprecated Use {@see $primaryKeyConstraint} instead. */
-    protected ?string $_primaryKeyName = null;
-
     /** @var UniqueConstraint[] */
     protected array $uniqueConstraints = [];
 
@@ -82,8 +77,6 @@ class Table extends AbstractNamedObject
     private readonly int $maxIdentifierLength;
 
     private ?PrimaryKeyConstraint $primaryKeyConstraint = null;
-
-    private bool $failedToParsePrimaryKeyConstraint = false;
 
     /**
      * @param array<Column>               $columns
@@ -140,48 +133,11 @@ class Table extends AbstractNamedObject
         return Parsers::getOptionallyQualifiedNameParser();
     }
 
-    /**
-     * Sets the Primary Key.
-     *
-     * @deprecated Use {@see addPrimaryKeyConstraint()} instead.
-     *
-     * @param non-empty-list<string> $columnNames
-     */
-    public function setPrimaryKey(array $columnNames, ?string $indexName = null): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6867',
-            '%s() is deprecated. Use Table::addPrimaryKeyConstraint() instead.',
-            __METHOD__,
-        );
-
-        if ($indexName === null) {
-            $indexName = 'primary';
-        }
-
-        $this->_addIndex($this->_createIndex($columnNames, $indexName, true, true));
-
-        foreach ($columnNames as $columnName) {
-            $column = $this->getColumn($columnName);
-
-            if (! $column->getNotnull()) {
-                throw InvalidIndexDefinition::primaryKeyIndexOnANullableColumn($column->getObjectName());
-            }
-        }
-
-        return $this;
-    }
-
     public function addPrimaryKeyConstraint(PrimaryKeyConstraint $primaryKeyConstraint): self
     {
-        $this->setPrimaryKey(
-            array_map(
-                static fn (UnqualifiedName $columnName): string => $columnName->toString(),
-                $primaryKeyConstraint->getColumnNames(),
-            ),
-            $primaryKeyConstraint->getObjectName()?->toString(),
-        );
+        if ($this->primaryKeyConstraint !== null) {
+            throw PrimaryKeyAlreadyExists::new($this->_name);
+        }
 
         $this->primaryKeyConstraint = $primaryKeyConstraint;
 
@@ -225,7 +181,7 @@ class Table extends AbstractNamedObject
             $this->maxIdentifierLength,
         );
 
-        return $this->_addIndex($this->_createIndex($columnNames, $indexName, false, false, $flags, $options));
+        return $this->_addIndex($this->_createIndex($columnNames, $indexName, false, $flags, $options));
     }
 
     /**
@@ -233,15 +189,7 @@ class Table extends AbstractNamedObject
      */
     public function dropPrimaryKey(): void
     {
-        $this->primaryKeyConstraint              = null;
-        $this->failedToParsePrimaryKeyConstraint = false;
-
-        if ($this->_primaryKeyName === null) {
-            return;
-        }
-
-        $this->dropIndex($this->_primaryKeyName);
-        $this->_primaryKeyName = null;
+        $this->primaryKeyConstraint = null;
     }
 
     /**
@@ -270,7 +218,7 @@ class Table extends AbstractNamedObject
             $this->maxIdentifierLength,
         );
 
-        return $this->_addIndex($this->_createIndex($columnNames, $indexName, true, false, [], $options));
+        return $this->_addIndex($this->_createIndex($columnNames, $indexName, true, [], $options));
     }
 
     /**
@@ -298,20 +246,6 @@ class Table extends AbstractNamedObject
         }
 
         $oldIndex = $this->_indexes[$oldName];
-
-        if ($oldIndex->isPrimary()) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6867',
-                'Renaming primary key constraint via %s() is deprecated. Use Table::dropPrimaryKey() and '
-                    . ' Table::addPrimaryKeyConstraint() instead.',
-                __METHOD__,
-            );
-
-            $this->dropPrimaryKey();
-
-            return $this->setPrimaryKey($oldIndex->getColumns(), $newName ?? null);
-        }
 
         unset($this->_indexes[$oldName]);
 
@@ -686,33 +620,8 @@ class Table extends AbstractNamedObject
         return $this->_columns[$name];
     }
 
-    /**
-     * Returns the primary key.
-     *
-     * @deprecated Use {@see getPrimaryKeyConstraint()} instead.
-     */
-    public function getPrimaryKey(): ?Index
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6867',
-            '%s() is deprecated. Use Table::getPrimaryKeyConstraint() instead.',
-            __METHOD__,
-        );
-
-        if ($this->_primaryKeyName !== null) {
-            return $this->getIndex($this->_primaryKeyName);
-        }
-
-        return null;
-    }
-
     public function getPrimaryKeyConstraint(): ?PrimaryKeyConstraint
     {
-        if ($this->failedToParsePrimaryKeyConstraint) {
-            throw InvalidState::tableHasInvalidPrimaryKeyConstraint($this->getName());
-        }
-
         return $this->primaryKeyConstraint;
     }
 
@@ -833,10 +742,6 @@ class Table extends AbstractNamedObject
             $replacedImplicitIndexNames[$implicitIndexName] = true;
         }
 
-        if ($this->_primaryKeyName !== null && $index->isPrimary()) {
-            throw PrimaryKeyAlreadyExists::new($this->_name);
-        }
-
         if (isset($this->_indexes[$indexName]) && ! isset($replacedImplicitIndexNames[$indexName])) {
             throw IndexAlreadyExists::new($indexName, $this->_name);
         }
@@ -845,43 +750,9 @@ class Table extends AbstractNamedObject
             unset($this->_indexes[$name], $this->implicitIndexNames[$name]);
         }
 
-        if ($index->isPrimary()) {
-            $this->_primaryKeyName = $indexName;
-
-            try {
-                $this->primaryKeyConstraint              = $this->parsePrimaryKeyConstraint($index);
-                $this->failedToParsePrimaryKeyConstraint = false;
-            } catch (InvalidState) {
-                $this->primaryKeyConstraint              = null;
-                $this->failedToParsePrimaryKeyConstraint = true;
-            }
-        }
-
         $this->_indexes[$indexName] = $index;
 
         return $this;
-    }
-
-    private function parsePrimaryKeyConstraint(Index $index): ?PrimaryKeyConstraint
-    {
-        $indexedColumns = $index->getIndexedColumns();
-
-        $columnNames = [];
-        foreach ($indexedColumns as $indexedColumn) {
-            if ($indexedColumn->getLength() !== null) {
-                return null;
-            }
-
-            $columnNames[] = $indexedColumn->getColumnName();
-        }
-
-        // Do not derive the constraint name from the index name in the upgrade path. The primary index name defaults to
-        // "PRIMARY", while the default constraint name is null (unspecified, to be generated by the database platform).
-        return new PrimaryKeyConstraint(
-            null,
-            $columnNames,
-            ! $index->hasFlag('nonclustered'),
-        );
     }
 
     protected function _addUniqueConstraint(UniqueConstraint $constraint): self
@@ -904,7 +775,7 @@ class Table extends AbstractNamedObject
         $indexCandidate = $this->_createIndex(array_map(
             static fn (UnqualifiedName $columnName): string => $columnName->toString(),
             $columnNames,
-        ), $indexName, true, false);
+        ), $indexName, true);
 
         foreach ($this->_indexes as $existingIndex) {
             if ($indexCandidate->isFulfilledBy($existingIndex)) {
@@ -936,7 +807,7 @@ class Table extends AbstractNamedObject
         $indexCandidate = $this->_createIndex(array_map(
             static fn (UnqualifiedName $columnName): string => $columnName->toString(),
             $constraint->getReferencingColumnNames(),
-        ), $indexName, false, false);
+        ), $indexName, false);
 
         foreach ($this->_indexes as $existingIndex) {
             if ($indexCandidate->isFulfilledBy($existingIndex)) {
@@ -1034,7 +905,6 @@ class Table extends AbstractNamedObject
         array $columns,
         string $indexName,
         bool $isUnique,
-        bool $isPrimary,
         array $flags = [],
         array $options = [],
     ): Index {
@@ -1048,7 +918,7 @@ class Table extends AbstractNamedObject
             }
         }
 
-        return new Index($indexName, $columns, $isUnique, $isPrimary, $flags, $options);
+        return new Index($indexName, $columns, $isUnique, false, $flags, $options);
     }
 
     /**
@@ -1089,7 +959,7 @@ class Table extends AbstractNamedObject
                 $index->getName(),
                 $columns,
                 $index->isUnique(),
-                $index->isPrimary(),
+                false,
                 $index->getFlags(),
                 $index->getOptions(),
             );

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -39,6 +39,8 @@ class TableDiff
         private readonly array $renamedIndexes = [],
         private readonly array $addedForeignKeys = [],
         private readonly array $droppedForeignKeys = [],
+        private readonly ?PrimaryKeyConstraint $addedPrimaryKeyConstraint = null,
+        private readonly ?PrimaryKeyConstraint $droppedPrimaryKeyConstraint = null,
     ) {
     }
 
@@ -169,6 +171,16 @@ class TableDiff
         return $this->droppedForeignKeys;
     }
 
+    public function getAddedPrimaryKeyConstraint(): ?PrimaryKeyConstraint
+    {
+        return $this->addedPrimaryKeyConstraint;
+    }
+
+    public function getDroppedPrimaryKeyConstraint(): ?PrimaryKeyConstraint
+    {
+        return $this->droppedPrimaryKeyConstraint;
+    }
+
     /**
      * Returns whether the diff is empty (contains no changes).
      */
@@ -181,6 +193,8 @@ class TableDiff
             && count($this->droppedIndexes) === 0
             && count($this->renamedIndexes) === 0
             && count($this->addedForeignKeys) === 0
-            && count($this->droppedForeignKeys) === 0;
+            && count($this->droppedForeignKeys) === 0
+            && $this->addedPrimaryKeyConstraint === null
+            && $this->droppedPrimaryKeyConstraint === null;
     }
 }

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -7,8 +7,6 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 
-use function array_filter;
-
 final class TableEditor
 {
     private ?OptionallyQualifiedName $name = null;
@@ -63,11 +61,6 @@ final class TableEditor
     public function setPrimaryKeyConstraint(?PrimaryKeyConstraint $primaryKeyConstraint): self
     {
         $this->primaryKeyConstraint = $primaryKeyConstraint;
-
-        $this->indexes = array_filter(
-            $this->indexes,
-            static fn (Index $index): bool => ! $index->isPrimary(),
-        );
 
         return $this;
     }

--- a/tests/Functional/AutoIncrementColumnTest.php
+++ b/tests/Functional/AutoIncrementColumnTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -20,7 +22,13 @@ class AutoIncrementColumnTest extends FunctionalTestCase
         $table = new Table('auto_increment_table');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('val', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
     }

--- a/tests/Functional/BinaryDataAccessTest.php
+++ b/tests/Functional/BinaryDataAccessTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -31,7 +33,13 @@ class BinaryDataAccessTest extends FunctionalTestCase
         $table = new Table('binary_fetch_table');
         $table->addColumn('test_int', 'integer');
         $table->addColumn('test_binary', 'binary', ['notnull' => false, 'length' => 4]);
-        $table->setPrimaryKey(['test_int']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('test_int'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -29,7 +31,13 @@ class BlobTest extends FunctionalTestCase
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('clobcolumn', Types::TEXT, ['notnull' => false]);
         $table->addColumn('blobcolumn', Types::BLOB, ['notnull' => false]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
     }
@@ -178,7 +186,13 @@ class BlobTest extends FunctionalTestCase
         $table->addColumn('id', 'integer');
         $table->addColumn('blobcolumn1', 'blob', ['notnull' => false]);
         $table->addColumn('blobcolumn2', 'blob', ['notnull' => false]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $params = ['test1', 'test2'];

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -13,6 +13,8 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -366,7 +368,13 @@ class ConnectionTest extends FunctionalTestCase
     {
         $table = new Table(self::TABLE);
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\TrimMode;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Statement;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -31,7 +33,13 @@ class DataAccessTest extends FunctionalTestCase
         $table->addColumn('test_int', Types::INTEGER);
         $table->addColumn('test_string', Types::STRING, ['length' => 32]);
         $table->addColumn('test_datetime', Types::DATETIME_MUTABLE, ['notnull' => false]);
-        $table->setPrimaryKey(['test_int']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('test_int'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 
@@ -642,7 +650,13 @@ class DataAccessTest extends FunctionalTestCase
         $table = new Table('fetch_table_date_math');
         $table->addColumn('test_date', Types::DATE_MUTABLE);
         $table->addColumn('test_days', Types::INTEGER);
-        $table->setPrimaryKey(['test_date']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('test_date'),
+                )
+                ->create(),
+        );
 
         $sm = $this->connection->createSchemaManager();
         $sm->createTable($table);

--- a/tests/Functional/Driver/DBAL6024Test.php
+++ b/tests/Functional/Driver/DBAL6024Test.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Driver;
 
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -23,7 +25,13 @@ class DBAL6024Test extends FunctionalTestCase
     {
         $table = new Table('mytable');
         $table->addColumn('id', 'integer');
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $schemaManager = $this->connection->createSchemaManager();
@@ -35,14 +43,11 @@ class DBAL6024Test extends FunctionalTestCase
 
         $diff = $schemaManager->createComparator()->compareTables($table, $newTable);
 
-        $statements = $this->connection->getDatabasePlatform()->getAlterTableSQL($diff);
-        foreach ($statements as $statement) {
-            $this->connection->executeStatement($statement);
-        }
+        $schemaManager->alterTable($diff);
 
         $validationSchema = $schemaManager->introspectSchema();
         $validationTable  = $validationSchema->getTable($table->getName());
 
-        self::assertNull($validationTable->getPrimaryKey());
+        self::assertNull($validationTable->getPrimaryKeyConstraint());
     }
 }

--- a/tests/Functional/Driver/DBAL6024Test.php
+++ b/tests/Functional/Driver/DBAL6024Test.php
@@ -26,11 +26,14 @@ class DBAL6024Test extends FunctionalTestCase
         $table->setPrimaryKey(['id']);
         $this->dropAndCreateTable($table);
 
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = $schemaManager->introspectTable('mytable');
+
         $newTable = clone $table;
         $newTable->dropPrimaryKey();
 
-        $schemaManager = $this->connection->createSchemaManager();
-        $diff          = $schemaManager->createComparator()->compareTables($table, $newTable);
+        $diff = $schemaManager->createComparator()->compareTables($table, $newTable);
 
         $statements = $this->connection->getDatabasePlatform()->getAlterTableSQL($diff);
         foreach ($statements as $statement) {

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -38,7 +40,13 @@ class ExceptionTest extends FunctionalTestCase
     {
         $table = new Table('duplicatekey_table');
         $table->addColumn('id', Types::INTEGER, []);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $this->connection->insert('duplicatekey_table', ['id' => 1]);
@@ -60,7 +68,13 @@ class ExceptionTest extends FunctionalTestCase
         $schemaManager = $this->connection->createSchemaManager();
         $table         = new Table('alreadyexist_table');
         $table->addColumn('id', Types::INTEGER, []);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->expectException(Exception\TableExistsException::class);
         $schemaManager->createTable($table);
@@ -72,7 +86,13 @@ class ExceptionTest extends FunctionalTestCase
         $table = new Table('notnull_table');
         $table->addColumn('id', Types::INTEGER, []);
         $table->addColumn('val', Types::INTEGER, ['notnull' => true]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $this->expectException(Exception\NotNullConstraintViolationException::class);
@@ -137,8 +157,13 @@ class ExceptionTest extends FunctionalTestCase
     {
         $table = new Table('syntax_error_table');
         $table->addColumn('id', Types::INTEGER, []);
-        $table->setPrimaryKey(['id']);
-
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $sql = 'SELECT id FRO syntax_error_table';

--- a/tests/Functional/ForeignKeyConstraintViolationsTest.php
+++ b/tests/Functional/ForeignKeyConstraintViolationsTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use PHPUnit\Framework\Assert;
@@ -48,7 +49,13 @@ final class ForeignKeyConstraintViolationsTest extends FunctionalTestCase
 
         $table2 = new Table('test_t2');
         $table2->addColumn('id', 'integer', ['notnull' => true]);
-        $table2->setPrimaryKey(['id']);
+        $table2->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $schemaManager->createTable($table2);
 
         if ($platform instanceof OraclePlatform) {

--- a/tests/Functional/ForeignKeyExceptionTest.php
+++ b/tests/Functional/ForeignKeyExceptionTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\IBMDB2;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
@@ -26,12 +28,24 @@ class ForeignKeyExceptionTest extends FunctionalTestCase
 
         $table = new Table('constraint_error_table');
         $table->addColumn('id', 'integer', []);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $owningTable = new Table('owning_table');
         $owningTable->addColumn('id', 'integer', []);
         $owningTable->addColumn('constraint_id', 'integer', []);
-        $owningTable->setPrimaryKey(['id']);
+        $owningTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $owningTable->addForeignKeyConstraint($table->getName(), ['constraint_id'], ['id']);
 
         $schemaManager->createTable($table);

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -35,7 +37,13 @@ class NoneTest extends FunctionalTestCase
 
         $table = new Table('users');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -22,13 +24,24 @@ class ModifyLimitQueryTest extends FunctionalTestCase
     {
         $table = new Table('modify_limit_table');
         $table->addColumn('test_int', Types::INTEGER);
-        $table->setPrimaryKey(['test_int']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('test_int'),
+                )
+                ->create(),
+        );
 
         $table2 = new Table('modify_limit_table2');
         $table2->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table2->addColumn('test_int', Types::INTEGER);
-        $table2->setPrimaryKey(['id']);
-
+        $table2->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
         $this->dropAndCreateTable($table2);
     }

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -170,7 +172,13 @@ class NamedParametersTest extends FunctionalTestCase
             $table->addColumn('id', Types::INTEGER);
             $table->addColumn('foo', Types::STRING, ['length' => 1]);
             $table->addColumn('bar', Types::STRING, ['length' => 1]);
-            $table->setPrimaryKey(['id']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+            );
 
             $sm = $this->connection->createSchemaManager();
             $sm->createTable($table);

--- a/tests/Functional/Platform/PlatformRestrictionsTest.php
+++ b/tests/Functional/Platform/PlatformRestrictionsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Platform;
 
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -27,11 +29,18 @@ class PlatformRestrictionsTest extends FunctionalTestCase
         $columnName = str_repeat('y', $platform->getMaxIdentifierLength());
         $table      = new Table($tableName);
         $table->addColumn($columnName, Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey([$columnName]);
+
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setColumnNames(
+                UnqualifiedName::unquoted($columnName),
+            )
+            ->create();
+
+        $table->addPrimaryKeyConstraint($primaryKeyConstraint);
         $this->dropAndCreateTable($table);
         $createdTable = $this->connection->createSchemaManager()->introspectTable($tableName);
 
         self::assertTrue($createdTable->hasColumn($columnName));
-        self::assertNotNull($createdTable->getPrimaryKey());
+        self::assertPrimaryKeyConstraintEquals($primaryKeyConstraint, $createdTable->getPrimaryKeyConstraint());
     }
 }

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\ColumnCase;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Portability\Connection;
 use Doctrine\DBAL\Portability\Middleware;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -181,7 +183,13 @@ class PortabilityTest extends FunctionalTestCase
             'length' => 1,
             'notnull' => false,
         ]);
-        $table->setPrimaryKey(['Test_Int']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('Test_Int'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Functional/PrimaryReadReplicaConnectionTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -28,7 +30,13 @@ class PrimaryReadReplicaConnectionTest extends FunctionalTestCase
         try {
             $table = new Table('primary_replica_table');
             $table->addColumn('test_int', Types::INTEGER);
-            $table->setPrimaryKey(['test_int']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('test_int'),
+                    )
+                    ->create(),
+            );
 
             $sm = $this->connection->createSchemaManager();
             $sm->createTable($table);

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -16,6 +16,8 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 use Doctrine\DBAL\Query\UnionType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -31,7 +33,13 @@ final class QueryBuilderTest extends FunctionalTestCase
     {
         $table = new Table('for_update');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/ResultMetadataTest.php
+++ b/tests/Functional/ResultMetadataTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Exception\InvalidColumnIndex;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -17,7 +19,13 @@ class ResultMetadataTest extends FunctionalTestCase
     {
         $table = new Table('result_metadata_table');
         $table->addColumn('test_int', 'integer');
-        $table->setPrimaryKey(['test_int']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('test_int'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/SQL/Builder/CreateAndDropSchemaObjectsSQLBuilderTest.php
+++ b/tests/Functional/SQL/Builder/CreateAndDropSchemaObjectsSQLBuilderTest.php
@@ -7,7 +7,10 @@ namespace Doctrine\DBAL\Tests\Functional\SQL\Builder;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
 
@@ -19,9 +22,10 @@ class CreateAndDropSchemaObjectsSQLBuilderTest extends FunctionalTestCase
         $name1 = OptionallyQualifiedName::unquoted('t1');
         $name2 = OptionallyQualifiedName::unquoted('t2');
 
-        $schema = new Schema();
-        $this->createTable($schema, $name1, $name2);
-        $this->createTable($schema, $name2, $name1);
+        $table1 = $this->createTable($name1, $name2);
+        $table2 = $this->createTable($name2, $name1);
+
+        $schema = new Schema([$table1, $table2]);
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);
@@ -39,15 +43,22 @@ class CreateAndDropSchemaObjectsSQLBuilderTest extends FunctionalTestCase
     }
 
     private function createTable(
-        Schema $schema,
         OptionallyQualifiedName $name,
         OptionallyQualifiedName $otherName,
-    ): void {
-        $table = $schema->createTable($name->toString());
+    ): Table {
+        $table = new Table($name->toString());
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('other_id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
         $table->addForeignKeyConstraint($otherName->toString(), ['other_id'], ['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
+
+        return $table;
     }
 
     /** @throws Exception */

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -20,7 +22,13 @@ class AlterTableTest extends FunctionalTestCase
         $table->addColumn('val', Types::INTEGER);
 
         $this->testMigration($table, static function (Table $table): void {
-            $table->setPrimaryKey(['id']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+            );
         });
     }
 
@@ -37,7 +45,13 @@ class AlterTableTest extends FunctionalTestCase
 
         $this->testMigration($table, static function (Table $table): void {
             $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-            $table->setPrimaryKey(['id']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+            );
         });
     }
 
@@ -60,11 +74,23 @@ class AlterTableTest extends FunctionalTestCase
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
-        $table->setPrimaryKey(['id1']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                )
+                ->create(),
+        );
 
         $this->testMigration($table, static function (Table $table): void {
             $table->dropPrimaryKey();
-            $table->setPrimaryKey(['id2']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id2'),
+                    )
+                    ->create(),
+            );
         });
     }
 
@@ -87,7 +113,14 @@ class AlterTableTest extends FunctionalTestCase
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
-        $table->setPrimaryKey(['id1', 'id2']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                    UnqualifiedName::unquoted('id2'),
+                )
+                ->create(),
+        );
 
         $this->testMigration($table, static function (Table $table): void {
             $table->dropPrimaryKey();
@@ -107,11 +140,24 @@ class AlterTableTest extends FunctionalTestCase
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
-        $table->setPrimaryKey(['id1', 'id2']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                    UnqualifiedName::unquoted('id2'),
+                )
+                ->create(),
+        );
 
         $this->testMigration($table, static function (Table $table): void {
             $table->dropPrimaryKey();
-            $table->setPrimaryKey(['id1']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id1'),
+                    )
+                    ->create(),
+            );
         });
     }
 
@@ -128,11 +174,24 @@ class AlterTableTest extends FunctionalTestCase
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
-        $table->setPrimaryKey(['id1']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                )
+                ->create(),
+        );
 
         $this->testMigration($table, static function (Table $table): void {
             $table->dropPrimaryKey();
-            $table->setPrimaryKey(['id1', 'id2']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id1'),
+                        UnqualifiedName::unquoted('id2'),
+                    )
+                    ->create(),
+            );
         });
     }
 
@@ -144,12 +203,25 @@ class AlterTableTest extends FunctionalTestCase
 
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER);
-        $table->setPrimaryKey(['id1']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                )
+                ->create(),
+        );
 
         $this->testMigration($table, static function (Table $table): void {
             $table->addColumn('id2', Types::INTEGER);
             $table->dropPrimaryKey();
-            $table->setPrimaryKey(['id1', 'id2']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id1'),
+                        UnqualifiedName::unquoted('id2'),
+                    )
+                    ->create(),
+            );
         });
     }
 
@@ -158,7 +230,13 @@ class AlterTableTest extends FunctionalTestCase
         $articles = new Table('articles');
         $articles->addColumn('id', Types::INTEGER);
         $articles->addColumn('sku', Types::INTEGER);
-        $articles->setPrimaryKey(['id']);
+        $articles->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $articles->addUniqueConstraint(['sku']);
 
         $orders = new Table('orders');

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -6,9 +6,7 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -59,8 +57,6 @@ class AlterTableTest extends FunctionalTestCase
             );
         }
 
-        $this->ensureDroppingPrimaryKeyConstraintIsSupported();
-
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
@@ -88,8 +84,6 @@ class AlterTableTest extends FunctionalTestCase
             );
         }
 
-        $this->ensureDroppingPrimaryKeyConstraintIsSupported();
-
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
@@ -109,8 +103,6 @@ class AlterTableTest extends FunctionalTestCase
                 'SQLite does not support auto-increment columns as part of composite primary key constraint',
             );
         }
-
-        $this->ensureDroppingPrimaryKeyConstraintIsSupported();
 
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
@@ -133,8 +125,6 @@ class AlterTableTest extends FunctionalTestCase
             );
         }
 
-        $this->ensureDroppingPrimaryKeyConstraintIsSupported();
-
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
@@ -148,7 +138,9 @@ class AlterTableTest extends FunctionalTestCase
 
     public function testAddNewColumnToPrimaryKey(): void
     {
-        $this->ensureDroppingPrimaryKeyConstraintIsSupported();
+        if ($this->connection->getDatabasePlatform() instanceof DB2Platform) {
+            self::markTestIncomplete('This test fails on IBM Db2 for an unrelated reason.');
+        }
 
         $table = new Table('alter_pk');
         $table->addColumn('id1', Types::INTEGER);
@@ -197,23 +189,6 @@ class AlterTableTest extends FunctionalTestCase
                 'articles_fk',
             );
         });
-    }
-
-    private function ensureDroppingPrimaryKeyConstraintIsSupported(): void
-    {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (
-            ! ($platform instanceof DB2Platform)
-            && ! ($platform instanceof OraclePlatform)
-            && ! ($platform instanceof SQLServerPlatform)
-        ) {
-            return;
-        }
-
-        self::markTestIncomplete(
-            'Dropping primary key constraint on the currently used database platform is not implemented.',
-        );
     }
 
     private function testMigration(Table $oldTable, callable $migration): void

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -220,11 +220,12 @@ class AlterTableTest extends FunctionalTestCase
     {
         $this->dropAndCreateTable($oldTable);
 
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $oldTable = $schemaManager->introspectTable($oldTable->getName());
         $newTable = clone $oldTable;
 
         $migration($newTable);
-
-        $schemaManager = $this->connection->createSchemaManager();
 
         $diff = $schemaManager->createComparator()
             ->compareTables($oldTable, $newTable);

--- a/tests/Functional/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Functional/Schema/ForeignKeyConstraintTest.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -39,11 +40,23 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
 
         $roles = new Table('roles');
         $roles->addColumn('id', Types::INTEGER);
-        $roles->setPrimaryKey(['id']);
+        $roles->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $teams = new Table('teams');
         $teams->addColumn('id', Types::INTEGER);
-        $teams->setPrimaryKey(['id']);
+        $teams->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $editor = ForeignKeyConstraint::editor()
             ->setReferencedColumnNames(
@@ -68,7 +81,13 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
                 )
                 ->create(),
         ]);
-        $users->setPrimaryKey(['id']);
+        $users->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $sm = $this->connection->createSchemaManager();
         $sm->createTable($roles);
@@ -93,12 +112,26 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
         $roles = new Table($rolesName->toString());
         $roles->addColumn('r_id1', Types::INTEGER);
         $roles->addColumn('r_id2', Types::INTEGER);
-        $roles->setPrimaryKey(['r_id1', 'r_id2']);
+        $roles->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('r_id1'),
+                    UnqualifiedName::unquoted('r_id2'),
+                )
+                ->create(),
+        );
 
         $teams = new Table($teamsName->toString());
         $teams->addColumn('t_id1', Types::INTEGER);
         $teams->addColumn('t_id2', Types::INTEGER);
-        $teams->setPrimaryKey(['t_id1', 't_id2']);
+        $teams->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('t_id1'),
+                    UnqualifiedName::unquoted('t_id2'),
+                )
+                ->create(),
+        );
 
         $foreignKeyConstraints = [
             ForeignKeyConstraint::editor()
@@ -135,7 +168,14 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
             new Column('team_id1', Type::getType(Types::INTEGER)),
             new Column('team_id2', Type::getType(Types::INTEGER)),
         ], [], [], $foreignKeyConstraints);
-        $users->setPrimaryKey(['u_id1', 'u_id2']);
+        $users->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('u_id1'),
+                    UnqualifiedName::unquoted('u_id2'),
+                )
+                ->create(),
+        );
 
         $sm = $this->connection->createSchemaManager();
         $sm->createTable($roles);
@@ -209,7 +249,13 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
 
         $roles = new Table('roles');
         $roles->addColumn('id', Types::INTEGER);
-        $roles->setPrimaryKey(['id']);
+        $roles->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $editor = ForeignKeyConstraint::editor()
             ->setReferencingColumnNames(
@@ -225,7 +271,13 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
             new Column('id', Type::getType(Types::INTEGER)),
             new Column('role_id', Type::getType(Types::INTEGER), ['notnull' => false]),
         ], [], [], [$editor->create()]);
-        $users->setPrimaryKey(['id']);
+        $users->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $sm = $this->connection->createSchemaManager();
 
@@ -320,7 +372,13 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
 
         $roles = new Table('roles');
         $roles->addColumn('id', Types::INTEGER);
-        $roles->setPrimaryKey(['id']);
+        $roles->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $users = new Table('users', [
             new Column('id', Type::getType(Types::INTEGER)),
@@ -339,7 +397,13 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
                 ->setDeferrability($deferrability)
                 ->create(),
         ]);
-        $users->setPrimaryKey(['id']);
+        $users->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $sm = $this->connection->createSchemaManager();
         $sm->createTable($roles);

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\BinaryType;
@@ -40,7 +42,13 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('foo', Types::INTEGER);
         $table->addColumn('bar', Types::STRING, ['length' => 32]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\BinaryType;
@@ -15,8 +14,6 @@ use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\DateTimeTzType;
 use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\Types;
-
-use function array_map;
 
 class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -90,35 +87,6 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $columns = $this->schemaManager->listTableColumns($table->getName());
         self::assertCount(7, $columns);
-    }
-
-    public function testListTableIndexesPrimaryKeyConstraintNameDiffersFromIndexName(): void
-    {
-        $table = new Table(
-            'list_table_indexes_pk_id_test',
-            [],
-            [],
-            [],
-            [],
-            [],
-            $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
-        );
-
-        $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
-        $table->addUniqueIndex(['id'], 'id_unique_index');
-        $this->dropAndCreateTable($table);
-
-        $this->schemaManager->createIndex(
-            new Index('id_pk_id_index', ['id'], true, true),
-            'list_table_indexes_pk_id_test',
-        );
-
-        $tableIndexes = $this->schemaManager->listTableIndexes('list_table_indexes_pk_id_test');
-
-        self::assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
-        self::assertEquals(['id'], array_map('strtolower', $tableIndexes['primary']->getColumns()));
-        self::assertTrue($tableIndexes['primary']->isUnique());
-        self::assertTrue($tableIndexes['primary']->isPrimary());
     }
 
     public function testListTableDateTypeColumns(): void

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\View;
@@ -146,7 +148,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $testTable = new Table('dbal511_default');
         $testTable->addColumn('id', Types::INTEGER);
         $testTable->addColumn('def', Types::STRING, ['default' => 'foo']);
-        $testTable->setPrimaryKey(['id']);
+        $testTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($testTable);
 
         $databaseTable = $this->schemaManager->introspectTable($testTable->getName());
@@ -245,7 +253,13 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             'notnull' => true,
             'autoincrement' => true,
         ]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);

--- a/tests/Functional/Schema/PrimaryKeyConstraintTest.php
+++ b/tests/Functional/Schema/PrimaryKeyConstraintTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\TestWith;
+
+final class PrimaryKeyConstraintTest extends FunctionalTestCase
+{
+    /**
+     * The list of tested platforms should be kept in-sync with
+     * {@see AbstractPlatformTestCase::testNamedPrimaryKeyConstraintIsReportedAsUnsupported()}.
+     */
+    public function testNameIntrospection(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof AbstractMySQLPlatform || $platform instanceof SQLitePlatform) {
+            self::markTestSkipped(
+                'The current database platform does not support named primary key constraints.',
+            );
+        }
+
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setName(
+                UnqualifiedName::unquoted('users_pk'),
+            )
+            ->setColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->create();
+
+        $table = new Table('users');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addPrimaryKeyConstraint($primaryKeyConstraint);
+
+        $this->dropAndCreateTable($table);
+
+        $sm = $this->connection->createSchemaManager();
+
+        $table = $sm->introspectTable('users');
+
+        $this->assertPrimaryKeyConstraintEquals($primaryKeyConstraint, $table->getPrimaryKeyConstraint());
+    }
+
+    /**
+     * The list of tested platforms should be kept in-sync with
+     * {@see AbstractPlatformTestCase::testNonClusteredPrimaryKeyConstraintIsReportedAsUnsupported()}.
+     */
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testIsClusteredIntrospection(bool $isClustered): void
+    {
+        if (! $isClustered && ! $this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            self::markTestSkipped(
+                'The current database platform does not support non-clustered primary key constraints.',
+            );
+        }
+
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->setIsClustered($isClustered)
+            ->create();
+
+        $table = new Table('users');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addPrimaryKeyConstraint($primaryKeyConstraint);
+
+        $this->dropAndCreateTable($table);
+
+        $sm = $this->connection->createSchemaManager();
+
+        $table = $sm->introspectTable('users');
+
+        $this->assertPrimaryKeyConstraintEquals($primaryKeyConstraint, $table->getPrimaryKeyConstraint());
+    }
+}

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -6,10 +6,10 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
-
-use function array_shift;
 
 class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -115,19 +115,23 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         // declared in the table. In that case, key_ordinal != index_column_id.
         // key_ordinal holds the index ordering. index_column_id is just a unique identifier
         // for index columns within the given index.
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setColumnNames(
+                UnqualifiedName::unquoted('colA'),
+                UnqualifiedName::unquoted('colB'),
+            )
+            ->create();
+
         $table = new Table('sqlsrv_pk_ordering');
         $table->addColumn('colA', Types::INTEGER, ['notnull' => true]);
         $table->addColumn('colB', Types::INTEGER, ['notnull' => true]);
-        $table->setPrimaryKey(['colB', 'colA']);
+        $table->addPrimaryKeyConstraint($primaryKeyConstraint);
         $this->schemaManager->createTable($table);
 
-        $indexes = $this->schemaManager->listTableIndexes('sqlsrv_pk_ordering');
-
-        self::assertCount(1, $indexes);
-        $firstIndex = array_shift($indexes);
-        self::assertNotNull($firstIndex);
-
-        self::assertSame(['colB', 'colA'], $firstIndex->getColumns());
+        self::assertPrimaryKeyConstraintEquals(
+            $primaryKeyConstraint,
+            $this->schemaManager->getTablePrimaryKeyConstraint('sqlsrv_pk_ordering'),
+        );
     }
 
     public function testNvarcharMaxIsLengthMinus1(): void

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -6,8 +6,6 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 
@@ -104,34 +102,6 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('another default value', $columns['df_string_3']->getDefault());
         self::assertEquals(0, $columns['df_boolean']->getDefault());
         self::assertEquals('column to rename', $columns['df_string_4_renamed']->getDefault());
-    }
-
-    public function testPkOrdering(): void
-    {
-        // SQL Server stores index column information in a system table with two
-        // columns that almost always have the same value: index_column_id and key_ordinal.
-        // The only situation when the two values doesn't match up is when a clustered index
-        // is declared that references columns in a different order from which they are
-        // declared in the table. In that case, key_ordinal != index_column_id.
-        // key_ordinal holds the index ordering. index_column_id is just a unique identifier
-        // for index columns within the given index.
-        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
-            ->setColumnNames(
-                UnqualifiedName::unquoted('colA'),
-                UnqualifiedName::unquoted('colB'),
-            )
-            ->create();
-
-        $table = new Table('sqlsrv_pk_ordering');
-        $table->addColumn('colA', Types::INTEGER, ['notnull' => true]);
-        $table->addColumn('colB', Types::INTEGER, ['notnull' => true]);
-        $table->addPrimaryKeyConstraint($primaryKeyConstraint);
-        $this->schemaManager->createTable($table);
-
-        self::assertPrimaryKeyConstraintEquals(
-            $primaryKeyConstraint,
-            $this->schemaManager->getTablePrimaryKeyConstraint('sqlsrv_pk_ordering'),
-        );
     }
 
     public function testNvarcharMaxIsLengthMinus1(): void

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\BlobType;
@@ -162,7 +163,13 @@ SQL;
         $table = new Table('test_pk_auto_increment');
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('text', Types::TEXT);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '1']);
@@ -257,13 +264,13 @@ SQL;
         CREATE TABLE artist(
           id INTEGER,
           name TEXT,
-          PRIMARY KEY(id)
+          PRIMARY KEY (id)
         );
 
         CREATE TABLE album(
           id INTEGER,
           name TEXT,
-          PRIMARY KEY(id)
+          PRIMARY KEY (id)
         );
 
         CREATE TABLE song(

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -1342,18 +1341,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     public function testSwitchPrimaryKeyOrder(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if (
-            $platform instanceof DB2Platform
-            || $platform instanceof OraclePlatform
-            || $platform instanceof SQLServerPlatform
-        ) {
-            self::markTestIncomplete(
-                'Dropping primary key constraint on the currently used database platform is not implemented.',
-            );
-        }
-
         $prototype = new Table('test_switch_pk_order');
         $prototype->addColumn('foo_id', Types::INTEGER);
         $prototype->addColumn('bar_id', Types::INTEGER);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -516,7 +516,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertTrue($table->hasColumn('test'));
         self::assertTrue($table->hasColumn('foreign_key_test'));
         self::assertCount(0, $table->getForeignKeys());
-        self::assertCount(1, $table->getIndexes());
+        self::assertCount(0, $table->getIndexes());
 
         $newTable = clone $table;
         $newTable->addColumn('foo', Types::INTEGER);
@@ -540,10 +540,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->alterTable($diff);
 
         $table = $this->schemaManager->introspectTable('alter_table');
-        self::assertCount(2, $table->getIndexes());
+        self::assertCount(1, $table->getIndexes());
         self::assertTrue($table->hasIndex('foo_idx'));
         self::assertEquals(['foo'], array_map('strtolower', $table->getIndex('foo_idx')->getColumns()));
-        self::assertFalse($table->getIndex('foo_idx')->isPrimary());
         self::assertFalse($table->getIndex('foo_idx')->isUnique());
 
         $newTable = clone $table;
@@ -555,7 +554,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->alterTable($diff);
 
         $table = $this->schemaManager->introspectTable('alter_table');
-        self::assertCount(2, $table->getIndexes());
+        self::assertCount(1, $table->getIndexes());
         self::assertTrue($table->hasIndex('foo_idx'));
         self::assertEquals(
             ['foo', 'foreign_key_test'],
@@ -571,14 +570,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->alterTable($diff);
 
         $table = $this->schemaManager->introspectTable('alter_table');
-        self::assertCount(2, $table->getIndexes());
+        self::assertCount(1, $table->getIndexes());
         self::assertTrue($table->hasIndex('bar_idx'));
         self::assertFalse($table->hasIndex('foo_idx'));
         self::assertEquals(
             ['foo', 'foreign_key_test'],
             array_map('strtolower', $table->getIndex('bar_idx')->getColumns()),
         );
-        self::assertFalse($table->getIndex('bar_idx')->isPrimary());
         self::assertFalse($table->getIndex('bar_idx')->isUnique());
 
         $newTable = clone $table;
@@ -1237,7 +1235,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $user = $this->schemaManager->introspectTable('user');
         self::assertCount(2, $user->getColumns());
-        self::assertCount(2, $user->getIndexes());
+        self::assertCount(1, $user->getIndexes());
         self::assertCount(1, $user->getForeignKeys());
     }
 
@@ -1250,7 +1248,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $user = $this->findTableByName($tables, 'user');
         self::assertNotNull($user);
         self::assertCount(2, $user->getColumns());
-        self::assertCount(2, $user->getIndexes());
+        self::assertCount(1, $user->getIndexes());
         self::assertCount(1, $user->getForeignKeys());
     }
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -392,12 +392,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tableIndexes = $this->schemaManager->listTableIndexes('list_table_indexes_test');
 
-        self::assertCount(3, $tableIndexes);
-
-        self::assertArrayHasKey('primary', $tableIndexes, 'listTableIndexes() has to return a "primary" array key.');
-        self::assertEquals(['id', 'other_id'], array_map('strtolower', $tableIndexes['primary']->getColumns()));
-        self::assertTrue($tableIndexes['primary']->isUnique());
-        self::assertTrue($tableIndexes['primary']->isPrimary());
+        self::assertCount(2, $tableIndexes);
 
         self::assertEquals('test_index_name', strtolower($tableIndexes['test_index_name']->getName()));
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test_index_name']->getColumns()));
@@ -1382,7 +1377,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table      = $schemaManager->introspectTable('test_switch_pk_order');
         $primaryKey = $table->getPrimaryKey();
         self::assertNotNull($primaryKey);
-        self::assertSame(['bar_id', 'foo_id'], array_map('strtolower', $primaryKey->getColumns()));
+        self::assertSame(['bar_id', 'foo_id'], array_map('strtolower', $primaryKey->getUnquotedColumns()));
     }
 
     public function testDropColumnWithDefault(): void
@@ -1464,7 +1459,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $primaryKey = $nestedSchemaTable->getPrimaryKey();
         self::assertNotNull($primaryKey);
-        self::assertEquals(['id'], $primaryKey->getColumns());
+        self::assertEquals(['id'], $primaryKey->getUnquotedColumns());
 
         $relatedFks = array_values($nestedSchemaTable->getForeignKeys());
         self::assertCount(1, $relatedFks);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -269,7 +270,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('baz1', Types::DATETIME_MUTABLE);
         $table->addColumn('baz2', Types::TIME_MUTABLE);
         $table->addColumn('baz3', Types::DATE_MUTABLE);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         return $table;
     }
@@ -396,12 +403,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('test_index_name', strtolower($tableIndexes['test_index_name']->getName()));
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test_index_name']->getColumns()));
         self::assertTrue($tableIndexes['test_index_name']->isUnique());
-        self::assertFalse($tableIndexes['test_index_name']->isPrimary());
 
         self::assertEquals('test_composite_idx', strtolower($tableIndexes['test_composite_idx']->getName()));
         self::assertEquals(['id', 'test'], array_map('strtolower', $tableIndexes['test_composite_idx']->getColumns()));
         self::assertFalse($tableIndexes['test_composite_idx']->isUnique());
-        self::assertFalse($tableIndexes['test_composite_idx']->isPrimary());
     }
 
     public function testDropAndCreateIndex(): void
@@ -418,7 +423,6 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals('test', strtolower($tableIndexes['test']->getName()));
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test']->getColumns()));
         self::assertTrue($tableIndexes['test']->isUnique());
-        self::assertFalse($tableIndexes['test']->isPrimary());
     }
 
     public function testDropAndCreateUniqueConstraint(): void
@@ -482,7 +486,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tableToCreate = $schema->createTable('table_to_create');
         $tableToCreate->addColumn('id', Types::INTEGER, ['notnull' => true]);
-        $tableToCreate->setPrimaryKey(['id']);
+        $tableToCreate->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $this->schemaManager->migrateSchema($schema);
 
@@ -650,7 +660,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $table = new Table('test_fk_base');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $tableFK = new Table(
             'test_fk_rename',
@@ -663,7 +679,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
         $tableFK->addColumn('id', Types::INTEGER);
         $tableFK->addColumn('fk_id', Types::INTEGER);
-        $tableFK->setPrimaryKey(['id']);
+        $tableFK->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
         $tableFK->addIndex(['fk_id'], 'fk_idx');
         $tableFK->addForeignKeyConstraint('test_fk_base', ['fk_id'], ['id']);
 
@@ -684,7 +706,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
         $tableFKNew->addColumn('id', Types::INTEGER);
         $tableFKNew->addColumn('rename_fk_id', Types::INTEGER);
-        $tableFKNew->setPrimaryKey(['id']);
+        $tableFKNew->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
         $tableFKNew->addIndex(['rename_fk_id'], 'fk_idx');
         $tableFKNew->addForeignKeyConstraint('test_fk_base', ['rename_fk_id'], ['id']);
 
@@ -710,7 +738,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $primaryTable = new Table('test_rename_index_primary');
         $primaryTable->addColumn('id', Types::INTEGER);
-        $primaryTable->setPrimaryKey(['id']);
+        $primaryTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $foreignTable = new Table('test_rename_index_foreign');
         $foreignTable->addColumn('fk', Types::INTEGER);
@@ -837,7 +871,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             $this->schemaManager->createSchemaConfig()->toTableConfiguration(),
         );
         $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
         $table->addColumn('test', Types::STRING, ['length' => 255]);
         $table->addColumn('foreign_key_test', Types::INTEGER);
 
@@ -857,7 +897,14 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
         $table->addColumn('id', Types::INTEGER, ['notnull' => true]);
         $table->addColumn('other_id', Types::INTEGER, ['notnull' => true]);
-        $table->setPrimaryKey(['id', 'other_id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                        UnqualifiedName::unquoted('other_id'),
+                    )
+                    ->create(),
+        );
         $table->addColumn('test', Types::STRING, ['length' => 255]);
 
         return $table;
@@ -883,7 +930,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             'length' => 1,
             'default' => 0,
         ]);
-        $oldTable->setPrimaryKey(['id']);
+        $oldTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $this->dropAndCreateTable($oldTable);
 
@@ -972,7 +1025,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $table = new Table($foreignTableName);
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 
@@ -982,7 +1041,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table->addColumn('bar', Types::STRING, ['length' => 32]);
         $table->addForeignKeyConstraint($foreignTableName, ['foo'], ['id']);
         $table->addIndex(['bar']);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 
@@ -1004,7 +1069,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $primaryTable = new Table('test_list_index_impl_primary');
         $primaryTable->addColumn('id', Types::INTEGER);
-        $primaryTable->setPrimaryKey(['id']);
+        $primaryTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $foreignTable = new Table('test_list_index_impl_foreign');
         $foreignTable->addColumn('fk1', Types::INTEGER);
@@ -1101,7 +1172,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $table = new Table('test_pk_auto_increment');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('text', Types::STRING, ['length' => 1]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '1']);
@@ -1179,22 +1256,34 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
     private function createReservedKeywordTables(): void
     {
-        $schema = new Schema();
-
-        $user = $schema->createTable('user');
+        $user = new Table('user');
         $user->addColumn('id', Types::INTEGER);
         $user->addColumn('group_id', Types::INTEGER);
-        $user->setPrimaryKey(['id']);
+        $user->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
         $user->addForeignKeyConstraint('group', ['group_id'], ['id']);
 
-        $group = $schema->createTable('group');
+        $group = new Table('group');
         $group->addColumn('id', Types::INTEGER);
-        $group->setPrimaryKey(['id']);
+        $group->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
         $platform = $this->connection->getDatabasePlatform();
 
         $this->dropTableIfExists($user->getObjectName()->toSQL($platform));
         $this->dropTableIfExists($group->getObjectName()->toSQL($platform));
+
+        $schema = new Schema([$user, $group]);
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);
@@ -1215,7 +1304,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $artists->addColumn('"Id"', Types::INTEGER);
         $artists->addColumn('"Name"', Types::INTEGER);
         $artists->addIndex(['"Name"'], '"Idx_Artist_Name"');
-        $artists->setPrimaryKey(['"Id"']);
+        $artists->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::quoted('Id'),
+                    )
+                    ->create(),
+        );
 
         $tracks = new Table('"Tracks"');
         $tracks->addColumn('"Id"', Types::INTEGER);
@@ -1228,7 +1323,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             [],
             '"Artists_Fk"',
         );
-        $tracks->setPrimaryKey(['"Id"']);
+        $tracks->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::quoted('Id'),
+                    )
+                    ->create(),
+        );
 
         $this->dropTableIfExists($tracks->getObjectName()->toSQL($platform));
         $this->dropTableIfExists($artists->getObjectName()->toSQL($platform));
@@ -1259,11 +1360,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             $platform->quoteSingleIdentifier('Name'),
         ], $artists->getIndex('"Idx_Artist_Name"')->getQuotedColumns($platform));
 
-        $primaryKey = $artists->getPrimaryKey();
+        $primaryKey = $artists->getPrimaryKeyConstraint();
         self::assertNotNull($primaryKey);
-        self::assertSame([
-            $platform->quoteSingleIdentifier('Id'),
-        ], $primaryKey->getQuotedColumns($platform));
+        self::assertUnqualifiedNameListEquals([
+            UnqualifiedName::quoted('Id'),
+        ], $primaryKey->getColumnNames());
 
         // Foreign table assertions
         self::assertUnqualifiedNameEquals(
@@ -1271,11 +1372,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             $tracks->getColumn('"Id"')->getObjectName(),
         );
 
-        $primaryKey = $tracks->getPrimaryKey();
+        $primaryKey = $tracks->getPrimaryKeyConstraint();
         self::assertNotNull($primaryKey);
-        self::assertSame([
-            $platform->quoteSingleIdentifier('Id'),
-        ], $primaryKey->getQuotedColumns($platform));
+        self::assertUnqualifiedNameListEquals([
+            UnqualifiedName::quoted('Id'),
+        ], $primaryKey->getColumnNames());
 
         self::assertUnqualifiedNameEquals(
             UnqualifiedName::quoted('Artist_Id'),
@@ -1308,17 +1409,23 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->dropTableIfExists('child');
         $this->dropTableIfExists('parent');
 
-        $schema = new Schema();
-
-        $parent = $schema->createTable('parent');
+        $parent = new Table('parent');
         $parent->addColumn('id', Types::INTEGER);
-        $parent->setPrimaryKey(['id']);
+        $parent->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+        );
 
-        $child = $schema->createTable('child');
+        $child = new Table('child');
         $child->addColumn('id', Types::INTEGER);
         $child->addColumn('parent_id', Types::INTEGER);
         $child->addIndex(['parent_id'], 'idx_1');
         $child->addForeignKeyConstraint('parent', ['parent_id'], ['id']);
+
+        $schema = new Schema([$parent, $child]);
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);
@@ -1345,12 +1452,28 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $prototype->addColumn('foo_id', Types::INTEGER);
         $prototype->addColumn('bar_id', Types::INTEGER);
 
-        $table = clone $prototype;
-        $table->setPrimaryKey(['foo_id', 'bar_id']);
+        $oldPrimaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setColumnNames(
+                UnqualifiedName::unquoted('foo_id'),
+                UnqualifiedName::unquoted('bar_id'),
+            )
+            ->create();
+
+        $table = $prototype->edit()
+            ->setPrimaryKeyConstraint($oldPrimaryKeyConstraint)
+            ->create();
         $this->dropAndCreateTable($table);
 
-        $table = clone $prototype;
-        $table->setPrimaryKey(['bar_id', 'foo_id']);
+        $newPrimaryKeyConstraint = $oldPrimaryKeyConstraint->edit()
+            ->setColumnNames(
+                UnqualifiedName::unquoted('bar_id'),
+                UnqualifiedName::unquoted('foo_id'),
+            )
+            ->create();
+
+        $table = $prototype->edit()
+            ->setPrimaryKeyConstraint($newPrimaryKeyConstraint)
+            ->create();
 
         $schemaManager = $this->connection->createSchemaManager();
 
@@ -1361,10 +1484,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertFalse($diff->isEmpty());
         $schemaManager->alterTable($diff);
 
-        $table      = $schemaManager->introspectTable('test_switch_pk_order');
-        $primaryKey = $table->getPrimaryKey();
-        self::assertNotNull($primaryKey);
-        self::assertSame(['bar_id', 'foo_id'], array_map('strtolower', $primaryKey->getUnquotedColumns()));
+        $table = $schemaManager->introspectTable('test_switch_pk_order');
+
+        self::assertPrimaryKeyConstraintEquals($newPrimaryKeyConstraint, $table->getPrimaryKeyConstraint());
     }
 
     public function testDropColumnWithDefault(): void
@@ -1420,15 +1542,21 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->connection->executeStatement('CREATE SCHEMA nested');
 
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setColumnNames(
+                UnqualifiedName::unquoted('id'),
+            )
+            ->create();
+
         $nestedRelatedTable = new Table('nested.schemarelated');
         $column             = $nestedRelatedTable->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
-        $nestedRelatedTable->setPrimaryKey(['id']);
+        $nestedRelatedTable->addPrimaryKeyConstraint($primaryKeyConstraint);
 
         $nestedSchemaTable = new Table('nested.schematable');
         $column            = $nestedSchemaTable->addColumn('id', Types::INTEGER);
         $column->setAutoincrement(true);
-        $nestedSchemaTable->setPrimaryKey(['id']);
+        $nestedSchemaTable->addPrimaryKeyConstraint($primaryKeyConstraint);
         $nestedSchemaTable->addForeignKeyConstraint($nestedRelatedTable->getName(), ['id'], ['id']);
         $nestedSchemaTable->setComment('This is a comment');
 
@@ -1444,9 +1572,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $nestedSchemaTable = $this->schemaManager->introspectTable('nested.schematable');
         self::assertTrue($nestedSchemaTable->hasColumn('id'));
 
-        $primaryKey = $nestedSchemaTable->getPrimaryKey();
-        self::assertNotNull($primaryKey);
-        self::assertEquals(['id'], $primaryKey->getUnquotedColumns());
+        self::assertPrimaryKeyConstraintEquals($primaryKeyConstraint, $nestedSchemaTable->getPrimaryKeyConstraint());
 
         $relatedFks = array_values($nestedSchemaTable->getForeignKeys());
         self::assertCount(1, $relatedFks);

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -39,13 +40,25 @@ final class SchemaManagerTest extends FunctionalTestCase
 
         $tableForeign = new Table($foreignTableName);
         $tableForeign->addColumn('id', 'integer');
-        $tableForeign->setPrimaryKey(['id']);
+        $tableForeign->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($tableForeign);
 
         $tableTo = new Table('other_schema.other_table');
         $tableTo->addColumn('id', 'integer');
         $tableTo->addColumn('user_id', 'integer');
-        $tableTo->setPrimaryKey(['id']);
+        $tableTo->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $tableTo->addForeignKeyConstraint($foreignTableName, ['user_id'], ['id']);
         $this->dropAndCreateTable($tableTo);
 
@@ -120,7 +133,13 @@ final class SchemaManagerTest extends FunctionalTestCase
 
         $table = new Table('test_autoincrement');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => $autoincrement]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $table = $this->schemaManager->introspectTable('test_autoincrement');
@@ -147,7 +166,14 @@ final class SchemaManagerTest extends FunctionalTestCase
         $table = new Table('test_autoincrement');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => $autoincrement]);
         $table->addColumn('id2', Types::INTEGER);
-        $table->setPrimaryKey(['id1', 'id2']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                    UnqualifiedName::unquoted('id2'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $table = $this->schemaManager->introspectTable('test_autoincrement');

--- a/tests/Functional/TemporaryTableTest.php
+++ b/tests/Functional/TemporaryTableTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -33,7 +35,13 @@ class TemporaryTableTest extends FunctionalTestCase
 
         $table = new Table('nontemporary');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 
@@ -65,7 +73,13 @@ class TemporaryTableTest extends FunctionalTestCase
 
         $table = new Table('nontemporary');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Ticket/DBAL202Test.php
+++ b/tests/Functional/Ticket/DBAL202Test.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -22,7 +24,13 @@ class DBAL202Test extends FunctionalTestCase
         } else {
             $table = new Table('DBAL202');
             $table->addColumn('id', Types::INTEGER);
-            $table->setPrimaryKey(['id']);
+            $table->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+            );
 
             $this->connection->createSchemaManager()->createTable($table);
         }

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -101,7 +103,13 @@ class TransactionTest extends FunctionalTestCase
 
         $table = new Table('storage');
         $table->addColumn('test_int', Types::INTEGER);
-        $table->setPrimaryKey(['test_int']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('test_int'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Tests\Functional;
 
 use BcMath\Number;
 use DateTime;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -42,7 +44,13 @@ class TypeConversionTest extends FunctionalTestCase
         $table->addColumn('test_smallfloat', Types::SMALLFLOAT, ['notnull' => false]);
         $table->addColumn('test_decimal', Types::DECIMAL, ['notnull' => false, 'scale' => 2, 'precision' => 10]);
         $table->addColumn('test_number', Types::NUMBER, ['notnull' => false, 'scale' => 2, 'precision' => 10]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
     }

--- a/tests/Functional/Types/AsciiStringTest.php
+++ b/tests/Functional/Types/AsciiStringTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
@@ -20,7 +22,13 @@ class AsciiStringTest extends FunctionalTestCase
         ]);
 
         $table->addColumn('val', Types::ASCII_STRING, ['length' => 4]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
     }

--- a/tests/Functional/Types/BigIntTypeTest.php
+++ b/tests/Functional/Types/BigIntTypeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -23,7 +25,13 @@ class BigIntTypeTest extends FunctionalTestCase
         $table = new Table('bigint_type_test');
         $table->addColumn('id', Types::SMALLINT, ['notnull' => true]);
         $table->addColumn('my_integer', Types::BIGINT, ['notnull' => false]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         $this->connection->executeStatement(<<<SQL
@@ -62,7 +70,13 @@ class BigIntTypeTest extends FunctionalTestCase
         $table = new Table('bigint_type_test');
         $table->addColumn('id', Types::SMALLINT, ['notnull' => true]);
         $table->addColumn('my_integer', Types::BIGINT, ['notnull' => false, 'unsigned' => true]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $this->dropAndCreateTable($table);
 
         // Insert (2 ** 64) - 1

--- a/tests/Functional/Types/BinaryTest.php
+++ b/tests/Functional/Types/BinaryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -28,7 +30,13 @@ class BinaryTest extends FunctionalTestCase
             'fixed' => true,
         ]);
         $table->addColumn('val', Types::BINARY, ['length' => 64]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
     }

--- a/tests/Functional/Types/EnumTypeTest.php
+++ b/tests/Functional/Types/EnumTypeTest.php
@@ -6,7 +6,10 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\EnumType;
 use Doctrine\DBAL\Types\Type;
@@ -45,18 +48,24 @@ final class EnumTypeTest extends FunctionalTestCase
 
     public function testDeployEnum(): void
     {
-        $schemaManager = $this->connection->createSchemaManager();
-        $schema        = new Schema(schemaConfig: $schemaManager->createSchemaConfig());
-        $table         = $schema->createTable('my_enum_table');
+        $table = new Table('my_enum_table');
         $table->addColumn('id', Types::BIGINT, ['notnull' => true]);
         $table->addColumn('suit', Types::ENUM, [
             'values' => ['hearts', 'diamonds', 'clubs', 'spades'],
             'notnull' => true,
             'default' => 'hearts',
         ]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
-        $schemaManager->createSchemaObjects($schema);
+        $this->dropAndCreateTable($table);
+
+        $schemaManager = $this->connection->createSchemaManager();
 
         $introspectedTable = $schemaManager->introspectTable('my_enum_table');
 
@@ -82,7 +91,13 @@ final class EnumTypeTest extends FunctionalTestCase
         $table         = $schema->createTable('my_enum_table');
         $table->addColumn('id', Types::BIGINT, ['notnull' => true]);
         $table->addColumn('suit', Types::ENUM);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->expectException(ColumnValuesRequired::class);
 

--- a/tests/Functional/Types/JsonTest.php
+++ b/tests/Functional/Types/JsonTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -23,7 +25,13 @@ class JsonTest extends FunctionalTestCase
         $table->addColumn('id', Types::INTEGER);
 
         $table->addColumn('val', Types::JSON);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
     }

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Driver\Exception\IdentityColumnsNotSupported;
 use Doctrine\DBAL\Driver\Exception\NoIdentityValue;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -28,7 +30,13 @@ class WriteTest extends FunctionalTestCase
             'length' => 32,
             'notnull' => false,
         ]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $this->dropAndCreateTable($table);
 
@@ -277,7 +285,13 @@ class WriteTest extends FunctionalTestCase
 
         $table = new Table('test_empty_identity');
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         try {
             $this->connection->createSchemaManager()->dropTable($table->getObjectName()->toSQL($platform));

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
@@ -140,7 +142,13 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         $keyTable = new Table('foo');
         $keyTable->addColumn('bar', Types::INTEGER);
         $keyTable->addColumn('baz', Types::STRING, ['length' => 32]);
-        $keyTable->setPrimaryKey(['bar']);
+        $keyTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('bar'),
+                )
+                ->create(),
+        );
         $keyTable->addUniqueIndex(['baz']);
 
         $oldTable = new Table('foo');

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -128,7 +128,11 @@ abstract class AbstractPlatformTestCase extends TestCase
         $table = new Table('test');
         $table->addColumn('id', Types::INTEGER, ['notnull' => true, 'autoincrement' => true]);
         $table->addColumn('test', Types::STRING, ['notnull' => false, 'length' => 255]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals($this->getGenerateTableSql(), $sql[0]);
@@ -222,7 +226,11 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $table = new Table('`quoted`');
         $table->addColumn('create', Types::STRING, ['length' => 255]);
-        $table->setPrimaryKey(['create']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('create'))
+                ->create(),
+        );
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals($this->getQuotedColumnInPrimaryKeySQL(), $sql);
@@ -528,7 +536,11 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $table = new Table('mytable');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
 
         $tableDiff = new TableDiff($table, renamedIndexes: [
             'idx_foo' => new Index('idx_bar', ['id']),
@@ -553,7 +565,11 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $table = new Table('table');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
 
         $tableDiff = new TableDiff($table, renamedIndexes: [
             'create' => new Index('select', ['id']),
@@ -581,7 +597,11 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $table = new Table('myschema.mytable');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
 
         $tableDiff = new TableDiff($table, renamedIndexes: ['idx_foo' => new Index('idx_bar', ['id'])]);
 
@@ -604,7 +624,11 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $table = new Table('`schema`.table');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
 
         $tableDiff = new TableDiff($table, renamedIndexes: [
             'create' => new Index('select', ['id']),
@@ -725,7 +749,11 @@ abstract class AbstractPlatformTestCase extends TestCase
     {
         $foreignTable = new Table('foreign_table');
         $foreignTable->addColumn('id', Types::INTEGER);
-        $foreignTable->setPrimaryKey(['id']);
+        $foreignTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
 
         $primaryTable = new Table('mytable');
         $primaryTable->addColumn('foo', Types::INTEGER);

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -8,6 +8,10 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Exception\UnsupportedPrimaryKeyConstraintDefinition;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
@@ -16,6 +20,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
@@ -865,5 +870,53 @@ abstract class AbstractPlatformTestCase extends TestCase
             "field 'values' is not an array" => [['values' => 'foo']],
             "field 'values' is an empty array" => [['values' => []]],
         ];
+    }
+
+    /**
+     * The list of tested platforms should be kept in-sync with
+     * {@see PrimaryKeyConstraintTest::testNameIntrospection()}.
+     */
+    public function testNamedPrimaryKeyConstraintIsReportedAsUnsupported(): void
+    {
+        if (! $this->platform instanceof MySqlPlatform && ! $this->platform instanceof SQLitePlatform) {
+            self::markTestSkipped('This current database platform supports named primary key constraints.');
+        }
+
+        $table = new Table('users');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setName(
+                    UnqualifiedName::unquoted('users_pk'),
+                )
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
+
+        $this->expectException(UnsupportedPrimaryKeyConstraintDefinition::class);
+        $this->platform->getCreateTableSQL($table);
+    }
+
+    /**
+     * The list of tested platforms should be kept in-sync with
+     * {@see PrimaryKeyConstraintTest::testIsClusteredIntrospection()}.
+     */
+    public function testNonClusteredPrimaryKeyConstraintIsReportedAsUnsupported(): void
+    {
+        if ($this->platform instanceof SQLServerPlatform) {
+            self::markTestSkipped('This current database platform supports non-clustered primary key constraints.');
+        }
+
+        $table = new Table('users');
+        $table->addColumn('id', Types::INTEGER);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setIsClustered(false)
+                ->setColumnNames(UnqualifiedName::unquoted('id'))
+                ->create(),
+        );
+
+        $this->expectException(UnsupportedPrimaryKeyConstraintDefinition::class);
+        $this->platform->getCreateTableSQL($table);
     }
 }

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -9,7 +9,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
-use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
@@ -119,7 +120,13 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         $table = new Table('test');
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('name', Types::STRING, ['length' => 50]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $table->addIndex(['name']);
         $table->addIndex(['id', 'name'], 'composite_idx');
 
@@ -139,7 +146,13 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('fk_1', Types::INTEGER);
         $table->addColumn('fk_2', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $table->addForeignKeyConstraint('foreign_table', ['fk_1', 'fk_2'], ['pk_1', 'pk_2']);
         $table->addForeignKeyConstraint(
             'foreign_table2',
@@ -169,7 +182,13 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         $table->addColumn('id', Types::INTEGER);
         $table->addColumn('check_max', Types::INTEGER, ['platformOptions' => ['max' => 10]]);
         $table->addColumn('check_min', Types::INTEGER, ['platformOptions' => ['min' => 10]]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         self::assertEquals(
             [
@@ -241,17 +260,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         );
 
         self::assertEquals('DROP VIEW fooview', $this->platform->getDropViewSQL('fooview'));
-    }
-
-    public function testGeneratesCreateUnnamedPrimaryKeySQL(): void
-    {
-        self::assertEquals(
-            'ALTER TABLE foo ADD PRIMARY KEY ("A", "B")',
-            $this->platform->getCreatePrimaryKeySQL(
-                new Index('any_pk_name', ['a', 'b'], true, true),
-                'foo',
-            ),
-        );
     }
 
     public function testGeneratesSQLSnippets(): void

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -365,7 +367,16 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         $oldTable = new Table('test');
         $oldTable->addColumn('id', 'integer');
-        $oldTable->setPrimaryKey(['id']);
+        $oldTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setName(
+                    UnqualifiedName::unquoted('test_pkey'),
+                )
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $newTable = clone $oldTable;
         $newTable->dropPrimaryKey();

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -343,7 +343,13 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         $newTable = new Table('mytable');
         $newTable->addColumn('id', Types::INTEGER);
-        $newTable->setPrimaryKey(['id']);
+        $newTable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $oldTable = clone $newTable;
         $oldTable->addColumn('parent_id', Types::INTEGER);
@@ -378,8 +384,9 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
                 ->create(),
         );
 
-        $newTable = clone $oldTable;
-        $newTable->dropPrimaryKey();
+        $newTable = $oldTable->edit()
+            ->setPrimaryKeyConstraint(null)
+            ->create();
 
         $diff = $this->createComparator()
             ->compareTables($oldTable, $newTable);

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -585,16 +585,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testCreateNonClusteredPrimaryKey(): void
-    {
-        $idx = new Index('idx', ['id'], false, true);
-        $idx->addFlag('nonclustered');
-        self::assertEquals(
-            'ALTER TABLE tbl ADD PRIMARY KEY NONCLUSTERED ([id])',
-            $this->platform->getCreatePrimaryKeySQL($idx, 'tbl'),
-        );
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -654,7 +644,13 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         $table = new Table('testschema.test');
         $table->addColumn('id', Types::INTEGER, ['comment' => 'This is a comment']);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $expectedSql = [
             'CREATE TABLE [testschema].[test] ([id] INT NOT NULL, PRIMARY KEY ([id]))',

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -15,6 +15,8 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -568,8 +570,14 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
     {
         $table = new Table('tbl');
         $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
-        $table->getIndex('primary')->addFlag('nonclustered');
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->setIsClustered(false)
+                ->create(),
+        );
 
         self::assertEquals(
             ['CREATE TABLE [tbl] ([id] INT NOT NULL, PRIMARY KEY NONCLUSTERED ([id]))'],
@@ -585,12 +593,6 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             'ALTER TABLE tbl ADD PRIMARY KEY NONCLUSTERED ([id])',
             $this->platform->getCreatePrimaryKeySQL($idx, 'tbl'),
         );
-    }
-
-    public function testAlterAddPrimaryKey(): void
-    {
-        $idx = new Index('idx', ['id'], false, true);
-        self::assertEquals('ALTER TABLE tbl ADD PRIMARY KEY ([id])', $this->platform->getCreateIndexSQL($idx, 'tbl'));
     }
 
     /**

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -14,13 +14,13 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-
-use function implode;
 
 /** @extends AbstractPlatformTestCase<SQLitePlatform> */
 class SQLitePlatformTest extends AbstractPlatformTestCase
@@ -193,22 +193,6 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    public function testGeneratesPrimaryIndexCreationSqlWithSchema(): void
-    {
-        $primaryIndexDef = new Index('i2', ['a', 'b'], false, true);
-
-        self::assertSame(
-            'TEST: main.mytable, i2 - a, b',
-            (new class () extends SqlitePlatform {
-                public function getCreatePrimaryKeySQL(Index $index, string $table): string
-                {
-                    return 'TEST: ' . $table . ', ' . $index->getName()
-                        . ' - ' . implode(', ', $index->getColumns());
-                }
-            })->getCreateIndexSQL($primaryIndexDef, 'main.mytable'),
-        );
-    }
-
     public function testGeneratesForeignKeyCreationSql(): void
     {
         $this->expectException(Exception::class);
@@ -243,7 +227,13 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
     {
         $table = new Table('test');
         $table->addColumn('"like"', Types::INTEGER, ['notnull' => true, 'autoincrement' => true]);
-        $table->setPrimaryKey(['"like"']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::quoted('like'),
+                )
+                ->create(),
+        );
 
         $createTableSQL = $this->platform->getCreateTableSQL($table);
         self::assertEquals(
@@ -295,7 +285,13 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table->addColumn('article', Types::INTEGER);
         $table->addColumn('post', Types::INTEGER);
         $table->addColumn('parent', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $table->addForeignKeyConstraint('article', ['article'], ['id'], ['deferrable' => true]);
         $table->addForeignKeyConstraint('post', ['post'], ['id'], ['deferred' => true]);
         $table->addForeignKeyConstraint('user', ['parent'], ['id'], ['deferrable' => true, 'deferred' => true]);
@@ -326,7 +322,13 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table->addColumn('article', Types::INTEGER);
         $table->addColumn('post', Types::INTEGER);
         $table->addColumn('parent', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
         $table->addForeignKeyConstraint('article', ['article'], ['id'], ['deferrable' => true]);
         $table->addForeignKeyConstraint('post', ['post'], ['id'], ['deferred' => true]);
         $table->addForeignKeyConstraint('user', ['parent'], ['id'], ['deferrable' => true, 'deferred' => true]);
@@ -653,7 +655,14 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
         $table = new Table('test_autoincrement');
         $table->addColumn('id1', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('id2', Types::INTEGER);
-        $table->setPrimaryKey(['id1', 'id2']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id1'),
+                    UnqualifiedName::unquoted('id2'),
+                )
+                ->create(),
+        );
 
         $this->expectException(UnsupportedTableDefinition::class);
         $this->platform->getCreateTableSQL($table);

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\SchemaDiff;
@@ -537,14 +538,26 @@ abstract class AbstractComparatorTestCase extends TestCase
         $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $table->addColumn('twitterId', Types::INTEGER);
         $table->addColumn('displayName', Types::STRING, ['length' => 32]);
-        $table->setPrimaryKey(['id']);
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $newtable = new Table('twitter_users');
         $newtable->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
         $newtable->addColumn('twitter_id', Types::INTEGER);
         $newtable->addColumn('display_name', Types::STRING, ['length' => 32]);
         $newtable->addColumn('logged_in_at', Types::DATETIME_MUTABLE);
-        $newtable->setPrimaryKey(['id']);
+        $newtable->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(
+                    UnqualifiedName::unquoted('id'),
+                )
+                ->create(),
+        );
 
         $tableDiff = $this->comparator->compareTables($table, $newtable);
 

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -15,9 +15,9 @@ use PHPUnit\Framework\TestCase;
 class IndexTest extends TestCase
 {
     /** @param mixed[] $options */
-    private function createIndex(bool $unique = false, bool $primary = false, array $options = []): Index
+    private function createIndex(bool $unique = false, array $options = []): Index
     {
-        return new Index('foo', ['bar', 'baz'], $unique, $primary, [], $options);
+        return new Index('foo', ['bar', 'baz'], $unique, false, [], $options);
     }
 
     public function testCreateIndex(): void
@@ -28,38 +28,19 @@ class IndexTest extends TestCase
         self::assertCount(2, $columns);
         self::assertEquals(['bar', 'baz'], $columns);
         self::assertFalse($idx->isUnique());
-        self::assertFalse($idx->isPrimary());
-    }
-
-    public function testCreatePrimary(): void
-    {
-        $idx = $this->createIndex(false, true);
-        self::assertTrue($idx->isUnique());
-        self::assertTrue($idx->isPrimary());
     }
 
     public function testCreateUnique(): void
     {
-        $idx = $this->createIndex(true, false);
+        $idx = $this->createIndex(true);
         self::assertTrue($idx->isUnique());
-        self::assertFalse($idx->isPrimary());
     }
 
     public function testFulfilledByUnique(): void
     {
-        $idx1 = $this->createIndex(true, false);
-        $idx2 = $this->createIndex(true, false);
+        $idx1 = $this->createIndex(true);
+        $idx2 = $this->createIndex(true);
         $idx3 = $this->createIndex();
-
-        self::assertTrue($idx1->isFulfilledBy($idx2));
-        self::assertFalse($idx1->isFulfilledBy($idx3));
-    }
-
-    public function testFulfilledByPrimary(): void
-    {
-        $idx1 = $this->createIndex(true, true);
-        $idx2 = $this->createIndex(true, true);
-        $idx3 = $this->createIndex(true, false);
 
         self::assertTrue($idx1->isFulfilledBy($idx2));
         self::assertFalse($idx1->isFulfilledBy($idx3));
@@ -69,11 +50,9 @@ class IndexTest extends TestCase
     {
         $idx1 = $this->createIndex();
         $idx2 = $this->createIndex();
-        $pri  = $this->createIndex(true, true);
         $uniq = $this->createIndex(true);
 
         self::assertTrue($idx1->isFulfilledBy($idx2));
-        self::assertTrue($idx1->isFulfilledBy($pri));
         self::assertTrue($idx1->isFulfilledBy($uniq));
     }
 
@@ -168,7 +147,7 @@ class IndexTest extends TestCase
         self::assertFalse($idx1->hasOption('where'));
         self::assertEmpty($idx1->getOptions());
 
-        $idx2 = $this->createIndex(false, false, ['where' => 'name IS NULL']);
+        $idx2 = $this->createIndex(false, ['where' => 'name IS NULL']);
         self::assertTrue($idx2->hasOption('where'));
         self::assertTrue($idx2->hasOption('WHERE'));
         self::assertSame('name IS NULL', $idx2->getOption('where'));
@@ -212,16 +191,9 @@ class IndexTest extends TestCase
         new Index('idx_user_name', ['user.name']);
     }
 
-    public function testPrimaryKeyWithColumnLength(): void
-    {
-        $this->expectException(InvalidIndexDefinition::class);
-
-        new Index('primary', ['id'], false, true, [], ['lengths' => [32]]);
-    }
-
     public function testPrimaryKeyWithNullColumnLength(): void
     {
-        $index = new Index('primary', ['id'], false, true, [], ['lengths' => [null]]);
+        $index = new Index('primary', ['id'], false, false, [], ['lengths' => [null]]);
 
         $indexedColumns = $index->getIndexedColumns();
 

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -231,4 +231,11 @@ class IndexTest extends TestCase
         self::assertEquals(UnqualifiedName::unquoted('last_name'), $indexedColumns[1]->getColumnName());
         self::assertNull($indexedColumns[1]->getLength());
     }
+
+    public function testPrimaryIndex(): void
+    {
+        $this->expectException(InvalidIndexDefinition::class);
+
+        new Index('users_pk', ['id'], false, true);
+    }
 }

--- a/tests/Schema/Platforms/MySQLSchemaTest.php
+++ b/tests/Schema/Platforms/MySQLSchemaTest.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
@@ -50,9 +52,16 @@ class MySQLSchemaTest extends TestCase
         $tableOld = new Table('test');
         $tableOld->addColumn('id', Types::INTEGER);
         $tableOld->addColumn('description', Types::STRING, ['length' => 65536]);
-        $tableNew = clone $tableOld;
 
-        $tableNew->setPrimaryKey(['id']);
+        $tableNew = $tableOld->edit()
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setColumnNames(
+                        UnqualifiedName::unquoted('id'),
+                    )
+                    ->create(),
+            )
+            ->create();
 
         $diff = $this->createComparator()
             ->compareTables($tableOld, $tableNew);

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -9,9 +9,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\InvalidForeignKeyConstraintDefinition;
-use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
 use Doctrine\DBAL\Schema\Exception\InvalidName;
-use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -249,17 +247,16 @@ class TableTest extends TestCase
             new Column('bar', $type),
         ];
         $indexes = [
-            new Index('the_primary', ['foo'], true, true),
-            new Index('bar_idx', ['bar'], false, false),
+            new Index('foo_idx', ['foo'], true),
+            new Index('bar_idx', ['bar']),
         ];
         $table   = new Table('foo', $columns, $indexes, []);
 
-        self::assertTrue($table->hasIndex('the_primary'));
+        self::assertTrue($table->hasIndex('foo_idx'));
         self::assertTrue($table->hasIndex('bar_idx'));
         self::assertFalse($table->hasIndex('some_idx'));
 
-        self::assertNotNull($table->getPrimaryKey());
-        self::assertSame('the_primary', $table->getIndex('the_primary')->getName());
+        self::assertSame('foo_idx', $table->getIndex('foo_idx')->getName());
         self::assertSame('bar_idx', $table->getIndex('bar_idx')->getName());
     }
 
@@ -271,19 +268,6 @@ class TableTest extends TestCase
         $table->getIndex('unknownIndex');
     }
 
-    public function testAddTwoPrimaryThrowsException(): void
-    {
-        $this->expectException(SchemaException::class);
-
-        $type    = Type::getType(Types::INTEGER);
-        $columns = [new Column('foo', $type), new Column('bar', $type)];
-        $indexes = [
-            new Index('the_primary', ['foo'], true, true),
-            new Index('other_primary', ['bar'], true, true),
-        ];
-        new Table('foo', $columns, $indexes, [], []);
-    }
-
     public function testAddTwoIndexesWithSameNameThrowsException(): void
     {
         $this->expectException(SchemaException::class);
@@ -291,8 +275,8 @@ class TableTest extends TestCase
         $type    = Type::getType(Types::INTEGER);
         $columns = [new Column('foo', $type), new Column('bar', $type)];
         $indexes = [
-            new Index('an_idx', ['foo'], false, false),
-            new Index('an_idx', ['bar'], false, false),
+            new Index('an_idx', ['foo']),
+            new Index('an_idx', ['bar']),
         ];
         new Table('foo', $columns, $indexes, [], []);
     }
@@ -305,31 +289,6 @@ class TableTest extends TestCase
         self::assertEquals('bar', $table->getOption('foo'));
     }
 
-    public function testBuilderSetPrimaryKey(): void
-    {
-        $table = new Table('foo');
-
-        $table->addColumn('bar', Types::INTEGER);
-        $table->setPrimaryKey(['bar']);
-
-        self::assertTrue($table->hasIndex('primary'));
-        self::assertInstanceOf(Index::class, $table->getPrimaryKey());
-        self::assertTrue($table->getIndex('primary')->isUnique());
-        self::assertTrue($table->getIndex('primary')->isPrimary());
-    }
-
-    public function testSetPrimaryKeyOnANullableColumn(): void
-    {
-        $table = new Table('users');
-
-        $id = $table->addColumn('id', Types::INTEGER)
-            ->setNotnull(false);
-
-        $this->expectException(InvalidIndexDefinition::class);
-
-        $table->setPrimaryKey(['id']);
-    }
-
     public function testBuilderAddUniqueIndex(): void
     {
         $table = new Table('foo');
@@ -339,7 +298,6 @@ class TableTest extends TestCase
 
         self::assertTrue($table->hasIndex('my_idx'));
         self::assertTrue($table->getIndex('my_idx')->isUnique());
-        self::assertFalse($table->getIndex('my_idx')->isPrimary());
     }
 
     public function testBuilderAddIndex(): void
@@ -351,7 +309,6 @@ class TableTest extends TestCase
 
         self::assertTrue($table->hasIndex('my_idx'));
         self::assertFalse($table->getIndex('my_idx')->isUnique());
-        self::assertFalse($table->getIndex('my_idx')->isPrimary());
     }
 
     public function testBuilderAddIndexWithInvalidNameThrowsException(): void
@@ -563,23 +520,6 @@ class TableTest extends TestCase
         self::assertSame(['bar', 'baz'], $table->getIndex('fulfilling_idx')->getColumns());
     }
 
-    public function testPrimaryKeyOverrulingUniqueIndexDoesNotDropUniqueIndex(): void
-    {
-        $table = new Table('bar');
-        $table->addColumn('baz', Types::INTEGER, []);
-        $table->addUniqueIndex(['baz'], 'idx_unique');
-
-        $table->setPrimaryKey(['baz']);
-
-        $indexes = $table->getIndexes();
-
-        // Table should only contain both the primary key table index and the unique one, even though it was overruled
-        self::assertCount(2, $indexes);
-
-        self::assertNotNull($table->getPrimaryKey());
-        self::assertTrue($table->hasIndex('idx_unique'));
-    }
-
     public function testAddingFulfillingRegularIndexOverridesImplicitForeignKeyConstraintIndex(): void
     {
         $foreignTable = new Table('foreign');
@@ -609,23 +549,6 @@ class TableTest extends TestCase
         self::assertCount(1, $localTable->getIndexes());
 
         $localTable->addUniqueIndex(['id'], 'explicit_idx');
-
-        self::assertCount(1, $localTable->getIndexes());
-        self::assertTrue($localTable->hasIndex('explicit_idx'));
-    }
-
-    public function testAddingFulfillingPrimaryKeyOverridesImplicitForeignKeyConstraintIndex(): void
-    {
-        $foreignTable = new Table('foreign');
-        $foreignTable->addColumn('id', Types::INTEGER);
-
-        $localTable = new Table('local');
-        $localTable->addColumn('id', Types::INTEGER);
-        $localTable->addForeignKeyConstraint($foreignTable->getName(), ['id'], ['id']);
-
-        self::assertCount(1, $localTable->getIndexes());
-
-        $localTable->setPrimaryKey(['id'], 'explicit_idx');
 
         self::assertCount(1, $localTable->getIndexes());
         self::assertTrue($localTable->hasIndex('explicit_idx'));
@@ -667,13 +590,21 @@ class TableTest extends TestCase
     public function testTableHasPrimaryKey(): void
     {
         $table = new Table('test');
-
-        self::assertNull($table->getPrimaryKey());
-
         $table->addColumn('foo', Types::INTEGER);
-        $table->setPrimaryKey(['foo']);
 
-        self::assertNotNull($table->getPrimaryKey());
+        self::assertNull($table->getPrimaryKeyConstraint());
+
+        $table->addPrimaryKeyConstraint(
+            PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted('foo'))
+                ->create(),
+        );
+
+        self::assertNotNull($table->getPrimaryKeyConstraint());
+
+        $table->dropPrimaryKey();
+
+        self::assertNull($table->getPrimaryKeyConstraint());
     }
 
     public function testAddForeignKeyWithQuotedColumnsAndTable(): void
@@ -705,18 +636,6 @@ class TableTest extends TestCase
         self::assertFalse($table->hasIndex('idx'));
     }
 
-    public function testDropPrimaryKey(): void
-    {
-        $table = new Table('test');
-        $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
-
-        self::assertNotNull($table->getPrimaryKey());
-
-        $table->dropPrimaryKey();
-        self::assertNull($table->getPrimaryKey());
-    }
-
     public function testRenameIndex(): void
     {
         $table = new Table('test');
@@ -724,48 +643,35 @@ class TableTest extends TestCase
         $table->addColumn('foo', Types::INTEGER);
         $table->addColumn('bar', Types::INTEGER);
         $table->addColumn('baz', Types::INTEGER);
-        $table->setPrimaryKey(['id'], 'pk');
         $table->addIndex(['foo'], 'idx', ['flag']);
         $table->addUniqueIndex(['bar', 'baz'], 'uniq');
 
         // Rename to custom name.
-        self::assertSame($table, $table->renameIndex('pk', 'pk_new'));
         self::assertSame($table, $table->renameIndex('idx', 'idx_new'));
         self::assertSame($table, $table->renameIndex('uniq', 'uniq_new'));
 
-        self::assertNotNull($table->getPrimaryKey());
-        self::assertTrue($table->hasIndex('pk_new'));
         self::assertTrue($table->hasIndex('idx_new'));
         self::assertTrue($table->hasIndex('uniq_new'));
 
-        self::assertFalse($table->hasIndex('pk'));
         self::assertFalse($table->hasIndex('idx'));
         self::assertFalse($table->hasIndex('uniq'));
 
-        self::assertEquals(new Index('pk_new', ['id'], true, true), $table->getPrimaryKey());
-        self::assertEquals(new Index('pk_new', ['id'], true, true), $table->getIndex('pk_new'));
         self::assertEquals(
             new Index('idx_new', ['foo'], false, false, ['flag']),
             $table->getIndex('idx_new'),
         );
-        self::assertEquals(new Index('uniq_new', ['bar', 'baz'], true), $table->getIndex('uniq_new'));
+        self::assertEquals(new Index('uniq_new', ['bar', 'baz'], true, false), $table->getIndex('uniq_new'));
 
         // Rename to auto-generated name.
-        self::assertSame($table, $table->renameIndex('pk_new', null));
         self::assertSame($table, $table->renameIndex('idx_new', null));
         self::assertSame($table, $table->renameIndex('uniq_new', null));
 
-        self::assertNotNull($table->getPrimaryKey());
-        self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
         self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
 
-        self::assertFalse($table->hasIndex('pk_new'));
         self::assertFalse($table->hasIndex('idx_new'));
         self::assertFalse($table->hasIndex('uniq_new'));
 
-        self::assertEquals(new Index('primary', ['id'], true, true), $table->getPrimaryKey());
-        self::assertEquals(new Index('primary', ['id'], true, true), $table->getIndex('primary'));
         self::assertEquals(
             new Index('IDX_D87F7E0C8C736521', ['foo'], false, false, ['flag']),
             $table->getIndex('IDX_D87F7E0C8C736521'),
@@ -776,12 +682,9 @@ class TableTest extends TestCase
         );
 
         // Rename to same name (changed case).
-        self::assertSame($table, $table->renameIndex('primary', 'PRIMARY'));
         self::assertSame($table, $table->renameIndex('IDX_D87F7E0C8C736521', 'idx_D87F7E0C8C736521'));
         self::assertSame($table, $table->renameIndex('UNIQ_D87F7E0C76FF8CAA78240498', 'uniq_D87F7E0C76FF8CAA78240498'));
 
-        self::assertNotNull($table->getPrimaryKey());
-        self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
         self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
     }
@@ -1013,84 +916,5 @@ class TableTest extends TestCase
 
         self::assertEquals(Identifier::unquoted('products'), $name->getUnqualifiedName());
         self::assertEquals(Identifier::unquoted('inventory'), $name->getQualifier());
-    }
-
-    public function testPrimaryKeyConstraintIsDerivedFromIndex(): void
-    {
-        $table = new Table('t');
-        $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
-
-        self::assertEquals(
-            PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
-                ->create(),
-            $table->getPrimaryKeyConstraint(),
-        );
-    }
-
-    public function testIndexIsDerivedFromPrimaryKeyConstraint(): void
-    {
-        $table = new Table('t');
-        $table->addColumn('id', Types::INTEGER);
-        $table->addPrimaryKeyConstraint(
-            PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
-                ->create(),
-        );
-
-        self::assertEquals(
-            new Index('primary', ['id'], false, true),
-            $table->getPrimaryKey(),
-        );
-    }
-
-    public function testDroppingIndexDropsPrimaryKeyConstraint(): void
-    {
-        $table = new Table('t');
-        $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
-
-        self::assertNotNull($table->getPrimaryKeyConstraint());
-
-        $table->dropPrimaryKey();
-
-        self::assertNull($table->getPrimaryKeyConstraint());
-    }
-
-    public function testCannotAddIndexToExistingPrimaryKeyConstraint(): void
-    {
-        $table = new Table('t');
-        $table->addColumn('id', Types::INTEGER);
-        $table->addPrimaryKeyConstraint(
-            PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
-                ->create(),
-        );
-
-        $this->expectException(PrimaryKeyAlreadyExists::class);
-        $table->setPrimaryKey(['id']);
-    }
-
-    public function testCannotAddPrimaryKeyConstrainToExistingIndex(): void
-    {
-        $table = new Table('t');
-        $table->addColumn('id', Types::INTEGER);
-        $table->setPrimaryKey(['id']);
-
-        $this->expectException(PrimaryKeyAlreadyExists::class);
-        $table->addPrimaryKeyConstraint(
-            PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
-                ->create(),
-        );
     }
 }


### PR DESCRIPTION
The affected features were deprecated in https://github.com/doctrine/dbal/pull/6867. See the upgrade notes for details on the end-user impact.

### Improvements
As a side effect, this change provides the following:
1. Dropping a primary key constraint is now supported on all platforms.
2. Naming a primary key constraint is now supported on all platforms except for MySQL and SQLite. This is a limitation of the platforms in question.

### Technical details
1. This PR only forbids passing `true` as the `$isPrimary` argument of the `Index` constructor but does not remove the parameter itself. Removing the parameter would require modifying code that instantiates non-PK indexes as well. Once we introduce `IndexEditor`, we will mark the constructor as `@internal` and then remove the parameter.
2. The code modified by the "Compare unquoted names to unquoted names" commit is incorrect in all DBAL versions but the corresponding issue is only reproducible on 5.0.x and only in-between the commits of this PR. The issue is that the comparison is performed between the quoted index column names (derived from the introspected PK constraint). This way, they will never match. In 4.3.x, all introspected SQLite objects are always unquoted, so the comparison works aas expected. 

Closes #807
Fixes #2294
Closes #3890