### PR TITLE
Mark identifiers as non-empty strings

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -40,7 +40,6 @@ use Traversable;
 
 use function array_key_exists;
 use function array_merge;
-use function assert;
 use function count;
 use function implode;
 use function is_array;
@@ -148,9 +147,9 @@ class Connection implements ServerVersionProvider
     /**
      * Gets the name of the currently selected database.
      *
-     * @return string|null The name of the database or NULL if a database is not selected.
-     *                     The platforms which don't support the concept of a database (e.g. embedded databases)
-     *                     must always return a string as an indicator of an implicitly selected database.
+     * @return ?non-empty-string The name of the database or NULL if a database is not selected.
+     *                           The platforms which don't support the concept of a database (e.g. embedded databases)
+     *                           must always return a string as an indicator of an implicitly selected database.
      *
      * @throws Exception
      */
@@ -158,11 +157,8 @@ class Connection implements ServerVersionProvider
     {
         $platform = $this->getDatabasePlatform();
         $query    = $platform->getDummySelectSQL($platform->getCurrentDatabaseExpression());
-        $database = $this->fetchOne($query);
 
-        assert(is_string($database) || $database === null);
-
-        return $database;
+        return $this->fetchOne($query);
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2199,6 +2199,8 @@ abstract class AbstractPlatform
 
     /**
      * Maximum length of any given database identifier, like tables or column names.
+     *
+     * @return positive-int
      */
     public function getMaxIdentifierLength(): int
     {

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -482,6 +482,8 @@ SQL,
      *
      * if the new string exceeds max identifier length,
      * keeps $suffix, cuts from $identifier as much as the part exceeding.
+     *
+     * @param non-empty-string $suffix
      */
     private function addSuffix(string $identifier, string $suffix): string
     {

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -785,7 +785,7 @@ class SQLitePlatform extends AbstractPlatform
      * Based on the table diff, returns a map where the keys are the lower-case old column names and the values are the
      * new column names. If the column was dropped, it is not present in the map.
      *
-     * @return array<string, string>
+     * @return array<non-empty-string, non-empty-string>
      */
     private function getDiffColumnNameMap(TableDiff $diff): array
     {
@@ -812,6 +812,7 @@ class SQLitePlatform extends AbstractPlatform
             $map[strtolower($columnName)] = $columnName;
         }
 
+        // @phpstan-ignore return.type
         return $map;
     }
 

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -360,7 +360,9 @@ abstract class AbstractAsset
             $isQuoted = $this->_quoted || $keywords->isKeyword($identifier);
 
             if (! $isQuoted) {
-                $parts[]           = $identifier;
+                $parts[] = $identifier;
+
+                /** @phpstan-ignore argument.type */
                 $normalizedParts[] = $folding->foldUnquotedIdentifier($identifier);
             } else {
                 $parts[]           = $platform->quoteSingleIdentifier($identifier);
@@ -405,6 +407,9 @@ abstract class AbstractAsset
      * very long names.
      *
      * @param array<int, string> $columnNames
+     * @param positive-int       $maxSize
+     *
+     * @return non-empty-string
      */
     protected function _generateIdentifierName(array $columnNames, string $prefix = '', int $maxSize = 30): string
     {

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -42,6 +42,8 @@ abstract class AbstractSchemaManager
      *
      * The property is initialized only once. If the underlying connection switches to a different schema, a new schema
      * manager instance will have to be created to reflect this change.
+     *
+     * @var ?non-empty-string
      */
     private ?string $currentSchemaName;
 
@@ -175,7 +177,7 @@ abstract class AbstractSchemaManager
     /**
      * Returns a list of all tables in the current database.
      *
-     * @return array<int, string>
+     * @return array<int, non-empty-string>
      *
      * @throws Exception
      */
@@ -252,6 +254,8 @@ abstract class AbstractSchemaManager
      * The <code>null</code> value means that there is no schema currently selected within the connection or the
      * corresponding database platform doesn't support schemas.
      *
+     * @return ?non-empty-string
+     *
      * @throws Exception
      */
     final protected function getCurrentSchemaName(): ?string
@@ -272,6 +276,8 @@ abstract class AbstractSchemaManager
      * Determines the name of the current schema.
      *
      * If the corresponding database platform supports schemas, the schema manager must implement this method.
+     *
+     * @return ?non-empty-string
      *
      * @throws Exception
      */
@@ -399,7 +405,7 @@ abstract class AbstractSchemaManager
     /**
      * Fetches definitions of table columns in the specified database and returns them grouped by table name.
      *
-     * @return array<string,list<array<string,mixed>>>
+     * @return array<non-empty-string,list<array<string,mixed>>>
      *
      * @throws Exception
      */
@@ -411,7 +417,7 @@ abstract class AbstractSchemaManager
     /**
      * Fetches definitions of index columns in the specified database and returns them grouped by table name.
      *
-     * @return array<string,list<array<string,mixed>>>
+     * @return array<non-empty-string,list<array<string,mixed>>>
      *
      * @throws Exception
      */
@@ -423,7 +429,7 @@ abstract class AbstractSchemaManager
     /**
      * Fetches definitions of foreign key columns in the specified database and returns them grouped by table name.
      *
-     * @return array<string, list<array<string, mixed>>>
+     * @return array<non-empty-string, list<array<string, mixed>>>
      *
      * @throws Exception
      */
@@ -436,7 +442,9 @@ abstract class AbstractSchemaManager
      * Fetches table options for the tables in the specified database and returns them grouped by table name.
      * If the table name is specified, narrows down the selection to this table.
      *
-     * @return array<string,array<string,mixed>>
+     * @param ?non-empty-string $tableName
+     *
+     * @return array<non-empty-string, array<string,mixed>>
      *
      * @throws Exception
      */
@@ -517,7 +525,7 @@ abstract class AbstractSchemaManager
 
         return $this->fetchTableOptionsByTable(
             $this->getDatabase(__METHOD__),
-            $normalizedName,
+            $normalizedName, // @phpstan-ignore argument.type
         )[$normalizedName] ?? [];
     }
 
@@ -881,7 +889,9 @@ abstract class AbstractSchemaManager
     /**
      * @deprecated Use the schema name and the unqualified table name separately instead.
      *
-     * @param array<string, string> $table
+     * @param array<string, mixed> $table
+     *
+     * @return non-empty-string
      */
     abstract protected function _getPortableTableDefinition(array $table): string;
 
@@ -968,7 +978,11 @@ abstract class AbstractSchemaManager
         return $schemaConfig;
     }
 
-    /** @throws Exception */
+    /**
+     * @return non-empty-string
+     *
+     * @throws Exception
+     */
     private function getDatabase(string $methodName): string
     {
         $database = $this->connection->getDatabase();
@@ -990,7 +1004,7 @@ abstract class AbstractSchemaManager
      *
      * @param list<array<string, mixed>> $rows
      *
-     * @return array<string,list<array<string,mixed>>>
+     * @return array<non-empty-string,list<array<string,mixed>>>
      */
     private function groupByTable(array $rows): array
     {
@@ -1001,6 +1015,7 @@ abstract class AbstractSchemaManager
             $data[$tableName][] = $row;
         }
 
+        /** @phpstan-ignore return.type */
         return $data;
     }
 }

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -478,7 +478,7 @@ SQL,
             $params[] = $tableName;
         }
 
-        /** @var array<string,array<string,mixed>> $metadata */
+        /** @var array<non-empty-string,array<string,mixed>> $metadata */
         $metadata = $this->connection->executeQuery($sql, $params)
             ->fetchAllAssociativeIndexed();
 

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -16,6 +16,7 @@ use function strlen;
  */
 final class Identifier
 {
+    /** @param non-empty-string $value */
     private function __construct(
         private readonly string $value,
         private readonly bool $isQuoted,
@@ -25,6 +26,7 @@ final class Identifier
         }
     }
 
+    /** @return non-empty-string */
     public function getValue(): string
     {
         return $this->value;
@@ -46,6 +48,8 @@ final class Identifier
      * Returns the literal value of the identifier normalized according to the rules of the given database platform.
      *
      * Consumers should use the normalized value for schema comparison and referencing the objects to be introspected.
+     *
+     * @return non-empty-string
      */
     public function toNormalizedValue(UnquotedIdentifierFolding $folding): string
     {
@@ -67,6 +71,8 @@ final class Identifier
 
     /**
      * Creates a quoted identifier.
+     *
+     * @param non-empty-string $value
      */
     public static function quoted(string $value): self
     {
@@ -75,6 +81,8 @@ final class Identifier
 
     /**
      * Creates an unquoted identifier.
+     *
+     * @param non-empty-string $value
      */
     public static function unquoted(string $value): self
     {

--- a/src/Schema/Name/OptionallyQualifiedName.php
+++ b/src/Schema/Name/OptionallyQualifiedName.php
@@ -50,6 +50,9 @@ final class OptionallyQualifiedName implements Name
 
     /**
      * Creates an optionally qualified name with all identifiers quoted.
+     *
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
      */
     public static function quoted(string $unqualifiedName, ?string $qualifier = null): self
     {
@@ -61,6 +64,9 @@ final class OptionallyQualifiedName implements Name
 
     /**
      * Creates an optionally qualified name with all identifiers unquoted.
+     *
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
      */
     public static function unquoted(string $unqualifiedName, ?string $qualifier = null): self
     {

--- a/src/Schema/Name/UnqualifiedName.php
+++ b/src/Schema/Name/UnqualifiedName.php
@@ -33,6 +33,8 @@ final class UnqualifiedName implements Name
 
     /**
      * Creates a quoted unqualified name.
+     *
+     * @param non-empty-string $value
      */
     public static function quoted(string $value): self
     {
@@ -41,6 +43,8 @@ final class UnqualifiedName implements Name
 
     /**
      * Creates an unquoted unqualified name.
+     *
+     * @param non-empty-string $value
      */
     public static function unquoted(string $value): self
     {

--- a/src/Schema/Name/UnquotedIdentifierFolding.php
+++ b/src/Schema/Name/UnquotedIdentifierFolding.php
@@ -29,6 +29,10 @@ enum UnquotedIdentifierFolding
 
     /**
      * Applies case folding to an unquoted identifier as a database platform would when processing an SQL statement.
+     *
+     * @param non-empty-string $value
+     *
+     * @return non-empty-string
      */
     public function foldUnquotedIdentifier(string $value): string
     {

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -52,6 +52,7 @@ class OracleSchemaManager extends AbstractSchemaManager
     {
         $table = array_change_key_case($table, CASE_LOWER);
 
+        /** @phpstan-ignore return.type */
         return $this->getQuotedIdentifierName($table['table_name']);
     }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -22,6 +22,7 @@ use function preg_match;
 use function sprintf;
 use function str_contains;
 use function str_replace;
+use function strlen;
 use function strtolower;
 
 use const CASE_LOWER;
@@ -65,12 +66,15 @@ SQL,
      *
      * @deprecated Use {@link determineCurrentSchemaName()} instead
      *
+     * @return non-empty-string
+     *
      * @throws Exception
      */
     protected function determineCurrentSchema(): string
     {
         $currentSchema = $this->connection->fetchOne('SELECT current_schema()');
         assert(is_string($currentSchema));
+        assert(strlen($currentSchema) > 0);
 
         return $currentSchema;
     }

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -601,6 +601,7 @@ SQL,
             $tableOptions[$table]['comment'] = $comment;
         }
 
+        /** @phpstan-ignore return.type */
         return $tableOptions;
     }
 

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -9,18 +9,22 @@ namespace Doctrine\DBAL\Schema;
  */
 class SchemaConfig
 {
+    /** @var positive-int */
     protected int $maxIdentifierLength = 63;
 
+    /** @var ?non-empty-string */
     protected ?string $name = null;
 
     /** @var array<string, mixed> */
     protected array $defaultTableOptions = [];
 
+    /** @param positive-int $length */
     public function setMaxIdentifierLength(int $length): void
     {
         $this->maxIdentifierLength = $length;
     }
 
+    /** @return positive-int */
     public function getMaxIdentifierLength(): int
     {
         return $this->maxIdentifierLength;
@@ -28,6 +32,8 @@ class SchemaConfig
 
     /**
      * Gets the default namespace of schema objects.
+     *
+     * @return ?non-empty-string
      */
     public function getName(): ?string
     {
@@ -36,6 +42,8 @@ class SchemaConfig
 
     /**
      * Sets the default namespace name of schema objects.
+     *
+     * @param ?non-empty-string $name
      */
     public function setName(?string $name): void
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -74,6 +74,7 @@ class Table extends AbstractNamedObject
     /** @deprecated Pass a {@link TableConfiguration} instance to the constructor instead. */
     protected ?SchemaConfig $_schemaConfig = null;
 
+    /** @var positive-int */
     private int $maxIdentifierLength;
 
     private ?PrimaryKeyConstraint $primaryKeyConstraint = null;
@@ -386,7 +387,12 @@ class Table extends AbstractNamedObject
         return $this->renamedColumns;
     }
 
-    /** @throws LogicException */
+    /**
+     * @param non-empty-string $oldName
+     * @param non-empty-string $newName
+     *
+     * @throws LogicException
+     */
     final public function renameColumn(string $oldName, string $newName): Column
     {
         $oldName = $this->normalizeIdentifier($oldName);
@@ -771,7 +777,11 @@ class Table extends AbstractNamedObject
         }
     }
 
-    /** @deprecated */
+    /**
+     * @deprecated
+     *
+     * @return positive-int
+     */
     protected function _getMaxIdentifierLength(): int
     {
         Deprecation::triggerIfCalledFromOutside(
@@ -946,9 +956,12 @@ class Table extends AbstractNamedObject
      * Normalizes a given identifier.
      *
      * Trims quotes and lowercases the given identifier.
+     *
+     * @return non-empty-string
      */
     private function normalizeIdentifier(string $identifier): string
     {
+        /** @phpstan-ignore return.type */
         return $this->trimQuotes(strtolower($identifier));
     }
 
@@ -1040,6 +1053,7 @@ class Table extends AbstractNamedObject
         return new Index($indexName, $columns, $isUnique, $isPrimary, $flags, $options);
     }
 
+    /** @param non-empty-string $newName */
     private function renameColumnInIndexes(string $oldName, string $newName): void
     {
         foreach ($this->_indexes as $key => $index) {
@@ -1069,6 +1083,10 @@ class Table extends AbstractNamedObject
         }
     }
 
+    /**
+     * @param non-empty-string $oldName
+     * @param non-empty-string $newName
+     */
     private function renameColumnInForeignKeyConstraints(string $oldName, string $newName): void
     {
         foreach ($this->_fkConstraints as $key => $constraint) {
@@ -1097,6 +1115,10 @@ class Table extends AbstractNamedObject
         }
     }
 
+    /**
+     * @param non-empty-string $oldName
+     * @param non-empty-string $newName
+     */
     private function renameColumnInUniqueConstraints(string $oldName, string $newName): void
     {
         foreach ($this->uniqueConstraints as $key => $constraint) {

--- a/src/Schema/TableConfiguration.php
+++ b/src/Schema/TableConfiguration.php
@@ -9,13 +9,19 @@ namespace Doctrine\DBAL\Schema;
  */
 final class TableConfiguration
 {
-    /** @internal The configuration can be only instantiated by a {@see SchemaConfig}. */
+    /**
+     * @internal The configuration can be only instantiated by a {@see SchemaConfig}.
+     *
+     * @param positive-int $maxIdentifierLength
+     */
     public function __construct(private readonly int $maxIdentifierLength)
     {
     }
 
     /**
      * Returns the maximum length of identifiers to be generated for the objects scoped to the table.
+     *
+     * @return positive-int
      */
     public function getMaxIdentifierLength(): int
     {

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -15,6 +15,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class RenameColumnTest extends FunctionalTestCase
 {
+    /**
+     * @param non-empty-string $columnName
+     * @param non-empty-string $newColumnName
+     */
     #[DataProvider('columnNameProvider')]
     public function testColumnPositionRetainedAfterImplicitRenaming(string $columnName, string $newColumnName): void
     {
@@ -59,6 +63,10 @@ class RenameColumnTest extends FunctionalTestCase
         return $renamed;
     }
 
+    /**
+     * @param non-empty-string $columnName
+     * @param non-empty-string $newColumnName
+     */
     #[DataProvider('columnNameProvider')]
     public function testColumnPositionRetainedAfterExplicitRenaming(string $columnName, string $newColumnName): void
     {
@@ -88,7 +96,7 @@ class RenameColumnTest extends FunctionalTestCase
         self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
     }
 
-    /** @return iterable<array{string,string}> */
+    /** @return iterable<array{non-empty-string,non-empty-string}> */
     public static function columnNameProvider(): iterable
     {
         yield ['c1', 'c1_x'];

--- a/tests/Schema/Name/IdentifierTest.php
+++ b/tests/Schema/Name/IdentifierTest.php
@@ -15,6 +15,7 @@ class IdentifierTest extends TestCase
     {
         $this->expectException(InvalidIdentifier::class);
 
+        /** @phpstan-ignore argument.type */
         Identifier::unquoted('');
     }
 


### PR DESCRIPTION
The goal of this change is to annotate the constructor parameters and return values in the `Identifier` class as `non-empty-string` because it's already enforced at runtime: https://github.com/doctrine/dbal/blob/d788eb5861ae4848a76b9eed564404627fc1e717/src/Schema/Name/Identifier.php#L23-L25

This ripples into changes of the same kind in `UnqualifiedName`, `OptionallyQualifiedName` and `UnquotedIdentifierFolding`. It also requires marking the max identifier length as `positive-int`, which is also good and desired.

Making the build pass requires adding some more `@phpstan-ignore` to the codebase. Those annotations indicate the deficiencies in the current API (e.g. all database object classes extend `AbstractAsset`, and its `getName()` doesn't guarantee that the object name is not empty because it depends on the object type). This will improve in 5.0.x.