### PR TITLE
Simplify Postgres column introspection

### DIFF
--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -722,9 +722,7 @@ class PostgreSQLPlatform extends AbstractPlatform
             'bytea'            => Types::BLOB,
             'char'             => Types::STRING,
             'date'             => Types::DATE_MUTABLE,
-            'datetime'         => Types::DATETIME_MUTABLE,
             'decimal'          => Types::DECIMAL,
-            'double'           => Types::FLOAT,
             'double precision' => Types::FLOAT,
             'float'            => Types::FLOAT,
             'float4'           => Types::SMALLFLOAT,
@@ -753,7 +751,6 @@ class PostgreSQLPlatform extends AbstractPlatform
             'tsvector'         => Types::TEXT,
             'uuid'             => Types::GUID,
             'varchar'          => Types::STRING,
-            'year'             => Types::DATE_MUTABLE,
             '_varchar'         => Types::STRING,
         ];
     }


### PR DESCRIPTION
There are a few code-level issues with this code:
1. There are no `datetime`, `double` or `year` type in Postgres, yet they are listed in the type mapping (this is probably a copy-paste from MySQL).
2. The SQL query uses subqueries. I don't think they hurt performance (unlike Oracle, the schema introspection queries in Postgres seems to be really fast), but they look like barnacles.
3. The logic of parsing the default expression is spread all over the method.
4. The logic of parsing type parameters (length, precision, scale) is spread all over the method.
5. The `$length` property of a column is assigned a value in multiple places. It's initialized with `null`, then assigned a parsed value, then conditionally set back to `null`.

This PR attempts to address the above issues. The goal is once we introduce `ColumnEditor` to construct a `Column` object via an object-oriented API, this code doesn't have to be rewritten too much and at the same time remains readable.