### PR TITLE
Remove configuration for reporting modified indexes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,6 +38,9 @@ The following auto-increment column definitions are no longer supported on SQLit
 
 The `TableDiff::getModifiedForeignKeys()` and `TableDiff::getModifiedIndexes()` methods have been removed.
 
+The comparator can be no longer configured to report modified indexes.
+The `ComparatorConfig::withReportModifiedIndexes()` method only accepts `false` as the argument and has been deprecated.
+
 ## BC BREAK: changes in `AbstractPlatform` constructor
 
 The `AbstractPlatform` class constructor is now `protected` and requires an `UnquotedIdentifierFolding` instance as its

--- a/src/Schema/ComparatorConfig.php
+++ b/src/Schema/ComparatorConfig.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Exception\InvalidArgumentException;
+use Doctrine\Deprecations\Deprecation;
+
 final class ComparatorConfig
 {
     public function __construct(
         private readonly bool $detectRenamedColumns = true,
         private readonly bool $detectRenamedIndexes = true,
-        private readonly bool $reportModifiedIndexes = true,
     ) {
     }
 
@@ -18,7 +20,6 @@ final class ComparatorConfig
         return new self(
             $detectRenamedColumns,
             $this->detectRenamedIndexes,
-            $this->reportModifiedIndexes,
         );
     }
 
@@ -32,7 +33,6 @@ final class ComparatorConfig
         return new self(
             $this->detectRenamedColumns,
             $detectRenamedIndexes,
-            $this->reportModifiedIndexes,
         );
     }
 
@@ -41,17 +41,20 @@ final class ComparatorConfig
         return $this->detectRenamedIndexes;
     }
 
+    /** @deprecated Reporting of modified indexes cannot be enabled anymore. */
     public function withReportModifiedIndexes(bool $reportModifiedIndexes): self
     {
-        return new self(
-            $this->detectRenamedColumns,
-            $this->detectRenamedIndexes,
-            $reportModifiedIndexes,
-        );
-    }
+        if ($reportModifiedIndexes) {
+            throw new InvalidArgumentException('Reporting of modified indexes cannot be enabled anymore.');
+        }
 
-    public function getReportModifiedIndexes(): bool
-    {
-        return $this->reportModifiedIndexes;
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/6898',
+            '%s is deprecated and has no effect on the comparator behavior.',
+            __METHOD__,
+        );
+
+        return $this;
     }
 }

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Tests\Functional\Schema;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
-use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
@@ -159,7 +158,7 @@ class AlterTableTest extends FunctionalTestCase
                     )
                     ->create(),
             );
-        }, (new ComparatorConfig())->withReportModifiedIndexes(false));
+        });
     }
 
     public function testAddNonAutoincrementColumnToPrimaryKeyWithAutoincrementColumn(): void
@@ -193,7 +192,7 @@ class AlterTableTest extends FunctionalTestCase
                     )
                     ->create(),
             );
-        }, (new ComparatorConfig())->withReportModifiedIndexes(false));
+        });
     }
 
     public function testAddNewColumnToPrimaryKey(): void
@@ -270,7 +269,7 @@ class AlterTableTest extends FunctionalTestCase
         });
     }
 
-    private function testMigration(Table $oldTable, callable $migration, ?ComparatorConfig $config = null): void
+    private function testMigration(Table $oldTable, callable $migration): void
     {
         $this->dropAndCreateTable($oldTable);
 
@@ -281,7 +280,7 @@ class AlterTableTest extends FunctionalTestCase
 
         $migration($newTable);
 
-        $diff = $schemaManager->createComparator($config ?? new ComparatorConfig())
+        $diff = $schemaManager->createComparator()
             ->compareTables($oldTable, $newTable);
 
         self::assertFalse($diff->isEmpty());

--- a/tests/Schema/ComparatorConfigTest.php
+++ b/tests/Schema/ComparatorConfigTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ComparatorConfigTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testEnableReportingOfModifiedIndexes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new ComparatorConfig())->withReportModifiedIndexes(true);
+    }
+
+    public function testDisableReportingOfModifiedIndexes(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6898');
+        (new ComparatorConfig())->withReportModifiedIndexes(false);
+    }
+}


### PR DESCRIPTION
`ComparatorConfig::getReportModifiedIndexes()` will be retroactively marked as internal in https://github.com/doctrine/dbal/pull/6899.