### PR TITLE
Use ColumnEditor for schema introspection

### DIFF
--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
@@ -39,17 +38,8 @@ class DB2SchemaManager extends AbstractSchemaManager
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        $length = $precision = $default = null;
-        $scale  = 0;
-        $fixed  = false;
-
-        if ($tableColumn['default'] !== null && $tableColumn['default'] !== 'NULL') {
-            $default = $tableColumn['default'];
-
-            if (preg_match('/^\'(.*)\'$/s', $default, $matches) === 1) {
-                $default = str_replace("''", "'", $matches[1]);
-            }
-        }
+        $editor = Column::editor()
+            ->setQuotedName($tableColumn['colname']);
 
         $type = $this->platform->getDoctrineTypeMapping($tableColumn['typename']);
 
@@ -59,7 +49,7 @@ class DB2SchemaManager extends AbstractSchemaManager
                     $type = Types::BINARY;
                 }
 
-                $length = $tableColumn['length'];
+                $editor->setLength($tableColumn['length']);
                 break;
 
             case 'character':
@@ -67,40 +57,48 @@ class DB2SchemaManager extends AbstractSchemaManager
                     $type = Types::BINARY;
                 }
 
-                $length = $tableColumn['length'];
-                $fixed  = true;
+                $editor
+                    ->setLength($tableColumn['length'])
+                    ->setFixed(true);
                 break;
 
             case 'clob':
-                $length = $tableColumn['length'];
+                $editor->setLength($tableColumn['length']);
                 break;
 
             case 'decimal':
             case 'double':
             case 'real':
-                $scale     = $tableColumn['scale'];
-                $precision = $tableColumn['length'];
+                $editor
+                    ->setPrecision($tableColumn['length'])
+                    ->setScale($tableColumn['scale']);
                 break;
         }
 
-        $options = [
-            'length'          => $length,
-            'fixed'           => $fixed,
-            'default'         => $default,
-            'autoincrement'   => $tableColumn['generated'] === 'D',
-            'notnull'         => $tableColumn['nulls'] === 'N',
-        ];
+        $editor
+            ->setTypeName($type)
+            ->setNotNull($tableColumn['nulls'] === 'N')
+            ->setDefaultValue($this->parseDefaultExpression($tableColumn['default']))
+            ->setAutoincrement($tableColumn['generated'] === 'D');
 
         if ($tableColumn['remarks'] !== null) {
-            $options['comment'] = $tableColumn['remarks'];
+            $editor->setComment($tableColumn['remarks']);
         }
 
-        if ($scale !== null && $precision !== null) {
-            $options['scale']     = $scale;
-            $options['precision'] = $precision;
+        return $editor->create();
+    }
+
+    private function parseDefaultExpression(?string $expression): ?string
+    {
+        if ($expression === null || $expression === 'NULL') {
+            return null;
         }
 
-        return new Column($tableColumn['colname'], Type::getType($type), $options);
+        if (preg_match('/^\'(.*)\'$/s', $expression, $matches) === 1) {
+            return str_replace("''", "'", $matches[1]);
+        }
+
+        return $expression;
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -16,7 +16,6 @@ use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_map;
@@ -111,48 +110,51 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        $dbType    = $tableColumn['data_type'];
-        $length    = null;
-        $scale     = 0;
-        $precision = null;
-        $fixed     = false;
-        $values    = [];
+        $dbType = $tableColumn['data_type'];
 
-        $type = $this->platform->getDoctrineTypeMapping($dbType);
+        $editor = Column::editor()
+            ->setQuotedName($tableColumn['column_name'])
+            ->setTypeName(
+                $this->platform->getDoctrineTypeMapping($dbType),
+            );
+
+        if (str_contains($tableColumn['column_type'], 'unsigned')) {
+            $editor->setUnsigned(true);
+        }
 
         switch ($dbType) {
             case 'char':
             case 'varchar':
-                $length = $tableColumn['character_maximum_length'];
+                $editor->setLength($tableColumn['character_maximum_length']);
                 break;
 
             case 'binary':
             case 'varbinary':
-                $length = $tableColumn['character_octet_length'];
+                $editor->setLength($tableColumn['character_octet_length']);
                 break;
 
             case 'tinytext':
-                $length = AbstractMySQLPlatform::LENGTH_LIMIT_TINYTEXT;
+                $editor->setLength(AbstractMySQLPlatform::LENGTH_LIMIT_TINYTEXT);
                 break;
 
             case 'text':
-                $length = AbstractMySQLPlatform::LENGTH_LIMIT_TEXT;
+                $editor->setLength(AbstractMySQLPlatform::LENGTH_LIMIT_TEXT);
                 break;
 
             case 'mediumtext':
-                $length = AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT;
+                $editor->setLength(AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMTEXT);
                 break;
 
             case 'tinyblob':
-                $length = AbstractMySQLPlatform::LENGTH_LIMIT_TINYBLOB;
+                $editor->setLength(AbstractMySQLPlatform::LENGTH_LIMIT_TINYBLOB);
                 break;
 
             case 'blob':
-                $length = AbstractMySQLPlatform::LENGTH_LIMIT_BLOB;
+                $editor->setLength(AbstractMySQLPlatform::LENGTH_LIMIT_BLOB);
                 break;
 
             case 'mediumblob':
-                $length = AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB;
+                $editor->setLength(AbstractMySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB);
                 break;
 
             case 'float':
@@ -160,10 +162,10 @@ class MySQLSchemaManager extends AbstractSchemaManager
             case 'real':
             case 'numeric':
             case 'decimal':
-                $precision = $tableColumn['numeric_precision'];
+                $editor->setPrecision($tableColumn['numeric_precision']);
 
                 if (isset($tableColumn['numeric_scale'])) {
-                    $scale = $tableColumn['numeric_scale'];
+                    $editor->setScale($tableColumn['numeric_scale']);
                 }
 
                 break;
@@ -172,41 +174,32 @@ class MySQLSchemaManager extends AbstractSchemaManager
         switch ($dbType) {
             case 'char':
             case 'binary':
-                $fixed = true;
+                $editor->setFixed(true);
                 break;
 
             case 'enum':
-                $values = $this->parseEnumExpression($tableColumn['column_type']);
+                $editor->setValues($this->parseEnumExpression($tableColumn['column_type']));
                 break;
         }
 
         if ($this->platform instanceof MariaDBPlatform) {
-            $columnDefault = $this->getMariaDBColumnDefault($this->platform, $tableColumn['column_default']);
+            $default = $this->getMariaDBColumnDefault($this->platform, $tableColumn['column_default']);
         } else {
-            $columnDefault = $tableColumn['column_default'];
+            $default = $tableColumn['column_default'];
         }
 
-        $options = [
-            'length'        => $length,
-            'unsigned'      => str_contains($tableColumn['column_type'], 'unsigned'),
-            'fixed'         => $fixed,
-            'default'       => $columnDefault,
-            'notnull'       => $tableColumn['is_nullable'] !== 'YES',
-            'scale'         => $scale,
-            'precision'     => $precision,
-            'autoincrement' => str_contains($tableColumn['extra'], 'auto_increment'),
-            'values'        => $values,
-        ];
+        $editor
+            ->setDefaultValue($default)
+            ->setNotNull($tableColumn['is_nullable'] !== 'YES')
+            ->setComment($tableColumn['column_comment'])
+            ->setCharset($tableColumn['character_set_name'])
+            ->setCollation($tableColumn['collation_name']);
 
-        if ($tableColumn['column_comment'] !== null) {
-            $options['comment'] = $tableColumn['column_comment'];
+        if (str_contains($tableColumn['extra'], 'auto_increment')) {
+            $editor->setAutoincrement(true);
         }
 
-        $column = new Column($tableColumn['column_name'], Type::getType($type), $options);
-        $column->setPlatformOption('charset', $tableColumn['character_set_name']);
-        $column->setPlatformOption('collation', $tableColumn['collation_name']);
-
-        return $column;
+        return $editor->create();
     }
 
     /** @return list<string> */

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -13,12 +13,9 @@ use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\Parsers;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
-use function array_key_exists;
 use function array_map;
-use function assert;
 use function implode;
 use function is_string;
 use function preg_match;
@@ -84,27 +81,11 @@ class OracleSchemaManager extends AbstractSchemaManager
             }
         }
 
-        $length = $precision = null;
-        $scale  = 0;
-        $fixed  = false;
+        $editor = Column::editor()
+            ->setQuotedName($tableColumn['column_name']);
 
-        assert(array_key_exists('data_default', $tableColumn));
-
-        // Default values returned from database sometimes have trailing spaces.
-        if (is_string($tableColumn['data_default'])) {
-            $tableColumn['data_default'] = trim($tableColumn['data_default']);
-        }
-
-        if ($tableColumn['data_default'] === '' || $tableColumn['data_default'] === 'NULL') {
-            $tableColumn['data_default'] = null;
-        }
-
-        if ($tableColumn['data_default'] !== null) {
-            // Default values returned from database are represented as literal expressions
-            if (preg_match('/^\'(.*)\'$/s', $tableColumn['data_default'], $matches) === 1) {
-                $tableColumn['data_default'] = str_replace("''", "'", $matches[1]);
-            }
-        }
+        $precision = null;
+        $scale     = 0;
 
         if ($tableColumn['data_precision'] !== null) {
             $precision = (int) $tableColumn['data_precision'];
@@ -140,35 +121,54 @@ class OracleSchemaManager extends AbstractSchemaManager
             case 'varchar':
             case 'varchar2':
             case 'nvarchar2':
-                $length = (int) $tableColumn['char_length'];
+                $editor->setLength((int) $tableColumn['char_length']);
                 break;
 
             case 'raw':
-                $length = (int) $tableColumn['data_length'];
-                $fixed  = true;
+                $editor
+                    ->setLength((int) $tableColumn['data_length'])
+                    ->setFixed(true);
                 break;
 
             case 'char':
             case 'nchar':
-                $length = (int) $tableColumn['char_length'];
-                $fixed  = true;
+                $editor
+                    ->setLength((int) $tableColumn['char_length'])
+                    ->setFixed(true);
                 break;
         }
 
-        $options = [
-            'notnull'    => $tableColumn['nullable'] === 'N',
-            'fixed'      => $fixed,
-            'default'    => $tableColumn['data_default'],
-            'length'     => $length,
-            'precision'  => $precision,
-            'scale'      => $scale,
-        ];
+        $editor
+            ->setTypeName($type)
+            ->setPrecision($precision)
+            ->setScale($scale)
+            ->setNotNull($tableColumn['nullable'] === 'N')
+            ->setDefaultValue($this->parseDefaultExpression($tableColumn['data_default']));
 
         if ($tableColumn['comments'] !== null) {
-            $options['comment'] = $tableColumn['comments'];
+            $editor->setComment($tableColumn['comments']);
         }
 
-        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), Type::getType($type), $options);
+        return $editor->create();
+    }
+
+    private function parseDefaultExpression(?string $expression): ?string
+    {
+        // Default values returned from the database sometimes have trailing spaces.
+        if (is_string($expression)) {
+            $expression = trim($expression);
+        }
+
+        if ($expression === null || $expression === 'NULL') {
+            return null;
+        }
+
+        // Default values returned from the database are represented as literal expressions
+        if (preg_match('/^\'(.*)\'$/s', $expression, $matches) === 1) {
+            return str_replace("''", "'", $matches[1]);
+        }
+
+        return $expression;
     }
 
     /**

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_map;
@@ -183,10 +182,8 @@ SQL,
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        $length    = null;
-        $precision = null;
-        $scale     = 0;
-        $fixed     = false;
+        $editor = Column::editor()
+            ->setQuotedName($tableColumn['attname']);
 
         $dbType = $tableColumn['typname'];
         if (
@@ -199,14 +196,16 @@ SQL,
             $completeType = $tableColumn['complete_type'];
         }
 
-        $type = $this->platform->getDoctrineTypeMapping($dbType);
+        $editor->setTypeName(
+            $this->platform->getDoctrineTypeMapping($dbType),
+        );
 
         switch ($dbType) {
             case 'bpchar':
             case 'varchar':
                 $parameters = $this->parseColumnTypeParameters($completeType);
                 if (count($parameters) > 0) {
-                    $length = $parameters[0];
+                    $editor->setLength($parameters[0]);
                 }
 
                 break;
@@ -217,41 +216,34 @@ SQL,
             case 'numeric':
                 $parameters = $this->parseColumnTypeParameters($completeType);
                 if (count($parameters) > 0) {
-                    $precision = $parameters[0];
+                    $editor->setPrecision($parameters[0]);
                 }
 
                 if (count($parameters) > 1) {
-                    $scale = $parameters[1];
+                    $editor->setScale($parameters[1]);
                 }
 
                 break;
         }
 
         if ($dbType === 'bpchar') {
-            $fixed = true;
+            $editor->setFixed(true);
         }
 
-        $options = [
-            'length'        => $length,
-            'notnull'       => (bool) $tableColumn['isnotnull'],
-            'default'       => $this->parseDefaultExpression($tableColumn['default']),
-            'precision'     => $precision,
-            'scale'         => $scale,
-            'fixed'         => $fixed,
-            'autoincrement' => $tableColumn['attidentity'] === 'd',
-        ];
+        $editor
+            ->setNotNull((bool) $tableColumn['isnotnull'])
+            ->setDefaultValue($this->parseDefaultExpression($tableColumn['default']))
+            ->setAutoincrement($tableColumn['attidentity'] === 'd');
 
         if ($tableColumn['comment'] !== null) {
-            $options['comment'] = $tableColumn['comment'];
+            $editor->setComment($tableColumn['comment']);
         }
-
-        $column = new Column($tableColumn['attname'], Type::getType($type), $options);
 
         if (! empty($tableColumn['collation'])) {
-            $column->setPlatformOption('collation', $tableColumn['collation']);
+            $editor->setCollation($tableColumn['collation']);
         }
 
-        return $column;
+        return $editor->create();
     }
 
     /**
@@ -327,7 +319,7 @@ SQL,
             <<<'SQL'
             SELECT n.nspname                            AS %s,
                    c.relname                            AS %s,
-                   quote_ident(a.attname)               AS attname,
+                   a.attname,
                    t.typname,
                    format_type(a.atttypid, a.atttypmod) AS complete_type,
                    bt.typname                           AS domain_type,

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Types\Type;
 
 use function assert;
 use function func_get_arg;
@@ -61,24 +60,11 @@ SQL,
 
         $length = (int) $tableColumn['length'];
 
-        $precision = null;
-
-        $scale = 0;
-        $fixed = false;
-
-        if ($tableColumn['scale'] !== null) {
-            $scale = (int) $tableColumn['scale'];
-        }
-
-        if ($tableColumn['precision'] !== null) {
-            $precision = (int) $tableColumn['precision'];
-        }
-
         switch ($dbType) {
             case 'nchar':
             case 'ntext':
                 // Unicode data requires 2 bytes per character
-                $length /= 2;
+                $length = (int) ($length / 2);
                 break;
 
             case 'nvarchar':
@@ -87,7 +73,7 @@ SQL,
                 }
 
                 // Unicode data requires 2 bytes per character
-                $length /= 2;
+                $length = (int) ($length / 2);
                 break;
 
             case 'varchar':
@@ -106,43 +92,45 @@ SQL,
                 break;
         }
 
-        if ($dbType === 'char' || $dbType === 'nchar' || $dbType === 'binary') {
-            $fixed = true;
-        }
-
         $type = $this->platform->getDoctrineTypeMapping($dbType);
 
-        $options = [
-            'fixed'         => $fixed,
-            'notnull'       => ! $tableColumn['is_nullable'],
-            'scale'         => $scale,
-            'precision'     => $precision,
-            'autoincrement' => (bool) $tableColumn['is_identity'],
-        ];
+        $editor = Column::editor()
+            ->setQuotedName($tableColumn['name'])
+            ->setTypeName(
+                $this->platform->getDoctrineTypeMapping($dbType),
+            )
+            ->setNotNull(! $tableColumn['is_nullable'])
+            ->setAutoincrement((bool) $tableColumn['is_identity']);
+
+        if ($tableColumn['scale'] !== null) {
+            $editor->setScale((int) $tableColumn['scale']);
+        }
+
+        if ($tableColumn['precision'] !== null) {
+            $editor->setPrecision((int) $tableColumn['precision']);
+        }
+
+        if ($dbType === 'char' || $dbType === 'nchar' || $dbType === 'binary') {
+            $editor->setFixed(true);
+        }
 
         if ($tableColumn['comment'] !== null) {
-            $options['comment'] = $tableColumn['comment'];
+            $editor->setComment($tableColumn['comment']);
         }
 
         if ($length !== 0 && ($type === 'text' || $type === 'string' || $type === 'binary')) {
-            $options['length'] = $length;
+            $editor->setLength($length);
         }
-
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
 
         if ($tableColumn['default'] !== null) {
-            $default = $this->parseDefaultExpression($tableColumn['default']);
-
-            $column->setDefault($default);
-            $column->setPlatformOption(
-                SQLServerPlatform::OPTION_DEFAULT_CONSTRAINT_NAME,
-                $tableColumn['df_name'],
-            );
+            $editor
+                ->setDefaultValue($this->parseDefaultExpression($tableColumn['default']))
+                ->setDefaultConstraintName($tableColumn['df_name']);
         }
 
-        $column->setPlatformOption('collation', $tableColumn['collation_name']);
+        $editor->setCollation($tableColumn['collation_name']);
 
-        return $column;
+        return $editor->create();
     }
 
     private function parseDefaultExpression(string $value): ?string

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Exception\UnsupportedSchema;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
@@ -71,27 +70,34 @@ class SQLiteSchemaManager extends AbstractSchemaManager
         $matchResult = preg_match('/^([A-Z\s]+?)(?:\s*\((\d+)(?:,\s*(\d+))?\))?$/', $tableColumn['type'], $matches);
         assert($matchResult === 1);
 
+        $editor = Column::editor()
+            ->setQuotedName($tableColumn['name']);
+
         $dbType = strtolower($matches[1]);
 
-        $length = $precision = null;
-        $fixed  = $unsigned = false;
-        $scale  = 0;
+        if (str_contains($dbType, ' unsigned')) {
+            $dbType = str_replace(' unsigned', '', $dbType);
+            $editor->setUnsigned(true);
+        }
+
+        $typeName = $this->platform->getDoctrineTypeMapping($dbType);
+
+        $editor->setTypeName($typeName);
+
+        if ($dbType === 'char') {
+            $editor->setFixed(true);
+        }
 
         if (isset($matches[2])) {
             if (isset($matches[3])) {
-                $precision = (int) $matches[2];
-                $scale     = (int) $matches[3];
+                $editor
+                    ->setPrecision((int) $matches[2])
+                    ->setScale((int) $matches[3]);
             } else {
-                $length = (int) $matches[2];
+                $editor->setLength((int) $matches[2]);
             }
         }
 
-        if (str_contains($dbType, ' unsigned')) {
-            $dbType   = str_replace(' unsigned', '', $dbType);
-            $unsigned = true;
-        }
-
-        $type    = $this->platform->getDoctrineTypeMapping($dbType);
         $default = $tableColumn['dflt_value'];
         if ($default === 'NULL') {
             $default = null;
@@ -104,31 +110,16 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             }
         }
 
-        $notnull = (bool) $tableColumn['notnull'];
+        $editor->setDefaultValue($default)
+            ->setAutoincrement($tableColumn['autoincrement'])
+            ->setComment($tableColumn['comment'])
+            ->setNotNull((bool) $tableColumn['notnull']);
 
-        if ($dbType === 'char') {
-            $fixed = true;
+        if ($typeName === Types::STRING || $typeName === Types::TEXT) {
+            $editor->setCollation($tableColumn['collation'] ?? 'BINARY');
         }
 
-        $options = [
-            'autoincrement' => $tableColumn['autoincrement'],
-            'comment'   => $tableColumn['comment'],
-            'length'    => $length,
-            'unsigned'  => $unsigned,
-            'fixed'     => $fixed,
-            'notnull'   => $notnull,
-            'default'   => $default,
-            'precision' => $precision,
-            'scale'     => $scale,
-        ];
-
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
-
-        if ($type === Types::STRING || $type === Types::TEXT) {
-            $column->setPlatformOption('collation', $tableColumn['collation'] ?? 'BINARY');
-        }
-
-        return $column;
+        return $editor->create();
     }
 
     /**


### PR DESCRIPTION
This PR reimplements column introspection in a way that the schema managers use `Column::editor()` instead of `new Column()` (the column constructor is internal and will change its signature).

This is consistent with how tables, indexes, primary key constraints and foreign key constraints are introspected in 5.0.x.