### PR TITLE
Refactor GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,7 +30,12 @@ env:
 jobs:
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"
-    runs-on: "${{ matrix.os }}"
+    uses: ./.github/workflows/phpunit-sqlite.yml
+    with:
+      os: ${{ matrix.os }}
+      php-version: ${{ matrix.php-version }}
+      extension: ${{ matrix.extension }}
+      dependency-versions: ${{ matrix.dependency-versions }}
 
     strategy:
       matrix:
@@ -39,63 +44,28 @@ jobs:
         php-version:
           - "7.4"
           - "8.4"
-          - "8.5"
-        dependencies:
+        dependency-versions:
           - "highest"
         extension:
           - "pdo_sqlite"
         include:
           - os: "ubuntu-22.04"
             php-version: "7.4"
-            dependencies: "lowest"
+            dependency-versions: "lowest"
             extension: "pdo_sqlite"
           - os: "ubuntu-24.04"
             php-version: "7.4"
-            dependencies: "highest"
+            dependency-versions: "highest"
             extension: "sqlite3"
 
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-          dependency-versions: "${{ matrix.dependencies }}"
-
-      - name: "Print SQLite version"
-        run: >
-          php -r 'printf("Testing with libsqlite version %s\n", (new PDO("sqlite::memory:"))->query("select sqlite_version()")->fetch()[0]);'
-        if: "${{ matrix.extension == 'pdo_sqlite' }}"
-
-      - name: "Print SQLite version"
-        run: >
-          php -r 'printf("Testing with libsqlite version %s\n", SQLite3::version()["versionString"]);'
-        if: "${{ matrix.extension == 'sqlite3' }}"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "phpunit-${{ matrix.extension }}-${{ matrix.dependencies }}-${{ matrix.php-version }}.coverage"
-          path: "coverage.xml"
-
-  phpunit-oci8:
-    name: "PHPUnit on OCI8"
-    runs-on: "ubuntu-24.04"
+  phpunit-oracle:
+    name: "PHPUnit with Oracle"
     needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-oracle.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      oracle-version: ${{ matrix.oracle-version }}
+      extension: ${{ matrix.extension }}
 
     strategy:
       matrix:
@@ -104,116 +74,25 @@ jobs:
         oracle-version:
           - "21"
           - "23"
+        extension:
+          - oci8
+          - pdo_oci
         include:
           - php-version: "7.4"
             oracle-version: "23"
-          - php-version: "8.5"
-            oracle-version: "23"
-
-    services:
-      oracle:
-        image: gvenzl/oracle-${{ matrix.oracle-version < 23 && 'xe' || 'free'  }}:${{ matrix.oracle-version }}
-        env:
-          ORACLE_PASSWORD: oracle
-        ports:
-          - "1521:1521"
-        options: >-
-          --health-cmd healthcheck.sh
-          --health-interval 20s
-          --health-timeout 10s
-          --health-retries 10
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          extensions: "oci8"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/oci8${{ matrix.oracle-version < 23 && '-21' || ''  }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.php-version }}-${{ matrix.oracle-version }}.coverage"
-          path: "coverage.xml"
-
-  phpunit-pdo-oci:
-    name: "PHPUnit on PDO_OCI"
-    runs-on: "ubuntu-24.04"
-    needs: "phpunit-smoke-check"
-
-    strategy:
-      matrix:
-        php-version:
-          - "8.4"
-        oracle-version:
-          - "21"
-          - "23"
-        include:
+            extension: oci8
           - php-version: "7.4"
             oracle-version: "23"
-          - php-version: "8.5"
-            oracle-version: "23"
-
-    services:
-      oracle:
-        image: gvenzl/oracle-${{ matrix.oracle-version < 23 && 'xe' || 'free'  }}:${{ matrix.oracle-version }}
-        env:
-          ORACLE_PASSWORD: oracle
-        ports:
-          - "1521:1521"
-        options: >-
-          --health-cmd healthcheck.sh
-          --health-interval 20s
-          --health-timeout 10s
-          --health-retries 10
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          extensions: "pdo_oci"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/pdo_oci${{ matrix.oracle-version < 23 && '-21' || ''  }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.php-version }}-${{ matrix.oracle-version }}.coverage"
-          path: "coverage.xml"
+            extension: pdo_oci
 
   phpunit-postgres:
     name: "PHPUnit with PostgreSQL"
-    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-postgres.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      postgres-version: ${{ matrix.postgres-version }}
+      extension: ${{ matrix.extension }}
 
     strategy:
       matrix:
@@ -230,60 +109,18 @@ jobs:
           - php-version: "7.4"
             postgres-version: "17"
             extension: "pgsql"
-          - php-version: "8.5"
-            postgres-version: "17"
-            extension: "pgsql"
           - php-version: "7.4"
             postgres-version: "17"
             extension: "pdo_pgsql"
-          - php-version: "8.5"
-            postgres-version: "17"
-            extension: "pdo_pgsql"
-
-    services:
-      postgres:
-        image: "postgres:${{ matrix.postgres-version }}"
-        env:
-          POSTGRES_PASSWORD: "postgres"
-
-        options: >-
-          --health-cmd "pg_isready"
-
-        ports:
-          - "5432:5432"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          extensions: "pgsql pdo_pgsql"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.postgres-version }}-${{ matrix.extension }}-${{ matrix.php-version }}.coverage"
-          path: "coverage.xml"
 
   phpunit-mariadb:
     name: "PHPUnit with MariaDB"
-    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-mariadb.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      mariadb-version: ${{ matrix.mariadb-version }}
+      extension: ${{ matrix.extension }}
 
     strategy:
       matrix:
@@ -304,61 +141,19 @@ jobs:
           - php-version: "7.4"
             mariadb-version: "11.4"
             extension: "mysqli"
-          - php-version: "8.5"
-            mariadb-version: "11.4"
-            extension: "mysqli"
           - php-version: "7.4"
             mariadb-version: "11.4"
             extension: "pdo_mysql"
-          - php-version: "8.5"
-            mariadb-version: "11.4"
-            extension: "pdo_mysql"
-
-    services:
-      mariadb:
-        image: "mariadb:${{ matrix.mariadb-version }}"
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: "doctrine_tests"
-
-        options: >-
-          --health-cmd "healthcheck.sh --connect --innodb_initialized || mysqladmin ping --protocol tcp --silent"
-
-        ports:
-          - "3306:3306"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-          extensions: "${{ matrix.extension }}"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.mariadb-version }}-${{ matrix.extension }}-${{ matrix.php-version }}.coverage"
-          path: "coverage.xml"
 
   phpunit-mysql:
     name: "PHPUnit with MySQL"
-    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-mysql.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      mysql-version: ${{ matrix.mysql-version }}
+      extension: ${{ matrix.extension }}
+      config-file-suffix: ${{ matrix.config-file-suffix }}
 
     strategy:
       matrix:
@@ -371,8 +166,6 @@ jobs:
         extension:
           - "mysqli"
           - "pdo_mysql"
-        config-file-suffix:
-          - ""
         include:
           - config-file-suffix: "-tls"
             php-version: "7.4"
@@ -381,72 +174,24 @@ jobs:
           - php-version: "7.4"
             mysql-version: "9.1"
             extension: "mysqli"
-          - php-version: "8.5"
-            mysql-version: "9.1"
-            extension: "mysqli"
           - php-version: "7.4"
             mysql-version: "9.1"
             extension: "pdo_mysql"
-          - php-version: "8.5"
-            mysql-version: "9.1"
-            extension: "pdo_mysql"
-
-    services:
-      mysql:
-        image: "mysql:${{ matrix.mysql-version }}"
-
-        options: >-
-          --health-cmd "mysqladmin ping --silent"
-          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
-          -e MYSQL_DATABASE=doctrine_tests
-          ${{ matrix.custom-entrypoint }}
-
-        ports:
-          - "3306:3306"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-          extensions: "${{ matrix.extension }}"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-
-      - name: "Copy TLS-related files"
-        run: 'docker cp "${{ job.services.mysql.id }}:/var/lib/mysql/ca.pem" . && docker cp "${{ job.services.mysql.id }}:/var/lib/mysql/client-cert.pem" . && docker cp "${{ job.services.mysql.id }}:/var/lib/mysql/client-key.pem" .'
-        if: "${{ endsWith(matrix.config-file-suffix, 'tls') }}"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}${{ matrix.config-file-suffix }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.mysql-version }}-${{ matrix.extension }}-${{ matrix.config-file-suffix }}-${{ matrix.php-version }}.coverage"
-          path: "coverage.xml"
 
   phpunit-mssql:
     name: "PHPUnit with SQL Server"
-    runs-on: "ubuntu-22.04"
     needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-sqlserver.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      extension: ${{ matrix.extension }}
+      collation: ${{ matrix.collation }}
 
     strategy:
       matrix:
         php-version:
           - "7.4"
           - "8.4"
-          - "8.5"
         extension:
           - "sqlsrv"
           - "pdo_sqlsrv"
@@ -460,117 +205,18 @@ jobs:
             php-version: "7.4"
             extension: "pdo_sqlsrv"
 
-    services:
-      mssql:
-        image: "mcr.microsoft.com/mssql/server:2019-latest"
-        env:
-          ACCEPT_EULA: "Y"
-          SA_PASSWORD: "Doctrine2018"
-          MSSQL_COLLATION: "${{ matrix.collation }}"
-
-        options: >-
-          --health-cmd "echo quit | /opt/mssql-tools18/bin/sqlcmd -C -S 127.0.0.1 -l 1 -U sa -P Doctrine2018"
-
-        ports:
-          - "1433:1433"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1"
-          tools: "pecl"
-          extensions: "${{ matrix.extension }}-5.10.0beta1"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-        with:
-          composer-options: "--ignore-platform-req=php+"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/${{ matrix.extension }}.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.extension }}-${{ matrix.php-version }}-${{ matrix.collation }}.coverage"
-          path: "coverage.xml"
-
   phpunit-ibm-db2:
     name: "PHPUnit with IBM DB2"
-    runs-on: "ubuntu-24.04"
     needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-db2.yml
+    with:
+      php-version: ${{ matrix.php-version }}
 
     strategy:
       matrix:
         php-version:
           - "7.4"
           - "8.4"
-          - "8.5"
-
-    services:
-      ibm_db2:
-        image: "icr.io/db2_community/db2:11.5.8.0"
-        env:
-          DB2INSTANCE: "db2inst1"
-          DB2INST1_PASSWORD: "Doctrine2018"
-          LICENSE: "accept"
-          DBNAME: "doctrine"
-
-        options: >-
-          --health-cmd "su - ${DB2INSTANCE} -c \"db2 -t CONNECT TO ${DBNAME};\""
-          --health-interval 30s
-          --health-timeout 10s
-          --health-retries 5
-          --privileged
-
-        ports:
-          - "50000:50000"
-
-    steps:
-      - name: "Create temporary tablespace"
-        run: "docker exec ${{ job.services.ibm_db2.id }} su - db2inst1 -c 'db2 -t CONNECT TO doctrine; db2 -t CREATE USER TEMPORARY TABLESPACE doctrine_tbsp PAGESIZE 4 K;'"
-
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install IBM DB2 CLI driver"
-        working-directory: /tmp
-        run: |
-          wget https://github.com/ibmdb/db2drivers/raw/refs/heads/main/clidriver/v11.5.9/linuxx64_odbc_cli.tar.gz
-          tar xf linuxx64_odbc_cli.tar.gz
-          rm linuxx64_odbc_cli.tar.gz
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          extensions: "ibm_db2"
-          coverage: "pcov"
-          ini-values: "zend.assertions=1, ibm_db2.instance_name=db2inst1"
-        env:
-          IBM_DB2_CONFIGURE_OPTS: "--with-IBM_DB2=/tmp/clidriver"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
-
-      - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -c ci/github/phpunit/ibm_db2.xml --coverage-clover=coverage.xml"
-
-      - name: "Upload coverage file"
-        uses: "actions/upload-artifact@v4"
-        with:
-          name: "${{ github.job }}-${{ matrix.php-version }}.coverage"
-          path: "coverage.xml"
 
   development-deps:
     name: "PHPUnit with PDO_SQLite and development dependencies"
@@ -606,8 +252,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     needs:
       - "phpunit-smoke-check"
-      - "phpunit-oci8"
-      - "phpunit-pdo-oci"
+      - "phpunit-oracle"
       - "phpunit-postgres"
       - "phpunit-mariadb"
       - "phpunit-mysql"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ env:
   fail-fast: true
 
 jobs:
-  phpunit-mariadb:
+  phpunit-mariadb-devel:
     name: "PHPUnit with MariaDB"
     runs-on: "ubuntu-24.04"
 
@@ -70,3 +70,114 @@ jobs:
           type: "stream"
           topic: "CI - Doctrine/DBAL"
           content: "There was an error running Doctrine on MariaDB:${{ matrix.mariadb-version }} - URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+
+  phpunit-sqlite:
+    name: PHPUnit with SQLite
+    uses: ./.github/workflows/phpunit-sqlite.yml
+    with:
+      os: ${{ matrix.os }}
+      php-version: ${{ matrix.php-version }}
+      extension: ${{ matrix.extension }}
+      dependency-versions: ${{ matrix.dependency-versions }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+        php-version:
+          - '8.5'
+        extension:
+          - pdo_sqlite
+          - sqlite3
+        dependency-versions:
+          - highest
+
+  phpunit-mariadb:
+    name: PHPUnit with MariaDB
+    uses: ./.github/workflows/phpunit-mariadb.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      mariadb-version: ${{ matrix.mariadb-version }}
+      extension: ${{ matrix.extension }}
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.5'
+        mariadb-version:
+          - '11.4'
+        extension:
+          - mysqli
+          - pdo_mysql
+
+  phpunit-mysql:
+    name: PHPUnit with MySQL
+    uses: ./.github/workflows/phpunit-mysql.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      mysql-version: ${{ matrix.mysql-version }}
+      extension: ${{ matrix.extension }}
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.5'
+        mysql-version:
+          - '9.1'
+        extension:
+          - mysqli
+          - pdo_mysql
+
+  phpunit-sqlserver:
+    name: PHPUnit with SQL Server
+    uses: ./.github/workflows/phpunit-sqlserver.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      extension: ${{ matrix.extension }}
+      collation: ${{ matrix.collation }}
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.5'
+        extension:
+          - sqlsrv
+          - pdo_sqlsrv
+        collation:
+          - Latin1_General_100_CI_AS_SC_UTF8
+
+  phpunit-oracle:
+    name: PHPUnit with Oracle
+    uses: ./.github/workflows/phpunit-oracle.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      oracle-version: ${{ matrix.oracle-version }}
+      extension: ${{ matrix.extension }}
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.5'
+        oracle-version:
+          - '23'
+        extension:
+          - oci8
+          - pdo_oci
+
+  phpunit-postgres:
+    name: PHPUnit with PostgreSQL
+    uses: ./.github/workflows/phpunit-postgres.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      postgres-version: ${{ matrix.postgres-version }}
+      extension: ${{ matrix.extension }}
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.5'
+        postgres-version:
+          - '17'
+        extension:
+          - pgsql
+          - pdo_pgsql

--- a/.github/workflows/phpunit-db2.yml
+++ b/.github/workflows/phpunit-db2.yml
@@ -1,0 +1,67 @@
+name: PHPUnit with Db2
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+
+jobs:
+  phpunit-db2:
+    runs-on: ubuntu-24.04
+
+    services:
+      db2:
+        image: icr.io/db2_community/db2:11.5.8.0
+        ports:
+          - '50000:50000'
+        env:
+          DB2INSTANCE: db2inst1
+          DB2INST1_PASSWORD: Doctrine2018
+          LICENSE: accept
+          DBNAME: doctrine
+        options: >-
+          --health-cmd "su - ${DB2INSTANCE} -c \"db2 -t CONNECT TO ${DBNAME};\""
+          --health-interval 30s
+          --health-timeout 10s
+          --health-retries 5
+          --privileged
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install IBM DB2 CLI driver
+        working-directory: /tmp
+        run: |
+          wget https://github.com/ibmdb/db2drivers/raw/refs/heads/main/clidriver/v11.5.9/linuxx64_odbc_cli.tar.gz
+          tar xf linuxx64_odbc_cli.tar.gz
+          rm linuxx64_odbc_cli.tar.gz
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ibm_db2
+          coverage: pcov
+          ini-values: zend.assertions=1
+        env:
+          IBM_DB2_CONFIGURE_OPTS: '--with-IBM_DB2=/tmp/clidriver'
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Create temporary tablespace
+        run: docker exec "${{ job.services.db2.id }}" su - db2inst1 -c "db2 -t CONNECT TO doctrine; db2 -t CREATE USER TEMPORARY TABLESPACE doctrine_tbsp PAGESIZE 4 K"
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/ibm_db2.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-php-${{ inputs.php-version }}.coverage
+          path: coverage.xml

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -1,0 +1,55 @@
+name: PHPUnit with MariaDB
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+      mariadb-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+
+jobs:
+  phpunit-mariadb:
+    runs-on: ubuntu-24.04
+
+    services:
+      mariadb:
+        image: mariadb:${{ inputs.mariadb-version }}
+        ports:
+          - '3306:3306'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_DATABASE: doctrine_tests
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized || mysqladmin ping --protocol tcp --silent"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extension }}
+          coverage: pcov
+          ini-values: zend.assertions=1
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}${{ inputs.config-file-suffix }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ inputs.mariadb-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}.coverage
+          path: coverage.xml

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -1,0 +1,63 @@
+name: PHPUnit with MySQL
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+      mysql-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+      config-file-suffix:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  phpunit-mysql:
+    runs-on: ubuntu-24.04
+
+    services:
+      mysql:
+        image: mysql:${{ inputs.mysql-version }}
+        ports:
+          - '3306:3306'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_DATABASE: doctrine_tests
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extension }}
+          coverage: pcov
+          ini-values: zend.assertions=1
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Copy TLS-related files
+        run: docker cp "${{ job.services.mysql.id }}:/var/lib/mysql/ca.pem" . && docker cp "${{ job.services.mysql.id }}:/var/lib/mysql/client-cert.pem" . && docker cp "${{ job.services.mysql.id }}:/var/lib/mysql/client-key.pem" .
+        if: ${{ endsWith(inputs.config-file-suffix, 'tls') }}
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}${{ inputs.config-file-suffix }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ inputs.mysql-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}${{ inputs.config-file-suffix }}.coverage
+          path: coverage.xml

--- a/.github/workflows/phpunit-oracle.yml
+++ b/.github/workflows/phpunit-oracle.yml
@@ -1,0 +1,57 @@
+name: PHPUnit with Oracle
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+      oracle-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+
+jobs:
+  phpunit-oracle:
+    runs-on: ubuntu-24.04
+
+    services:
+      oracle:
+        image: gvenzl/oracle-${{ inputs.oracle-version < 23 && 'xe' || 'free' }}:${{ inputs.oracle-version }}
+        ports:
+          - '1521:1521'
+        env:
+          ORACLE_PASSWORD: oracle
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 20s
+          --health-timeout 10s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extension }}
+          coverage: pcov
+          ini-values: zend.assertions=1
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}${{ inputs.oracle-version < 23 && '-21' || '' }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ inputs.oracle-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}.coverage
+          path: coverage.xml

--- a/.github/workflows/phpunit-postgres.yml
+++ b/.github/workflows/phpunit-postgres.yml
@@ -1,0 +1,54 @@
+name: PHPUnit with PostgreSQL
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+      postgres-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+
+jobs:
+  phpunit-postgres:
+    runs-on: ubuntu-24.04
+
+    services:
+      postgres:
+        image: postgres:${{ inputs.postgres-version }}
+        ports:
+          - '5432:5432'
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extension }}
+          coverage: pcov
+          ini-values: zend.assertions=1
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ inputs.postgres-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}.coverage
+          path: coverage.xml

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -1,0 +1,57 @@
+name: PHPUnit with SQLite
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      php-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+      dependency-versions:
+        required: true
+        type: string
+
+jobs:
+  phpunit-sqlite:
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: pcov
+          ini-values: zend.assertions=1
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+          dependency-versions: ${{ inputs.dependency-versions }}
+
+      - name: Print SQLite version
+        run: >
+          php -r 'printf("Testing with SQLite version %s\n", (new PDO("sqlite::memory:"))->query("select sqlite_version()")->fetch()[0]);'
+        if: ${{ inputs.extension == 'pdo_sqlite' }}
+
+      - name: Print SQLite version
+        run: >
+          php -r 'printf("Testing with SQLite version %s\n", SQLite3::version()["versionString"]);'
+        if: ${{ inputs.extension == 'sqlite3' }}
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-php-${{ inputs.php-version }}-${{ inputs.extension }}-${{ inputs.dependency-versions }}.coverage
+          path: coverage.xml

--- a/.github/workflows/phpunit-sqlserver.yml
+++ b/.github/workflows/phpunit-sqlserver.yml
@@ -1,0 +1,57 @@
+name: PHPUnit with SQL Server
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+      collation:
+        required: true
+        type: string
+
+jobs:
+  phpunit-sqlserver:
+    runs-on: ubuntu-22.04
+
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        ports:
+          - '1433:1433'
+        env:
+          ACCEPT_EULA: 'Y'
+          SA_PASSWORD: Doctrine2018
+          MSSQL_COLLATION: ${{ inputs.collation }}
+        options: >-
+          --health-cmd "echo quit | /opt/mssql-tools18/bin/sqlcmd -C -S 127.0.0.1 -l 1 -U sa -P Doctrine2018"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extension }}-5.10.0beta1
+          coverage: pcov
+          ini-values: zend.assertions=1
+          tools: pecl
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-php-${{ inputs.php-version }}-${{ inputs.extension }}-${{ inputs.collation }}.coverage
+          path: coverage.xml


### PR DESCRIPTION
### The problem

If a build with unstable dependencies (e.g. a development PHP version) fails, it fails the entire job ([example](https://github.com/doctrine/dbal/actions/runs/14952027783/job/42002789776)).

### The solution

1. Introduce a reusable parameterized workflow per driver (e.g. Run "PHPUnit on MySQL")
2. Reference it from the corresponding job in the "Continuous Integration" workflow; leave only stable dependencies there.
3. Move the builds against development PHP versions into the nightly workflow; reuse the same per-driver workflows there.

### Minor changes

1. The YAML code is formatted by the rules of [this YAML formatter](https://jsonformatter.org/yaml-formatter). Excessive double quotes have been removed. Single quotes are used where necessary.
2. The `oci8` and `pdo_oci` have been combined in a single one with the `extension` parameter. This is consistent with the rest of the jobs.
3. The `dependency` parameter has been renamed to `dependency-versions` to match the one from `ramsey/composer-install`
4. The `ibm-db2` job has been renamed to `db2` (the product name is Db2); the `mssql` one has been renamed to `sqlserver` (this is quite common and matches the platform name).
5. The "libsqlite" in the job output has been replaced with "SQLite" since there doesn't seem to be such a thing as "libsqlite".
6. The format of the code coverage file name has been made more consistent across jobs.
7. The "Create temporary tablespace" step has been moved closer to "Run PHPUnit". This will reduce the likelihood of the job failing because the tablespace is created too early. This may be unnecessary but I saw this failure once even after https://github.com/doctrine/dbal/pull/6859.

### TODO
- [x] Refactor the rest of the jobs
- [ ] After the merge: update https://github.com/doctrine/dbal/issues/6620
