### PR TITLE
Clean up SQL Server column type parsing

### DIFF
--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -21,7 +21,6 @@ use function preg_match;
 use function sprintf;
 use function str_contains;
 use function str_replace;
-use function strtok;
 
 use const CASE_LOWER;
 
@@ -61,8 +60,7 @@ SQL,
      */
     protected function _getPortableTableColumnDefinition(array $tableColumn): Column
     {
-        $dbType = strtok($tableColumn['type'], '(), ');
-        assert(is_string($dbType));
+        $dbType = $tableColumn['type'];
 
         $length = (int) $tableColumn['length'];
 
@@ -70,10 +68,6 @@ SQL,
 
         $scale = 0;
         $fixed = false;
-
-        if (! isset($tableColumn['name'])) {
-            $tableColumn['name'] = '';
-        }
 
         if ($tableColumn['scale'] !== null) {
             $scale = (int) $tableColumn['scale'];

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -24,7 +24,8 @@ class DBAL461Test extends TestCase
 
         $reflectionMethod = new ReflectionMethod($schemaManager, '_getPortableTableColumnDefinition');
         $column           = $reflectionMethod->invoke($schemaManager, [
-            'type' => 'numeric(18,0)',
+            'name' => 'test',
+            'type' => 'numeric',
             'length' => null,
             'default' => null,
             'notnull' => false,


### PR DESCRIPTION
There's no need to parse the value of `$tableColumn['type']` in `SQLServerSchemaManager#_getPortableSequenceDefinition()`. This element contains only the name of the type, while all type parameters (e.g. length, precision and scale) are contained in other elements.

It was likely a copy/paste from the MySQL schema manager, where the type does need to be parsed: https://github.com/doctrine/dbal/blob/f7bbcb4c15e98be11921b95aa147022043095446/src/Schema/MySQLSchemaManager.php#L124-L125

Additionally, the `isset($tableColumn['name'])` check is redundant. A column always has a name.