### PR TITLE
Require PHP 8.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,11 +27,11 @@ environment:
   - db: mssql
     driver: sqlsrv
     db_version: sql2017
-    php: 8.1
+    php: 8.3
   - db: mssql
     driver: pdo_sqlsrv
     db_version: sql2017
-    php: 8.1
+    php: 8.3
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;C:\tools\composer;%PATH%
@@ -64,18 +64,19 @@ install:
           Add-Content php.ini "`n extension=php_sqlite3.dll"
           Add-Content php.ini "`n extension=php_curl.dll"
 
-          $DLLVersion = "5.10.0"
+          $DLLVersion = "5.12.0"
+          $VSVersion = "vs16"
           cd c:\tools\php\ext
-          $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip"
-          $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip"
+          $source = "https://downloads.php.net/~windows/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-x64.zip"
+          $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-x64.zip"
           Invoke-WebRequest $source -OutFile $destination
-          7z x -y php_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip > $null
-          $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip"
-          $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip"
+          7z x -y php_sqlsrv-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-x64.zip > $null
+          $source = "https://downloads.php.net/~windows/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-x64.zip"
+          $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-x64.zip"
           Invoke-WebRequest $source -OutFile $destination
-          7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-vs16-x64.zip > $null
+          7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-x64.zip > $null
           $DLLVersion = (Invoke-WebRequest "https://pecl.php.net/rest/r/pcov/stable.txt").Content
-          Invoke-WebRequest https://downloads.php.net/~windows/pecl/releases/pcov/$($DLLVersion)/php_pcov-$($DLLVersion)-$($env:php)-nts-vs16-$($env:platform).zip -OutFile pcov.zip
+          Invoke-WebRequest https://downloads.php.net/~windows/pecl/releases/pcov/$($DLLVersion)/php_pcov-$($DLLVersion)-$($env:php)-nts-$($VSVersion)-$($env:platform).zip -OutFile pcov.zip
           7z x -y pcov.zip > $null
           Remove-Item c:\tools\php\* -include .zip
           cd c:\tools\php

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,7 +46,7 @@ jobs:
           - "pdo_sqlite"
         include:
           - os: "ubuntu-20.04"
-            php-version: "8.1"
+            php-version: "8.3"
             dependencies: "lowest"
             extension: "pdo_sqlite"
           - os: "ubuntu-22.04"
@@ -106,7 +106,7 @@ jobs:
           - "21"
           - "23"
         include:
-          - php-version: "8.1"
+          - php-version: "8.3"
             oracle-version: "23"
           - php-version: "8.5"
             oracle-version: "23"
@@ -166,7 +166,7 @@ jobs:
           - "21"
           - "23"
         include:
-          - php-version: "8.1"
+          - php-version: "8.3"
             oracle-version: "23"
           - php-version: "8.5"
             oracle-version: "23"
@@ -231,10 +231,10 @@ jobs:
           - "pgsql"
           - "pdo_pgsql"
         include:
-          - php-version: "8.1"
+          - php-version: "8.3"
             postgres-version: "17"
             extension: "pgsql"
-          - php-version: "8.1"
+          - php-version: "8.3"
             postgres-version: "17"
             extension: "pdo_pgsql"
           - php-version: "8.5"
@@ -309,10 +309,10 @@ jobs:
           - "mysqli"
           - "pdo_mysql"
         include:
-          - php-version: "8.1"
+          - php-version: "8.3"
             mariadb-version: "11.4"
             extension: "mysqli"
-          - php-version: "8.1"
+          - php-version: "8.3"
             mariadb-version: "11.4"
             extension: "pdo_mysql"
           - php-version: "8.5"
@@ -383,10 +383,10 @@ jobs:
           - ""
         include:
           - config-file-suffix: "-tls"
-            php-version: "8.1"
+            php-version: "8.3"
             mysql-version: "9.1"
             extension: "mysqli"
-          - php-version: "8.1"
+          - php-version: "8.3"
             mysql-version: "9.1"
             extension: "mysqli"
           - php-version: "8.5"
@@ -449,7 +449,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
+          - "8.3"
           - "8.4"
           - "8.5"
         extension:
@@ -459,10 +459,10 @@ jobs:
           - "Latin1_General_100_CI_AS_SC_UTF8"
         include:
           - collation: "Latin1_General_100_CS_AS_SC_UTF8"
-            php-version: "8.1"
+            php-version: "8.3"
             extension: "sqlsrv"
           - collation: "Latin1_General_100_CS_AS_SC_UTF8"
-            php-version: "8.1"
+            php-version: "8.3"
             extension: "pdo_sqlsrv"
 
     services:
@@ -516,7 +516,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
+          - "8.3"
           - "8.4"
           - "8.5"
 
@@ -584,7 +584,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
+          - "8.3"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "doctrine/deprecations": "^0.5.3|^1",
         "psr/cache": "^1|^2|^3",
         "psr/log": "^1|^2|^3"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
     <!-- Show progress of the run and show sniff names -->
     <arg value="ps"/>
 
-    <config name="php_version" value="80100"/>
+    <config name="php_version" value="80300"/>
 
     <file>src</file>
     <file>tests</file>

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -134,17 +134,12 @@ class Configuration
         return $this;
     }
 
-    /** @return true */
     public function getDisableTypeComments(): bool
     {
         return true;
     }
 
-    /**
-     * @param true $disableTypeComments
-     *
-     * @return $this
-     */
+    /** @return $this */
     public function setDisableTypeComments(bool $disableTypeComments): self
     {
         if (! $disableTypeComments) {

--- a/src/Driver/PgSQL/Exception/UnexpectedValue.php
+++ b/src/Driver/PgSQL/Exception/UnexpectedValue.php
@@ -20,8 +20,7 @@ final class UnexpectedValue extends UnexpectedValueException implements Exceptio
         ));
     }
 
-    /** @return null */
-    public function getSQLState(): string|null
+    public function getSQLState(): null
     {
         return null;
     }


### PR DESCRIPTION
PHP 8.1 and 8.2 are no longer supported by the community. PHPUnit 12 also requires PHP 8.3 or newer (see https://github.com/doctrine/dbal/pull/6888).

The code/phpDoc changes are needed to address the following coding standard violations:
```
FILE: src/Driver/PgSQL/Exception/UnexpectedValue.php
------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------
 23 | ERROR | [x] Method \Doctrine\DBAL\Driver\PgSQL\Exception\UnexpectedValue::getSQLState() has useless
    |       |     @return annotation. (SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation)
------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------------------------


FILE: src/Configuration.php
------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------------
 137 | ERROR | [x] Method \Doctrine\DBAL\Configuration::getDisableTypeComments() has useless @return
     |       |     annotation. (SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation)
 144 | ERROR | [x] Method \Doctrine\DBAL\Configuration::setDisableTypeComments() has useless @param
     |       |     annotation for parameter $disableTypeComments.
     |       |     (SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation)
------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------------------------
```
They are reported because the `enableStandaloneNullTrueFalseTypeHints` parameter defaults to `true` on PHP 8.2+. I don't think we want to turn it off just to retain the annotations, and we cannot modify the `Configuration` method signatures because it's not `final`. Modifying the return type in `UnexpectedValue` is fine because it is `final`.