### PR TITLE
Clean up SQLite column definition parsing

### DIFF
--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -32,7 +32,6 @@ use function str_contains;
 use function str_replace;
 use function strcasecmp;
 use function strtolower;
-use function trim;
 
 use const CASE_LOWER;
 
@@ -74,21 +73,21 @@ class SQLiteSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableColumnDefinition(array $tableColumn): Column
     {
-        $matchResult = preg_match('/^([^()]*)\\s*(\\(((\\d+)(,\\s*(\\d+))?)\\))?/', $tableColumn['type'], $matches);
+        $matchResult = preg_match('/^([A-Z\s]+?)(?:\s*\((\d+)(?:,\s*(\d+))?\))?$/', $tableColumn['type'], $matches);
         assert($matchResult === 1);
 
-        $dbType = trim(strtolower($matches[1]));
+        $dbType = strtolower($matches[1]);
 
         $length = $precision = null;
         $fixed  = $unsigned = false;
         $scale  = 0;
 
-        if (isset($matches[4])) {
-            if (isset($matches[6])) {
-                $precision = (int) $matches[4];
-                $scale     = (int) $matches[6];
+        if (isset($matches[2])) {
+            if (isset($matches[3])) {
+                $precision = (int) $matches[2];
+                $scale     = (int) $matches[3];
             } else {
-                $length = (int) $matches[4];
+                $length = (int) $matches[2];
             }
         }
 


### PR DESCRIPTION
This is similar to https://github.com/doctrine/dbal/pull/6931, https://github.com/doctrine/dbal/pull/6932 and https://github.com/doctrine/dbal/pull/6933.

The changes are:
1. Use non-capturing groups in the regular expressions. This way, the matches are indexed as 1, 2, 3 instead of 1, 4, 6.
2. Make the pattern that captures the type name non-greedy (`+?`) and add `$` at the end of the pattern. This way, the first capture group will capture the whitespace in the type name (e.g. `double precision`) but not the space that may separate the type name and parameters (e.g. `varchar (32)`). This eliminates the need to `trim()` the type name.
3. Remove escaping for backslashes (e.g. `\\d` → `\d`). Yes, technically, the first backslash escapes the `\` in `\d` according to the PHP syntax, but PHP doesn't strictly require that, and the modified expression is easier to copy/paste and use in some regex debugging tool.