### PR TITLE
Deprecate "version" column platform option

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## The `version` column platform option has been deprecated
+
+The `version` column platform option has been deprecated without a replacement.
+
 ## The `Doctrine\DBAL\Query\Limit` class has been marked as internal
 
 ## Deprecated extension of some classes

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -173,6 +173,12 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
         if (isset($column['version']) && $column['version'] === true) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6940',
+                'The "version" column platform option is deprecated.',
+            );
+
             return 'TIMESTAMP';
         }
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -174,6 +174,12 @@ class DB2Platform extends AbstractPlatform
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
         if (isset($column['version']) && $column['version'] === true) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6940',
+                'The "version" column platform option is deprecated.',
+            );
+
             return 'TIMESTAMP(0) WITH DEFAULT';
         }
 
@@ -473,6 +479,12 @@ class DB2Platform extends AbstractPlatform
         }
 
         if (isset($column['version']) && $column['version'] === true) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/6940',
+                'The "version" column platform option is deprecated.',
+            );
+
             if ($column['type'] instanceof DateTimeType) {
                 $column['default'] = '1';
             }


### PR DESCRIPTION
See https://github.com/doctrine/dbal/pull/6939 for more context.

The `version` option is undocumented, untested, and it's hard to tell what it's supposed to do given the name. My best guess is that it makes the platform use a type analogous to `TIMESTAMP` but with the default value equal to "now". From the old JIRA on the internet archive (I cannot find the link), it looks like a leftover from the times when the ORM and the DBAL were a single project, so this option was meant to support some versioning.

We deprecated and removed the "now" functionality in https://github.com/doctrine/dbal/pull/4753.