### PR TITLE
Include object name in editor exception messages

### DIFF
--- a/src/Schema/Exception/InvalidForeignKeyConstraintDefinition.php
+++ b/src/Schema/Exception/InvalidForeignKeyConstraintDefinition.php
@@ -4,23 +4,40 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Exception;
 
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\SchemaException;
 use LogicException;
 
+use function sprintf;
+
 final class InvalidForeignKeyConstraintDefinition extends LogicException implements SchemaException
 {
-    public static function referencedTableNameNotSet(): self
+    public static function referencedTableNameNotSet(?UnqualifiedName $constraintName): self
     {
-        return new self('Foreign key constraint referenced table name is not set.');
+        return new self(sprintf(
+            'Referenced table name is not set for foreign key constraint %s.',
+            self::formatName($constraintName),
+        ));
     }
 
-    public static function referencingColumnNamesNotSet(): self
+    public static function referencingColumnNamesNotSet(?UnqualifiedName $constraintName): self
     {
-        return new self('Foreign key constraint referencing column names are not set.');
+        return new self(sprintf(
+            'Referencing column names are not set for foreign key constraint %s.',
+            self::formatName($constraintName),
+        ));
     }
 
-    public static function referencedColumnNamesNotSet(): self
+    public static function referencedColumnNamesNotSet(?UnqualifiedName $constraintName): self
     {
-        return new self('Foreign key constraint referenced column names are not set.');
+        return new self(sprintf(
+            'Referenced column names are not set for foreign key constraint %s.',
+            self::formatName($constraintName),
+        ));
+    }
+
+    private static function formatName(?UnqualifiedName $constraintName): string
+    {
+        return $constraintName === null ? '<unnamed>' : $constraintName->toString();
     }
 }

--- a/src/Schema/Exception/InvalidIndexDefinition.php
+++ b/src/Schema/Exception/InvalidIndexDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Exception;
 
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\SchemaException;
 use LogicException;
 
@@ -16,13 +17,17 @@ final class InvalidIndexDefinition extends LogicException implements SchemaExcep
         return new self('Index name is not set.');
     }
 
-    public static function columnsNotSet(): self
+    public static function columnsNotSet(UnqualifiedName $indexName): self
     {
-        return new self('Index column names are not set.');
+        return new self(sprintf('Columns are not set for index %s.', $indexName->toString()));
     }
 
-    public static function fromNonPositiveColumnLength(int $length): self
+    public static function fromNonPositiveColumnLength(UnqualifiedName $columnName, int $length): self
     {
-        return new self(sprintf('Indexed column length must be a positive integer, %d given.', $length));
+        return new self(sprintf(
+            'Indexed column length must be a positive integer, %d given for column %s.',
+            $length,
+            $columnName->toString(),
+        ));
     }
 }

--- a/src/Schema/Exception/InvalidTableDefinition.php
+++ b/src/Schema/Exception/InvalidTableDefinition.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Exception;
 
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\SchemaException;
 use LogicException;
+
+use function sprintf;
 
 final class InvalidTableDefinition extends LogicException implements SchemaException
 {
@@ -14,8 +17,8 @@ final class InvalidTableDefinition extends LogicException implements SchemaExcep
         return new self('Table name is not set.');
     }
 
-    public static function columnsNotSet(): self
+    public static function columnsNotSet(OptionallyQualifiedName $tableName): self
     {
-        return new self('Table columns are not set.');
+        return new self(sprintf('Columns are not set for table %s.', $tableName->toString()));
     }
 }

--- a/src/Schema/Exception/InvalidUniqueConstraintDefinition.php
+++ b/src/Schema/Exception/InvalidUniqueConstraintDefinition.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Exception;
 
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\SchemaException;
 use LogicException;
 
+use function sprintf;
+
 final class InvalidUniqueConstraintDefinition extends LogicException implements SchemaException
 {
-    public static function columnNamesAreNotSet(): self
+    public static function columnNamesAreNotSet(?UnqualifiedName $constraintName): self
     {
-        return new self('Unique constraint column names are not set.');
+        return new self(sprintf(
+            'Column names are not set for unique constraint %s.',
+            $constraintName === null ? '<unnamed>' : $constraintName->toString(),
+        ));
     }
 }

--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -215,15 +215,15 @@ final class ForeignKeyConstraintEditor
     public function create(): ForeignKeyConstraint
     {
         if (count($this->referencingColumnNames) < 1) {
-            throw InvalidForeignKeyConstraintDefinition::referencingColumnNamesNotSet();
+            throw InvalidForeignKeyConstraintDefinition::referencingColumnNamesNotSet($this->name);
         }
 
         if ($this->referencedTableName === null) {
-            throw InvalidForeignKeyConstraintDefinition::referencedTableNameNotSet();
+            throw InvalidForeignKeyConstraintDefinition::referencedTableNameNotSet($this->name);
         }
 
         if (count($this->referencedColumnNames) < 1) {
-            throw InvalidForeignKeyConstraintDefinition::referencedColumnNamesNotSet();
+            throw InvalidForeignKeyConstraintDefinition::referencedColumnNamesNotSet($this->name);
         }
 
         return new ForeignKeyConstraint(

--- a/src/Schema/Index/IndexedColumn.php
+++ b/src/Schema/Index/IndexedColumn.php
@@ -17,7 +17,7 @@ final readonly class IndexedColumn
     public function __construct(private UnqualifiedName $columnName, private ?int $length)
     {
         if ($length !== null && $length <= 0) {
-            throw InvalidIndexDefinition::fromNonPositiveColumnLength($length);
+            throw InvalidIndexDefinition::fromNonPositiveColumnLength($columnName, $length);
         }
     }
 

--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -133,7 +133,7 @@ final class IndexEditor
         }
 
         if (count($this->columns) < 1) {
-            throw InvalidIndexDefinition::columnsNotSet();
+            throw InvalidIndexDefinition::columnsNotSet($this->name);
         }
 
         $columnNames = $lengths = $flags = [];

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -129,7 +129,7 @@ final class TableEditor
         }
 
         if (count($this->columns) === 0) {
-            throw InvalidTableDefinition::columnsNotSet();
+            throw InvalidTableDefinition::columnsNotSet($this->name);
         }
 
         return new Table(

--- a/src/Schema/UniqueConstraintEditor.php
+++ b/src/Schema/UniqueConstraintEditor.php
@@ -98,7 +98,7 @@ final class UniqueConstraintEditor
     public function create(): UniqueConstraint
     {
         if (count($this->columnNames) < 1) {
-            throw InvalidUniqueConstraintDefinition::columnNamesAreNotSet();
+            throw InvalidUniqueConstraintDefinition::columnNamesAreNotSet($this->name);
         }
 
         return new UniqueConstraint(


### PR DESCRIPTION
This PR includes the object name in the messages of the exceptions thrown by the corresponding editor (suggested in https://github.com/doctrine/dbal/pull/6934#discussion_r2066998385).

The pattern is the following:
1. For the objects that must be named (e.g. `Table`, `Index`), accept the object name in all static constructors of the `Invalid{Object}Definition` exception except for `nameNotSet()`. The logic is that if the name is not set, `nameNotSet()` would be thrown, so if a different exception is being constructed, the name is set.
2. For the objects that can be optionally named (e.g. `UniqueConstraint`, `ForeignKeyConstraint`), accept the nullable object name in all static constructors except for `nameNotSet()`. If the name is not set, display `<unnamed>` instead of the name.