### PR TITLE
GitHub Actions tweaks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -235,6 +235,8 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
+        env:
+          fail-fast: true
 
       - name: "Lower minimum stability"
         run: "composer config minimum-stability dev"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,8 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           extensions: "${{ matrix.extension }}"
+        env:
+          fail-fast: true
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "12 3 * * *"
 
-env:
-  fail-fast: true
-
 jobs:
   phpunit-mariadb-devel:
     name: "PHPUnit with MariaDB"

--- a/.github/workflows/phpunit-db2.yml
+++ b/.github/workflows/phpunit-db2.yml
@@ -47,6 +47,7 @@ jobs:
           coverage: pcov
           ini-values: zend.assertions=1
         env:
+          fail-fast: true
           IBM_DB2_CONFIGURE_OPTS: '--with-IBM_DB2=/tmp/clidriver'
 
       - name: Install dependencies with Composer

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -39,6 +39,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -43,6 +43,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-oracle.yml
+++ b/.github/workflows/phpunit-oracle.yml
@@ -41,6 +41,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-postgres.yml
+++ b/.github/workflows/phpunit-postgres.yml
@@ -38,6 +38,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -30,6 +30,8 @@ jobs:
           php-version: ${{ inputs.php-version }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-sqlserver.yml
+++ b/.github/workflows/phpunit-sqlserver.yml
@@ -41,6 +41,8 @@ jobs:
           coverage: pcov
           ini-values: zend.assertions=1
           tools: pecl
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3


### PR DESCRIPTION
A recent [nightly run](https://github.com/doctrine/dbal/actions/runs/14976899880/job/42092146138) indicated a couple more issues with the workflow:
1. The `pdo_oci` build on PHP 8.5 still failed but in a way different than before:
   1. The failure to set up PHP didn't immediately fail the job:
   ```
   ==> Setup PHP
   ✓ PHP Installed PHP 8.5.0-dev (e[11](https://github.com/doctrine/dbal/actions/runs/14976899880/job/42092146138#step:4:12)a702c0569a2b5a2282fcba4862731ebfb91a3)

   ==> Setup Extensions
   ✗ pdo_oci Could not install pdo_oci on PHP 8.5.0-dev

   ==> Setup Tools
   ✓ composer Added composer 2.8.8
   ```
   2. All integration tests failed with the same error message:
   ```
   There were 975 errors:

   1) Doctrine\DBAL\Tests\Driver\Mysqli\ConnectionTest::testHostnameIsRequiredForPersistentConnection
   Doctrine\DBAL\Exception\DriverException: An exception occurred in the driver: could not find driver

   ...

   975) Doctrine\DBAL\Tests\Functional\WriteTest::testDeleteWhereIsNull
   Doctrine\DBAL\Exception\DriverException: An exception occurred in the driver: could not find driver
   ```
2. The failure of the `pdo_oci` job canceled the `oci8` one (I restarted it manually).

The first issue is solved by running `shivammathur/setup-php` with `fail-fast: true` ([documentation](https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional)). I don't know how it worked in the `continuous-integration` workflow without this flag and why it's not the default behavior. Even if it was the global `fail-fast: true` environment variable that defined the behavior of the setup action, it should have defined in the nightly workflow as well.

The second issue is addressed by removing `fail-fast: true` from the `nightly` workflow. We don't need to optimize the workflow runtime there, and if one job against a given database platform fails, it doesn't mean that the others would and thus should be canceled (the focus is on testing unstable dependencies, not the code).