### PR TITLE
Use Ubuntu 22.04 for builds with lowest dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-22.04"
+          - "ubuntu-24.04"
         php-version:
           - "7.4"
           - "8.4"
@@ -49,7 +49,7 @@ jobs:
             php-version: "7.4"
             dependencies: "lowest"
             extension: "pdo_sqlite"
-          - os: "ubuntu-22.04"
+          - os: "ubuntu-24.04"
             php-version: "7.4"
             dependencies: "highest"
             extension: "sqlite3"
@@ -94,7 +94,7 @@ jobs:
 
   phpunit-oci8:
     name: "PHPUnit on OCI8"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -153,7 +153,7 @@ jobs:
 
   phpunit-pdo-oci:
     name: "PHPUnit on PDO_OCI"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -212,7 +212,7 @@ jobs:
 
   phpunit-postgres:
     name: "PHPUnit with PostgreSQL"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -282,7 +282,7 @@ jobs:
 
   phpunit-mariadb:
     name: "PHPUnit with MariaDB"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -357,7 +357,7 @@ jobs:
 
   phpunit-mysql:
     name: "PHPUnit with MySQL"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -505,7 +505,7 @@ jobs:
 
   phpunit-ibm-db2:
     name: "PHPUnit with IBM DB2"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
 
     strategy:
@@ -574,7 +574,7 @@ jobs:
 
   development-deps:
     name: "PHPUnit with PDO_SQLite and development dependencies"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       matrix:
@@ -603,7 +603,7 @@ jobs:
 
   upload_coverage:
     name: "Upload coverage to Codecov"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     needs:
       - "phpunit-smoke-check"
       - "phpunit-oci8"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,7 @@ jobs:
         extension:
           - "pdo_sqlite"
         include:
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "7.4"
             dependencies: "lowest"
             extension: "pdo_sqlite"
@@ -438,7 +438,7 @@ jobs:
 
   phpunit-mssql:
     name: "PHPUnit with SQL Server"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
 
     strategy:


### PR DESCRIPTION
Ubuntu 20.04 is unsupported starting Apr 15, 2025.

See: https://github.com/actions/runner-images/issues/11101.

As a piggyback, let's also upgrade the non-lowest builds to use Ubuntu 24.04.