### PR TITLE
Mark classes as read-only, internal and final

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated extension of some classes
+
+Extending the following classes has been deprecated. Use them directly.
+
+- `QueryCacheProfile`
+- `StaticServerVersionProvider`
+- `ColumnDiff`
+- `TableDiff`
+- `SchemaDiff`
+
 ## Deprecated `Index` methods, properties and behavior
 
 The following `Index` methods and properties have been deprecated:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,8 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## The `Doctrine\DBAL\Query\Limit` class has been marked as internal
+
 ## Deprecated extension of some classes
 
 Extending the following classes has been deprecated. Use them directly.

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -18,6 +18,7 @@ use function sha1;
  * It is a value object, setter methods return NEW instances.
  *
  * @phpstan-import-type WrapperParameterType from Connection
+ * @final
  */
 class QueryCacheProfile
 {

--- a/src/Connection/StaticServerVersionProvider.php
+++ b/src/Connection/StaticServerVersionProvider.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Connection;
 
 use Doctrine\DBAL\ServerVersionProvider;
 
+/** @final */
 class StaticServerVersionProvider implements ServerVersionProvider
 {
     public function __construct(private readonly string $version)

--- a/src/Platforms/MySQL/DefaultTableOptions.php
+++ b/src/Platforms/MySQL/DefaultTableOptions.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms\MySQL;
 
 /** @internal */
-final class DefaultTableOptions
+final readonly class DefaultTableOptions
 {
-    public function __construct(private readonly string $charset, private readonly string $collation)
+    public function __construct(private string $charset, private string $collation)
     {
     }
 

--- a/src/Query/CommonTableExpression.php
+++ b/src/Query/CommonTableExpression.php
@@ -8,7 +8,7 @@ use function count;
 use function sprintf;
 
 /** @internal */
-final class CommonTableExpression
+final readonly class CommonTableExpression
 {
     /**
      * @param string[]|null $columns
@@ -16,9 +16,9 @@ final class CommonTableExpression
      * @throws QueryException
      */
     public function __construct(
-        public readonly string $name,
-        public readonly string|QueryBuilder $query,
-        public readonly ?array $columns,
+        public string $name,
+        public string|QueryBuilder $query,
+        public ?array $columns,
     ) {
         if ($columns !== null && count($columns) === 0) {
             throw new QueryException(sprintf('Columns defined in CTE "%s" should not be an empty array.', $name));

--- a/src/Query/ForUpdate.php
+++ b/src/Query/ForUpdate.php
@@ -7,10 +7,10 @@ namespace Doctrine\DBAL\Query;
 use Doctrine\DBAL\Query\ForUpdate\ConflictResolutionMode;
 
 /** @internal */
-final class ForUpdate
+final readonly class ForUpdate
 {
     public function __construct(
-        private readonly ConflictResolutionMode $conflictResolutionMode,
+        private ConflictResolutionMode $conflictResolutionMode,
     ) {
     }
 

--- a/src/Query/From.php
+++ b/src/Query/From.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query;
 
 /** @internal */
-final class From
+final readonly class From
 {
     public function __construct(
-        public readonly string $table,
-        public readonly ?string $alias = null,
+        public string $table,
+        public ?string $alias = null,
     ) {
     }
 }

--- a/src/Query/Join.php
+++ b/src/Query/Join.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query;
 
 /** @internal */
-final class Join
+final readonly class Join
 {
     private function __construct(
-        public readonly string $type,
-        public readonly string $table,
-        public readonly string $alias,
-        public readonly ?string $condition,
+        public string $type,
+        public string $table,
+        public string $alias,
+        public ?string $condition,
     ) {
     }
 

--- a/src/Query/Limit.php
+++ b/src/Query/Limit.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Query;
 
+/** @internal */
 final class Limit
 {
     public function __construct(

--- a/src/Query/Union.php
+++ b/src/Query/Union.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query;
 
 /** @internal */
-final class Union
+final readonly class Union
 {
     public function __construct(
-        public readonly string|QueryBuilder $query,
-        public readonly ?UnionType $type = null,
+        public string|QueryBuilder $query,
+        public ?UnionType $type = null,
     ) {
     }
 }

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -8,6 +8,8 @@ use function strcasecmp;
 
 /**
  * Represents the change of a column.
+ *
+ * @final
  */
 class ColumnDiff
 {

--- a/src/Schema/Index/IndexedColumn.php
+++ b/src/Schema/Index/IndexedColumn.php
@@ -7,14 +7,14 @@ namespace Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Exception\InvalidIndexDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
-final class IndexedColumn
+final readonly class IndexedColumn
 {
     /**
      * @internal
      *
      * @param ?positive-int $length
      */
-    public function __construct(private readonly UnqualifiedName $columnName, private readonly ?int $length)
+    public function __construct(private UnqualifiedName $columnName, private ?int $length)
     {
         if ($length !== null && $length <= 0) {
             throw InvalidIndexDefinition::fromNonPositiveColumnLength($length);

--- a/src/Schema/Name/GenericName.php
+++ b/src/Schema/Name/GenericName.php
@@ -17,10 +17,10 @@ use function implode;
  *
  * @internal
  */
-final class GenericName implements Name
+final readonly class GenericName implements Name
 {
     /** @var non-empty-list<Identifier> $identifiers */
-    private readonly array $identifiers;
+    private array $identifiers;
 
     public function __construct(Identifier $firstIdentifier, Identifier ...$otherIdentifiers)
     {

--- a/src/Schema/Name/Identifier.php
+++ b/src/Schema/Name/Identifier.php
@@ -14,12 +14,12 @@ use function strlen;
 /**
  * Represents an SQL identifier.
  */
-final class Identifier
+final readonly class Identifier
 {
     /** @param non-empty-string $value */
     private function __construct(
-        private readonly string $value,
-        private readonly bool $isQuoted,
+        private string $value,
+        private bool $isQuoted,
     ) {
         if (strlen($this->value) === 0) {
             throw InvalidIdentifier::fromEmpty();

--- a/src/Schema/Name/OptionallyQualifiedName.php
+++ b/src/Schema/Name/OptionallyQualifiedName.php
@@ -10,9 +10,9 @@ use Doctrine\DBAL\Schema\Name;
 /**
  * An optionally qualified {@see Name} consisting of an unqualified name and an optional unqualified qualifier.
  */
-final class OptionallyQualifiedName implements Name
+final readonly class OptionallyQualifiedName implements Name
 {
-    public function __construct(private readonly Identifier $unqualifiedName, private readonly ?Identifier $qualifier)
+    public function __construct(private Identifier $unqualifiedName, private ?Identifier $qualifier)
     {
     }
 

--- a/src/Schema/Name/Parser/OptionallyQualifiedNameParser.php
+++ b/src/Schema/Name/Parser/OptionallyQualifiedNameParser.php
@@ -15,9 +15,9 @@ use function count;
  *
  * @implements Parser<OptionallyQualifiedName>
  */
-final class OptionallyQualifiedNameParser implements Parser
+final readonly class OptionallyQualifiedNameParser implements Parser
 {
-    public function __construct(private readonly GenericNameParser $genericNameParser)
+    public function __construct(private GenericNameParser $genericNameParser)
     {
     }
 

--- a/src/Schema/Name/Parser/UnqualifiedNameParser.php
+++ b/src/Schema/Name/Parser/UnqualifiedNameParser.php
@@ -15,9 +15,9 @@ use function count;
  *
  * @implements Parser<UnqualifiedName>
  */
-final class UnqualifiedNameParser implements Parser
+final readonly class UnqualifiedNameParser implements Parser
 {
-    public function __construct(private readonly GenericNameParser $genericNameParser)
+    public function __construct(private GenericNameParser $genericNameParser)
     {
     }
 

--- a/src/Schema/Name/UnqualifiedName.php
+++ b/src/Schema/Name/UnqualifiedName.php
@@ -10,9 +10,9 @@ use Doctrine\DBAL\Schema\Name;
 /**
  * An unqualified {@see Name} consisting of a single identifier.
  */
-final class UnqualifiedName implements Name
+final readonly class UnqualifiedName implements Name
 {
-    public function __construct(private readonly Identifier $identifier)
+    public function __construct(private Identifier $identifier)
     {
     }
 

--- a/src/Schema/PrimaryKeyConstraint.php
+++ b/src/Schema/PrimaryKeyConstraint.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use function count;
 
 /** @implements OptionallyNamedObject<UnqualifiedName> */
-final class PrimaryKeyConstraint implements OptionallyNamedObject
+final readonly class PrimaryKeyConstraint implements OptionallyNamedObject
 {
     /**
      * @internal Use {@link PrimaryKeyConstraint::editor()} to instantiate an editor and
@@ -23,9 +23,9 @@ final class PrimaryKeyConstraint implements OptionallyNamedObject
      * @param non-empty-list<UnqualifiedName> $columnNames
      */
     public function __construct(
-        private readonly ?UnqualifiedName $name,
-        private readonly array $columnNames,
-        private readonly bool $isClustered,
+        private ?UnqualifiedName $name,
+        private array $columnNames,
+        private bool $isClustered,
     ) {
         if (count($this->columnNames) < 1) {
             throw InvalidPrimaryKeyConstraintDefinition::columnNamesNotSet();

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -9,6 +9,8 @@ use function count;
 
 /**
  * Differences between two schemas.
+ *
+ * @final
  */
 class SchemaDiff
 {

--- a/src/Schema/TableConfiguration.php
+++ b/src/Schema/TableConfiguration.php
@@ -7,14 +7,14 @@ namespace Doctrine\DBAL\Schema;
 /**
  * Contains platform-specific parameters used for creating and managing objects scoped to a {@see Table}.
  */
-final class TableConfiguration
+final readonly class TableConfiguration
 {
     /**
      * @internal The configuration can be only instantiated by a {@see SchemaConfig}.
      *
      * @param positive-int $maxIdentifierLength
      */
-    public function __construct(private readonly int $maxIdentifierLength)
+    public function __construct(private int $maxIdentifierLength)
     {
     }
 

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -12,6 +12,8 @@ use function count;
 
 /**
  * Table Diff.
+ *
+ * @final
  */
 class TableDiff
 {

--- a/tests/Functional/Schema/Types/Money.php
+++ b/tests/Functional/Schema/Types/Money.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Schema\Types;
 
-final class Money
+final readonly class Money
 {
     public function __construct(
-        private readonly string $value,
+        private string $value,
     ) {
     }
 


### PR DESCRIPTION
With PHP 8.2 being the minimum supported version, we can mark some classes as read-only.

It only applies to the non-internal classes, because even if a class is final and cannot be extended with mutable properties, a user may set a dynamic property on a class instance. Without the `readonly` modifier, it will trigger a deprecation warning, but with the modifier, it will be a fatal error.

In order to enable marking more classes as read-only, this PR:
1. Annotates some classes as `@final` to make them `final` in 5.0.x.
2. Annotates one class as `@internal`.

P.S. The `QueryCacheProfile` class is mocked in one of the tests. I couldn't come up with a good way to rework it: https://github.com/doctrine/dbal/blob/1a328d545bbc5083d444da5c75100770284f700a/tests/ConnectionTest.php#L651-L689

What the test should make sure is that for different values of `$query`, `$params`, `$types` and connection parameters, the connection will use a different cache key. But the password is ignored (i.e. changing the password shouldn't affect the cache key).

It looks like this logic should be the responsibility of the connection (which interacts with the cache), not of the profile (which just defines the caching parameters): https://github.com/doctrine/dbal/blob/227e79be33e9dfe45803f4ffb1a218fed394b353/src/Cache/QueryCacheProfile.php#L61-L76

The dependency of a "cache profile" on the query, query parameters, parameter types and connection parameters looks odd.