### PR TITLE
Quote introspected table name on Oracle

### DIFF
--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -512,15 +512,11 @@ SQL;
 
         $sql .= ' FROM ALL_TAB_COMMENTS WHERE ' . implode(' AND ', $conditions);
 
-        /** @var array<string,array<string,mixed>> $metadata */
-        $metadata = $this->_conn->executeQuery($sql, $params)
-            ->fetchAllAssociativeIndexed();
-
         $tableOptions = [];
-        foreach ($metadata as $table => $data) {
+        foreach ($this->_conn->iterateAssociative($sql, $params) as $data) {
             $data = array_change_key_case($data, CASE_LOWER);
 
-            $tableOptions[$table] = [
+            $tableOptions[$this->_getPortableTableDefinition($data)] = [
                 'comment' => $data['comments'],
             ];
         }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -381,7 +381,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->connection->executeStatement('SET search_path TO "001_test"');
         $this->markConnectionNotReusable();
 
-        $this->testIntrospectReservedKeywordTableViaListTableDetails();
+        $this->testIntrospectReservedKeywordTableViaIntrospectTable();
     }
 
     public function testListTablesExcludesViews(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1617,14 +1617,31 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals($expected, $onlineTable->getIndexes());
     }
 
-    public function testCommentInTable(): void
+    /**
+     * This and the following test could be merged with {@see testIntrospectReservedKeywordTableViaIntrospectTable()}
+     * and the following one, but in this case,
+     * {@see PostgreSQLSchemaManagerTest::testListTableDetailsWhenCurrentSchemaNameQuoted()} would fail because
+     * introspection of table comments in a non-default schema doesn't work properly on PostgreSQL.
+     */
+    public function testCommentInReservedKeywordTableViaIntrospectTable(): void
     {
-        $table = new Table('table_with_comment');
-        $table->addColumn('id', Types::INTEGER);
-        $table->setComment('Foo with control characters \'\\');
-        $this->dropAndCreateTable($table);
+        $this->createReservedKeywordTables();
 
-        $table = $this->schemaManager->introspectTable('table_with_comment');
+        $table = $this->schemaManager->introspectTable('"user"');
+        self::assertSame('Foo with control characters \'\\', $table->getComment());
+    }
+
+    public function testCommentInReservedKeywordTableViaListTables(): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestIncomplete('This test currently fails on PostgreSQL due to a bug.');
+        }
+
+        $this->createReservedKeywordTables();
+
+        $tables = $this->schemaManager->listTables();
+        $table  = $this->findTableByName($tables, 'user');
+
         self::assertSame('Foo with control characters \'\\', $table->getComment());
     }
 
@@ -1672,7 +1689,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertSame($foreignColumns, array_map('strtolower', $foreignKey->getForeignColumns()));
     }
 
-    public function testIntrospectReservedKeywordTableViaListTableDetails(): void
+    public function testIntrospectReservedKeywordTableViaIntrospectTable(): void
     {
         $this->createReservedKeywordTables();
 
@@ -1709,6 +1726,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $user->addColumn('group_id', Types::INTEGER);
         $user->setPrimaryKey(['id']);
         $user->addForeignKeyConstraint('group', ['group_id'], ['id']);
+        $user->setComment('Foo with control characters \'\\');
 
         $group = $schema->createTable('group');
         $group->addColumn('id', Types::INTEGER);


### PR DESCRIPTION
Fixes #6764

The failing tests indicate bugs in table comment introspection on Postgres:
1. When the table is in a non-default schema.
2. When a table is introspected not individually but as part of the whole schema.