### PR TITLE
fix: Normalize boolean parameter binding for native pgsql driver

### DIFF
--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -81,8 +81,13 @@ final class Statement implements StatementInterface
             throw UnknownParameter::new((string) $param);
         }
 
-        $this->parameters[$this->parameterMap[$param]]     = $value;
-        $this->parameterTypes[$this->parameterMap[$param]] = $type;
+        if ($type === ParameterType::BOOLEAN) {
+            $this->parameters[$this->parameterMap[$param]]     = (bool) $value === false ? 'f' : 't';
+            $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;
+        } else {
+            $this->parameters[$this->parameterMap[$param]]     = $value;
+            $this->parameterTypes[$this->parameterMap[$param]] = $type;
+        }
 
         return true;
     }

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+
+class BooleanBindingTest extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        if (TestUtil::isDriverOneOf('pdo_oci', 'oci8')) {
+            self::markTestSkipped('Boolean inserts do not work for PDO_OCI and OCI8 as of now');
+        }
+
+        $table = new Table('boolean_test_table');
+        $table->addColumn('val', 'boolean');
+        $this->dropAndCreateTable($table);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropTableIfExists('boolean_test_table');
+    }
+
+    /** @dataProvider booleanProvider */
+    public function testBooleanInsert(bool $input): void
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $result = $queryBuilder->insert('boolean_test_table')->values([
+            'val' => $queryBuilder->createNamedParameter($input, ParameterType::BOOLEAN),
+        ])->executeStatement();
+
+        self::assertSame(1, $result);
+    }
+
+    /** @return bool[][] */
+    public static function booleanProvider(): array
+    {
+        return [[true], [false]];
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6780

#### Summary
This PR fixes incorrect boolean parameter binding behavior when using the native `pgsql` driver in Doctrine DBAL.

Previously, when binding a boolean `false` value using the native pgsql driver, Doctrine incorrectly serialized the value as an empty string (`''`). PostgreSQL does not accept empty strings for boolean fields, resulting in the following error:
```
invalid input syntax for type boolean: "
```
This PR involves below changes:

- Normalize boolean values to `'t'` (true) or `'f'` (false) in `Driver\PgSQL\Statement`.
- Adjust parameter types to `ParameterType::STRING` when binding booleans for pgsql to reflect the transformed type.
- Add functional tests to validate boolean `true` and `false` insertion behavior for all databases.
















