### PR TITLE
Deprecate renaming index to an auto-generated name

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated renaming an index to an auto-generated name
+
+Renaming an index to an auto-generated name by passing NULL as the `$newName` argument to `Table::renameIndex()` is
+deprecated. Pass the new index name instead.
+
 ## Deprecated features related to primary key constraints
 
 1. The `AbstractPlatform::getCreatePrimaryKeySQL()` method has been deprecated. Use the schema manager to create and

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -31,6 +31,7 @@ use function implode;
 use function in_array;
 use function preg_match;
 use function sprintf;
+use function strlen;
 use function strtolower;
 
 /**
@@ -298,22 +299,31 @@ class Table extends AbstractNamedObject
      */
     public function renameIndex(string $oldName, ?string $newName = null): self
     {
-        $oldName           = $this->normalizeIdentifier($oldName);
+        if ($newName === null || strlen($newName) === 0) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6879',
+                'Passing NULL as the $newName argument to %s() is deprecated. Pass the new index name instead',
+                __METHOD__,
+            );
+        }
+
+        $normalizedOldName = $this->normalizeIdentifier($oldName);
         $normalizedNewName = $this->normalizeIdentifier($newName);
 
-        if ($oldName === $normalizedNewName) {
+        if ($normalizedOldName === $normalizedNewName) {
             return $this;
         }
 
-        if (! $this->hasIndex($oldName)) {
-            throw IndexDoesNotExist::new($oldName, $this->_name);
+        if (! $this->hasIndex($normalizedOldName)) {
+            throw IndexDoesNotExist::new($normalizedOldName, $this->_name);
         }
 
         if ($this->hasIndex($normalizedNewName)) {
             throw IndexAlreadyExists::new($normalizedNewName, $this->_name);
         }
 
-        $oldIndex = $this->_indexes[$oldName];
+        $oldIndex = $this->_indexes[$normalizedOldName];
 
         if ($oldIndex->isPrimary()) {
             Deprecation::triggerIfCalledFromOutside(
@@ -329,7 +339,7 @@ class Table extends AbstractNamedObject
             return $this->setPrimaryKey($oldIndex->getColumns(), $newName ?? null);
         }
 
-        unset($this->_indexes[$oldName]);
+        unset($this->_indexes[$normalizedOldName]);
 
         if ($oldIndex->isUnique()) {
             return $this->addUniqueIndex($oldIndex->getColumns(), $newName, $oldIndex->getOptions());

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -740,6 +740,8 @@ class TableTest extends TestCase
         );
         self::assertEquals(new Index('uniq_new', ['bar', 'baz'], true), $table->getIndex('uniq_new'));
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6879');
+
         // Rename to auto-generated name.
         self::assertSame($table, $table->renameIndex('pk_new', null));
         self::assertSame($table, $table->renameIndex('idx_new', null));


### PR DESCRIPTION
Renaming an index to an auto-generated value (the one that you don't control) has little sense. The method can accept null only because internally it drops and re-adds the index, and the underlying `Table#addIndex()` and `Table#addUniqueIndex()` accept null and can auto-generate the name.

The method was introduced in https://github.com/doctrine/dbal/pull/473, which doesn't any mention any requirements that would warrant such a method signature.

The `$oldName` variable has been renamed to `$normalizedOldName` just for symmetry with `$normalizedNewName` and to reflect the actual meaning of its value. This rename doesn't introduce any changes in the logic.