### PR TITLE
Manually merge 4.2.x into 4.3.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -245,6 +245,8 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
+        env:
+          fail-fast: true
 
       - name: "Lower minimum stability"
         run: "composer config minimum-stability dev"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -231,6 +231,8 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
+        env:
+          fail-fast: true
 
       - name: "Lower minimum stability"
         run: "composer config minimum-stability dev"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -235,6 +235,8 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
+        env:
+          fail-fast: true
 
       - name: "Lower minimum stability"
         run: "composer config minimum-stability dev"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,8 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           extensions: "${{ matrix.extension }}"
+        env:
+          fail-fast: true
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "12 3 * * *"
 
-env:
-  fail-fast: true
-
 jobs:
   phpunit-mariadb-devel:
     name: "PHPUnit with MariaDB"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,9 +5,6 @@ on:
     - cron: "12 3 * * *"
   workflow_dispatch:
 
-env:
-  fail-fast: true
-
 jobs:
   phpunit-mariadb-devel:
     name: "PHPUnit with MariaDB"
@@ -50,6 +47,8 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           extensions: "${{ matrix.extension }}"
+        env:
+          fail-fast: true
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "12 3 * * *"
 
-env:
-  fail-fast: true
-
 jobs:
   phpunit-mariadb-devel:
     name: "PHPUnit with MariaDB"
@@ -50,6 +47,8 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           extensions: "${{ matrix.extension }}"
+        env:
+          fail-fast: true
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/phpunit-db2.yml
+++ b/.github/workflows/phpunit-db2.yml
@@ -47,6 +47,7 @@ jobs:
           coverage: pcov
           ini-values: zend.assertions=1
         env:
+          fail-fast: true
           IBM_DB2_CONFIGURE_OPTS: '--with-IBM_DB2=/tmp/clidriver'
 
       - name: Install dependencies with Composer

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -39,6 +39,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -43,6 +43,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-oracle.yml
+++ b/.github/workflows/phpunit-oracle.yml
@@ -41,6 +41,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-postgres.yml
+++ b/.github/workflows/phpunit-postgres.yml
@@ -38,6 +38,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-postgres.yml
+++ b/.github/workflows/phpunit-postgres.yml
@@ -42,6 +42,8 @@ jobs:
           extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -30,6 +30,8 @@ jobs:
           php-version: ${{ inputs.php-version }}
           coverage: pcov
           ini-values: zend.assertions=1
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-sqlserver.yml
+++ b/.github/workflows/phpunit-sqlserver.yml
@@ -41,6 +41,8 @@ jobs:
           coverage: pcov
           ini-values: zend.assertions=1
           tools: pecl
+        env:
+          fail-fast: true
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v3

--- a/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="pdo_sqlsrv"/>

--- a/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="pdo_sqlsrv"/>

--- a/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="sqlsrv"/>

--- a/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="sqlsrv"/>

--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlsrv.xml
+++ b/ci/github/phpunit/pdo_sqlsrv.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlsrv.xml
+++ b/ci/github/phpunit/pdo_sqlsrv.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -5,7 +5,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -6,6 +6,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,9 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
          failOnRisky="true"
          failOnWarning="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BooleanBindingTest extends FunctionalTestCase
 {
@@ -27,7 +28,7 @@ class BooleanBindingTest extends FunctionalTestCase
         $this->dropTableIfExists('boolean_test_table');
     }
 
-    /** @dataProvider booleanProvider */
+    #[DataProvider('booleanProvider')]
     public function testBooleanInsert(bool $input): void
     {
         $queryBuilder = $this->connection->createQueryBuilder();


### PR DESCRIPTION
I've reverted the `failOnPhpunitDeprecation="true"` configuration introduced in https://github.com/doctrine/dbal/pull/6959. The problem is that even though the test suite itself is deprecation-free, the dependencies aren't. The following is triggered by Doctrine Deprecations ([failing build](https://github.com/doctrine/dbal/actions/runs/15088587737/job/42414277088)):
```
There were 58 PHPUnit test runner deprecations:

1) Metadata found in doc-comment for method Doctrine\DBAL\Tests\DriverManagerTest::enableDeprecationTracking(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

...

58) Metadata found in doc-comment for method Doctrine\DBAL\Tests\Platforms\SQLite\ComparatorTest::verifyDeprecationsAreTriggered(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```

~~For some reason, I cannot reproduce this locally~~:
```
$ phpunit --fail-on-phpunit-deprecation

...

OK, but there were issues!
Tests: 3501, Assertions: 5177, Skipped: 569, Incomplete: 13.
```

Oh, it was the lowest dependencies build. I guess, we should have just bumped the requirement.

I'm leaving the `displayDetailsOnPhpunitDeprecations="true"` configuration for better visibility of the deprecations.