### PR TITLE
fix: normalize boolean parameter binding for native pgsql driver

### DIFF
--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -81,8 +81,13 @@ final class Statement implements StatementInterface
             throw UnknownParameter::new((string) $param);
         }
 
-        $this->parameters[$this->parameterMap[$param]]     = $value;
-        $this->parameterTypes[$this->parameterMap[$param]] = $type;
+        if ($type === ParameterType::BOOLEAN) {
+            $this->parameters[$this->parameterMap[$param]]     = ($value === false ? 'f' : 't');
+            $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;
+        } else {
+            $this->parameters[$this->parameterMap[$param]]     = $value;
+            $this->parameterTypes[$this->parameterMap[$param]] = $type;
+        }
 
         return true;
     }
@@ -102,7 +107,7 @@ final class Statement implements StatementInterface
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/pull/5558',
                 'Not passing $type to Statement::bindParam() is deprecated.'
-                . ' Pass the type corresponding to the parameter being bound.',
+                    . ' Pass the type corresponding to the parameter being bound.',
             );
         }
 
@@ -132,7 +137,7 @@ final class Statement implements StatementInterface
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/pull/5556',
                 'Passing $params to Statement::execute() is deprecated. Bind parameters using'
-                . ' Statement::bindParam() or Statement::bindValue() instead.',
+                    . ' Statement::bindParam() or Statement::bindValue() instead.',
             );
 
             foreach ($params as $param => $value) {

--- a/tests/Functional/Driver/PgSQL/BooleanBindingTest.php
+++ b/tests/Functional/Driver/PgSQL/BooleanBindingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PgSQL;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+
+class BooleanBindingTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (TestUtil::isDriverOneOf('pgsql')) {
+            $table = new Table('t');
+            $table->addColumn('v', 'boolean');
+            $this->dropAndCreateTable($table);
+
+            return;
+        }
+
+        self::markTestSkipped('This test requires the pgsql driver.');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->dropTableIfExists('t');
+    }
+
+    public function testBooleanTrue(): void
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $result = $queryBuilder->insert('t')->values([
+            'v' => $queryBuilder->createNamedParameter(true, ParameterType::BOOLEAN),
+        ])->executeStatement();
+
+        self::assertSame(1, $result);
+
+        $value = $this->connection->fetchOne('SELECT v FROM t');
+        self::assertTrue($value);
+    }
+
+    public function testBooleanFalse(): void
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $result = $queryBuilder->insert('t')->values([
+            'v' => $queryBuilder->createNamedParameter(false, ParameterType::BOOLEAN),
+        ])->executeStatement();
+
+        self::assertSame(1, $result);
+
+        $value = $this->connection->fetchOne('SELECT v FROM t');
+        self::assertFalse($value);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6780

#### Summary

This PR fixes incorrect boolean parameter binding behavior when using the native `pgsql` driver in Doctrine DBAL.

Previously, when binding a boolean `false` value using the native pgsql driver, Doctrine incorrectly serialized the value as an empty string (`''`). PostgreSQL does not accept empty strings for boolean fields, resulting in the following error:

```
invalid input syntax for type boolean: "
```

This PR involves below changes:
- Normalize boolean values to `'t'` (true) or `'f'` (false) in `Driver\PgSQL\Statement`.
- Adjust parameter types to `ParameterType::STRING` when binding booleans for `pgsql` to reflect the transformed type.
- Add functional tests to validate boolean true and false insertion and ensure correct round-trip behavior.

