### PR TITLE
Add shorthand name-related methods to schema object editors

### DIFF
--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -52,10 +52,10 @@ final class ForeignKeyConstraintEditor
     }
 
     public function setReferencingColumnNames(
-        UnqualifiedName $firstColumName,
+        UnqualifiedName $firstColumnName,
         UnqualifiedName ...$otherColumnNames,
     ): self {
-        $this->referencingColumnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+        $this->referencingColumnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
 
         return $this;
     }
@@ -68,10 +68,10 @@ final class ForeignKeyConstraintEditor
     }
 
     public function setReferencedColumnNames(
-        UnqualifiedName $firstColumName,
+        UnqualifiedName $firstColumnName,
         UnqualifiedName ...$otherColumnNames,
     ): self {
-        $this->referencedColumnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+        $this->referencedColumnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
 
         return $this;
     }

--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -51,11 +51,59 @@ final class ForeignKeyConstraintEditor
         return $this;
     }
 
+    /** @param non-empty-string $name */
+    public function setUnquotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::unquoted($name);
+
+        return $this;
+    }
+
+    /** @param non-empty-string $name */
+    public function setQuotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::quoted($name);
+
+        return $this;
+    }
+
     public function setReferencingColumnNames(
         UnqualifiedName $firstColumnName,
         UnqualifiedName ...$otherColumnNames,
     ): self {
-        $this->referencingColumnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
+        $this->referencingColumnNames = [$firstColumnName, ...array_values($otherColumnNames)];
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setUnquotedReferencingColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->referencingColumnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::unquoted($name),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setQuotedReferencingColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->referencingColumnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::quoted($name),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
 
         return $this;
     }
@@ -67,11 +115,71 @@ final class ForeignKeyConstraintEditor
         return $this;
     }
 
+    /**
+     * @param non-empty-string  $unqualifiedReferencedTableName
+     * @param ?non-empty-string $referencedTableNameQualifier
+     */
+    public function setUnquotedReferencedTableName(
+        string $unqualifiedReferencedTableName,
+        ?string $referencedTableNameQualifier = null,
+    ): self {
+        $this->referencedTableName =
+            OptionallyQualifiedName::unquoted($unqualifiedReferencedTableName, $referencedTableNameQualifier);
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string  $unqualifiedReferencedTableName
+     * @param ?non-empty-string $referencedTableNameQualifier
+     */
+    public function setQuotedReferencedTableName(
+        string $unqualifiedReferencedTableName,
+        ?string $referencedTableNameQualifier = null,
+    ): self {
+        $this->referencedTableName =
+            OptionallyQualifiedName::quoted($unqualifiedReferencedTableName, $referencedTableNameQualifier);
+
+        return $this;
+    }
+
     public function setReferencedColumnNames(
         UnqualifiedName $firstColumnName,
         UnqualifiedName ...$otherColumnNames,
     ): self {
-        $this->referencedColumnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
+        $this->referencedColumnNames = [$firstColumnName, ...array_values($otherColumnNames)];
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setUnquotedReferencedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->referencedColumnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::unquoted($name),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setQuotedReferencedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->referencedColumnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::quoted($name),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
 
         return $this;
     }

--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function array_map;
-use function array_merge;
 use function array_values;
 use function count;
 
@@ -40,6 +39,22 @@ final class IndexEditor
         return $this;
     }
 
+    /** @param non-empty-string $name */
+    public function setUnquotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::unquoted($name);
+
+        return $this;
+    }
+
+    /** @param non-empty-string $name */
+    public function setQuotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::quoted($name);
+
+        return $this;
+    }
+
     public function setType(IndexType $type): self
     {
         $this->type = $type;
@@ -49,7 +64,7 @@ final class IndexEditor
 
     public function setColumns(IndexedColumn $firstColumn, IndexedColumn ...$otherColumns): self
     {
-        $this->columns = array_merge([$firstColumn], array_values($otherColumns));
+        $this->columns = [$firstColumn, ...array_values($otherColumns)];
 
         return $this;
     }
@@ -58,7 +73,39 @@ final class IndexEditor
     {
         $this->columns = array_map(
             static fn (UnqualifiedName $name) => new IndexedColumn($name, null),
-            array_merge([$firstColumnName], array_values($otherColumnNames)),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setUnquotedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->columns = array_map(
+            static fn (string $name): IndexedColumn => new IndexedColumn(UnqualifiedName::unquoted($name), null),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setQuotedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->columns = array_map(
+            static fn (string $name): IndexedColumn => new IndexedColumn(UnqualifiedName::quoted($name), null),
+            [$firstColumnName, ...array_values($otherColumnNames)],
         );
 
         return $this;

--- a/src/Schema/PrimaryKeyConstraintEditor.php
+++ b/src/Schema/PrimaryKeyConstraintEditor.php
@@ -35,9 +35,9 @@ final class PrimaryKeyConstraintEditor
         return $this;
     }
 
-    public function setColumnNames(UnqualifiedName $firstColumName, UnqualifiedName ...$otherColumnNames): self
+    public function setColumnNames(UnqualifiedName $firstColumnName, UnqualifiedName ...$otherColumnNames): self
     {
-        $this->columnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+        $this->columnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
 
         return $this;
     }

--- a/src/Schema/PrimaryKeyConstraintEditor.php
+++ b/src/Schema/PrimaryKeyConstraintEditor.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Schema\Exception\InvalidPrimaryKeyConstraintDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
-use function array_merge;
+use function array_map;
 use function array_values;
 use function count;
 
@@ -35,9 +35,57 @@ final class PrimaryKeyConstraintEditor
         return $this;
     }
 
+    /** @param non-empty-string $name */
+    public function setUnquotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::unquoted($name);
+
+        return $this;
+    }
+
+    /** @param non-empty-string $name */
+    public function setQuotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::quoted($name);
+
+        return $this;
+    }
+
     public function setColumnNames(UnqualifiedName $firstColumnName, UnqualifiedName ...$otherColumnNames): self
     {
-        $this->columnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
+        $this->columnNames = [$firstColumnName, ...array_values($otherColumnNames)];
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setUnquotedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->columnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::unquoted($name),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setQuotedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->columnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::quoted($name),
+            [$firstColumnName, ...array_values($otherColumnNames)],
+        );
 
         return $this;
     }

--- a/src/Schema/UniqueConstraintEditor.php
+++ b/src/Schema/UniqueConstraintEditor.php
@@ -33,9 +33,9 @@ final class UniqueConstraintEditor
         return $this;
     }
 
-    public function setColumnNames(UnqualifiedName $firstColumName, UnqualifiedName ...$otherColumnNames): self
+    public function setColumnNames(UnqualifiedName $firstColumnName, UnqualifiedName ...$otherColumnNames): self
     {
-        $this->columnNames = array_merge([$firstColumName], array_values($otherColumnNames));
+        $this->columnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
 
         return $this;
     }

--- a/src/Schema/UniqueConstraintEditor.php
+++ b/src/Schema/UniqueConstraintEditor.php
@@ -33,9 +33,57 @@ final class UniqueConstraintEditor
         return $this;
     }
 
+    /** @param non-empty-string $name */
+    public function setUnquotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::unquoted($name);
+
+        return $this;
+    }
+
+    /** @param non-empty-string $name */
+    public function setQuotedName(string $name): self
+    {
+        $this->name = UnqualifiedName::quoted($name);
+
+        return $this;
+    }
+
     public function setColumnNames(UnqualifiedName $firstColumnName, UnqualifiedName ...$otherColumnNames): self
     {
         $this->columnNames = array_merge([$firstColumnName], array_values($otherColumnNames));
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setUnquotedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->columnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::unquoted($name),
+            array_merge([$firstColumnName], array_values($otherColumnNames)),
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $firstColumnName
+     * @param non-empty-string ...$otherColumnNames
+     */
+    public function setQuotedColumnNames(
+        string $firstColumnName,
+        string ...$otherColumnNames,
+    ): self {
+        $this->columnNames = array_map(
+            static fn (string $name): UnqualifiedName => UnqualifiedName::quoted($name),
+            array_merge([$firstColumnName], array_values($otherColumnNames)),
+        );
 
         return $this;
     }

--- a/tests/Functional/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Functional/Schema/ForeignKeyConstraintTest.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Type;
@@ -88,28 +87,16 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
 
         $foreignKeyConstraints = [
             ForeignKeyConstraint::editor()
-                ->setName(UnqualifiedName::unquoted('fk_roles'))
-                ->setReferencingColumnNames(
-                    UnqualifiedName::unquoted('role_id1'),
-                    UnqualifiedName::unquoted('role_id2'),
-                )
-                ->setReferencedTableName($roles->getObjectName())
-                ->setReferencedColumnNames(
-                    UnqualifiedName::unquoted('r_id1'),
-                    UnqualifiedName::unquoted('r_id2'),
-                )
+                ->setUnquotedName('fk_roles')
+                ->setUnquotedReferencingColumnNames('role_id1', 'role_id2')
+                ->setUnquotedReferencedTableName('roles')
+                ->setUnquotedReferencedColumnNames('r_id1', 'r_id2')
                 ->create(),
             ForeignKeyConstraint::editor()
-                ->setName(UnqualifiedName::unquoted('fk_teams'))
-                ->setReferencingColumnNames(
-                    UnqualifiedName::unquoted('team_id1'),
-                    UnqualifiedName::unquoted('team_id2'),
-                )
-                ->setReferencedTableName($teams->getObjectName())
-                ->setReferencedColumnNames(
-                    UnqualifiedName::unquoted('t_id1'),
-                    UnqualifiedName::unquoted('t_id2'),
-                )
+                ->setUnquotedName('fk_teams')
+                ->setUnquotedReferencingColumnNames('team_id1', 'team_id2')
+                ->setUnquotedReferencedTableName('teams')
+                ->setUnquotedReferencedColumnNames('t_id1', 't_id2')
                 ->create(),
         ];
 
@@ -198,13 +185,9 @@ final class ForeignKeyConstraintTest extends FunctionalTestCase
         $roles->setPrimaryKey(['id']);
 
         $editor = ForeignKeyConstraint::editor()
-            ->setReferencingColumnNames(
-                UnqualifiedName::unquoted('role_id'),
-            )
+            ->setUnquotedReferencingColumnNames('role_id')
             ->setReferencedTableName($roles->getObjectName())
-            ->setReferencedColumnNames(
-                UnqualifiedName::unquoted('id'),
-            );
+            ->setUnquotedReferencedColumnNames('id');
         $setter($editor, $action);
 
         $users = new Table('users', [

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -440,12 +439,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         $uniqueConstraint = UniqueConstraint::editor()
-            ->setName(
-                UnqualifiedName::unquoted('uniq_id'),
-            )
-            ->setColumnNames(
-                UnqualifiedName::unquoted('id'),
-            )
+            ->setUnquotedName('uniq_id')
+            ->setUnquotedColumnNames('id')
             ->create();
 
         $this->schemaManager->createUniqueConstraint($uniqueConstraint, $table->getName());

--- a/tests/Functional/Schema/UniqueConstraintTest.php
+++ b/tests/Functional/Schema/UniqueConstraintTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -24,10 +23,10 @@ final class UniqueConstraintTest extends FunctionalTestCase
             new Column('email', Type::getType(Types::STRING), ['length' => 255]),
         ], [], [
             UniqueConstraint::editor()
-                ->setColumnNames(UnqualifiedName::unquoted('username'))
+                ->setUnquotedColumnNames('username')
                 ->create(),
             UniqueConstraint::editor()
-                ->setColumnNames(UnqualifiedName::unquoted('email'))
+                ->setUnquotedColumnNames('email')
                 ->create(),
         ], []);
 

--- a/tests/Functional/UniqueConstraintViolationsTest.php
+++ b/tests/Functional/UniqueConstraintViolationsTest.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -59,8 +58,8 @@ final class UniqueConstraintViolationsTest extends FunctionalTestCase
             );
         } else {
             $createConstraint = UniqueConstraint::editor()
-                ->setName(UnqualifiedName::unquoted($constraintName))
-                ->setColumnNames(UnqualifiedName::unquoted('unique_field'))
+                ->setUnquotedName($constraintName)
+                ->setUnquotedColumnNames('unique_field')
                 ->create();
         }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -190,11 +189,8 @@ abstract class AbstractPlatformTestCase extends TestCase
         $where            = 'test IS NULL AND test2 IS NOT NULL';
         $indexDef         = new Index('name', ['test', 'test2'], false, false, [], ['where' => $where]);
         $uniqueConstraint = UniqueConstraint::editor()
-            ->setName(UnqualifiedName::unquoted('name'))
-            ->setColumnNames(
-                UnqualifiedName::unquoted('test'),
-                UnqualifiedName::unquoted('test2'),
-            )
+            ->setUnquotedName('name')
+            ->setUnquotedColumnNames('test', 'test2')
             ->create();
 
         $expected = ' WHERE ' . $where;

--- a/tests/Schema/ForeignKeyConstraintEditorTest.php
+++ b/tests/Schema/ForeignKeyConstraintEditorTest.php
@@ -64,6 +64,114 @@ class ForeignKeyConstraintEditorTest extends TestCase
         self::assertEquals($name, $constraint->getObjectName());
     }
 
+    public function testSetUnquotedName(): void
+    {
+        $constraint = $this->createMinimalValidEditor()
+            ->setUnquotedName('fk_users_id')
+            ->create();
+
+        self::assertEquals(
+            UnqualifiedName::unquoted('fk_users_id'),
+            $constraint->getObjectName(),
+        );
+    }
+
+    public function testSetQuotedName(): void
+    {
+        $constraint = $this->createMinimalValidEditor()
+            ->setQuotedName('fk_users_id')
+            ->create();
+
+        self::assertEquals(
+            UnqualifiedName::quoted('fk_users_id'),
+            $constraint->getObjectName(),
+        );
+    }
+
+    public function testSetUnquotedReferencingColumnNames(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setUnquotedReferencingColumnNames('account_id', 'user_id')
+            ->setReferencedTableName($this->createTableName())
+            ->setUnquotedReferencedColumnNames('unused1', 'unused2')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::unquoted('user_id'),
+        ], $constraint->getReferencingColumnNames());
+    }
+
+    public function testSetQuotedReferencingColumnNames(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setQuotedReferencingColumnNames('account_id', 'user_id')
+            ->setReferencedTableName($this->createTableName())
+            ->setQuotedReferencedColumnNames('unused1', 'unused2')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::quoted('account_id'),
+            UnqualifiedName::quoted('user_id'),
+        ], $constraint->getReferencingColumnNames());
+    }
+
+    public function testSetUnquotedReferencedTableName(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames($this->createColumnName())
+            ->setUnquotedReferencedTableName('users', 'public')
+            ->setReferencedColumnNames($this->createColumnName())
+            ->create();
+
+        self::assertEquals(
+            OptionallyQualifiedName::unquoted('users', 'public'),
+            $constraint->getReferencedTableName(),
+        );
+    }
+
+    public function testSetQuotedReferencedTableName(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setReferencingColumnNames($this->createColumnName())
+            ->setQuotedReferencedTableName('users', 'public')
+            ->setReferencedColumnNames($this->createColumnName())
+            ->create();
+
+        self::assertEquals(
+            OptionallyQualifiedName::quoted('users', 'public'),
+            $constraint->getReferencedTableName(),
+        );
+    }
+
+    public function testSetUnquotedReferencedColumnNames(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setUnquotedReferencingColumnNames('unused1', 'unused2')
+            ->setReferencedTableName($this->createTableName())
+            ->setUnquotedReferencedColumnNames('account_id', 'id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::unquoted('id'),
+        ], $constraint->getReferencedColumnNames());
+    }
+
+    public function testSetQuotedReferencedColumnNames(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setQuotedReferencingColumnNames('unused1', 'unused2')
+            ->setReferencedTableName($this->createTableName())
+            ->setQuotedReferencedColumnNames('account_id', 'id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::quoted('account_id'),
+            UnqualifiedName::quoted('id'),
+        ], $constraint->getReferencedColumnNames());
+    }
+
     public function testSetMatchType(): void
     {
         $editor = $this->createMinimalValidEditor();

--- a/tests/Schema/PrimaryKeyConstraintEditorTest.php
+++ b/tests/Schema/PrimaryKeyConstraintEditorTest.php
@@ -20,12 +20,60 @@ class PrimaryKeyConstraintEditorTest extends TestCase
         $editor->create();
     }
 
+    public function testSetUnquotedName(): void
+    {
+        $constraint = PrimaryKeyConstraint::editor()
+            ->setUnquotedName('pk_users')
+            ->setColumnNames($this->createColumnName())
+            ->create();
+
+        self::assertEquals(
+            UnqualifiedName::unquoted('pk_users'),
+            $constraint->getObjectName(),
+        );
+    }
+
+    public function testSetQuotedName(): void
+    {
+        $constraint = PrimaryKeyConstraint::editor()
+            ->setQuotedName('pk_users')
+            ->setColumnNames($this->createColumnName())
+            ->create();
+
+        self::assertEquals(
+            UnqualifiedName::quoted('pk_users'),
+            $constraint->getObjectName(),
+        );
+    }
+
+    public function testSetUnquotedColumnNames(): void
+    {
+        $constraint = PrimaryKeyConstraint::editor()
+            ->setUnquotedColumnNames('account_id', 'user_id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::unquoted('user_id'),
+        ], $constraint->getColumnNames());
+    }
+
+    public function testSetQuotedColumnNames(): void
+    {
+        $constraint = PrimaryKeyConstraint::editor()
+            ->setQuotedColumnNames('account_id', 'user_id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::quoted('account_id'),
+            UnqualifiedName::quoted('user_id'),
+        ], $constraint->getColumnNames());
+    }
+
     public function testSetIsClustered(): void
     {
-        $columnName = UnqualifiedName::unquoted('id');
-
         $constraint = PrimaryKeyConstraint::editor()
-            ->setColumnNames($columnName)
+            ->setUnquotedColumnNames('id')
             ->create();
 
         self::assertTrue($constraint->isClustered());
@@ -34,5 +82,10 @@ class PrimaryKeyConstraintEditorTest extends TestCase
             ->setIsClustered(false)
             ->create();
         self::assertFalse($constraint->isClustered());
+    }
+
+    private function createColumnName(): UnqualifiedName
+    {
+        return UnqualifiedName::unquoted('id');
     }
 }

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
@@ -1018,9 +1017,7 @@ class TableTest extends TestCase
 
         self::assertEquals(
             PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
+                ->setUnquotedColumnNames('id')
                 ->create(),
             $table->getPrimaryKeyConstraint(),
         );
@@ -1032,9 +1029,7 @@ class TableTest extends TestCase
         $table->addColumn('id', Types::INTEGER);
         $table->addPrimaryKeyConstraint(
             PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
+                ->setUnquotedColumnNames('id')
                 ->create(),
         );
 
@@ -1063,9 +1058,7 @@ class TableTest extends TestCase
         $table->addColumn('id', Types::INTEGER);
         $table->addPrimaryKeyConstraint(
             PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
+                ->setUnquotedColumnNames('id')
                 ->create(),
         );
 
@@ -1082,9 +1075,7 @@ class TableTest extends TestCase
         $this->expectException(PrimaryKeyAlreadyExists::class);
         $table->addPrimaryKeyConstraint(
             PrimaryKeyConstraint::editor()
-                ->setColumnNames(
-                    UnqualifiedName::unquoted('id'),
-                )
+                ->setUnquotedColumnNames('id')
                 ->create(),
         );
     }

--- a/tests/Schema/UniqueConstraintEditorTest.php
+++ b/tests/Schema/UniqueConstraintEditorTest.php
@@ -19,12 +19,60 @@ class UniqueConstraintEditorTest extends TestCase
             ->create();
     }
 
+    public function testSetUnquotedName(): void
+    {
+        $constraint = UniqueConstraint::editor()
+            ->setUnquotedName('uq_id')
+            ->setColumnNames($this->createColumnName())
+            ->create();
+
+        self::assertEquals(
+            UnqualifiedName::unquoted('uq_id'),
+            $constraint->getObjectName(),
+        );
+    }
+
+    public function testSetQuotedName(): void
+    {
+        $constraint = UniqueConstraint::editor()
+            ->setQuotedName('uq_id')
+            ->setColumnNames($this->createColumnName())
+            ->create();
+
+        self::assertEquals(
+            UnqualifiedName::quoted('uq_id'),
+            $constraint->getObjectName(),
+        );
+    }
+
+    public function testSetUnquotedColumnNames(): void
+    {
+        $constraint = UniqueConstraint::editor()
+            ->setUnquotedColumnNames('account_id', 'user_id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::unquoted('user_id'),
+        ], $constraint->getColumnNames());
+    }
+
+    public function testSetQuotedColumnNames(): void
+    {
+        $constraint = UniqueConstraint::editor()
+            ->setQuotedColumnNames('account_id', 'user_id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::quoted('account_id'),
+            UnqualifiedName::quoted('user_id'),
+        ], $constraint->getColumnNames());
+    }
+
     public function testSetIsClustered(): void
     {
-        $columnName = UnqualifiedName::unquoted('user_id');
-
         $editor = UniqueConstraint::editor()
-            ->setColumnNames($columnName);
+            ->setUnquotedColumnNames('user_id');
 
         $constraint = $editor->create();
         self::assertFalse($constraint->isClustered());
@@ -33,5 +81,10 @@ class UniqueConstraintEditorTest extends TestCase
             ->setIsClustered(true)
             ->create();
         self::assertTrue($constraint->isClustered());
+    }
+
+    private function createColumnName(): UnqualifiedName
+    {
+        return UnqualifiedName::unquoted('id');
     }
 }

--- a/tests/Schema/UniqueConstraintTest.php
+++ b/tests/Schema/UniqueConstraintTest.php
@@ -35,9 +35,7 @@ class UniqueConstraintTest extends TestCase
     public function testGetNullObjectName(): void
     {
         $uniqueConstraint = UniqueConstraint::editor()
-            ->setColumnNames(
-                UnqualifiedName::unquoted('user_id'),
-            )
+            ->setUnquotedColumnNames('user_id')
             ->create();
 
         self::assertNull($uniqueConstraint->getObjectName());


### PR DESCRIPTION
Currently, the API of the schema object editors requires a bit too much boilerplate when it comes to defining names. We need to construct a name and pass it to the editor. For example: https://github.com/doctrine/dbal/blob/fc92aad6b0cc27d8c767cbb5672c2fd7ac4309b8/tests/Functional/Schema/ForeignKeyConstraintTest.php#L89-L114

This experience could be improved if for every `set*Name()` method we introduced an additional pair of `setUnquoted*Name()` and `setQuoted*Name()`. This way, the editor would construct the name and set it. The same code after the rework: https://github.com/doctrine/dbal/blob/e6dd11922e6a4ba03b1875c32145fd1995942742/tests/Functional/Schema/ForeignKeyConstraintTest.php#L88-L101

Adding these new methods will reduce boilerplate code in tests (primarily in 5.0.x where all affected objects are created via editors) and in the new user-land code that will construct schema objects.

## Intended usage of the "unquoted" versions of the methods

These will be used by:
1. The majority of the users, since they will expect to see the natural case of identifiers defined by the target database platforms.
2. The majority of the tests, since most of them are not about preserving the case of identifiers.

## Intended usage of the "quoted" versions of the methods

These will be used by:
1. The users who want to preserve the case of identifiers on the platforms compliant with the SQL standard (e.g. being able to use `CamelCase` names on Postgres).
2. The tests that cover the scenarios where the case of identifiers is expected to be preserved regardless of the target database platform.

## Mixing quoted and unquoted identifiers

If quoted and unquoted identifiers need to be mixed on a single object, the existing `set*Name()` methods can be used.