### PR TITLE
Mark ComparatorConfig::getReportModifiedIndexes() as internal

### DIFF
--- a/src/Schema/ComparatorConfig.php
+++ b/src/Schema/ComparatorConfig.php
@@ -50,6 +50,7 @@ final class ComparatorConfig
         );
     }
 
+    /** @internal This method is intended solely to provide an upgrade path to DBAL 5.0. */
     public function getReportModifiedIndexes(): bool
     {
         return $this->reportModifiedIndexes;


### PR DESCRIPTION
`ComparatorConfig::getReportModifiedIndexes()` was introduced solely to provide an upgrade path and is not meant to be used outside of the library. It will be removed in https://github.com/doctrine/dbal/pull/6898.