### PR TITLE
Normalize column names when filtering them

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -10,6 +10,7 @@ use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
 use function array_keys;
+use function array_map;
 use function array_merge;
 use function in_array;
 use function preg_match;
@@ -749,6 +750,8 @@ class Table extends AbstractAsset
      */
     private function filterColumns(array $columnNames, bool $reverse = false): array
     {
+        $columnNames = array_map([$this, 'normalizeIdentifier'], $columnNames);
+
         return array_filter($this->_columns, static function (string $columnName) use ($columnNames, $reverse): bool {
             return in_array($columnName, $columnNames, true) !== $reverse;
         }, ARRAY_FILTER_USE_KEY);

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 use function array_shift;
+use function array_values;
 use function current;
 
 class TableTest extends TestCase
@@ -48,6 +49,26 @@ class TableTest extends TestCase
         self::assertInstanceOf(Column::class, $table->getColumn('bar'));
 
         self::assertCount(2, $table->getColumns());
+    }
+
+    /** @dataProvider getNormalizesAssetNames */
+    public function testColumnsOrder(string $assetName): void
+    {
+        $type      = Type::getType(Types::INTEGER);
+        $columns   = [];
+        $columns[] = new Column('bar', $type);
+        $columns[] = new Column('BAZ', $type);
+        $columns[] = new Column($assetName, $type);
+        $table     = new Table('foo', $columns, [], []);
+
+        $table->setPrimaryKey([$assetName]);
+        $table->addForeignKeyConstraint('bar', ['BAZ'], ['baz']);
+
+        $orderedColumns = array_values($table->getColumns());
+
+        self::assertSame($columns[2], $orderedColumns[0]);
+        self::assertSame($columns[1], $orderedColumns[1]);
+        self::assertSame($columns[0], $orderedColumns[2]);
     }
 
     public function testColumnsCaseInsensitive(): void


### PR DESCRIPTION
This fixes Table::getColumns not returning columns in their documented order (PK > FK > rest).
Fixes https://github.com/doctrine/dbal/issues/4158