### PR TITLE
Populate foreign key constraint options only with non-default values

### DIFF
--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -226,6 +226,20 @@ final class ForeignKeyConstraintEditor
             throw InvalidForeignKeyConstraintDefinition::referencedColumnNamesNotSet($this->name);
         }
 
+        $options = [];
+
+        if ($this->matchType !== MatchType::SIMPLE) {
+            $options['match'] = $this->matchType->value;
+        }
+
+        if ($this->onUpdateAction !== ReferentialAction::NO_ACTION) {
+            $options['onUpdate'] = $this->onUpdateAction->value;
+        }
+
+        if ($this->onDeleteAction !== ReferentialAction::NO_ACTION) {
+            $options['onDelete'] = $this->onDeleteAction->value;
+        }
+
         return new ForeignKeyConstraint(
             array_map(
                 static fn (UnqualifiedName $columnName) => $columnName->toString(),
@@ -237,11 +251,7 @@ final class ForeignKeyConstraintEditor
                 $this->referencedColumnNames,
             ),
             $this->name?->toString() ?? '',
-            array_merge([
-                'match' => $this->matchType->value,
-                'onUpdate' => $this->onUpdateAction->value,
-                'onDelete' => $this->onDeleteAction->value,
-            ], match ($this->deferrability) {
+            array_merge($options, match ($this->deferrability) {
                 Deferrability::NOT_DEFERRABLE => [],
                 Deferrability::DEFERRABLE => ['deferrable' => true],
                 Deferrability::DEFERRED => ['deferrable' => true, 'deferred' => true],

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -220,7 +220,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     {
         return [
             'CREATE TABLE `quoted` (`create` VARCHAR(255) NOT NULL, foo VARCHAR(255) NOT NULL, '
-                . '`bar` VARCHAR(255) NOT NULL, INDEX IDX_22660D028FD6E0FB8C736521D79164E3 (`create`, foo, `bar`))',
+                . '`bar` VARCHAR(255) NOT NULL, INDEX IDX_22660D028FD6E0FB8C7365216D704F76 (`create`, foo, `bar`))',
             'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY (`create`, foo, `bar`)'
                 . ' REFERENCES `foreign` (`create`, bar, `foo-bar`)',
             'ALTER TABLE `quoted` ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY (`create`, foo, `bar`)'

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
@@ -422,47 +423,58 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testQuotedColumnInForeignKeyPropagation(): void
     {
-        $table = new Table('`quoted`', [
-            Column::editor()
-                ->setUnquotedName('create')
-                ->setTypeName(Types::STRING)
-                ->setLength(255)
-                ->create(),
-            Column::editor()
-                ->setUnquotedName('foo')
-                ->setTypeName(Types::STRING)
-                ->setLength(255)
-                ->create(),
-            Column::editor()
-                ->setQuotedName('bar')
-                ->setTypeName(Types::STRING)
-                ->setLength(255)
-                ->create(),
-        ]);
+        $referencingColumnNames = [
+            UnqualifiedName::unquoted('create'),
+            UnqualifiedName::unquoted('foo'),
+            UnqualifiedName::quoted('bar'),
+        ];
 
-        $table->addForeignKeyConstraint(
-            'foreign',
-            ['create', 'foo', '"bar"'],
-            ['create', 'bar', '"foo-bar"'],
-            [],
-            'FK_WITH_RESERVED_KEYWORD',
-        );
+        $referencedColumnNames = [
+            UnqualifiedName::unquoted('create'),
+            UnqualifiedName::unquoted('bar'),
+            UnqualifiedName::quoted('foo-bar'),
+        ];
 
-        $table->addForeignKeyConstraint(
-            'foo',
-            ['create', 'foo', '`bar`'],
-            ['create', 'bar', '`foo-bar`'],
-            [],
-            'FK_WITH_NON_RESERVED_KEYWORD',
-        );
-
-        $table->addForeignKeyConstraint(
-            '`foo-bar`',
-            ['create', 'foo', '`bar`'],
-            ['create', 'bar', '`foo-bar`'],
-            [],
-            'FK_WITH_INTENDED_QUOTATION',
-        );
+        $table = Table::editor()
+            ->setQuotedName('quoted')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('create')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('foo')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setQuotedName('bar')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('FK_WITH_RESERVED_KEYWORD')
+                    ->setReferencingColumnNames(...$referencingColumnNames)
+                    ->setUnquotedReferencedTableName('foreign')
+                    ->setReferencedColumnNames(...$referencedColumnNames)
+                    ->create(),
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('FK_WITH_NON_RESERVED_KEYWORD')
+                    ->setReferencingColumnNames(...$referencingColumnNames)
+                    ->setUnquotedReferencedTableName('foo')
+                    ->setReferencedColumnNames(...$referencedColumnNames)
+                    ->create(),
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('FK_WITH_INTENDED_QUOTATION')
+                    ->setReferencingColumnNames(...$referencingColumnNames)
+                    ->setQuotedReferencedTableName('foo-bar')
+                    ->setReferencedColumnNames(...$referencedColumnNames)
+                    ->create(),
+            )
+            ->create();
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals($this->getQuotedColumnInForeignKeySQL(), $sql);
@@ -974,32 +986,47 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     public function testGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): void
     {
-        $foreignTable = new Table('foreign_table', [
-            Column::editor()
-                ->setUnquotedName('id')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-        ]);
-        $foreignTable->setPrimaryKey(['id']);
-
-        $primaryTable = new Table('mytable', [
-            Column::editor()
-                ->setUnquotedName('foo')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-            Column::editor()
-                ->setUnquotedName('bar')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-            Column::editor()
-                ->setUnquotedName('baz')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-        ]);
-        $primaryTable->addIndex(['foo'], 'idx_foo');
-        $primaryTable->addIndex(['bar'], 'idx_bar');
-        $primaryTable->addForeignKeyConstraint($foreignTable->getName(), ['foo'], ['id'], [], 'fk_foo');
-        $primaryTable->addForeignKeyConstraint($foreignTable->getName(), ['bar'], ['id'], [], 'fk_bar');
+        $primaryTable = Table::editor()
+            ->setUnquotedName('mytable')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('foo')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('bar')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('baz')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_foo')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+                Index::editor()
+                    ->setUnquotedName('idx_bar')
+                    ->setUnquotedColumnNames('bar')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_foo')
+                    ->setUnquotedReferencingColumnNames('foo')
+                    ->setUnquotedReferencedTableName('foreign_table')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_bar')
+                    ->setUnquotedReferencingColumnNames('bar')
+                    ->setUnquotedReferencedTableName('foreign_table')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
 
         $tableDiff = new TableDiff($primaryTable, renamedIndexes: [
             'idx_foo' => new Index('idx_foo_renamed', ['foo']),

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -442,8 +442,8 @@ abstract class AbstractPlatformTestCase extends TestCase
 
         $table->addForeignKeyConstraint(
             'foreign',
-            ['create', 'foo', '`bar`'],
-            ['create', 'bar', '`foo-bar`'],
+            ['create', 'foo', '"bar"'],
+            ['create', 'bar', '"foo-bar"'],
             [],
             'FK_WITH_RESERVED_KEYWORD',
         );

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -69,7 +69,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
                 . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C7365216D704F76 ON "quoted" ("create", foo, "bar")',
         ];
     }
 

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -306,7 +306,7 @@ SQL
                 . ' REFERENCES foo ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar")'
                 . ' REFERENCES "foo-bar" ("create", bar, "foo-bar")',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C7365216D704F76 ON "quoted" ("create", foo, "bar")',
         ];
     }
 

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -379,7 +379,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         return [
             'CREATE TABLE "quoted" ("create" VARCHAR(255) NOT NULL, '
             . 'foo VARCHAR(255) NOT NULL, "bar" VARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C7365216D704F76 ON "quoted" ("create", foo, "bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'
             . ' REFERENCES "foreign" ("create", bar, "foo-bar")',
             'ALTER TABLE "quoted" ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD FOREIGN KEY ("create", foo, "bar")'

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -644,7 +644,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         return [
             'CREATE TABLE [quoted] ([create] NVARCHAR(255) NOT NULL, '
                 . 'foo NVARCHAR(255) NOT NULL, [bar] NVARCHAR(255) NOT NULL)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON [quoted] ([create], foo, [bar])',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C7365216D704F76 ON [quoted] ([create], foo, [bar])',
             'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_RESERVED_KEYWORD'
                 . ' FOREIGN KEY ([create], foo, [bar]) REFERENCES [foreign] ([create], bar, [foo-bar])',
             'ALTER TABLE [quoted] ADD CONSTRAINT FK_WITH_NON_RESERVED_KEYWORD'

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -471,7 +471,7 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
             'REFERENCES foo ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE, ' .
             'CONSTRAINT FK_WITH_INTENDED_QUOTATION FOREIGN KEY ("create", foo, "bar") ' .
             'REFERENCES "foo-bar" ("create", bar, "foo-bar") NOT DEFERRABLE INITIALLY IMMEDIATE)',
-            'CREATE INDEX IDX_22660D028FD6E0FB8C736521D79164E3 ON "quoted" ("create", foo, "bar")',
+            'CREATE INDEX IDX_22660D028FD6E0FB8C7365216D704F76 ON "quoted" ("create", foo, "bar")',
         ];
     }
 


### PR DESCRIPTION
The current implementation if `ForeignKeyConstraintEditor::create()` populates the `match`, `onUpdate` and `onDelete` options of the foreign key constraints even if they weren't explicitly set and thus are equal to their default values.

This is correct – the default options match to the corresponding defaults in SQL. The "problem" is that if a table is constructed via the editor, its `CREATE TABLE` SQL will explicitly contain the default clauses like `ON UPDATE NO ACTION`. Functionally, this is still not a problem, I just want to keep the behavior of the editor such that switching the implementation of the table construction doesn't change the generated SQL.

The second problem is auto-generated index names for quoted columns. This issue is tracked in https://github.com/doctrine/dbal/issues/6733 – the resulting auto-generated name depends on the quote character used to declare a quoted name. Since `TableEditor` internally uses `Identifier::toString()` which in turn uses double quotes, switching from `new Table()` with backticks to `TableEditor` would result in different auto-generated name. This is inevitable. I've extracted this into a separate commit to demonstrate that this is an existing issue, and the change is test-only.