### PR TITLE
Fix testChangeIndexWithForeignKeys() configuration

### DIFF
--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -1309,7 +1310,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $child->dropIndex('idx_1');
         $child->addIndex(['parent_id'], 'idx_2');
 
-        $diff = $schemaManager->createComparator()->compareTables(
+        $diff = $schemaManager->createComparator(
+            (new ComparatorConfig())->withDetectRenamedIndexes(false),
+        )->compareTables(
             $schemaManager->introspectTable('child'),
             $child,
         );


### PR DESCRIPTION
The test in question and the corresponding MySQL platform code were added back in 2012 (b68179bb2293f5f789b2618e2c1a1074e1f38f75). The idea is that in certain cases on MySQL and IBM Db2, we want to drop and create an index in the same `ALTER TABLE` statement, but the default implementation in `AbstractPlatform` does it in separate statements (as more portable).

With the introduction of the support for index rename detection (https://github.com/doctrine/dbal/pull/764), the dropped and added back index in the test scenario started being detected as renamed, so the logic in question no longer kicks in. It results this code in being not covered by tests (see the coverage for [MySQL](https://app.codecov.io/gh/doctrine/dbal/blob/4.2.x/src%2FPlatforms%2FAbstractMySQLPlatform.php#L437) and [IBM Db2](https://app.codecov.io/gh/doctrine/dbal/blob/4.2.x/src%2FPlatforms%2FDB2Platform.php#L458) on Codecov).

This code is a hack, but fixing it will require a lot of rework. For now, we at least want to make sure that it's tested.

I'm targeting `4.3.x` because the support for disabling index rename detection (#6300) doesn't exist in `4.2.x`. The [MySQL](https://app.codecov.io/gh/doctrine/dbal/pull/6872/indirect-changes) branch is now covered. Not sure why the IBM Db2 branch is still not.