### PR TITLE
Update TableEditor API

### DIFF
--- a/src/Schema/Exception/InvalidTableDefinition.php
+++ b/src/Schema/Exception/InvalidTableDefinition.php
@@ -13,4 +13,9 @@ final class InvalidTableDefinition extends LogicException implements SchemaExcep
     {
         return new self('Table name is not set.');
     }
+
+    public static function columnsNotSet(): self
+    {
+        return new self('Table columns are not set.');
+    }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -993,10 +993,10 @@ class Table extends AbstractNamedObject
     {
         return self::editor()
             ->setName($this->getObjectName())
-            ->setColumns($this->_columns)
-            ->setIndexes($this->_indexes)
-            ->setUniqueConstraints($this->uniqueConstraints)
-            ->setForeignKeyConstraints($this->_fkConstraints)
+            ->setColumns(...array_values($this->_columns))
+            ->setIndexes(...array_values($this->_indexes))
+            ->setUniqueConstraints(...array_values($this->uniqueConstraints))
+            ->setForeignKeyConstraints(...array_values($this->_fkConstraints))
             ->setOptions($this->_options)
             ->setConfiguration(
                 new TableConfiguration($this->maxIdentifierLength),

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -45,6 +45,28 @@ final class TableEditor
         return $this;
     }
 
+    /**
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
+     */
+    public function setUnquotedName(string $unqualifiedName, ?string $qualifier = null): self
+    {
+        $this->name = OptionallyQualifiedName::unquoted($unqualifiedName, $qualifier);
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
+     */
+    public function setQuotedName(string $unqualifiedName, ?string $qualifier = null): self
+    {
+        $this->name = OptionallyQualifiedName::quoted($unqualifiedName, $qualifier);
+
+        return $this;
+    }
+
     public function setColumns(Column $firstColumn, Column ...$otherColumns): self
     {
         $this->columns = [$firstColumn, ...$otherColumns];

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 
 use function array_filter;
+use function count;
 
 final class TableEditor
 {
@@ -44,16 +45,14 @@ final class TableEditor
         return $this;
     }
 
-    /** @param array<Column> $columns */
-    public function setColumns(array $columns): self
+    public function setColumns(Column $firstColumn, Column ...$otherColumns): self
     {
-        $this->columns = $columns;
+        $this->columns = [$firstColumn, ...$otherColumns];
 
         return $this;
     }
 
-    /** @param array<Index> $indexes */
-    public function setIndexes(array $indexes): self
+    public function setIndexes(Index ...$indexes): self
     {
         $this->indexes = $indexes;
 
@@ -72,16 +71,14 @@ final class TableEditor
         return $this;
     }
 
-    /** @param array<UniqueConstraint> $uniqueConstraints */
-    public function setUniqueConstraints(array $uniqueConstraints): self
+    public function setUniqueConstraints(UniqueConstraint ...$uniqueConstraints): self
     {
         $this->uniqueConstraints = $uniqueConstraints;
 
         return $this;
     }
 
-    /** @param array<ForeignKeyConstraint> $foreignKeyConstraints */
-    public function setForeignKeyConstraints(array $foreignKeyConstraints): self
+    public function setForeignKeyConstraints(ForeignKeyConstraint ...$foreignKeyConstraints): self
     {
         $this->foreignKeyConstraints = $foreignKeyConstraints;
 
@@ -107,6 +104,10 @@ final class TableEditor
     {
         if ($this->name === null) {
             throw InvalidTableDefinition::nameNotSet();
+        }
+
+        if (count($this->columns) === 0) {
+            throw InvalidTableDefinition::columnsNotSet();
         }
 
         return new Table(

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -4,14 +4,42 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class TableEditorTest extends TestCase
 {
+    public function testSetUnquotedName(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts', 'public')
+            ->setColumns($this->createColumn())
+            ->create();
+
+        self::assertEquals(
+            OptionallyQualifiedName::unquoted('accounts', 'public'),
+            $table->getObjectName(),
+        );
+    }
+
+    public function testSetQuotedName(): void
+    {
+        $table = Table::editor()
+            ->setQuotedName('contacts', 'dbo')
+            ->setColumns($this->createColumn())
+            ->create();
+
+        self::assertEquals(
+            OptionallyQualifiedName::quoted('contacts', 'dbo'),
+            $table->getObjectName(),
+        );
+    }
+
     public function testSetName(): void
     {
         $name = OptionallyQualifiedName::unquoted('contacts');
@@ -31,5 +59,20 @@ class TableEditorTest extends TestCase
         $this->expectException(InvalidTableDefinition::class);
 
         Table::editor()->create();
+    }
+
+    public function testColumnsNotSet(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts');
+
+        $this->expectException(InvalidTableDefinition::class);
+
+        $editor->create();
+    }
+
+    private function createColumn(): Column
+    {
+        return new Column('id', Type::getType(Types::INTEGER));
     }
 }

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class TableEditorTest extends TestCase
@@ -15,8 +16,10 @@ class TableEditorTest extends TestCase
     {
         $name = OptionallyQualifiedName::unquoted('contacts');
 
-        $table = (new Table('accounts'))
-            ->edit()
+        $table = new Table('accounts');
+        $table->addColumn('id', Types::INTEGER);
+
+        $table = $table->edit()
             ->setName($name)
             ->create();
 


### PR DESCRIPTION
This PR makes `TableEditor::set*()` methods accept variadic arguments (like all other editors) and introduces shorthand methods for `setName()` (also like in all other editors, see https://github.com/doctrine/dbal/pull/6927). None of these changes are breaking since this code hasn't been released yet.

Also, it adds a check for empty columns in `TableEditor::create()`.