### PR TITLE
Do not trim single quote in comments on SQLite

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -37,7 +37,6 @@ use function str_replace;
 use function strpos;
 use function strtolower;
 use function substr;
-use function trim;
 
 /**
  * The SQLitePlatform class describes the specifics and dialects of the SQLite
@@ -288,9 +287,7 @@ class SQLitePlatform extends AbstractPlatform
 
         $tableComment = '';
         if (isset($options['comment'])) {
-            $comment = trim($options['comment'], " '");
-
-            $tableComment = $this->getInlineTableCommentSQL($comment);
+            $tableComment = $this->getInlineTableCommentSQL($options['comment']);
         }
 
         $query = ['CREATE TABLE ' . $name . ' ' . $tableComment . '(' . $queryFields . ')'];

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1202,11 +1202,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     {
         $table = new Table('table_with_comment');
         $table->addColumn('id', Types::INTEGER);
-        $table->setComment('Foo with control characters \'\\');
+        $table->setComment('\'\\ Foo with control characters \'\\');
         $this->dropAndCreateTable($table);
 
         $table = $this->schemaManager->introspectTable('table_with_comment');
-        self::assertSame('Foo with control characters \'\\', $table->getComment());
+        self::assertSame('\'\\ Foo with control characters \'\\', $table->getComment());
     }
 
     public function testCreatedCompositeForeignKeyOrderIsCorrectAfterCreation(): void


### PR DESCRIPTION
The single quote is trimmed from the comment for no reason. The updated test would pass only because the comment didn’t begin or end with a quote.