### PR TITLE
Fix merging driver options in the pdo_sqlsrv driver test

### DIFF
--- a/tests/Functional/Driver/PDO/SQLSrv/DriverTest.php
+++ b/tests/Functional/Driver/PDO/SQLSrv/DriverTest.php
@@ -13,6 +13,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 use function array_merge;
+use function array_replace;
 
 #[RequiresPhpExtension('pdo_sqlsrv')]
 class DriverTest extends AbstractDriverTestCase
@@ -44,7 +45,7 @@ class DriverTest extends AbstractDriverTestCase
         $params = TestUtil::getConnectionParams();
 
         if (isset($params['driverOptions'])) {
-            $driverOptions = array_merge($params['driverOptions'], $driverOptions);
+            $driverOptions = array_replace($params['driverOptions'], $driverOptions);
         }
 
         return (new Driver())->connect(


### PR DESCRIPTION
This issue affects only the test suite and only if the `pdo_sqlsrv` connection is configured with additional DSN parameters, for instance:
```xml
<var name="db_driver_option_TrustServerCertificate" value="1" />
```

In this case, the `testDriverOptions()` test will fail with the following error:
```
phpunit -c phpunit-pdo-sqlsrv.xml \
  --filter testDriverOptions \
  tests/Functional/Driver/PDO/SQLSrv/DriverTest.php

There was 1 error:

1) Doctrine\DBAL\Tests\Functional\Driver\PDO\SQLSrv\DriverTest::testDriverOptions
Doctrine\DBAL\Driver\PDO\Exception: SQLSTATE[IMSSP]: An unsupported attribute was designated on the PDO object.

src/Driver/PDO/Exception.php:24
src/Driver/PDO/SQLSrv/Driver.php:65
tests/Functional/Driver/PDO/SQLSrv/DriverTest.php:50
tests/Functional/Driver/PDO/SQLSrv/DriverTest.php:68
```

The reason is that the `pdo_sqlsrv` DBAL driver accepts both the DSN and PDO parameters in the `driverOptions` connection parameter: https://github.com/doctrine/dbal/blob/54be50e2f2ea4cdbbdee35b9d0cf08cd9cb9bcb8/src/Driver/PDO/SQLSrv/Driver.php#L36-L40

Prior to the fix, the code would merge the configuration provided by PHPUnit with the configuration provided by the test using `array_merge()` and lose the key representing the PDO attribute:
```php
$dsnOptions = ['TrustServerCertificate' => '1'];
$pdoOptions = [8 => 1];

var_dump(array_merge($dsnOptions, $pdoOptions));

// array(2) {
//   ["TrustServerCertificate"]=>
//   string(1) "1"
//   [0]=>
//   int(1)
// }
```

`array_replace()` preserves numeric keys in the case if both string string keys designated for the DSN and numeric keys designated for PDO are present.