### PR TITLE
Remove DB2Platform:getPreAlterTableIndexForeignKeySQL()

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -451,41 +451,6 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
-    {
-        $sql = [];
-
-        $tableNameSQL = $diff->getOldTable()->getQuotedName($this);
-
-        foreach ($diff->getDroppedIndexes() as $droppedIndex) {
-            foreach ($diff->getAddedIndexes() as $addedIndex) {
-                if ($droppedIndex->getColumns() !== $addedIndex->getColumns()) {
-                    continue;
-                }
-
-                if ($droppedIndex->isPrimary()) {
-                    $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP PRIMARY KEY';
-                } elseif ($droppedIndex->isUnique()) {
-                    $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' DROP UNIQUE ' . $droppedIndex->getQuotedName($this);
-                } else {
-                    $sql[] = $this->getDropIndexSQL($droppedIndex->getQuotedName($this), $tableNameSQL);
-                }
-
-                $sql[] = $this->getCreateIndexSQL($addedIndex, $tableNameSQL);
-
-                $diff->unsetAddedIndex($addedIndex);
-                $diff->unsetDroppedIndex($droppedIndex);
-
-                break;
-            }
-        }
-
-        return array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
     {
         if (str_contains($tableName, '.')) {


### PR DESCRIPTION
This is a follow-up for https://github.com/doctrine/dbal/pull/6872. This code is never executed (see [Codecov](https://app.codecov.io/gh/doctrine/dbal/blob/4cfeef382b3d33384dc170f7814ebcc8db674dbf/src%2FPlatforms%2FDB2Platform.php#L466)) because of the following condition: https://github.com/doctrine/dbal/blob/4e26424cea33c8e6929f1cbad085a91f3ef0beb1/src/Platforms/DB2Platform.php#L462-L464

This condition is incorrect because the column names in the introspected schema aren't guaranteed to be in the same case as defined by the application. Specifically, in our test suite, most identifiers are lower-cased and unquoted, so they become upper-cased in the database.

Unlike the override in `AbstractMySQLPlatform` which addresses the scenario covered by `testChangeIndexWithForeignKeys()`, it is not clear what this override is for. Even if the incorrect condition is fixed, in this test scenario (the only one that triggers this code branch), it effectively builds the same SQL as the default implementation would build:
```sql
DROP INDEX idx_1;  
CREATE INDEX idx_2 ON child (parent_id);
```

It _may_ compensate for some deficiency in the `getDropIndexSQL()` implementation. Compare the two: https://github.com/doctrine/dbal/blob/615a60189d9a55b9f5232adc481da80ad3f76dc4/src/Platforms/AbstractPlatform.php#L793-L796 https://github.com/doctrine/dbal/blob/4e26424cea33c8e6929f1cbad085a91f3ef0beb1/src/Platforms/DB2Platform.php#L466-L472
But if that's the case, this logic should be used regardless of the dropped/added index column match. In any event, this is effectively unreachable code.