### PR TITLE
Fail on PHPUnit deprecations

### DIFF
--- a/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="pdo_sqlsrv"/>

--- a/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="sqlsrv"/>

--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlsrv.xml
+++ b/ci/github/phpunit/pdo_sqlsrv.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
A recent PR (https://github.com/doctrine/dbal/pull/6936) introduced the usage of `@dataProvider` in a test, which now triggers a PHPUnit deprecation on 4.3.x where we use PHPUnit 11.5:
```
➜ phpunit tests/Functional/BooleanBindingTest.php
PHPUnit 11.5.15 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.7
Configuration: /Users/morozov/Projects/dbal/phpunit.xml

..                                                                                              2 / 2 (100%)

Time: 00:00.032, Memory: 16.00 MB

OK, but there were issues!
Tests: 2, Assertions: 2, PHPUnit Deprecations: 1.
```

Prior to that, our test suite had been deprecation-free if not forever, then at least for most of the time.

I don't think it would hurt if we disallowed the usage of deprecated PHPUnit APIs. If it becomes a problem, we can revert this.

### Implementation Details 
1. The configuration parameters being added are available since around PHPUnit 10.5, while the 3.x branches require PHPUnit 9, so I'm updating the PHPUnit configuration only in 4.x.
2. Even though the test in question was added to 3.9.x and exists in 4.2.x, I'm not changing the test in question in this PR. The reason is that 3.9.x and 4.2.x contain more than one occurrence of `@dataProvider`, which all have been reworked in 4.3.x. I will rework the test during the merge up.