### PR TITLE
Clean up MySQL column type parsing

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -234,7 +234,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      */
     public function getColumnTypeSQLSnippet(string $tableAlias, string $databaseName): string
     {
-        return $tableAlias . '.COLUMN_TYPE';
+        return $tableAlias . '.DATA_TYPE';
     }
 
     /**

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -41,7 +41,7 @@ class MariaDBPlatform extends AbstractMySQLPlatform
         // The check for `CONSTRAINT_SCHEMA = $databaseName` is mandatory here to prevent performance issues
         return <<<SQL
             IF(
-                $tableAlias.COLUMN_TYPE = 'longtext'
+                $tableAlias.DATA_TYPE = 'longtext'
                 AND EXISTS(
                     SELECT * FROM information_schema.CHECK_CONSTRAINTS $subQueryAlias
                     WHERE $subQueryAlias.CONSTRAINT_SCHEMA = $databaseName
@@ -53,7 +53,7 @@ class MariaDBPlatform extends AbstractMySQLPlatform
                     )
                 ),
                 'json',
-                $tableAlias.COLUMN_TYPE
+                $tableAlias.DATA_TYPE
             )
         SQL;
     }


### PR DESCRIPTION
The current implementation uses `information_schema.COLUMNS.COLUMN_TYPE` and parses the SQL representation of the type using `strtok()` and `preg_match()`: https://github.com/doctrine/dbal/blob/f7bbcb4c15e98be11921b95aa147022043095446/src/Schema/MySQLSchemaManager.php#L125 https://github.com/doctrine/dbal/blob/f7bbcb4c15e98be11921b95aa147022043095446/src/Schema/MySQLSchemaManager.php#L150-L160

This is unnecessary, because most of the type information is available in the structured format. Specifically:
1. `DATA_TYPE` contains the name of the type (e.g. `varchar`), so we don't need to parse it.
2. `CHARACTER_MAXIMUM_LENGTH` contains the length of character types in characters.
3. The same is true for other type's properties.

The only properties that still need to be parsed out of the `COLUMN_TYPE` is `UNSIGNED` and `ENUM` elements, because they are not part of the SQL standard, so we select this column as well.

The current implementation is also a bit convoluted in a way that it first unconditionally sets the `$length` property and then unsets it for some types (because at least for some of them, the number in parenthesis is not the length but the display width): https://github.com/doctrine/dbal/blob/f7bbcb4c15e98be11921b95aa147022043095446/src/Schema/MySQLSchemaManager.php#L128 https://github.com/doctrine/dbal/blob/f7bbcb4c15e98be11921b95aa147022043095446/src/Schema/MySQLSchemaManager.php#L188-L196

It attempts to use `$tableColumn['length']` before `strtok()`, but there is no "length" column in the introspection query result.

The new implementation sets it on a per-type basis by sourcing from the corresponding column.