### PR TITLE
Preserve the non-clustered property of the PK constraint

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -26,6 +26,7 @@ use LogicException;
 use function array_map;
 use function array_merge;
 use function array_values;
+use function assert;
 use function count;
 use function implode;
 use function in_array;
@@ -199,6 +200,13 @@ class Table extends AbstractNamedObject
             ),
             $primaryKeyConstraint->getObjectName()?->toString(),
         );
+
+        // there is no way to set a primary index with flags. we have to set it and then add the flag
+        if (! $primaryKeyConstraint->isClustered()) {
+            $index = $this->getPrimaryKey();
+            assert($index !== null);
+            $index->addFlag('nonclustered');
+        }
 
         $this->primaryKeyConstraint = $primaryKeyConstraint;
 

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -567,14 +568,21 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
     public function testCreateNonClusteredPrimaryKeyInTable(): void
     {
-        $table = new Table('tbl', [
-            Column::editor()
-                ->setUnquotedName('id')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-        ]);
-        $table->setPrimaryKey(['id']);
-        $table->getIndex('primary')->addFlag('nonclustered');
+        $table = Table::editor()
+            ->setUnquotedName('tbl')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->setIsClustered(false)
+                    ->create(),
+            )
+            ->create();
 
         self::assertEquals(
             ['CREATE TABLE tbl (id INT NOT NULL, PRIMARY KEY NONCLUSTERED (id))'],


### PR DESCRIPTION
If a non-clustered primary key constraint is added to a table, its non-clustered property is lost in translation in 4.3.x. This is documented in the 132a805952c255134017dad2fea32457ee170167 commit message (#6870).

At that time I though it would be hard to fix (or it wasn't worth fixing), but with a fresh eye it looks doable. The modified test switches from the deprecated to the recommended API and covers the issue.