### PR TITLE
Add `ArrayType` as a generic wrapper for a "list of custom types"

### DIFF
--- a/src/ArrayType.php
+++ b/src/ArrayType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL;
+
+use Doctrine\DBAL\Types\Type;
+
+class ArrayType
+{
+    public function __construct(private readonly string|Type|ParameterType $baseType)
+    {
+    }
+
+    public function getBaseType(): Type|string|ParameterType
+    {
+        return $this->baseType;
+    }
+}

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -54,7 +54,7 @@ use function sprintf;
  * configuration, emulated transaction nesting, lazy connecting and more.
  *
  * @phpstan-import-type Params from DriverManager
- * @phpstan-type WrapperParameterType = string|Type|ParameterType|ArrayParameterType
+ * @phpstan-type WrapperParameterType = string|Type|ParameterType|ArrayParameterType|ArrayType
  * @phpstan-type WrapperParameterTypeArray = array<
  *    int<0, max>,
  *    WrapperParameterType>|array<string, WrapperParameterType
@@ -1423,7 +1423,7 @@ class Connection implements ServerVersionProvider
             $needsConversion = true;
         } else {
             foreach ($types as $key => $type) {
-                if ($type instanceof ArrayParameterType) {
+                if ($type instanceof ArrayParameterType || $type instanceof ArrayType) {
                     $needsConversion = true;
                     break;
                 }

--- a/src/ExpandArrayParameters.php
+++ b/src/ExpandArrayParameters.php
@@ -90,7 +90,7 @@ final class ExpandArrayParameters implements Visitor
 
         $type = $this->types[$key];
 
-        if (! $type instanceof ArrayParameterType) {
+        if (! $type instanceof ArrayParameterType && ! $type instanceof ArrayType) {
             $this->appendTypedParameter([$value], $type);
 
             return;
@@ -102,7 +102,11 @@ final class ExpandArrayParameters implements Visitor
             return;
         }
 
-        $this->appendTypedParameter($value, ArrayParameterType::toElementParameterType($type));
+        if ($type instanceof ArrayType) {
+            $this->appendTypedParameter($value, $type->getBaseType());
+        } else {
+            $this->appendTypedParameter($value, ArrayParameterType::toElementParameterType($type));
+        }
     }
 
     /** @return array<int<0, max>,string|ParameterType|Type> */

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query;
 
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ArrayType;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
@@ -377,7 +378,7 @@ class QueryBuilder
     public function setParameter(
         int|string $key,
         mixed $value,
-        string|ParameterType|Type|ArrayParameterType $type = ParameterType::STRING,
+        string|ParameterType|Type|ArrayParameterType|ArrayType $type = ParameterType::STRING,
     ): self {
         $this->params[$key] = $value;
         $this->types[$key]  = $type;
@@ -449,7 +450,7 @@ class QueryBuilder
      *
      * @param int|string $key The key of the bound parameter type
      */
-    public function getParameterType(int|string $key): string|ParameterType|Type|ArrayParameterType
+    public function getParameterType(int|string $key): string|ParameterType|Type|ArrayParameterType|ArrayType
     {
         return $this->types[$key] ?? ParameterType::STRING;
     }
@@ -1484,7 +1485,7 @@ class QueryBuilder
      */
     public function createNamedParameter(
         mixed $value,
-        string|ParameterType|Type|ArrayParameterType $type = ParameterType::STRING,
+        string|ParameterType|Type|ArrayParameterType|ArrayType $type = ParameterType::STRING,
         ?string $placeHolder = null,
     ): string {
         if ($placeHolder === null) {
@@ -1516,7 +1517,7 @@ class QueryBuilder
      */
     public function createPositionalParameter(
         mixed $value,
-        string|ParameterType|Type|ArrayParameterType $type = ParameterType::STRING,
+        string|ParameterType|Type|ArrayParameterType|ArrayType $type = ParameterType::STRING,
     ): string {
         $this->setParameter($this->boundCounter, $value, $type);
         $this->boundCounter++;

--- a/tests/Connection/ExpandArrayParametersTest.php
+++ b/tests/Connection/ExpandArrayParametersTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Connection;
 use Doctrine\DBAL\ArrayParameters\Exception\MissingNamedParameter;
 use Doctrine\DBAL\ArrayParameters\Exception\MissingPositionalParameter;
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ArrayType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ExpandArrayParameters;
 use Doctrine\DBAL\ParameterType;
@@ -380,6 +381,15 @@ class ExpandArrayParametersTest extends TestCase
                 ParameterType::BINARY,
                 ParameterType::BINARY,
             ],
+        ];
+
+        yield 'ArrayType wrapped around a custom type' => [
+            'SELECT * FROM Foo WHERE foo IN (?)',
+            [['this', 'that']],
+            [new ArrayType('my_type')],
+            'SELECT * FROM Foo WHERE foo IN (?, ?)',
+            ['this', 'that'],
+            ['my_type', 'my_type'],
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | 

#### Summary

The [list of parameters conversion](https://www.doctrine-project.org/projects/doctrine-dbal/en/4.2/reference/data-retrieval-and-manipulation.html#list-of-parameters-conversion) is currently limited to a few types expressed by the `ArrayParameterType` enum.

In https://github.com/doctrine/orm/pull/11897, it might be necessary to express "list of parameters of a given custom type".

As suggested in https://github.com/doctrine/orm/pull/11897#discussion_r2021000392, this PR is an initial exploration of using a new `ArrayType` to be wrapped around any other underlying type.

