### PR TITLE
Move MySQL-related code out of abstract platform

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -414,6 +414,15 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
     }
 
+    /**
+     * Returns the SQL fragment representing an index.
+     */
+    private function getIndexDeclarationSQL(Index $index): string
+    {
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getObjectName()->toSQL($this)
+            . ' (' . implode(', ', $index->getQuotedColumns($this)) . ')';
+    }
+
     protected function getCreateIndexSQLFlags(Index $index): string
     {
         $type = '';

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -995,10 +995,6 @@ abstract class AbstractPlatform
             $elements[] = $this->getPrimaryKeyConstraintDeclarationSQL($parameters['primaryKey']);
         }
 
-        foreach ($parameters['indexes'] as $definition) {
-            $elements[] = $this->getIndexDeclarationSQL($definition);
-        }
-
         $elements = array_merge($elements, $this->getCheckDeclarationSQL($columns));
 
         $query = 'CREATE TABLE ' . $tableName->toSQL($this) . ' (' . implode(', ', $elements) . ')';
@@ -1445,26 +1441,6 @@ abstract class AbstractPlatform
         $chunks[] = $this->buildUnqualifiedNameListSQL($constraint->getColumnNames());
 
         return implode(' ', $chunks);
-    }
-
-    /**
-     * Obtains DBMS specific SQL code portion needed to set an index
-     * declaration to be used in statements like CREATE TABLE.
-     *
-     * @param Index $index The index definition.
-     *
-     * @return string DBMS specific SQL code portion needed to set an index.
-     */
-    protected function getIndexDeclarationSQL(Index $index): string
-    {
-        $columns = $index->getColumns();
-
-        if (count($columns) === 0) {
-            throw new InvalidArgumentException('Incomplete definition. "columns" required.');
-        }
-
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getObjectName()->toSQL($this)
-            . ' (' . implode(', ', $index->getQuotedColumns($this)) . ')' . $this->getPartialIndexSQL($index);
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -241,28 +241,18 @@ class DB2Platform extends AbstractPlatform
         return 'CURRENT TIMESTAMP';
     }
 
-    protected function getIndexDeclarationSQL(Index $index): string
-    {
-        // Index declaration in statements like CREATE TABLE is not supported.
-        throw NotSupported::new(__METHOD__);
-    }
-
     /**
      * {@inheritDoc}
      */
     protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
-        $indexes = $parameters['indexes'];
+        $sql = parent::_getCreateTableSQL($tableName, $columns, $parameters);
 
-        $parameters['indexes'] = [];
-
-        $sqls = parent::_getCreateTableSQL($tableName, $columns, $parameters);
-
-        foreach ($indexes as $definition) {
-            $sqls[] = $this->getCreateIndexSQL($definition, $tableName->toSQL($this));
+        foreach ($parameters['indexes'] as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $tableName->toSQL($this));
         }
 
-        return $sqls;
+        return $sql;
     }
 
     /**

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -319,10 +319,6 @@ class OraclePlatform extends AbstractPlatform
      */
     protected function _getCreateTableSQL(OptionallyQualifiedName $tableName, array $columns, array $parameters): array
     {
-        $indexes = $parameters['indexes'];
-
-        $parameters['indexes'] = [];
-
         $sql = parent::_getCreateTableSQL($tableName, $columns, $parameters);
 
         foreach ($columns as $column) {
@@ -339,7 +335,7 @@ class OraclePlatform extends AbstractPlatform
             $sql = array_merge($sql, $this->getCreateAutoincrementSql($tableName, $column['name']));
         }
 
-        foreach ($indexes as $index) {
+        foreach ($parameters['indexes'] as $index) {
             $sql[] = $this->getCreateIndexSQL($index, $tableName->toSQL($this));
         }
 


### PR DESCRIPTION
### Background

MySQL is the only supported platform that considers an index part of the table and allows creating indexes within the `CREATE TABLE` statement. All others treat indexes as separate relations and require `CREATE TABLE (...)` and `CREATE INDEX ... ON <table>` to be separate statements.

### The problem

The current `AbstractPlatform` API was designed after MySQL and doesn't make sense for other platforms:
1. The `AbstractPlatform::_getCreateTableSQL()` method accepts indexes via `$parameters['indexes']` in order to create them as part of the table (relevant only for MySQ), but it's not invoked from `AbstractMySQLPlatform::_getCreateTableSQL()`.
2. The Db2 and Oracle platform classes do invoke `AbstractPlatform::_getCreateTableSQL()`, but since these platforms don't treat indexes as part of the table, they have to unset `$parameters['indexes']`. The following is effectively dead code: https://github.com/doctrine/dbal/blob/f29f027c2fb62027c4b53bfa49bdea5c54dc96fd/src/Platforms/AbstractPlatform.php#L1036-L1038
3. The `AbstractPlatform::getIndexDeclarationSQL()` method returns the SQL that represents an index as part of table declaration, but it only make sense for MySQL. All other platforms technically have to override it as not implemented, but only the Db2 platform class does that.

### The solution
1. Move  `AbstractPlatform::getIndexDeclarationSQL()` to the MySQL platform class.
2. Do not handle `$parameters['indexes']` in `AbstractPlatform::_getCreateTableSQL()`.