### PR TITLE
Clean up Table::renameIndex() code

### DIFF
--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Exception\IndexDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -774,6 +775,14 @@ class TableTest extends TestCase
         self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
         self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
+    }
+
+    public function testRenameNonExistingIndexToTheSameName(): void
+    {
+        $table = new Table('test');
+
+        $this->expectException(IndexDoesNotExist::class);
+        $table->renameIndex('test', 'test');
     }
 
     public function testKeepsIndexOptionsOnRenamingRegularIndex(): void


### PR DESCRIPTION
There are a few issues with the current implementation:
1. If the new name is null, then its normalization and comparison with the old one doesn't make sense: https://github.com/doctrine/dbal/blob/615a60189d9a55b9f5232adc481da80ad3f76dc4/src/Schema/Table.php#L299-L304
2. In order to support this scenario, `Table::normalizeIdentifier()` has to accept null as an argument: https://github.com/doctrine/dbal/blob/615a60189d9a55b9f5232adc481da80ad3f76dc4/src/Schema/Table.php#L947-L951 Empty identifier is invalid.
3. If the old and the new names are the same, but the index with this name doesn't exist, the method returns instead of throwing an exception. It should return only as a shortcut for a successful no-op rename, not when one of the arguments is invalid (see the added test).

Even though the last point is logically a bug, it doesn't affect correctly written code. On the other hand, fixing it may break incorrectly written code, so I think it's fine if we keep the existing behavior in 4.2.x and change it only in 4.3.x.