### PR TITLE
Remove "jsonb" and "version" options

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed support for the `jsonb` column platform option
+
+The `jsonb` column platform option is no longer supported. `JSONB` columns on PostgreSQL are now introspected
+as columns of type `JSONB`, not as columns of type `JSON` with `jsonb` option set.
+
 ## BC BREAK: Classes marked as read-only:
 
 The following classes have been marked as read-only:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed support for the `version` column platform option
+
+The `version` column platform option is no longer supported.
+
 ## BC BREAK: Removed support for the `jsonb` column platform option
 
 The `jsonb` column platform option is no longer supported. `JSONB` columns on PostgreSQL are now introspected

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,7 @@ The `version` column platform option is no longer supported.
 The `jsonb` column platform option is no longer supported. `JSONB` columns on PostgreSQL are now introspected
 as columns of type `JSONB`, not as columns of type `JSON` with `jsonb` option set.
 
-## BC BREAK: Classes marked as read-only:
+## BC BREAK: Classes marked as read-only
 
 The following classes have been marked as read-only:
 
@@ -60,7 +60,7 @@ The following classes have been marked as read-only:
 - `Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider`
 - `Doctrine\DBAL\Tools\DsnParser`
 
-## BC BREAK: Classes marked as final:
+## BC BREAK: Classes marked as final
 
 The following classes have been marked as final:
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -129,14 +129,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      */
     public function getJsonTypeDeclarationSQL(array $column): string
     {
-        if (! empty($column['jsonb'])) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6939',
-                'The "jsonb" column platform option is deprecated. Use the "JSONB" type instead.',
-            );
-        }
-
         return 'JSON';
     }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function array_merge;
@@ -167,16 +166,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
-        if (isset($column['version']) && $column['version'] === true) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6940',
-                'The "version" column platform option is deprecated.',
-            );
-
-            return 'TIMESTAMP';
-        }
-
         return 'DATETIME';
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -870,7 +870,7 @@ abstract class AbstractPlatform
         $columns = [];
 
         foreach ($table->getColumns() as $column) {
-            $columns[] = $this->columnToArray($column);
+            $columns[] = $column->toArray();
         }
 
         $sql = $this->_getCreateTableSQL($tableName, $columns, $parameters);
@@ -2131,17 +2131,6 @@ abstract class AbstractPlatform
         return $sql;
     }
 
-    /**
-     * @return ColumnProperties An associative array with the name of the properties of the column being declared as
-     *                          array keys.
-     */
-    private function columnToArray(Column $column): array
-    {
-        return array_merge($column->toArray(), [
-            'version' => $column->hasPlatformOption('version') ? $column->getPlatformOption('version') : false,
-        ]);
-    }
-
     /** @internal */
     public function createSQLParser(): Parser
     {
@@ -2158,8 +2147,8 @@ abstract class AbstractPlatform
      */
     public function columnsEqual(Column $column1, Column $column2): bool
     {
-        $column1Array = $this->columnToArray($column1);
-        $column2Array = $this->columnToArray($column2);
+        $column1Array = $column1->toArray();
+        $column2Array = $column2->toArray();
 
         $name = UnqualifiedName::unquoted('dummy');
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -47,7 +47,6 @@ use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function addcslashes;
 use function array_map;
@@ -256,14 +255,6 @@ abstract class AbstractPlatform
      */
     public function getJsonTypeDeclarationSQL(array $column): string
     {
-        if (! empty($column['jsonb'])) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6939',
-                'The "jsonb" column platform option is deprecated. Use the "JSONB" type instead.',
-            );
-        }
-
         return $this->getClobTypeDeclarationSQL($column);
     }
 

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -18,9 +18,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function count;
@@ -174,16 +172,6 @@ class DB2Platform extends AbstractPlatform
      */
     public function getDateTimeTypeDeclarationSQL(array $column): string
     {
-        if (isset($column['version']) && $column['version'] === true) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6940',
-                'The "version" column platform option is deprecated.',
-            );
-
-            return 'TIMESTAMP(0) WITH DEFAULT';
-        }
-
         return 'TIMESTAMP(0)';
     }
 
@@ -496,18 +484,6 @@ class DB2Platform extends AbstractPlatform
     {
         if (isset($column['autoincrement']) && $column['autoincrement'] === true) {
             return '';
-        }
-
-        if (isset($column['version']) && $column['version'] === true) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6940',
-                'The "version" column platform option is deprecated.',
-            );
-
-            if ($column['type'] instanceof DateTimeType) {
-                $column['default'] = '1';
-            }
         }
 
         return parent::getDefaultValueDeclarationSQL($column);

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\Deprecation;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -262,7 +261,6 @@ class PostgreSQLPlatform extends AbstractPlatform
                 || $columnDiff->hasScaleChanged()
                 || $columnDiff->hasFixedChanged()
                 || $columnDiff->hasLengthChanged()
-                || $columnDiff->hasPlatformOptionsChanged()
             ) {
                 $type = $newColumn->getType();
 
@@ -723,7 +721,7 @@ class PostgreSQLPlatform extends AbstractPlatform
             'integer'          => Types::INTEGER,
             'interval'         => Types::STRING,
             'json'             => Types::JSON,
-            'jsonb'            => Types::JSON,
+            'jsonb'            => Types::JSONB,
             'money'            => Types::DECIMAL,
             'numeric'          => Types::DECIMAL,
             'serial'           => Types::INTEGER,
@@ -773,16 +771,6 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getJsonTypeDeclarationSQL(array $column): string
     {
-        if (! empty($column['jsonb'])) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6939',
-                'The "jsonb" column platform option is deprecated. Use the "JSONB" type instead.',
-            );
-
-            return 'JSONB';
-        }
-
         return 'JSON';
     }
 

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
 use function method_exists;
@@ -33,7 +32,6 @@ use function method_exists;
  *     charset?: ?string,
  *     collation?: ?string,
  *     default_constraint_name?: string,
- *     jsonb?: bool,
  *     version?: bool,
  * }
  */
@@ -160,14 +158,6 @@ class Column extends AbstractNamedObject
     /** @param PlatformOptions $platformOptions */
     public function setPlatformOptions(array $platformOptions): self
     {
-        if (isset($platformOptions['jsonb']) && $platformOptions['jsonb']) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6939',
-                'The "jsonb" column platform option is deprecated. Use the "JSONB" type instead.',
-            );
-        }
-
         $this->_platformOptions = $platformOptions;
 
         return $this;
@@ -176,14 +166,6 @@ class Column extends AbstractNamedObject
     /** @param key-of<PlatformOptions> $name */
     public function setPlatformOption(string $name, mixed $value): self
     {
-        if ($name === 'jsonb' && (bool) $value === true) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/6939',
-                'The "jsonb" column platform option is deprecated. Use the "JSONB" type instead.',
-            );
-        }
-
         $this->_platformOptions[$name] = $value;
 
         return $this;

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -32,7 +32,6 @@ use function method_exists;
  *     charset?: ?string,
  *     collation?: ?string,
  *     default_constraint_name?: string,
- *     version?: bool,
  * }
  */
 class Column extends AbstractNamedObject

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -188,7 +187,6 @@ SQL,
         $precision = null;
         $scale     = 0;
         $fixed     = false;
-        $jsonb     = false;
 
         $dbType = $tableColumn['typname'];
         if (
@@ -231,8 +229,6 @@ SQL,
 
         if ($dbType === 'bpchar') {
             $fixed = true;
-        } elseif ($dbType === 'jsonb') {
-            $jsonb = true;
         }
 
         $options = [
@@ -253,10 +249,6 @@ SQL,
 
         if (! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);
-        }
-
-        if ($column->getType() instanceof JsonType) {
-            $column->setPlatformOption('jsonb', $jsonb);
         }
 
         return $column;

--- a/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
+++ b/tests/Functional/Schema/PostgreSQL/ComparatorTest.php
@@ -79,7 +79,7 @@ final class ComparatorTest extends FunctionalTestCase
 
         $onlineTable = clone $table;
         $table->getColumn('test')
-            ->setPlatformOption('jsonb', true);
+            ->setType(Type::getType(Types::JSONB));
 
         $compareResult = $this->comparator->compareTables($onlineTable, $table);
         self::assertCount(1, $compareResult->getChangedColumns());
@@ -87,7 +87,7 @@ final class ComparatorTest extends FunctionalTestCase
 
         $changedColumn = $compareResult->getChangedColumns()['test'];
 
-        self::assertTrue($changedColumn->hasPlatformOptionsChanged());
+        self::assertTrue($changedColumn->hasTypeChanged());
         self::assertEquals(1, $changedColumn->countChangedProperties());
     }
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DecimalType;
 use Doctrine\DBAL\Types\IntegerType;
-use Doctrine\DBAL\Types\JsonType;
+use Doctrine\DBAL\Types\JsonbType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -323,13 +323,12 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function testJsonbColumn(): void
     {
         $table = new Table('test_jsonb');
-        $table->addColumn('foo', Types::JSON)->setPlatformOption('jsonb', true);
+        $table->addColumn('foo', Types::JSONB);
         $this->dropAndCreateTable($table);
 
         $columns = $this->schemaManager->listTableColumns('test_jsonb');
 
-        self::assertInstanceOf(JsonType::class, $columns['foo']->getType());
-        self::assertTrue($columns['foo']->getPlatformOption('jsonb'));
+        self::assertInstanceOf(JsonbType::class, $columns['foo']->getType());
     }
 
     public function testListNegativeColumnDefaultValue(): void

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -177,8 +177,6 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
     public function testGetDateTimeTypeDeclarationSql(): void
     {
-        self::assertEquals('DATETIME', $this->platform->getDateTimeTypeDeclarationSQL(['version' => false]));
-        self::assertEquals('TIMESTAMP', $this->platform->getDateTimeTypeDeclarationSQL(['version' => true]));
         self::assertEquals('DATETIME', $this->platform->getDateTimeTypeDeclarationSQL([]));
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -29,7 +29,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -40,8 +39,6 @@ use function sprintf;
 /** @template T of AbstractPlatform */
 abstract class AbstractPlatformTestCase extends TestCase
 {
-    use VerifyDeprecations;
-
     /** @var T */
     protected AbstractPlatform $platform;
 
@@ -549,10 +546,8 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testReturnsJsonbTypeDeclarationSQL(): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6939');
-
         self::assertSame(
-            $this->platform->getJsonTypeDeclarationSQL(['jsonb' => true]),
+            $this->platform->getJsonTypeDeclarationSQL([]),
             $this->platform->getJsonbTypeDeclarationSQL([]),
         );
     }

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -230,12 +230,6 @@ class DB2PlatformTest extends AbstractPlatformTestCase
         self::assertEquals('SMALLINT', $this->platform->getBooleanTypeDeclarationSQL($fullColumnDef));
         self::assertEquals('CLOB(1M)', $this->platform->getClobTypeDeclarationSQL($fullColumnDef));
         self::assertEquals('DATE', $this->platform->getDateTypeDeclarationSQL($fullColumnDef));
-
-        self::assertEquals(
-            'TIMESTAMP(0) WITH DEFAULT',
-            $this->platform->getDateTimeTypeDeclarationSQL(['version' => true]),
-        );
-
         self::assertEquals('TIMESTAMP(0)', $this->platform->getDateTimeTypeDeclarationSQL($fullColumnDef));
         self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL($fullColumnDef));
     }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -644,8 +644,11 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testReturnsJsonTypeDeclarationSQL(): void
     {
         self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL([]));
-        self::assertSame('JSON', $this->platform->getJsonTypeDeclarationSQL(['jsonb' => false]));
-        self::assertSame('JSONB', $this->platform->getJsonTypeDeclarationSQL(['jsonb' => true]));
+    }
+
+    public function testReturnsJsonbTypeDeclarationSQL(): void
+    {
+        self::assertSame('JSONB', $this->platform->getJsonbTypeDeclarationSQL([]));
     }
 
     public function testReturnsSmallIntTypeDeclarationSQL(): void
@@ -670,8 +673,12 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('json'));
         self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('json'));
+    }
+
+    public function testInitializesJsonbTypeMapping(): void
+    {
         self::assertTrue($this->platform->hasDoctrineTypeMappingFor('jsonb'));
-        self::assertEquals(Types::JSON, $this->platform->getDoctrineTypeMapping('jsonb'));
+        self::assertEquals(Types::JSONB, $this->platform->getDoctrineTypeMapping('jsonb'));
     }
 
     public function testGetListSequencesSQL(): void
@@ -697,10 +704,10 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         $tableDiff = new TableDiff($table, changedColumns: [
             'payload' => new ColumnDiff(
                 $table->getColumn('payload'),
-                (new Column(
+                new Column(
                     'payload',
-                    Type::getType(Types::JSON),
-                ))->setPlatformOption('jsonb', true),
+                    Type::getType(Types::JSONB),
+                ),
             ),
         ]);
 
@@ -713,7 +720,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     public function testAlterTableChangeJsonbToJson(): void
     {
         $table = new Table('mytable');
-        $table->addColumn('payload', Types::JSON)->setPlatformOption('jsonb', true);
+        $table->addColumn('payload', Types::JSONB);
 
         $tableDiff = new TableDiff($table, changedColumns: [
             'payload' => new ColumnDiff(

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -15,14 +15,11 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ColumnTest extends TestCase
 {
-    use VerifyDeprecations;
-
     public function testGet(): void
     {
         $column = $this->createColumn();
@@ -179,21 +176,5 @@ class ColumnTest extends TestCase
         $column = new Column('id', Type::getType(Types::INTEGER));
 
         self::assertEquals(Identifier::unquoted('id'), $column->getObjectName()->getIdentifier());
-    }
-
-    public function testSetPlatformOptionJsonb(): void
-    {
-        $column = new Column('jsonb', Type::getType(Types::JSON));
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6939');
-        $column->setPlatformOption('jsonb', true);
-    }
-
-    public function testSetPlatformOptionsJsonb(): void
-    {
-        $column = new Column('jsonb', Type::getType(Types::JSON));
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6939');
-        $column->setPlatformOptions(['jsonb' => true]);
     }
 }


### PR DESCRIPTION
This PR removes support for the "jsonb" and "version" column platform options deprecated in https://github.com/doctrine/dbal/pull/6939 and https://github.com/doctrine/dbal/pull/6940 respectively. `JSONB` columns on PostgreSQL are now introspected as columns of type `JSONB`.