### PR TITLE
Nightly build tweaks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,9 +24,6 @@ on:
   schedule:
     - cron: "42 3 * * *"
 
-env:
-  fail-fast: true
-
 jobs:
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: "ubuntu-24.04"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.4"
@@ -80,6 +81,7 @@ jobs:
       dependency-versions: ${{ matrix.dependency-versions }}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-24.04
@@ -100,6 +102,7 @@ jobs:
       extension: ${{ matrix.extension }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - '8.5'
@@ -118,6 +121,7 @@ jobs:
       extension: ${{ matrix.extension }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - '8.5'
@@ -136,6 +140,7 @@ jobs:
       collation: ${{ matrix.collation }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - '8.5'
@@ -154,6 +159,7 @@ jobs:
       extension: ${{ matrix.extension }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - '8.5'
@@ -172,6 +178,7 @@ jobs:
       extension: ${{ matrix.extension }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - '8.5'


### PR DESCRIPTION
The changes in https://github.com/doctrine/dbal/pull/6952 addressed the first of the two issues, but not the second – one of the Oracle jobs is still canceled because the other one (expectedly) fails ([here](https://github.com/doctrine/dbal/actions/runs/15005500586)). The reason is that it turns out that the default value of `jobs.<job_id>.strategy.fail-fast` is `true` ([documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)).

This explains the behavior that I couldn't explain the the previous PR:
> I don't know how it worked in the `continuous-integration` workflow without this flag and why it's not the default behavior. Even if it was the global `fail-fast: true` environment variable that defined the behavior of the setup action, it should have defined in the nightly workflow as well.

It worked without `fail-fast: true` defined at the step level because this variable was set globally. From the documentation it is now clear that the global environment variable `fail-fast: true` doesn't affect the jobs, it only affects the `shivammathur/setup-php` action (which is quite non-obvious, so I still believe we need to define it in every step individually and not globally).

Therefore:
1. We set `jobs.<job_id>.strategy.fail-fast` to `false` on all nightly jobs (in order to allow the nightly jobs to run independently, as intended in https://github.com/doctrine/dbal/pull/6952)
2. We remove the global environment variables `fail-fast: true`, because it's already explicitly set in all `shivammathur/setup-php` steps.