### PR TITLE
Rework foreign key constraint introspection on SQLite

### DIFF
--- a/tests/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Schema/SQLiteSchemaManagerTest.php
@@ -211,6 +211,8 @@ class SQLiteSchemaManagerTest extends TestCase
     public function testListTableForeignKeysDefaultDatabasePassing(): void
     {
         $conn = $this->createMock(Connection::class);
+        $conn->method('getDatabase')
+            ->willReturn('main');
 
         $manager = new class ($conn, new SQLitePlatform()) extends SQLiteSchemaManager {
             public static string $passedDatabaseName;


### PR DESCRIPTION
This is similar to https://github.com/doctrine/dbal/pull/6904. This is not a user-facing issue but a code-level concern that I want to address before refactoring the code.

### Background

1. In SQLite, not all foreign key constraint details are available via SQL. Some of them require parsing the table DDL.
2. Schema managers can fetch foreign key constraints for one table or for the entire database in the minimal possible number of interactions with the database.

### The problem

By design, the `fetchForeignKeyColumns()` method is supposed to fetch all the data. In the SQLite case, it's supposed to make the SQL query and parse the DDLs of all corresponding tables. In practice, this logic is spread across three different methods, which makes it harder to maintain

### The solution

Instead of overriding `fetchForeignKeyColumnsByTable()` (which is only supposed to group the results of `fetchForeignKeyColumns()`) and `listTableForeignKeys()` (which isn't supposed to fetch anything), override `fetchForeignKeyColumns()`.

As a side effect, `addDetailsToTableForeignKeyColumns()` no longer needs to be shared between the two above methods and can be inlined.

As another side effect, `SQLiteSchemaManager#listTableForeignKeys()` now respects the current database name returned by the connection, so it needs to be properly mocked in the test. The `SqliteSchemaManager::select*()` methods still don't, so this is not a user-facing improvement (yet).