### PR TITLE
Mark classes as read-only and final 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,49 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Classes marked as read-only:
+
+The following classes have been marked as read-only:
+
+- `Doctrine\DBAL\Cache\QueryCacheProfile`
+- `Doctrine\DBAL\Connection\StaticServerVersionProvider`
+- `Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString`
+- `Doctrine\DBAL\Driver\IBMDB2\Connection`
+- `Doctrine\DBAL\Driver\IBMDB2\DataSourceName`
+- `Doctrine\DBAL\Driver\IBMDB2\Result`
+- `Doctrine\DBAL\Driver\Mysqli\Initializer\Charset`
+- `Doctrine\DBAL\Driver\Mysqli\Initializer\Options`
+- `Doctrine\DBAL\Driver\Mysqli\Initializer\Secure`
+- `Doctrine\DBAL\Driver\OCI8\Connection`
+- `Doctrine\DBAL\Driver\OCI8\Result`
+- `Doctrine\DBAL\Driver\OCI8\Statement`
+- `Doctrine\DBAL\Driver\PDO\Connection`
+- `Doctrine\DBAL\Driver\PDO\Result`
+- `Doctrine\DBAL\Driver\PDO\Statement`
+- `Doctrine\DBAL\Driver\PgSQL\Connection`
+- `Doctrine\DBAL\Driver\SQLSrv\Connection`
+- `Doctrine\DBAL\Driver\SQLSrv\Result`
+- `Doctrine\DBAL\Driver\SQLite3\Connection`
+- `Doctrine\DBAL\Logging\Middleware`
+- `Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider\ConnectionCharsetMetadataProvider`
+- `Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider\ConnectionCollationMetadataProvider`
+- `Doctrine\DBAL\Platforms\SQLServer\SQL\Builder\SQLServerSelectSQLBuilder`
+- `Doctrine\DBAL\Portability\Middleware`
+- `Doctrine\DBAL\Query`
+- `Doctrine\DBAL\Query\Limit`
+- `Doctrine\DBAL\Query\SelectQuery`
+- `Doctrine\DBAL\Query\UnionQuery`
+- `Doctrine\DBAL\Result`
+- `Doctrine\DBAL\SQL\Builder\CreateSchemaObjectsSQLBuilder`
+- `Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder`
+- `Doctrine\DBAL\SQL\Builder\DefaultUnionSQLBuilder`
+- `Doctrine\DBAL\SQL\Builder\DropSchemaObjectsSQLBuilder`
+- `Doctrine\DBAL\Schema\ColumnDiff`
+- `Doctrine\DBAL\Schema\ComparatorConfig`
+- `Doctrine\DBAL\Schema\SchemaDiff`
+- `Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider`
+- `Doctrine\DBAL\Tools\DsnParser`
+
 ## BC BREAK: Classes marked as final:
 
 The following classes have been marked as final:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Classes marked as final:
+
+The following classes have been marked as final:
+
+- `StaticServerVersionProvider`
+- `ColumnDiff`
+- `TableDiff`
+- `SchemaDiff`
+
 ## BC BREAK: Changes in `Index` methods, properties and behavior
 
 The following `Index` methods and properties have been removed:

--- a/src/Cache/QueryCacheProfile.php
+++ b/src/Cache/QueryCacheProfile.php
@@ -20,12 +20,12 @@ use function sha1;
  * @phpstan-import-type WrapperParameterType from Connection
  * @final
  */
-class QueryCacheProfile
+readonly class QueryCacheProfile
 {
     public function __construct(
-        private readonly int $lifetime = 0,
-        private readonly ?string $cacheKey = null,
-        private readonly ?CacheItemPoolInterface $resultCache = null,
+        private int $lifetime = 0,
+        private ?string $cacheKey = null,
+        private ?CacheItemPoolInterface $resultCache = null,
     ) {
     }
 

--- a/src/Connection/StaticServerVersionProvider.php
+++ b/src/Connection/StaticServerVersionProvider.php
@@ -6,9 +6,9 @@ namespace Doctrine\DBAL\Connection;
 
 use Doctrine\DBAL\ServerVersionProvider;
 
-final class StaticServerVersionProvider implements ServerVersionProvider
+final readonly class StaticServerVersionProvider implements ServerVersionProvider
 {
-    public function __construct(private readonly string $version)
+    public function __construct(private string $version)
     {
     }
 

--- a/src/Connection/StaticServerVersionProvider.php
+++ b/src/Connection/StaticServerVersionProvider.php
@@ -6,8 +6,7 @@ namespace Doctrine\DBAL\Connection;
 
 use Doctrine\DBAL\ServerVersionProvider;
 
-/** @final */
-class StaticServerVersionProvider implements ServerVersionProvider
+final class StaticServerVersionProvider implements ServerVersionProvider
 {
     public function __construct(private readonly string $version)
     {

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -13,9 +13,9 @@ use function sprintf;
  *
  * @link https://docs.oracle.com/database/121/NETAG/naming.htm
  */
-final class EasyConnectString
+final readonly class EasyConnectString
 {
-    private function __construct(private readonly string $string)
+    private function __construct(private string $string)
     {
     }
 

--- a/src/Driver/IBMDB2/Connection.php
+++ b/src/Driver/IBMDB2/Connection.php
@@ -26,14 +26,14 @@ use function error_get_last;
 use const DB2_AUTOCOMMIT_OFF;
 use const DB2_AUTOCOMMIT_ON;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
     /**
      * @internal The connection can be only instantiated by its driver.
      *
      * @param resource $connection
      */
-    public function __construct(private readonly mixed $connection)
+    public function __construct(private mixed $connection)
     {
     }
 

--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -13,11 +13,11 @@ use function str_contains;
 /**
  * IBM DB2 DSN
  */
-final class DataSourceName
+final readonly class DataSourceName
 {
     private function __construct(
         #[SensitiveParameter]
-        private readonly string $string,
+        private string $string,
     ) {
     }
 

--- a/src/Driver/IBMDB2/Result.php
+++ b/src/Driver/IBMDB2/Result.php
@@ -17,14 +17,14 @@ use function db2_num_fields;
 use function db2_num_rows;
 use function db2_stmt_error;
 
-final class Result implements ResultInterface
+final readonly class Result implements ResultInterface
 {
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      *
      * @param resource $statement
      */
-    public function __construct(private readonly mixed $statement)
+    public function __construct(private mixed $statement)
     {
     }
 

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -9,9 +9,9 @@ use Doctrine\DBAL\Driver\Mysqli\Initializer;
 use mysqli;
 use mysqli_sql_exception;
 
-final class Charset implements Initializer
+final readonly class Charset implements Initializer
 {
-    public function __construct(private readonly string $charset)
+    public function __construct(private string $charset)
     {
     }
 

--- a/src/Driver/Mysqli/Initializer/Options.php
+++ b/src/Driver/Mysqli/Initializer/Options.php
@@ -10,10 +10,10 @@ use mysqli;
 
 use function mysqli_options;
 
-final class Options implements Initializer
+final readonly class Options implements Initializer
 {
     /** @param array<int,mixed> $options */
-    public function __construct(private readonly array $options)
+    public function __construct(private array $options)
     {
     }
 

--- a/src/Driver/Mysqli/Initializer/Secure.php
+++ b/src/Driver/Mysqli/Initializer/Secure.php
@@ -8,15 +8,15 @@ use Doctrine\DBAL\Driver\Mysqli\Initializer;
 use mysqli;
 use SensitiveParameter;
 
-final class Secure implements Initializer
+final readonly class Secure implements Initializer
 {
     public function __construct(
         #[SensitiveParameter]
-        private readonly string $key,
-        private readonly string $cert,
-        private readonly string $ca,
-        private readonly string $capath,
-        private readonly string $cipher,
+        private string $key,
+        private string $cert,
+        private string $ca,
+        private string $capath,
+        private string $cipher,
     ) {
     }
 

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -20,17 +20,17 @@ use function oci_server_version;
 use function preg_match;
 use function str_replace;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
-    private readonly Parser $parser;
-    private readonly ExecutionMode $executionMode;
+    private Parser $parser;
+    private ExecutionMode $executionMode;
 
     /**
      * @internal The connection can be only instantiated by its driver.
      *
      * @param resource $connection
      */
-    public function __construct(private readonly mixed $connection)
+    public function __construct(private mixed $connection)
     {
         $this->parser        = new Parser(false);
         $this->executionMode = new ExecutionMode();

--- a/src/Driver/OCI8/Result.php
+++ b/src/Driver/OCI8/Result.php
@@ -25,14 +25,14 @@ use const OCI_NUM;
 use const OCI_RETURN_LOBS;
 use const OCI_RETURN_NULLS;
 
-final class Result implements ResultInterface
+final readonly class Result implements ResultInterface
 {
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      *
      * @param resource $statement
      */
-    public function __construct(private readonly mixed $statement)
+    public function __construct(private mixed $statement)
     {
     }
 

--- a/src/Driver/OCI8/Statement.php
+++ b/src/Driver/OCI8/Statement.php
@@ -22,7 +22,7 @@ use const OCI_NO_AUTO_COMMIT;
 use const OCI_TEMP_BLOB;
 use const SQLT_CHR;
 
-final class Statement implements StatementInterface
+final readonly class Statement implements StatementInterface
 {
     /**
      * @internal The statement can be only instantiated by its driver connection.
@@ -32,10 +32,10 @@ final class Statement implements StatementInterface
      * @param array<int,string> $parameterMap
      */
     public function __construct(
-        private readonly mixed $connection,
-        private readonly mixed $statement,
-        private readonly array $parameterMap,
-        private readonly ExecutionMode $executionMode,
+        private mixed $connection,
+        private mixed $statement,
+        private array $parameterMap,
+        private ExecutionMode $executionMode,
     ) {
     }
 

--- a/src/Driver/PDO/Connection.php
+++ b/src/Driver/PDO/Connection.php
@@ -13,10 +13,10 @@ use PDOStatement;
 
 use function assert;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
     /** @internal The connection can be only instantiated by its driver. */
-    public function __construct(private readonly PDO $connection)
+    public function __construct(private PDO $connection)
     {
         $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }

--- a/src/Driver/PDO/Result.php
+++ b/src/Driver/PDO/Result.php
@@ -11,10 +11,10 @@ use PDOException;
 use PDOStatement;
 use ValueError;
 
-final class Result implements ResultInterface
+final readonly class Result implements ResultInterface
 {
     /** @internal The result can be only instantiated by its driver connection or statement. */
-    public function __construct(private readonly PDOStatement $statement)
+    public function __construct(private PDOStatement $statement)
     {
     }
 

--- a/src/Driver/PDO/Statement.php
+++ b/src/Driver/PDO/Statement.php
@@ -11,10 +11,10 @@ use PDO;
 use PDOException;
 use PDOStatement;
 
-final class Statement implements StatementInterface
+final readonly class Statement implements StatementInterface
 {
     /** @internal The statement can be only instantiated by its driver connection. */
-    public function __construct(private readonly PDOStatement $stmt)
+    public function __construct(private PDOStatement $stmt)
     {
     }
 

--- a/src/Driver/PgSQL/Connection.php
+++ b/src/Driver/PgSQL/Connection.php
@@ -20,11 +20,11 @@ use function pg_send_query;
 use function pg_version;
 use function uniqid;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
-    private readonly Parser $parser;
+    private Parser $parser;
 
-    public function __construct(private readonly PgSqlConnection $connection)
+    public function __construct(private PgSqlConnection $connection)
     {
         $this->parser = new Parser(false);
     }

--- a/src/Driver/SQLSrv/Connection.php
+++ b/src/Driver/SQLSrv/Connection.php
@@ -16,14 +16,14 @@ use function sqlsrv_rows_affected;
 use function sqlsrv_server_info;
 use function str_replace;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
     /**
      * @internal The connection can be only instantiated by its driver.
      *
      * @param resource $connection
      */
-    public function __construct(private readonly mixed $connection)
+    public function __construct(private mixed $connection)
     {
     }
 

--- a/src/Driver/SQLSrv/Result.php
+++ b/src/Driver/SQLSrv/Result.php
@@ -17,14 +17,14 @@ use function sqlsrv_rows_affected;
 use const SQLSRV_FETCH_ASSOC;
 use const SQLSRV_FETCH_NUMERIC;
 
-final class Result implements ResultInterface
+final readonly class Result implements ResultInterface
 {
     /**
      * @internal The result can be only instantiated by its driver connection or statement.
      *
      * @param resource $statement
      */
-    public function __construct(private readonly mixed $statement)
+    public function __construct(private mixed $statement)
     {
     }
 

--- a/src/Driver/SQLite3/Connection.php
+++ b/src/Driver/SQLite3/Connection.php
@@ -11,10 +11,10 @@ use SQLite3;
 use function assert;
 use function sprintf;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
     /** @internal The connection can be only instantiated by its driver. */
-    public function __construct(private readonly SQLite3 $connection)
+    public function __construct(private SQLite3 $connection)
     {
     }
 

--- a/src/Logging/Middleware.php
+++ b/src/Logging/Middleware.php
@@ -8,9 +8,9 @@ use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 use Psr\Log\LoggerInterface;
 
-final class Middleware implements MiddlewareInterface
+final readonly class Middleware implements MiddlewareInterface
 {
-    public function __construct(private readonly LoggerInterface $logger)
+    public function __construct(private LoggerInterface $logger)
     {
     }
 

--- a/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
+++ b/src/Platforms/MySQL/CharsetMetadataProvider/ConnectionCharsetMetadataProvider.php
@@ -9,9 +9,9 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQL\CharsetMetadataProvider;
 
 /** @internal */
-final class ConnectionCharsetMetadataProvider implements CharsetMetadataProvider
+final readonly class ConnectionCharsetMetadataProvider implements CharsetMetadataProvider
 {
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private Connection $connection)
     {
     }
 

--- a/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
+++ b/src/Platforms/MySQL/CollationMetadataProvider/ConnectionCollationMetadataProvider.php
@@ -9,9 +9,9 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQL\CollationMetadataProvider;
 
 /** @internal */
-final class ConnectionCollationMetadataProvider implements CollationMetadataProvider
+final readonly class ConnectionCollationMetadataProvider implements CollationMetadataProvider
 {
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private Connection $connection)
     {
     }
 

--- a/src/Platforms/SQLServer/SQL/Builder/SQLServerSelectSQLBuilder.php
+++ b/src/Platforms/SQLServer/SQL/Builder/SQLServerSelectSQLBuilder.php
@@ -12,11 +12,11 @@ use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use function count;
 use function implode;
 
-final class SQLServerSelectSQLBuilder implements SelectSQLBuilder
+final readonly class SQLServerSelectSQLBuilder implements SelectSQLBuilder
 {
     /** @internal The SQL builder should be instantiated only by database platforms. */
     public function __construct(
-        private readonly SQLServerPlatform $platform,
+        private SQLServerPlatform $platform,
     ) {
     }
 

--- a/src/Portability/Middleware.php
+++ b/src/Portability/Middleware.php
@@ -8,9 +8,9 @@ use Doctrine\DBAL\ColumnCase;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 
-final class Middleware implements MiddlewareInterface
+final readonly class Middleware implements MiddlewareInterface
 {
-    public function __construct(private readonly int $mode, private readonly ?ColumnCase $case)
+    public function __construct(private int $mode, private ?ColumnCase $case)
     {
     }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -9,16 +9,16 @@ namespace Doctrine\DBAL;
  *
  * @phpstan-import-type WrapperParameterType from Connection
  */
-final class Query
+final readonly class Query
 {
     /**
      * @param array<mixed> $params
      * @phpstan-param array<WrapperParameterType> $types
      */
     public function __construct(
-        private readonly string $sql,
-        private readonly array $params,
-        private readonly array $types,
+        private string $sql,
+        private array $params,
+        private array $types,
     ) {
     }
 

--- a/src/Query/Limit.php
+++ b/src/Query/Limit.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Query;
 
 /** @internal */
-final class Limit
+final readonly class Limit
 {
     public function __construct(
-        private readonly ?int $maxResults,
-        private readonly int $firstResult,
+        private ?int $maxResults,
+        private int $firstResult,
     ) {
     }
 

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Query;
 
-final class SelectQuery
+final readonly class SelectQuery
 {
     /**
      * @internal This class should be instantiated only by {@link QueryBuilder}.
@@ -15,15 +15,15 @@ final class SelectQuery
      * @param string[] $orderBy
      */
     public function __construct(
-        private readonly bool $distinct,
-        private readonly array $columns,
-        private readonly array $from,
-        private readonly ?string $where,
-        private readonly array $groupBy,
-        private readonly ?string $having,
-        private readonly array $orderBy,
-        private readonly Limit $limit,
-        private readonly ?ForUpdate $forUpdate,
+        private bool $distinct,
+        private array $columns,
+        private array $from,
+        private ?string $where,
+        private array $groupBy,
+        private ?string $having,
+        private array $orderBy,
+        private Limit $limit,
+        private ?ForUpdate $forUpdate,
     ) {
     }
 

--- a/src/Query/UnionQuery.php
+++ b/src/Query/UnionQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Query;
 
-final class UnionQuery
+final readonly class UnionQuery
 {
     /**
      * @internal This class should be instantiated only by {@link QueryBuilder}.
@@ -13,9 +13,9 @@ final class UnionQuery
      * @param string[] $orderBy
      */
     public function __construct(
-        private readonly array $unionParts,
-        private readonly array $orderBy,
-        private readonly Limit $limit,
+        private array $unionParts,
+        private array $orderBy,
+        private Limit $limit,
     ) {
     }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -13,10 +13,10 @@ use function array_shift;
 use function assert;
 use function count;
 
-class Result
+readonly class Result
 {
     /** @internal The result can be only instantiated by {@see Connection} or {@see Statement}. */
-    public function __construct(private readonly DriverResult $result, private readonly Connection $connection)
+    public function __construct(private DriverResult $result, private Connection $connection)
     {
     }
 

--- a/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/CreateSchemaObjectsSQLBuilder.php
@@ -11,9 +11,9 @@ use Doctrine\DBAL\Schema\Table;
 
 use function array_merge;
 
-final class CreateSchemaObjectsSQLBuilder
+final readonly class CreateSchemaObjectsSQLBuilder
 {
-    public function __construct(private readonly AbstractPlatform $platform)
+    public function __construct(private AbstractPlatform $platform)
     {
     }
 

--- a/src/SQL/Builder/DefaultSelectSQLBuilder.php
+++ b/src/SQL/Builder/DefaultSelectSQLBuilder.php
@@ -13,13 +13,13 @@ use Doctrine\DBAL\Query\SelectQuery;
 use function count;
 use function implode;
 
-final class DefaultSelectSQLBuilder implements SelectSQLBuilder
+final readonly class DefaultSelectSQLBuilder implements SelectSQLBuilder
 {
     /** @internal The SQL builder should be instantiated only by database platforms. */
     public function __construct(
-        private readonly AbstractPlatform $platform,
-        private readonly ?string $forUpdateSQL,
-        private readonly ?string $skipLockedSQL,
+        private AbstractPlatform $platform,
+        private ?string $forUpdateSQL,
+        private ?string $skipLockedSQL,
     ) {
     }
 

--- a/src/SQL/Builder/DefaultUnionSQLBuilder.php
+++ b/src/SQL/Builder/DefaultUnionSQLBuilder.php
@@ -11,10 +11,10 @@ use Doctrine\DBAL\Query\UnionType;
 use function count;
 use function implode;
 
-final class DefaultUnionSQLBuilder implements UnionSQLBuilder
+final readonly class DefaultUnionSQLBuilder implements UnionSQLBuilder
 {
     public function __construct(
-        private readonly AbstractPlatform $platform,
+        private AbstractPlatform $platform,
     ) {
     }
 

--- a/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
+++ b/src/SQL/Builder/DropSchemaObjectsSQLBuilder.php
@@ -11,9 +11,9 @@ use Doctrine\DBAL\Schema\Table;
 
 use function array_merge;
 
-final class DropSchemaObjectsSQLBuilder
+final readonly class DropSchemaObjectsSQLBuilder
 {
-    public function __construct(private readonly AbstractPlatform $platform)
+    public function __construct(private AbstractPlatform $platform)
     {
     }
 

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -8,10 +8,8 @@ use function strcasecmp;
 
 /**
  * Represents the change of a column.
- *
- * @final
  */
-class ColumnDiff
+final class ColumnDiff
 {
     /** @internal The diff can be only instantiated by a {@see Comparator}. */
     public function __construct(private readonly Column $oldColumn, private readonly Column $newColumn)

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -9,10 +9,10 @@ use function strcasecmp;
 /**
  * Represents the change of a column.
  */
-final class ColumnDiff
+final readonly class ColumnDiff
 {
     /** @internal The diff can be only instantiated by a {@see Comparator}. */
-    public function __construct(private readonly Column $oldColumn, private readonly Column $newColumn)
+    public function __construct(private Column $oldColumn, private Column $newColumn)
     {
     }
 

--- a/src/Schema/ComparatorConfig.php
+++ b/src/Schema/ComparatorConfig.php
@@ -7,11 +7,11 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\Deprecations\Deprecation;
 
-final class ComparatorConfig
+final readonly class ComparatorConfig
 {
     public function __construct(
-        private readonly bool $detectRenamedColumns = true,
-        private readonly bool $detectRenamedIndexes = true,
+        private bool $detectRenamedColumns = true,
+        private bool $detectRenamedIndexes = true,
     ) {
     }
 

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -9,10 +9,8 @@ use function count;
 
 /**
  * Differences between two schemas.
- *
- * @final
  */
-class SchemaDiff
+final class SchemaDiff
 {
     /** @var array<TableDiff> */
     private readonly array $alteredTables;

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -10,10 +10,10 @@ use function count;
 /**
  * Differences between two schemas.
  */
-final class SchemaDiff
+final readonly class SchemaDiff
 {
     /** @var array<TableDiff> */
-    private readonly array $alteredTables;
+    private array $alteredTables;
 
     /**
      * Constructs an SchemaDiff object.
@@ -30,14 +30,14 @@ final class SchemaDiff
      * @param array<Sequence>  $droppedSequences
      */
     public function __construct(
-        private readonly array $createdSchemas,
-        private readonly array $droppedSchemas,
-        private readonly array $createdTables,
+        private array $createdSchemas,
+        private array $droppedSchemas,
+        private array $createdTables,
         array $alteredTables,
-        private readonly array $droppedTables,
-        private readonly array $createdSequences,
-        private readonly array $alteredSequences,
-        private readonly array $droppedSequences,
+        private array $droppedTables,
+        private array $createdSequences,
+        private array $alteredSequences,
+        private array $droppedSequences,
     ) {
         $this->alteredTables = array_filter($alteredTables, static function (TableDiff $diff): bool {
             return ! $diff->isEmpty();

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -12,10 +12,8 @@ use function count;
 
 /**
  * Table Diff.
- *
- * @final
  */
-class TableDiff
+final class TableDiff
 {
     /**
      * Constructs a TableDiff object.

--- a/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
+++ b/src/Tools/Console/ConnectionProvider/SingleConnectionProvider.php
@@ -10,11 +10,11 @@ use Doctrine\DBAL\Tools\Console\ConnectionProvider;
 
 use function sprintf;
 
-class SingleConnectionProvider implements ConnectionProvider
+final readonly class SingleConnectionProvider implements ConnectionProvider
 {
     public function __construct(
-        private readonly Connection $connection,
-        private readonly string $defaultConnectionName = 'default',
+        private Connection $connection,
+        private string $defaultConnectionName = 'default',
     ) {
     }
 

--- a/src/Tools/DsnParser.php
+++ b/src/Tools/DsnParser.php
@@ -22,11 +22,11 @@ use function strpos;
 use function substr;
 
 /** @phpstan-import-type Params from DriverManager */
-final class DsnParser
+final readonly class DsnParser
 {
     /** @param array<string, string|class-string<Driver>> $schemeMapping An array used to map DSN schemes to DBAL drivers */
     public function __construct(
-        private readonly array $schemeMapping = [],
+        private array $schemeMapping = [],
     ) {
     }
 


### PR DESCRIPTION
This is a continuation of the effort started in https://github.com/doctrine/dbal/pull/6923.

Unlike `SchemaDiff` and `ColumnDiff`, `TableDiff` currently cannot be made read-only because it's mutated by `AbstractMySQLPlatform`: https://github.com/doctrine/dbal/blob/45d8ac6cb633d0229ad07f72a4c93c9870e419e8/src/Platforms/AbstractMySQLPlatform.php#L409-L410