### PR TITLE
Populate indexed column lengths only with non-null values

### DIFF
--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -136,13 +136,21 @@ final class IndexEditor
             throw InvalidIndexDefinition::columnsNotSet($this->name);
         }
 
-        $columnNames = $lengths = $flags = [];
-        foreach ($this->columns as $column) {
+        $columnNames = $lengths = $options = $flags = [];
+        foreach ($this->columns as $i => $column) {
             $columnNames[] = $column->getColumnName()->toString();
-            $lengths[]     = $column->getLength();
+
+            $length = $column->getLength();
+            if ($length === null) {
+                continue;
+            }
+
+            $lengths[$i] = $column->getLength();
         }
 
-        $options = ['lengths' => $lengths];
+        if (count($lengths) !== 0) {
+            $options['lengths'] = $lengths;
+        }
 
         if ($this->type === IndexType::FULLTEXT) {
             $flags[] = 'fulltext';

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -473,21 +473,37 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testCompareIndexBasedOnPropertiesNotName(): void
     {
-        $tableA = new Table('foo', [
-            Column::editor()
-                ->setUnquotedName('id')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-        ]);
-        $tableA->addIndex(['id'], 'foo_bar_idx');
+        $tableA = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('foo_bar_idx')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
 
-        $tableB = new Table('foo', [
-            Column::editor()
-                ->setUnquotedName('ID')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
-        ]);
-        $tableB->addIndex(['id'], 'bar_foo_idx');
+        $tableB = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('ID')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('bar_foo_idx')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
 
         self::assertEquals(
             new TableDiff($tableA, renamedIndexes: [


### PR DESCRIPTION
This change is similar to https://github.com/doctrine/dbal/pull/6964. If an index is constructed via `IndexEditor`, even if none of the indexed columns have the length specified, its `$options` will have a `length` element populated with nulls. This isn't a problem per se but may fail the results of comparison of the expected index constructed via `new Index()` and the actual constructed via `IndexEditor`.

Without the code change in `IndexEditor`, the rewritten test would fail.

On its own, the current behavior isn't right or wrong. The MySQL schema manager also populates all column lengths, even if they are null.