### PR TITLE
Deprecate Index features and introduce IndexEditor 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,32 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated `Index` methods, properties and behavior
+
+The following `Index` methods and properties have been deprecated:
+
+- `Index::getColumns()`, `Index::getQuotedColumns()`, `Index::getUnquotedColumns()`,
+  `Index::$_columns` – use `Index::getIndexedColumns()` instead.
+- `Index::isSimpleIndex()`, `Index::isUnique()`, `Index::$_isUnique` – use `Index::getType()` and compare with
+  `IndexType::REGULAR` or `IndexType::UNIQUE` instead.
+- `Index::addFlag()`, `Index::removeFlag()`, `Index::getFlags()`, `Index::hasFlag()`, `Index::$_flags` – use
+  `IndexEditor::setType()`, `Index::getType()`, `IndexEditor::setIsClustered()` and `Index::isClustered()` instead.
+- `Index::getOption()`, `Index::hasOption()` and `Index::getOptions()` – use `Index::getIndexedColumns()` and
+  `Index::getPredicate()` instead.
+- `Index::overrules()`, `Index::hasColumnAtPosition()` – no replacement provided.
+- `AbstractPlatform::supportsColumnLengthIndexes()` – no replacement provided.
+
+Additionally,
+1. Instantiation of an index without columns is deprecated.
+2. The `Index::spansColumns()` method has been marked as internal.
+3. Passing an empty string as partial index predicate has been deprecated.
+
+The following conflicting index configurations have been deprecated:
+1. Spatial index with column lengths specified.
+2. Clustered fulltext or spatial index.
+3. Partial fulltext or spatial index.
+4. Clustered partial index.
+
 ## Deprecated features related to primary key constraints
 
 1. The `AbstractPlatform::getCreatePrimaryKeySQL()` method has been deprecated. Use the schema manager to create and
@@ -129,7 +155,7 @@ the `Schema` class itself.
 
 ## Deprecated `ForeignKeyConstraint` methods, properties and behavior
 
-The following `ForeignKeyConstraint` methods and property have been deprecated:
+The following `ForeignKeyConstraint` methods and properties have been deprecated:
 
 - `ForeignKeyConstraint::getForeignTableName()`, `ForeignKeyConstraint::getQuotedForeignTableName()`,
   `ForeignKeyConstraint::getUnqualifiedForeignTableName()`, `ForeignKeyConstraint::$_foreignTableName` – use

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,8 @@ Additionally,
 1. Instantiation of an index without columns is deprecated.
 2. The `Index::spansColumns()` method has been marked as internal.
 3. Passing an empty string as partial index predicate has been deprecated.
+4. The `Index` constructor has been marked as internal. Use `Index::editor()` to instantiate an editor and
+   `IndexEditor::create()` to create an index.
 
 The following conflicting index configurations have been deprecated:
 1. Spatial index with column lengths specified.

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -846,8 +846,16 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         return TransactionIsolationLevel::REPEATABLE_READ;
     }
 
+    /** @deprecated */
     public function supportsColumnLengthIndexes(): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return true;
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2053,9 +2053,18 @@ abstract class AbstractPlatform
 
     /**
      * Whether the platform supports indexes with column length definitions.
+     *
+     * @deprecated
      */
     public function supportsColumnLengthIndexes(): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         return false;
     }
 

--- a/src/Schema/Exception/InvalidIndexDefinition.php
+++ b/src/Schema/Exception/InvalidIndexDefinition.php
@@ -11,6 +11,16 @@ use function sprintf;
 
 final class InvalidIndexDefinition extends LogicException implements SchemaException
 {
+    public static function nameNotSet(): self
+    {
+        return new self('Index name is not set.');
+    }
+
+    public static function columnsNotSet(): self
+    {
+        return new self('Index column names are not set.');
+    }
+
     public static function fromNonPositiveColumnLength(int $length): self
     {
         return new self(sprintf('Indexed column length must be a positive integer, %d given.', $length));

--- a/src/Schema/Exception/InvalidIndexDefinition.php
+++ b/src/Schema/Exception/InvalidIndexDefinition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+final class InvalidIndexDefinition extends LogicException implements SchemaException
+{
+    public static function fromNonPositiveColumnLength(int $length): self
+    {
+        return new self(sprintf('Indexed column length must be a positive integer, %d given.', $length));
+    }
+}

--- a/src/Schema/Exception/InvalidState.php
+++ b/src/Schema/Exception/InvalidState.php
@@ -16,6 +16,16 @@ final class InvalidState extends LogicException implements SchemaException
         return new self('Object name has not been initialized.');
     }
 
+    public static function indexHasInvalidType(string $indexName): self
+    {
+        return new self(sprintf('Index "%s" has invalid type.', $indexName));
+    }
+
+    public static function indexHasInvalidPredicate(string $indexName): self
+    {
+        return new self(sprintf('Index "%s" has invalid predicate.', $indexName));
+    }
+
     public static function indexHasInvalidColumns(string $indexName): self
     {
         return new self(sprintf('Index "%s" has invalid columns.', $indexName));

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -36,10 +36,13 @@ class Index extends AbstractNamedObject
     /**
      * Asset identifier instances of the column names the index is associated with.
      *
+     * @deprecated Use {@see getIndexedColumns()} instead.
+     *
      * @var array<string, Identifier>
      */
     protected array $_columns = [];
 
+    /** @deprecated Use {@see getType()} and compare with {@see IndexType::UNIQUE} instead. */
     protected bool $_isUnique = false;
 
     /** @deprecated Use {@see PrimaryKeyConstraint()} instead. */
@@ -47,6 +50,8 @@ class Index extends AbstractNamedObject
 
     /**
      * Platform specific flags for indexes.
+     *
+     * @deprecated
      *
      * @var array<string, true>
      */
@@ -114,6 +119,12 @@ class Index extends AbstractNamedObject
             $predicate = $options['where'];
 
             if (strlen($predicate) === 0) {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6886',
+                    'Passing an empty string as index predicate is deprecated.',
+                );
+
                 $this->failedToParsePredicate = true;
             } else {
                 $this->predicate = $predicate;
@@ -191,10 +202,19 @@ class Index extends AbstractNamedObject
     /**
      * Returns the names of the referencing table columns the constraint is associated with.
      *
+     * @deprecated Use {@see getIndexedColumns()} instead.
+     *
      * @return non-empty-list<string>
      */
     public function getColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() instead.',
+            __METHOD__,
+        );
+
         /** @phpstan-ignore return.type */
         return array_keys($this->_columns);
     }
@@ -206,12 +226,21 @@ class Index extends AbstractNamedObject
      * is a keyword reserved by the platform.
      * Otherwise, the plain unquoted value as inserted is returned.
      *
+     * @deprecated Use {@see getIndexedColumns()} instead.
+     *
      * @param AbstractPlatform $platform The platform to use for quotation.
      *
      * @return list<string>
      */
     public function getQuotedColumns(AbstractPlatform $platform): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() instead.',
+            __METHOD__,
+        );
+
         $subParts = $platform->supportsColumnLengthIndexes() && $this->hasOption('lengths')
             ? $this->getOption('lengths') : [];
 
@@ -232,22 +261,50 @@ class Index extends AbstractNamedObject
         return $columns;
     }
 
-    /** @return non-empty-list<string> */
+    /**
+     * @deprecated Use {@see getIndexedColumns()} instead.
+     *
+     * @return non-empty-list<string>
+     */
     public function getUnquotedColumns(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() instead.',
+            __METHOD__,
+        );
+
         return array_map($this->trimQuotes(...), $this->getColumns());
     }
 
     /**
      * Is the index neither unique nor primary key?
+     *
+     * @deprecated Use {@see getType()} and compare with {@see IndexType::REGULAR} instead.
      */
     public function isSimpleIndex(): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getType() and compare with IndexType::REGULAR instead.',
+            __METHOD__,
+        );
+
         return ! $this->_isPrimary && ! $this->_isUnique;
     }
 
+    /** @deprecated Use {@see getType()} and compare with {@see IndexType::UNIQUE} instead. */
     public function isUnique(): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getType() and compare with IndexType::UNIQUE instead.',
+            __METHOD__,
+        );
+
         return $this->_isUnique;
     }
 
@@ -263,8 +320,16 @@ class Index extends AbstractNamedObject
         return $this->_isPrimary;
     }
 
+    /** @deprecated Use {@see getIndexedColumns()} instead. */
     public function hasColumnAtPosition(string $name, int $pos = 0): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() instead.',
+            __METHOD__,
+        );
+
         $name         = $this->trimQuotes(strtolower($name));
         $indexColumns = array_map('strtolower', $this->getUnquotedColumns());
 
@@ -273,6 +338,8 @@ class Index extends AbstractNamedObject
 
     /**
      * Checks if this index exactly spans the given column names in the correct order.
+     *
+     * @internal
      *
      * @param array<int, string> $columnNames
      */
@@ -339,9 +406,18 @@ class Index extends AbstractNamedObject
 
     /**
      * Detects if the other index is a non-unique, non primary index that can be overwritten by this one.
+     *
+     * @deprecated
      */
     public function overrules(Index $other): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated.',
+            __METHOD__,
+        );
+
         if ($other->isPrimary()) {
             return false;
         }
@@ -358,20 +434,39 @@ class Index extends AbstractNamedObject
     /**
      * Returns platform specific flags for indexes.
      *
+     * @deprecated Use {@see getType()} and {@see isClustered()} instead.
+     *
      * @return array<int, string>
      */
     public function getFlags(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getType() and Index::isClustered() instead.',
+            __METHOD__,
+        );
+
         return array_keys($this->_flags);
     }
 
     /**
      * Adds Flag for an index that translates to platform specific handling.
      *
+     * @deprecated Use {@see edit()}, {@see IndexEditor::setType()} and {@see IndexEditor::setIsClustered()} instead.
+     *
      * @example $index->addFlag('CLUSTERED')
      */
     public function addFlag(string $flag): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::edit(), IndexEditor::setType() and IndexEditor::setIsClustered()'
+                . ' instead.',
+            __METHOD__,
+        );
+
         $this->_flags[strtolower($flag)] = true;
 
         $this->validateFlags();
@@ -383,35 +478,80 @@ class Index extends AbstractNamedObject
 
     /**
      * Does this index have a specific flag?
+     *
+     * @deprecated Use {@see getType()} and {@see isClustered()} instead.
      */
     public function hasFlag(string $flag): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getType() and Index::isClustered() instead.',
+            __METHOD__,
+        );
+
         return isset($this->_flags[strtolower($flag)]);
     }
 
     /**
-     * Removes a flag.
+     * @deprecated Use {@see edit()}, {@see IndexEditor::setType()} and {@see IndexEditor::setIsClustered()}
+     *             instead.
      */
     public function removeFlag(string $flag): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::edit(), IndexEditor::setType() and IndexEditor::setIsClustered()'
+            . ' instead.',
+            __METHOD__,
+        );
+
         unset($this->_flags[strtolower($flag)]);
 
         $this->type = $this->inferType();
     }
 
+    /** @deprecated Use {@see getIndexedColumns()} and {@see getPredicate()} instead. */
     public function hasOption(string $name): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() and Index::getPredicate() instead.',
+            __METHOD__,
+        );
+
         return isset($this->options[strtolower($name)]);
     }
 
+    /** @deprecated Use {@see getIndexedColumns()} and {@see getPredicate()} instead. */
     public function getOption(string $name): mixed
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() and Index::getPredicate() instead.',
+            __METHOD__,
+        );
+
         return $this->options[strtolower($name)];
     }
 
-    /** @return array<string, mixed> */
+    /**
+     * @deprecated Use {@see getIndexedColumns()} and {@see getPredicate()} instead.
+     *
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6886',
+            '%s is deprecated. Use Index::getIndexedColumns() and Index::getPredicate() instead.',
+            __METHOD__,
+        );
+
         return $this->options;
     }
 

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -78,6 +78,9 @@ class Index extends AbstractNamedObject
     private bool $failedToParsePredicate = false;
 
     /**
+     * @internal Use {@link Index::editor()} to instantiate an editor and {@link IndexEditor::create()} to create an
+     *           index.
+     *
      * @param non-empty-list<string> $columns
      * @param array<int, string>     $flags
      * @param array<string, mixed>   $options
@@ -733,5 +736,26 @@ class Index extends AbstractNamedObject
 
         return array_filter($this->options['lengths'] ?? [], $filter)
             === array_filter($other->options['lengths'] ?? [], $filter);
+    }
+
+    /**
+     * Instantiates a new index editor.
+     */
+    public static function editor(): IndexEditor
+    {
+        return new IndexEditor();
+    }
+
+    /**
+     * Instantiates a new index editor and initializes it with the properties of the current index.
+     */
+    public function edit(): IndexEditor
+    {
+        return self::editor()
+            ->setName($this->getObjectName())
+            ->setType($this->getType())
+            ->setColumns(...$this->getIndexedColumns())
+            ->setIsClustered($this->isClustered())
+            ->setPredicate($this->getPredicate());
     }
 }

--- a/src/Schema/Index/IndexType.php
+++ b/src/Schema/Index/IndexType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Index;
+
+enum IndexType
+{
+    case REGULAR;
+    case UNIQUE;
+    case FULLTEXT;
+    case SPATIAL;
+}

--- a/src/Schema/Index/IndexedColumn.php
+++ b/src/Schema/Index/IndexedColumn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Index;
 
+use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 final class IndexedColumn
@@ -15,6 +16,9 @@ final class IndexedColumn
      */
     public function __construct(private readonly UnqualifiedName $columnName, private readonly ?int $length)
     {
+        if ($length !== null && $length <= 0) {
+            throw InvalidIndexDefinition::fromNonPositiveColumnLength($length);
+        }
     }
 
     public function getColumnName(): UnqualifiedName
@@ -22,6 +26,7 @@ final class IndexedColumn
         return $this->columnName;
     }
 
+    /** @return ?positive-int */
     public function getLength(): ?int
     {
         return $this->length;

--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
+use Doctrine\DBAL\Schema\Index\IndexedColumn;
+use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+use function array_map;
+use function array_merge;
+use function array_values;
+use function count;
+
+final class IndexEditor
+{
+    private ?UnqualifiedName $name = null;
+
+    private IndexType $type = IndexType::REGULAR;
+
+    /** @var list<IndexedColumn> */
+    private array $columns = [];
+
+    private bool $isClustered = false;
+
+    /** @var ?non-empty-string */
+    private ?string $predicate = null;
+
+    /** @internal Use {@link Index::editor()} or {@link Index::edit()} to create an instance */
+    public function __construct()
+    {
+    }
+
+    public function setName(?UnqualifiedName $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function setType(IndexType $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function setColumns(IndexedColumn $firstColumn, IndexedColumn ...$otherColumns): self
+    {
+        $this->columns = array_merge([$firstColumn], array_values($otherColumns));
+
+        return $this;
+    }
+
+    public function setColumnNames(UnqualifiedName $firstColumnName, UnqualifiedName ...$otherColumnNames): self
+    {
+        $this->columns = array_map(
+            static fn (UnqualifiedName $name) => new IndexedColumn($name, null),
+            array_merge([$firstColumnName], array_values($otherColumnNames)),
+        );
+
+        return $this;
+    }
+
+    public function setIsClustered(bool $isClustered): self
+    {
+        $this->isClustered = $isClustered;
+
+        return $this;
+    }
+
+    /** @param ?non-empty-string $predicate */
+    public function setPredicate(?string $predicate): self
+    {
+        $this->predicate = $predicate;
+
+        return $this;
+    }
+
+    public function create(): Index
+    {
+        if ($this->name === null) {
+            throw InvalidIndexDefinition::nameNotSet();
+        }
+
+        if (count($this->columns) < 1) {
+            throw InvalidIndexDefinition::columnsNotSet();
+        }
+
+        $columnNames = $lengths = $flags = [];
+        foreach ($this->columns as $column) {
+            $columnNames[] = $column->getColumnName()->toString();
+            $lengths[]     = $column->getLength();
+        }
+
+        $options = ['lengths' => $lengths];
+
+        if ($this->type === IndexType::FULLTEXT) {
+            $flags[] = 'fulltext';
+        } elseif ($this->type === IndexType::SPATIAL) {
+            $flags[] = 'spatial';
+        }
+
+        if ($this->isClustered) {
+            $flags[] = 'clustered';
+        }
+
+        if ($this->predicate !== null) {
+            $options['where'] = $this->predicate;
+        }
+
+        return new Index(
+            $this->name->toString(),
+            $columnNames,
+            $this->type === IndexType::UNIQUE,
+            false,
+            $flags,
+            $options,
+        );
+    }
+}

--- a/tests/Schema/Index/IndexedColumnTest.php
+++ b/tests/Schema/Index/IndexedColumnTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Index;
+
+use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
+use Doctrine\DBAL\Schema\Index\IndexedColumn;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use PHPUnit\Framework\TestCase;
+
+class IndexedColumnTest extends TestCase
+{
+    public function testNonPositiveColumnLength(): void
+    {
+        $this->expectException(InvalidIndexDefinition::class);
+
+        // @phpstan-ignore argument.type
+        new IndexedColumn(UnqualifiedName::unquoted('id'), -1);
+    }
+}

--- a/tests/Schema/IndexEditorTest.php
+++ b/tests/Schema/IndexEditorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class IndexEditorTest extends TestCase
+{
+    public function testNameNotSet(): void
+    {
+        $editor = Index::editor()
+            ->setColumnNames(UnqualifiedName::unquoted('id'));
+
+        $this->expectException(InvalidIndexDefinition::class);
+
+        $editor->create();
+    }
+
+    public function testColumnsNotSet(): void
+    {
+        $editor = Index::editor()
+            ->setName(UnqualifiedName::unquoted('idx_user_id'));
+
+        $this->expectException(InvalidIndexDefinition::class);
+
+        $editor->create();
+    }
+
+    public function testPreservesRegularIndexProperties(): void
+    {
+        $index1 = new Index(
+            'idx_user_name',
+            ['user_name'],
+            false,
+            false,
+            [],
+            [
+                'lengths' => [32],
+                'where' => 'is_active = 1',
+            ],
+        );
+
+        $index2 = $index1->edit()
+            ->create();
+
+        self::assertSame('idx_user_name', $index2->getName());
+        self::assertSame(['user_name'], $index2->getColumns());
+        self::assertFalse($index2->isUnique());
+        self::assertFalse($index2->isPrimary());
+        self::assertSame([], $index2->getFlags());
+        self::assertSame([
+            'lengths' => [32],
+            'where' => 'is_active = 1',
+        ], $index2->getOptions());
+    }
+
+    /** @param array<string> $flags */
+    #[TestWith([['fulltext']])]
+    #[TestWith([['spatial']])]
+    #[TestWith([['clustered']])]
+    public function testPreservesIndexFlags(array $flags): void
+    {
+        $index1 = new Index(
+            'idx_test',
+            ['test'],
+            false,
+            false,
+            $flags,
+        );
+
+        $index2 = $index1->edit()
+            ->create();
+
+        self::assertSame($flags, $index2->getFlags());
+    }
+}

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -282,12 +282,19 @@ class IndexTest extends TestCase
         self::assertNull($indexedColumns[1]->getLength());
     }
 
+    public function testUnsupportedFlag(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
+        new Index('idx_user_name', ['name'], false, false, ['banana']);
+    }
+
     /** @param list<string> $flags */
     #[TestWith([true, ['fulltext']])]
     #[TestWith([true, ['spatial']])]
     #[TestWith([false, ['fulltext', 'spatial']])]
     public function testConflictInFlagsSignificantForTypeInference(bool $isUnique, array $flags): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
         $index = new Index('idx_user_name', ['name'], $isUnique, false, $flags);
 
         $this->expectException(InvalidState::class);
@@ -300,6 +307,7 @@ class IndexTest extends TestCase
     #[TestWith([['nonclustered', 'clustered'], IndexType::REGULAR])]
     public function testConflictInFlagsInsignificantForTypeInference(array $flags, IndexType $expectedType): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
         $index = new Index('idx_user_name', ['name'], false, false, $flags);
 
         self::assertEquals($expectedType, $index->getType());
@@ -312,6 +320,7 @@ class IndexTest extends TestCase
     #[TestWith([true, [], IndexType::UNIQUE])]
     public function testParseType(bool $isUnique, array $flags, IndexType $expectedType): void
     {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
         $index = new Index('idx_user_name', ['user_id'], $isUnique, false, $flags);
 
         self::assertEquals($expectedType, $index->getType());
@@ -321,6 +330,7 @@ class IndexTest extends TestCase
     #[TestWith(['is_active = 1'])]
     public function testGetPredicate(?string $predicate): void
     {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
         $index = new Index('idx_user_name', ['user_id'], false, false, [], ['where' => $predicate]);
 
         self::assertEquals($predicate, $index->getPredicate());
@@ -328,9 +338,19 @@ class IndexTest extends TestCase
 
     public function testEmptyPredicate(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
         $index = new Index('idx_user_name', ['user_id'], false, false, [], ['where' => '']);
 
         $this->expectException(InvalidState::class);
         $index->getPredicate();
+    }
+
+    #[TestWith(['fulltext'])]
+    #[TestWith(['spatial'])]
+    #[TestWith(['clustered'])]
+    public function testPartialIndexWithConflictingFlags(string $flag): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6886');
+        new Index('idx_user_name', ['user_id'], false, false, [$flag], ['where' => 'is_active = 1']);
     }
 }


### PR DESCRIPTION
This is a continuation of the rework started in https://github.com/doctrine/dbal/pull/6685 (unique constraints) and https://github.com/doctrine/dbal/pull/6728 (foreign key constraints), now applied to indexes. See the upgrade notes for details on the end-user impact.

### Deprecation details
The `Index#overrules()` method is currently used by the ORM's `SchemaTool` ([source](https://github.com/doctrine/orm/blob/3.3.1/src/Tools/SchemaTool.php#L318-L320)). It should be easy to replace with a check if the the index columns are the same or a prefix of the PK columns. All other logic of `overrules()` (checking for the index type and the details of the partial index) is irrelevant in this case. I don't really understand how `Index#overrules()` is different from `Index#isFulfilledBy()` (besides the fact that it means the opposite).

`Index#isFulfilledBy()` will be available for now, but as soon as we get rid of implicit indexes (not very soon), it will become irrelevant to the DBAL. At that point, the ORM will be a more appropriate place for it.