### PR TITLE
Add more TableEditor methods

### DIFF
--- a/src/Schema/Collections/Exception.php
+++ b/src/Schema/Collections/Exception.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Collections;
+
+use Doctrine\DBAL\Schema\SchemaException;
+
+/** @internal */
+interface Exception extends SchemaException
+{
+}

--- a/src/Schema/Collections/Exception/ObjectAlreadyExists.php
+++ b/src/Schema/Collections/Exception/ObjectAlreadyExists.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Collections\Exception;
+
+use Doctrine\DBAL\Schema\Collections\Exception;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+final class ObjectAlreadyExists extends LogicException implements Exception
+{
+    public function __construct(string $message, private readonly UnqualifiedName $objectName)
+    {
+        parent::__construct($message);
+    }
+
+    public function getObjectName(): UnqualifiedName
+    {
+        return $this->objectName;
+    }
+
+    public static function new(UnqualifiedName $objectName): self
+    {
+        return new self(sprintf('Object %s already exists.', $objectName->toString()), $objectName);
+    }
+}

--- a/src/Schema/Collections/Exception/ObjectDoesNotExist.php
+++ b/src/Schema/Collections/Exception/ObjectDoesNotExist.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Collections\Exception;
+
+use Doctrine\DBAL\Schema\Collections\Exception;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+final class ObjectDoesNotExist extends LogicException implements Exception
+{
+    public function __construct(string $message, private readonly UnqualifiedName $objectName)
+    {
+        parent::__construct($message);
+    }
+
+    public function getObjectName(): UnqualifiedName
+    {
+        return $this->objectName;
+    }
+
+    public static function new(UnqualifiedName $objectName): self
+    {
+        return new self(sprintf('Object %s does not exist.', $objectName->toString()), $objectName);
+    }
+}

--- a/src/Schema/Collections/ObjectSet.php
+++ b/src/Schema/Collections/ObjectSet.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Collections;
+
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+/**
+ * A set of objects where each object is uniquely identified by its {@link UnqualifiedName}.
+ *
+ * @internal
+ *
+ * @template E of object
+ */
+interface ObjectSet
+{
+    /**
+     * Checks if the set is empty.
+     */
+    public function isEmpty(): bool;
+
+    /**
+     * Returns the element with the given name. If no such element exists, null is returned.
+     *
+     * @phpstan-return E|null
+     */
+    public function get(UnqualifiedName $elementName): ?object;
+
+    /**
+     * Adds the given element to the set.
+     *
+     * @phpstan-param E $element
+     *
+     * @throws ObjectAlreadyExists If an element with the same name already exists.
+     */
+    public function add(object $element): void;
+
+    /**
+     * Removes the element with the given name from the set.
+     *
+     * @throws ObjectDoesNotExist If no element with the given name exists.
+     */
+    public function remove(UnqualifiedName $elementName): void;
+
+    /**
+     * Modifies the element with the given name using the provided callable.
+     *
+     * @param callable(E): E $modification
+     *
+     * @throws ObjectDoesNotExist If no element with the given name exists.
+     * @throws ObjectAlreadyExists If an element with the name after modification already exists.
+     */
+    public function modify(UnqualifiedName $elementName, callable $modification): void;
+
+    /**
+     * Clears the set, removing all elements.
+     */
+    public function clear(): void;
+
+    /**
+     * Returns the elements of the set represented as a list.
+     *
+     * @phpstan-return list<E>
+     */
+    public function toList(): array;
+}

--- a/src/Schema/Collections/OptionallyUnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/OptionallyUnqualifiedNamedObjectSet.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Collections;
+
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\OptionallyNamedObject;
+
+use function array_splice;
+use function count;
+use function strtolower;
+
+/**
+ * An ordered set of {@link OptionallyNamedObject}s with names being {@link UnqualifiedName}.
+ *
+ * New objects are added to the end of the set. The order of elements is preserved during modification.
+ *
+ * If an object is unnamed, it can be added to the set but cannot be referenced and, therefore, modified or removed
+ * from the set. Two unnamed objects are considered as having different names.
+ *
+ * @internal
+ *
+ * @template E of OptionallyNamedObject<UnqualifiedName>
+ * @template-implements ObjectSet<E>
+ */
+final class OptionallyUnqualifiedNamedObjectSet implements ObjectSet
+{
+    /** @var list<E> */
+    private array $elements = [];
+
+    /** @var array<string, int> */
+    private array $elementPositionsByKey = [];
+
+    /** @phpstan-param E ...$elements */
+    public function __construct(OptionallyNamedObject ...$elements)
+    {
+        foreach ($elements as $element) {
+            $this->add($element);
+        }
+    }
+
+    public function isEmpty(): bool
+    {
+        return count($this->elements) === 0;
+    }
+
+    public function get(UnqualifiedName $elementName): ?OptionallyNamedObject
+    {
+        $key = $this->getKey($elementName);
+
+        if (isset($this->elementPositionsByKey[$key])) {
+            return $this->elements[$this->elementPositionsByKey[$key]];
+        }
+
+        return null;
+    }
+
+    public function add(object $element): void
+    {
+        $elementName = $element->getObjectName();
+
+        if ($elementName !== null) {
+            $key = $this->getKey($elementName);
+
+            if (isset($this->elementPositionsByKey[$key])) {
+                throw ObjectAlreadyExists::new($elementName);
+            }
+
+            $this->elementPositionsByKey[$key] = count($this->elements);
+        }
+
+        $this->elements[] = $element;
+    }
+
+    public function remove(UnqualifiedName $elementName): void
+    {
+        $key = $this->getKey($elementName);
+
+        if (! isset($this->elementPositionsByKey[$key])) {
+            throw ObjectDoesNotExist::new($elementName);
+        }
+
+        $this->removeByKey($key);
+    }
+
+    public function modify(UnqualifiedName $elementName, callable $modification): void
+    {
+        $key = $this->getKey($elementName);
+
+        if (! isset($this->elementPositionsByKey[$key])) {
+            throw ObjectDoesNotExist::new($elementName);
+        }
+
+        $position = $this->elementPositionsByKey[$key];
+
+        $this->replace($key, $position, $modification($this->elements[$position]));
+    }
+
+    public function clear(): void
+    {
+        $this->elements = $this->elementPositionsByKey = [];
+    }
+
+    /** {@inheritDoc} */
+    public function toList(): array
+    {
+        return $this->elements;
+    }
+
+    /**
+     * Replaces the element corresponding to the old key with the provided element.
+     *
+     * @phpstan-param E $element
+     *
+     * @throws ObjectAlreadyExists If an element with the same name as the element name already exists.
+     */
+    private function replace(string $oldKey, int $position, OptionallyNamedObject $element): void
+    {
+        $elementName = $element->getObjectName();
+
+        if ($elementName !== null) {
+            $newKey = $this->getKey($elementName);
+
+            if ($newKey !== $oldKey) {
+                if (isset($this->elementPositionsByKey[$newKey])) {
+                    throw ObjectAlreadyExists::new($elementName);
+                }
+
+                unset($this->elementPositionsByKey[$oldKey]);
+
+                $this->elementPositionsByKey[$newKey] = $position;
+            }
+        } else {
+            unset($this->elementPositionsByKey[$oldKey]);
+        }
+
+        // @phpstan-ignore assign.propertyType
+        $this->elements[$position] = $element;
+    }
+
+    private function removeByKey(string $key): void
+    {
+        $position = $this->elementPositionsByKey[$key];
+
+        array_splice($this->elements, $position, 1);
+        unset($this->elementPositionsByKey[$key]);
+
+        foreach ($this->elementPositionsByKey as $elementKey => $elementPosition) {
+            if ($elementPosition <= $position) {
+                continue;
+            }
+
+            $this->elementPositionsByKey[$elementKey]--;
+        }
+    }
+
+    private function getKey(UnqualifiedName $name): string
+    {
+        return strtolower($name->getIdentifier()->getValue());
+    }
+}

--- a/src/Schema/Collections/UnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/UnqualifiedNamedObjectSet.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Collections;
+
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\NamedObject;
+
+use function array_combine;
+use function array_keys;
+use function array_search;
+use function array_values;
+use function assert;
+use function count;
+use function strtolower;
+
+/**
+ * An ordered set of {@link NamedObject}s with names being {@link UnqualifiedName}.
+ *
+ * New objects are added to the end of the set. The order of elements is preserved during modification.
+ *
+ * @internal
+ *
+ * @template E of NamedObject<UnqualifiedName>
+ * @template-implements ObjectSet<E>
+ */
+final class UnqualifiedNamedObjectSet implements ObjectSet
+{
+    /** @var array<string, E> */
+    private array $elements = [];
+
+    /** @phpstan-param E ...$elements */
+    public function __construct(NamedObject ...$elements)
+    {
+        foreach ($elements as $element) {
+            $this->add($element);
+        }
+    }
+
+    public function isEmpty(): bool
+    {
+        return count($this->elements) === 0;
+    }
+
+    public function get(UnqualifiedName $elementName): ?NamedObject
+    {
+        $key = $this->getKey($elementName);
+
+        return $this->elements[$key] ?? null;
+    }
+
+    public function add(object $element): void
+    {
+        $elementName = $element->getObjectName();
+        $key         = $this->getKey($elementName);
+
+        if (isset($this->elements[$key])) {
+            throw ObjectAlreadyExists::new($elementName);
+        }
+
+        $this->elements[$key] = $element;
+    }
+
+    public function remove(UnqualifiedName $elementName): void
+    {
+        $key = $this->getKey($elementName);
+
+        if (! isset($this->elements[$key])) {
+            throw ObjectDoesNotExist::new($elementName);
+        }
+
+        unset($this->elements[$key]);
+    }
+
+    public function modify(UnqualifiedName $elementName, callable $modification): void
+    {
+        $key = $this->getKey($elementName);
+
+        if (! isset($this->elements[$key])) {
+            throw ObjectDoesNotExist::new($elementName);
+        }
+
+        $this->replace($key, $modification($this->elements[$key]));
+    }
+
+    public function clear(): void
+    {
+        $this->elements = [];
+    }
+
+    /** {@inheritDoc} */
+    public function toList(): array
+    {
+        return array_values($this->elements);
+    }
+
+    /**
+     * Replaces the element corresponding to the old key with the provided element. The position of the element in the
+     * set is preserved.
+     *
+     * @phpstan-param E $element
+     *
+     * @throws ObjectAlreadyExists If an element with the same name as the element name already exists.
+     */
+    private function replace(string $oldKey, NamedObject $element): void
+    {
+        $elementName = $element->getObjectName();
+        $newKey      = $this->getKey($elementName);
+
+        if ($newKey === $oldKey) {
+            $this->elements[$oldKey] = $element;
+
+            return;
+        }
+
+        if (isset($this->elements[$newKey])) {
+            throw ObjectAlreadyExists::new($elementName);
+        }
+
+        $keys   = array_keys($this->elements);
+        $values = array_values($this->elements);
+
+        $position = array_search($oldKey, $keys, true);
+        assert($position !== false);
+
+        $keys[$position]   = $newKey;
+        $values[$position] = $element;
+
+        $this->elements = array_combine($keys, $values);
+    }
+
+    private function getKey(UnqualifiedName $name): string
+    {
+        return strtolower($name->getIdentifier()->getValue());
+    }
+}

--- a/src/Schema/Exception/InvalidTableModification.php
+++ b/src/Schema/Exception/InvalidTableModification.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+final class InvalidTableModification extends LogicException implements SchemaException
+{
+    public static function columnAlreadyExists(
+        ?OptionallyQualifiedName $tableName,
+        ObjectAlreadyExists $previous,
+    ): self {
+        return new self(sprintf(
+            'Column %s already exists on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function columnDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ObjectDoesNotExist $previous,
+    ): self {
+        return new self(sprintf(
+            'Column %s does not exist on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function indexAlreadyExists(
+        ?OptionallyQualifiedName $tableName,
+        ObjectAlreadyExists $previous,
+    ): self {
+        return new self(sprintf(
+            'Index %s already exists on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function indexDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ObjectDoesNotExist $previous,
+    ): self {
+        return new self(sprintf(
+            'Index %s does not exist on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function primaryKeyConstraintAlreadyExists(?OptionallyQualifiedName $tableName): self
+    {
+        return new self(sprintf(
+            'Primary key constraint already exists on table %s.',
+            self::formatTableName($tableName),
+        ));
+    }
+
+    public static function primaryKeyConstraintDoesNotExist(?OptionallyQualifiedName $tableName): self
+    {
+        return new self(sprintf(
+            'Primary key constraint does not exist on table %s.',
+            self::formatTableName($tableName),
+        ));
+    }
+
+    public static function uniqueConstraintAlreadyExists(
+        ?OptionallyQualifiedName $tableName,
+        ObjectAlreadyExists $previous,
+    ): self {
+        return new self(sprintf(
+            'Unique constraint %s already exists on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function uniqueConstraintDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ObjectDoesNotExist $previous,
+    ): self {
+        return new self(sprintf(
+            'Unique constraint %s does not exist on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function foreignKeyConstraintAlreadyExists(
+        ?OptionallyQualifiedName $tableName,
+        ObjectAlreadyExists $previous,
+    ): self {
+        return new self(sprintf(
+            'Foreign key constraint %s already exists on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function foreignKeyConstraintDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ObjectDoesNotExist $previous,
+    ): self {
+        return new self(sprintf(
+            'Foreign key constraint %s does not exist on table %s.',
+            $previous->getObjectName()->toString(),
+            self::formatTableName($tableName),
+        ), previous: $previous);
+    }
+
+    public static function indexedColumnDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        UnqualifiedName $indexName,
+        UnqualifiedName $columnName,
+    ): self {
+        return new self(sprintf(
+            'Column %s referenced by index %s does not exist on table %s.',
+            $columnName->toString(),
+            $indexName->toString(),
+            self::formatTableName($tableName),
+        ));
+    }
+
+    public static function primaryKeyConstraintColumnDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ?UnqualifiedName $constraintName,
+        UnqualifiedName $columnName,
+    ): self {
+        return new self(sprintf(
+            'Column %s referenced by primary key constraint %s does not exist on table %s.',
+            $columnName->toString(),
+            self::formatConstraintName($constraintName),
+            self::formatTableName($tableName),
+        ));
+    }
+
+    public static function uniqueConstraintColumnDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ?UnqualifiedName $constraintName,
+        UnqualifiedName $columnName,
+    ): self {
+        return new self(sprintf(
+            'Column %s referenced by unique constraint %s does not exist on table %s.',
+            $columnName->toString(),
+            self::formatConstraintName($constraintName),
+            self::formatTableName($tableName),
+        ));
+    }
+
+    public static function foreignKeyConstraintReferencingColumnDoesNotExist(
+        ?OptionallyQualifiedName $tableName,
+        ?UnqualifiedName $constraintName,
+        UnqualifiedName $columnName,
+    ): self {
+        return new self(sprintf(
+            'Referencing column %s of foreign key constraint %s does not exist on table %s.',
+            $columnName->toString(),
+            self::formatConstraintName($constraintName),
+            self::formatTableName($tableName),
+        ));
+    }
+
+    private static function formatTableName(?OptionallyQualifiedName $tableName): string
+    {
+        return $tableName === null ? '<unnamed>' : $tableName->toString();
+    }
+
+    private static function formatConstraintName(?UnqualifiedName $constraintName): string
+    {
+        return $constraintName === null ? '<unnamed>' : $constraintName->toString();
+    }
+}

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -999,13 +999,23 @@ class Table extends AbstractNamedObject
      */
     public function edit(): TableEditor
     {
-        return self::editor()
+        $editor = self::editor()
             ->setName($this->getObjectName())
             ->setColumns(...array_values($this->_columns))
             ->setIndexes(...array_values($this->_indexes))
+            ->setPrimaryKeyConstraint($this->primaryKeyConstraint)
             ->setUniqueConstraints(...array_values($this->uniqueConstraints))
-            ->setForeignKeyConstraints(...array_values($this->_fkConstraints))
-            ->setOptions($this->_options)
+            ->setForeignKeyConstraints(...array_values($this->_fkConstraints));
+
+        $options = $this->_options;
+
+        if (isset($options['comment'])) {
+            $editor->setComment($options['comment']);
+            unset($options['comment']);
+        }
+
+        return $editor
+            ->setOptions($options)
             ->setConfiguration(
                 new TableConfiguration($this->maxIdentifierLength),
             );

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -4,38 +4,56 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Collections\OptionallyUnqualifiedNamedObjectSet;
+use Doctrine\DBAL\Schema\Collections\UnqualifiedNamedObjectSet;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
+use Doctrine\DBAL\Schema\Exception\InvalidTableModification;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
-use function array_filter;
-use function count;
+use function strcasecmp;
 
 final class TableEditor
 {
     private ?OptionallyQualifiedName $name = null;
 
-    /** @var array<Column> */
-    private array $columns = [];
+    /** @var UnqualifiedNamedObjectSet<Column> */
+    private readonly UnqualifiedNamedObjectSet $columns;
 
-    /** @var array<Index> */
-    private array $indexes = [];
+    /** @var UnqualifiedNamedObjectSet<Index> */
+    private UnqualifiedNamedObjectSet $indexes;
 
     private ?PrimaryKeyConstraint $primaryKeyConstraint = null;
 
-    /** @var array<UniqueConstraint> */
-    private array $uniqueConstraints = [];
+    /** @var OptionallyUnqualifiedNamedObjectSet<UniqueConstraint> */
+    private readonly OptionallyUnqualifiedNamedObjectSet $uniqueConstraints;
 
-    /** @var array<ForeignKeyConstraint> */
-    private array $foreignKeyConstraints = [];
+    /** @var OptionallyUnqualifiedNamedObjectSet<ForeignKeyConstraint> */
+    private readonly OptionallyUnqualifiedNamedObjectSet $foreignKeyConstraints;
 
     /** @var array<string, mixed> */
     private array $options = [];
+
+    private string $comment = '';
 
     private ?TableConfiguration $configuration = null;
 
     /** @internal Use {@link Table::editor()} or {@link Table::edit()} to create an instance */
     public function __construct()
     {
+        // @phpstan-ignore assign.propertyType (PHPStan doesn't infer the element type)
+        $this->columns = new UnqualifiedNamedObjectSet();
+
+        // @phpstan-ignore assign.propertyType
+        $this->indexes = new UnqualifiedNamedObjectSet();
+
+        // @phpstan-ignore assign.propertyType
+        $this->uniqueConstraints = new OptionallyUnqualifiedNamedObjectSet();
+
+        // @phpstan-ignore assign.propertyType
+        $this->foreignKeyConstraints = new OptionallyUnqualifiedNamedObjectSet();
     }
 
     public function setName(OptionallyQualifiedName $name): self
@@ -69,40 +87,427 @@ final class TableEditor
 
     public function setColumns(Column $firstColumn, Column ...$otherColumns): self
     {
-        $this->columns = [$firstColumn, ...$otherColumns];
+        $this->columns->clear();
+
+        foreach ([$firstColumn, ...$otherColumns] as $column) {
+            $this->addColumn($column);
+        }
 
         return $this;
     }
 
-    public function setIndexes(Index ...$indexes): self
+    public function addColumn(Column $column): self
     {
-        $this->indexes = $indexes;
+        try {
+            $this->columns->add($column);
+        } catch (ObjectAlreadyExists $e) {
+            throw InvalidTableModification::columnAlreadyExists($this->name, $e);
+        }
 
         return $this;
+    }
+
+    /** @param callable(ColumnEditor): void $modification */
+    public function modifyColumn(UnqualifiedName $columnName, callable $modification): self
+    {
+        try {
+            $this->columns->modify($columnName, static function (Column $column) use ($modification): Column {
+                $editor = $column->edit();
+
+                $modification($editor);
+
+                return $editor->create();
+            });
+        } catch (ObjectDoesNotExist $e) {
+            throw InvalidTableModification::columnDoesNotExist($this->name, $e);
+        } catch (ObjectAlreadyExists $e) {
+            throw InvalidTableModification::columnAlreadyExists($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string             $columnName
+     * @param callable(ColumnEditor): void $modification
+     */
+    public function modifyColumnByUnquotedName(string $columnName, callable $modification): self
+    {
+        return $this->modifyColumn(UnqualifiedName::unquoted($columnName), $modification);
+    }
+
+    public function renameColumn(UnqualifiedName $oldColumnName, UnqualifiedName $newColumnName): self
+    {
+        $this->modifyColumn($oldColumnName, static function (ColumnEditor $editor) use ($newColumnName): void {
+            $editor->setName($newColumnName);
+        });
+
+        $this->renameColumnInIndexes($oldColumnName, $newColumnName);
+        $this->renameColumnInPrimaryKeyConstraint($oldColumnName, $newColumnName);
+        $this->renameColumnInForeignKeyConstraints($oldColumnName, $newColumnName);
+        $this->renameColumnInUniqueConstraints($oldColumnName, $newColumnName);
+
+        return $this;
+    }
+
+    private function renameColumnInIndexes(UnqualifiedName $oldColumnName, UnqualifiedName $newColumnName): void
+    {
+        foreach ($this->indexes->toList() as $index) {
+            $modified = false;
+            $columns  = [];
+
+            foreach ($index->getIndexedColumns() as $column) {
+                $columnName = $column->getColumnName();
+                if ($this->namesEqual($columnName, $oldColumnName)) {
+                    $columns[] = new Index\IndexedColumn($newColumnName, $column->getLength());
+                    $modified  = true;
+                } else {
+                    $columns[] = $column;
+                }
+            }
+
+            if (! $modified) {
+                continue;
+            }
+
+            $this->indexes->modify($index->getObjectName(), static function (Index $index) use ($columns): Index {
+                return $index->edit()
+                    ->setColumns(...$columns)
+                    ->create();
+            });
+        }
+    }
+
+    private function renameColumnInPrimaryKeyConstraint(
+        UnqualifiedName $oldColumnName,
+        UnqualifiedName $newColumnName,
+    ): void {
+        if ($this->primaryKeyConstraint === null) {
+            return;
+        }
+
+        $modified    = false;
+        $columnNames = [];
+
+        foreach ($this->primaryKeyConstraint->getColumnNames() as $columnName) {
+            if ($this->namesEqual($columnName, $oldColumnName)) {
+                $columnNames[] = $newColumnName;
+                $modified      = true;
+            } else {
+                $columnNames[] = $columnName;
+            }
+        }
+
+        if (! $modified) {
+            return;
+        }
+
+        $this->primaryKeyConstraint = $this->primaryKeyConstraint->edit()
+            ->setColumnNames(...$columnNames)
+            ->create();
+    }
+
+    private function renameColumnInUniqueConstraints(
+        UnqualifiedName $oldColumnName,
+        UnqualifiedName $newColumnName,
+    ): void {
+        $this->renameColumnInConstraints(
+            $this->uniqueConstraints,
+            $oldColumnName,
+            $newColumnName,
+            static fn (UniqueConstraint $constraint): array => $constraint->getColumnNames(),
+            static function (UniqueConstraint $constraint, array $columnNames): UniqueConstraint {
+                return $constraint->edit()
+                    ->setColumnNames(...$columnNames)
+                    ->create();
+            },
+        );
+    }
+
+    private function renameColumnInForeignKeyConstraints(
+        UnqualifiedName $oldColumnName,
+        UnqualifiedName $newColumnName,
+    ): void {
+        $this->renameColumnInConstraints(
+            $this->foreignKeyConstraints,
+            $oldColumnName,
+            $newColumnName,
+            static fn (ForeignKeyConstraint $constraint): array => $constraint->getReferencingColumnNames(),
+            static function (ForeignKeyConstraint $constraint, array $columnNames): ForeignKeyConstraint {
+                return $constraint->edit()
+                    ->setReferencingColumnNames(...$columnNames)
+                    ->create();
+            },
+        );
+    }
+
+    /**
+     * Generic method to rename a column in constraints
+     *
+     * @param OptionallyUnqualifiedNamedObjectSet<T> $collection
+     * @param callable(T): list<UnqualifiedName>     $getColumnNames
+     * @param callable(T, list<UnqualifiedName>): T  $modify
+     *
+     * @template T of OptionallyNamedObject<UnqualifiedName>
+     */
+    private function renameColumnInConstraints(
+        OptionallyUnqualifiedNamedObjectSet $collection,
+        UnqualifiedName $oldColumnName,
+        UnqualifiedName $newColumnName,
+        callable $getColumnNames,
+        callable $modify,
+    ): void {
+        $constraints = [];
+        $anyModified = false;
+
+        foreach ($collection->toList() as $constraint) {
+            $newColumnNames = [];
+            $modified       = false;
+
+            foreach ($getColumnNames($constraint) as $columnName) {
+                if ($this->namesEqual($columnName, $oldColumnName)) {
+                    $newColumnNames[] = $newColumnName;
+                    $modified         = true;
+                } else {
+                    $newColumnNames[] = $columnName;
+                }
+            }
+
+            if ($modified) {
+                $constraint  = $modify($constraint, $newColumnNames);
+                $anyModified = true;
+            }
+
+            $constraints[] = $constraint;
+        }
+
+        if (! $anyModified) {
+            return;
+        }
+
+        $collection->clear();
+
+        foreach ($constraints as $constraint) {
+            $collection->add($constraint);
+        }
+    }
+
+    /**
+     * @param non-empty-string $oldColumnName
+     * @param non-empty-string $newColumnName
+     */
+    public function renameColumnByUnquotedName(string $oldColumnName, string $newColumnName): self
+    {
+        return $this->renameColumn(
+            UnqualifiedName::unquoted($oldColumnName),
+            UnqualifiedName::unquoted($newColumnName),
+        );
+    }
+
+    public function dropColumn(UnqualifiedName $columnName): self
+    {
+        try {
+            $this->columns->remove($columnName);
+        } catch (ObjectDoesNotExist $e) {
+            throw InvalidTableModification::columnDoesNotExist($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    /** @param non-empty-string $columnName */
+    public function dropColumnByUnquotedName(string $columnName): self
+    {
+        return $this->dropColumn(UnqualifiedName::unquoted($columnName));
+    }
+
+    public function setIndexes(Index ...$indexes): self
+    {
+        $this->indexes->clear();
+
+        foreach ($indexes as $index) {
+            $this->addIndex($index);
+        }
+
+        return $this;
+    }
+
+    public function addIndex(Index $index): self
+    {
+        try {
+            $this->indexes->add($index);
+        } catch (ObjectAlreadyExists $e) {
+            throw InvalidTableModification::indexAlreadyExists($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    public function renameIndex(UnqualifiedName $oldIndexName, UnqualifiedName $newIndexName): self
+    {
+        try {
+            $this->indexes->modify($oldIndexName, static function (Index $index) use ($newIndexName): Index {
+                return $index->edit()
+                    ->setName($newIndexName)
+                    ->create();
+            });
+        } catch (ObjectDoesNotExist $e) {
+            throw InvalidTableModification::indexDoesNotExist($this->name, $e);
+        } catch (ObjectAlreadyExists $e) {
+            throw InvalidTableModification::indexAlreadyExists($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $oldIndexName
+     * @param non-empty-string $newIndexName
+     */
+    public function renameIndexByUnquotedName(string $oldIndexName, string $newIndexName): self
+    {
+        return $this->renameIndex(
+            UnqualifiedName::unquoted($oldIndexName),
+            UnqualifiedName::unquoted($newIndexName),
+        );
+    }
+
+    public function dropIndex(UnqualifiedName $indexName): self
+    {
+        try {
+            $this->indexes->remove($indexName);
+        } catch (ObjectDoesNotExist $e) {
+            throw InvalidTableModification::indexDoesNotExist($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    /** @param non-empty-string $indexName */
+    public function dropIndexByUnquotedName(string $indexName): self
+    {
+        return $this->dropIndex(UnqualifiedName::unquoted($indexName));
     }
 
     public function setPrimaryKeyConstraint(?PrimaryKeyConstraint $primaryKeyConstraint): self
     {
         $this->primaryKeyConstraint = $primaryKeyConstraint;
 
-        $this->indexes = array_filter(
-            $this->indexes,
-            static fn (Index $index): bool => ! $index->isPrimary(),
-        );
+        foreach ($this->indexes->toList() as $index) {
+            if (! $index->isPrimary()) {
+                continue;
+            }
+
+            $this->indexes->remove($index->getObjectName());
+        }
 
         return $this;
+    }
+
+    public function addPrimaryKeyConstraint(PrimaryKeyConstraint $primaryKeyConstraint): self
+    {
+        if ($this->primaryKeyConstraint !== null) {
+            throw InvalidTableModification::primaryKeyConstraintAlreadyExists($this->name);
+        }
+
+        return $this->setPrimaryKeyConstraint($primaryKeyConstraint);
+    }
+
+    public function dropPrimaryKeyConstraint(): self
+    {
+        if ($this->primaryKeyConstraint === null) {
+            throw InvalidTableModification::primaryKeyConstraintDoesNotExist($this->name);
+        }
+
+        return $this->setPrimaryKeyConstraint(null);
     }
 
     public function setUniqueConstraints(UniqueConstraint ...$uniqueConstraints): self
     {
-        $this->uniqueConstraints = $uniqueConstraints;
+        $this->uniqueConstraints->clear();
+
+        foreach ($uniqueConstraints as $uniqueConstraint) {
+            $this->addUniqueConstraint($uniqueConstraint);
+        }
 
         return $this;
     }
 
+    public function addUniqueConstraint(UniqueConstraint $uniqueConstraint): self
+    {
+        try {
+            $this->uniqueConstraints->add($uniqueConstraint);
+        } catch (ObjectAlreadyExists $e) {
+            throw InvalidTableModification::uniqueConstraintAlreadyExists($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    public function dropUniqueConstraint(UnqualifiedName $constraintName): self
+    {
+        try {
+            $this->uniqueConstraints->remove($constraintName);
+        } catch (ObjectDoesNotExist $e) {
+            throw InvalidTableModification::uniqueConstraintDoesNotExist($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    /** @param non-empty-string $constraintName */
+    public function dropUniqueConstraintByUnquotedName(string $constraintName): self
+    {
+        return $this->dropUniqueConstraint(UnqualifiedName::unquoted($constraintName));
+    }
+
     public function setForeignKeyConstraints(ForeignKeyConstraint ...$foreignKeyConstraints): self
     {
-        $this->foreignKeyConstraints = $foreignKeyConstraints;
+        $this->foreignKeyConstraints->clear();
+
+        foreach ($foreignKeyConstraints as $foreignKeyConstraint) {
+            $this->addForeignKeyConstraint($foreignKeyConstraint);
+        }
+
+        return $this;
+    }
+
+    public function addForeignKeyConstraint(ForeignKeyConstraint $foreignKeyConstraint): self
+    {
+        try {
+            $this->foreignKeyConstraints->add($foreignKeyConstraint);
+        } catch (ObjectAlreadyExists $e) {
+            throw InvalidTableModification::foreignKeyConstraintAlreadyExists($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    public function dropForeignKeyConstraint(UnqualifiedName $constraintName): self
+    {
+        try {
+            $this->foreignKeyConstraints->remove($constraintName);
+        } catch (ObjectDoesNotExist $e) {
+            throw InvalidTableModification::foreignKeyConstraintDoesNotExist($this->name, $e);
+        }
+
+        return $this;
+    }
+
+    /** @param non-empty-string $constraintName */
+    public function dropForeignKeyConstraintByUnquotedName(string $constraintName): self
+    {
+        return $this->dropForeignKeyConstraint(UnqualifiedName::unquoted($constraintName));
+    }
+
+    private function namesEqual(UnqualifiedName $name1, UnqualifiedName $name2): bool
+    {
+        return strcasecmp($name1->getIdentifier()->getValue(), $name2->getIdentifier()->getValue()) === 0;
+    }
+
+    public function setComment(string $comment): self
+    {
+        $this->comment = $comment;
 
         return $this;
     }
@@ -128,17 +533,23 @@ final class TableEditor
             throw InvalidTableDefinition::nameNotSet();
         }
 
-        if (count($this->columns) === 0) {
+        if ($this->columns->isEmpty()) {
             throw InvalidTableDefinition::columnsNotSet($this->name);
+        }
+
+        $options = $this->options;
+
+        if ($this->comment !== '') {
+            $options['comment'] = $this->comment;
         }
 
         return new Table(
             $this->name->toString(),
-            $this->columns,
-            $this->indexes,
-            $this->uniqueConstraints,
-            $this->foreignKeyConstraints,
-            $this->options,
+            $this->columns->toList(),
+            $this->indexes->toList(),
+            $this->uniqueConstraints->toList(),
+            $this->foreignKeyConstraints->toList(),
+            $options,
             $this->configuration,
             $this->primaryKeyConstraint,
         );

--- a/tests/Schema/Collections/OptionallyUnqualifiedNamedObjectSetTest.php
+++ b/tests/Schema/Collections/OptionallyUnqualifiedNamedObjectSetTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Collections;
+
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Collections\OptionallyUnqualifiedNamedObjectSet;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\OptionallyNamedObject;
+use PHPUnit\Framework\TestCase;
+
+class OptionallyUnqualifiedNamedObjectSetTest extends TestCase
+{
+    public function testInstantiationWithoutArguments(): void
+    {
+        $set = new OptionallyUnqualifiedNamedObjectSet();
+
+        self::assertTrue($set->isEmpty());
+        self::assertEmpty($set->toList());
+    }
+
+    public function testInstantiationWithArguments(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1, $object2);
+
+        self::assertSame([$object1, $object2], $set->toList());
+    }
+
+    public function testAdd(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1);
+
+        $set->add($object2);
+        self::assertSame([$object1, $object2], $set->toList());
+    }
+
+    public function testAddExistingObject(): void
+    {
+        $object = $this->createObject('object', 1);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object);
+
+        $this->expectException(ObjectAlreadyExists::class);
+
+        $set->add($object);
+    }
+
+    public function testRemove(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1, $object2);
+
+        $set->remove(UnqualifiedName::unquoted('object1'));
+        self::assertSame([$object2], $set->toList());
+    }
+
+    public function testRemoveNonExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1);
+
+        $this->expectException(ObjectDoesNotExist::class);
+
+        $set->remove(UnqualifiedName::unquoted('object2'));
+    }
+
+    public function testGetExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+        $object3 = $this->createObject('object3', 3);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1, $object2, $object3);
+
+        self::assertSame($object1, $set->get(UnqualifiedName::unquoted('object1')));
+        self::assertSame($object3, $set->get(UnqualifiedName::unquoted('object3')));
+    }
+
+    public function testGetNonExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1, $object2);
+
+        self::assertNull($set->get(UnqualifiedName::unquoted('object3')));
+    }
+
+    public function testModifyObject(): void
+    {
+        $object11 = $this->createObject('object1', 11);
+        $object12 = $this->createObject('object1', 12);
+        $object2  = $this->createObject('object2', 2);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object11, $object2);
+
+        $set->modify(
+            UnqualifiedName::unquoted('object1'),
+            static fn (OptionallyNamedObject $object): OptionallyNamedObject => $object12,
+        );
+
+        self::assertSame([$object12, $object2], $set->toList());
+    }
+
+    public function testModifyNonExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1);
+
+        $this->expectException(ObjectDoesNotExist::class);
+
+        $set->modify(
+            UnqualifiedName::unquoted('object2'),
+            static fn (OptionallyNamedObject $object): OptionallyNamedObject => $object,
+        );
+    }
+
+    public function testRenameToExistingName(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+        $object3 = $this->createObject('object3', 3);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1, $object2, $object3);
+
+        $this->expectException(ObjectAlreadyExists::class);
+
+        $set->modify(
+            UnqualifiedName::unquoted('object1'),
+            static fn (OptionallyNamedObject $object): OptionallyNamedObject => $object3,
+        );
+    }
+
+    public function testRenameToNullName(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject(null, 2);
+        $object3 = $this->createObject('object3', 3);
+
+        $set = new OptionallyUnqualifiedNamedObjectSet($object1, $object2, $object3);
+
+        $set->modify(
+            UnqualifiedName::unquoted('object1'),
+            static fn (OptionallyNamedObject $object): OptionallyNamedObject => $object2,
+        );
+
+        self::assertSame([$object2, $object2, $object3], $set->toList());
+    }
+
+    /**
+     * @param ?non-empty-string $name
+     *
+     * @return OptionallyNamedObject<UnqualifiedName>
+     */
+    private function createObject(?string $name, int $value): OptionallyNamedObject
+    {
+        return new /** @template-implements OptionallyNamedObject<UnqualifiedName> */
+        class ($name, $value) implements OptionallyNamedObject {
+            private readonly ?UnqualifiedName $name;
+
+            /** @param ?non-empty-string $name */
+            public function __construct(?string $name, private readonly int $value)
+            {
+                $this->name = $name !== null ? UnqualifiedName::unquoted($name) : null;
+            }
+
+            public function getObjectName(): ?UnqualifiedName
+            {
+                return $this->name;
+            }
+
+            public function getValue(): int
+            {
+                return $this->value;
+            }
+        };
+    }
+}

--- a/tests/Schema/Collections/UnqualifiedNamedObjectSetTest.php
+++ b/tests/Schema/Collections/UnqualifiedNamedObjectSetTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Collections;
+
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
+use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
+use Doctrine\DBAL\Schema\Collections\UnqualifiedNamedObjectSet;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\NamedObject;
+use PHPUnit\Framework\TestCase;
+
+class UnqualifiedNamedObjectSetTest extends TestCase
+{
+    public function testInstantiationWithoutArguments(): void
+    {
+        $set = new UnqualifiedNamedObjectSet();
+
+        self::assertTrue($set->isEmpty());
+        self::assertEmpty($set->toList());
+    }
+
+    public function testInstantiationWithArguments(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1, $object2);
+
+        self::assertSame([$object1, $object2], $set->toList());
+    }
+
+    public function testAdd(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1);
+
+        $set->add($object2);
+        self::assertSame([$object1, $object2], $set->toList());
+    }
+
+    public function testAddExistingObject(): void
+    {
+        $object = $this->createObject('object', 1);
+
+        $set = new UnqualifiedNamedObjectSet($object);
+
+        $this->expectException(ObjectAlreadyExists::class);
+
+        $set->add($object);
+    }
+
+    public function testRemove(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1, $object2);
+
+        $set->remove($object1->getObjectName());
+        self::assertSame([$object2], $set->toList());
+    }
+
+    public function testRemoveNonExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1);
+
+        $this->expectException(ObjectDoesNotExist::class);
+
+        $set->remove($object2->getObjectName());
+    }
+
+    public function testGetExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1, $object2);
+
+        self::assertSame($object1, $set->get($object1->getObjectName()));
+        self::assertSame($object2, $set->get($object2->getObjectName()));
+    }
+
+    public function testGetNonExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1);
+
+        self::assertNull($set->get($object2->getObjectName()));
+    }
+
+    public function testModifyObjectWithoutRenaming(): void
+    {
+        $object11 = $this->createObject('object1', 11);
+        $object12 = $this->createObject('object1', 12);
+        $object2  = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object11, $object2);
+
+        $set->modify(
+            $object11->getObjectName(),
+            static fn (NamedObject $object): NamedObject => $object12,
+        );
+
+        self::assertSame([$object12, $object2], $set->toList());
+    }
+
+    public function testModifyObjectWithRenaming(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+        $object3 = $this->createObject('object3', 3);
+
+        $set = new UnqualifiedNamedObjectSet($object1, $object2);
+
+        $set->modify(
+            $object1->getObjectName(),
+            static fn (NamedObject $object): NamedObject => $object3,
+        );
+
+        self::assertNull($set->get($object1->getObjectName()));
+        self::assertSame($object3, $set->get($object3->getObjectName()));
+        self::assertSame([$object3, $object2], $set->toList());
+    }
+
+    public function testModifyNonExistingObject(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1);
+
+        $this->expectException(ObjectDoesNotExist::class);
+
+        $set->modify(
+            $object2->getObjectName(),
+            static fn (NamedObject $object): NamedObject => $object,
+        );
+    }
+
+    public function testRenameToExistingName(): void
+    {
+        $object1 = $this->createObject('object1', 1);
+        $object2 = $this->createObject('object2', 2);
+
+        $set = new UnqualifiedNamedObjectSet($object1, $object2);
+
+        $this->expectException(ObjectAlreadyExists::class);
+
+        $set->modify(
+            $object1->getObjectName(),
+            static fn (NamedObject $object): NamedObject => $object2,
+        );
+    }
+
+    /**
+     * @param non-empty-string $name
+     *
+     * @return NamedObject<UnqualifiedName>
+     */
+    private function createObject(string $name, int $value): NamedObject
+    {
+        return new /** @template-implements NamedObject<UnqualifiedName> */
+        class ($name, $value) implements NamedObject {
+            private readonly UnqualifiedName $name;
+
+            /** @param non-empty-string $name */
+            public function __construct(string $name, private readonly int $value)
+            {
+                $this->name = UnqualifiedName::unquoted($name);
+            }
+
+            public function getObjectName(): UnqualifiedName
+            {
+                return $this->name;
+            }
+
+            public function getValue(): int
+            {
+                return $this->value;
+            }
+        };
+    }
+}

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
+use Doctrine\DBAL\Schema\Exception\InvalidTableModification;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
+
+use function array_values;
 
 class TableEditorTest extends TestCase
 {
@@ -17,7 +26,7 @@ class TableEditorTest extends TestCase
     {
         $table = Table::editor()
             ->setUnquotedName('accounts', 'public')
-            ->setColumns($this->createColumn())
+            ->setColumns($this->createColumn('id', Types::INTEGER))
             ->create();
 
         self::assertEquals(
@@ -30,7 +39,7 @@ class TableEditorTest extends TestCase
     {
         $table = Table::editor()
             ->setQuotedName('contacts', 'dbo')
-            ->setColumns($this->createColumn())
+            ->setColumns($this->createColumn('id', Types::INTEGER))
             ->create();
 
         self::assertEquals(
@@ -44,10 +53,7 @@ class TableEditorTest extends TestCase
         $name = OptionallyQualifiedName::unquoted('contacts');
 
         $table = new Table('accounts', [
-            Column::editor()
-                ->setUnquotedName('id')
-                ->setTypeName(Types::INTEGER)
-                ->create(),
+            $this->createColumn('id', Types::INTEGER),
         ]);
 
         $table = $table->edit()
@@ -74,11 +80,528 @@ class TableEditorTest extends TestCase
         $editor->create();
     }
 
-    private function createColumn(): Column
+    public function testAddExistingColumn(): void
+    {
+        $column = $this->createColumn('id', Types::INTEGER);
+
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($column);
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->addColumn($column);
+    }
+
+    public function testModifyColumn(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->modifyColumnByUnquotedName('id', static function (ColumnEditor $editor): void {
+                $editor->setTypeName(Types::BIGINT);
+            })
+            ->create();
+
+        self::assertEquals([
+            Column::editor()
+                ->setUnquotedName('id')
+                ->setTypeName(Types::BIGINT)
+                ->create(),
+        ], $table->getColumns());
+    }
+
+    public function testModifyNonExistingColumn(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->modifyColumnByUnquotedName('account_id', static function (ColumnEditor $editor): void {
+        });
+    }
+
+    public function testRenameColumn(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns(
+                $this->createColumn('id', Types::INTEGER),
+                $this->createColumn('username', Types::STRING),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_username')
+                    ->setUnquotedColumnNames('id', 'username')
+                    ->create(),
+            )
+            ->setUniqueConstraints(
+                UniqueConstraint::editor()
+                    ->setUnquotedColumnNames('id', 'username')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedReferencingColumnNames('id', 'username')
+                    ->setUnquotedReferencedTableName('users')
+                    ->setUnquotedReferencedColumnNames('id', 'username')
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id', 'username')
+                    ->create(),
+            )
+            ->renameColumnByUnquotedName('username', 'user_name')
+            ->create();
+
+        self::assertEquals([
+            Column::editor()
+                ->setUnquotedName('id')
+                ->setTypeName(Types::INTEGER)
+                ->create(),
+            Column::editor()
+                ->setUnquotedName('user_name')
+                ->setTypeName(Types::STRING)
+                ->create(),
+        ], $table->getColumns());
+
+        self::assertEquals(
+            Index::editor()
+                ->setUnquotedName('idx_username')
+                ->setUnquotedColumnNames('id', 'user_name')
+                ->create(),
+            $table->getIndex('idx_username'),
+        );
+
+        self::assertEquals([
+            UniqueConstraint::editor()
+                ->setUnquotedColumnNames('id', 'user_name')
+                ->create(),
+        ], array_values($table->getUniqueConstraints()));
+
+        self::assertEquals([
+            ForeignKeyConstraint::editor()
+                ->setUnquotedReferencingColumnNames('id', 'user_name')
+                ->setUnquotedReferencedTableName('users')
+                ->setUnquotedReferencedColumnNames('id', 'username')
+                ->create(),
+        ], array_values($table->getForeignKeys()));
+
+        self::assertEquals(
+            PrimaryKeyConstraint::editor()
+                ->setUnquotedColumnNames('id', 'user_name')
+                ->create(),
+            $table->getPrimaryKeyConstraint(),
+        );
+    }
+
+    public function testRenameColumnToExistingName(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns(
+                $this->createColumn('id', Types::INTEGER),
+                $this->createColumn('value', Types::STRING),
+            );
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->renameColumnByUnquotedName('id', 'value');
+    }
+
+    public function testDropColumn(): void
+    {
+        $column1 = $this->createColumn('id', Types::INTEGER);
+        $column2 = $this->createColumn('value', Types::STRING);
+
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($column1, $column2)
+            ->dropColumnByUnquotedName('id')
+            ->create();
+
+        self::assertEquals([$column2], $table->getColumns());
+    }
+
+    public function testDropNonExistingColumn(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->dropColumnByUnquotedName('account_id');
+    }
+
+    public function testSetIndexes(): void
+    {
+        $index = Index::editor()
+            ->setUnquotedName('idx_id')
+            ->setUnquotedColumnNames('id')
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setIndexes($index)
+            ->create();
+
+        self::assertSame([$index], array_values($table->getIndexes()));
+    }
+
+    public function testAddExistingIndex(): void
+    {
+        $index = Index::editor()
+            ->setUnquotedName('idx_id')
+            ->setUnquotedColumnNames('id')
+            ->create();
+
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setIndexes($index);
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->addIndex($index);
+    }
+
+    public function testRenameIndex(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('idx_id')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->renameIndexByUnquotedName('idx_id', 'idx_account_id')
+            ->create();
+
+        self::assertEquals([
+            Index::editor()
+                ->setUnquotedName('idx_account_id')
+                ->setUnquotedColumnNames('id')
+                ->create(),
+        ], array_values($table->getIndexes()));
+    }
+
+    public function testRenameNonExistingIndex(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->renameIndexByUnquotedName('idx_id', 'idx_account_id');
+    }
+
+    public function testRenameIndexToExistingName(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_id')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+                Index::editor()
+                    ->setUnquotedName('idx_account_id')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            );
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->renameIndexByUnquotedName('idx_id', 'idx_account_id');
+    }
+
+    public function testDropIndex(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_id')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->dropIndexByUnquotedName('idx_id')
+            ->create();
+
+        self::assertEmpty($table->getIndexes());
+    }
+
+    public function testDropNonExistingIndex(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->dropIndexByUnquotedName('idx_id');
+    }
+
+    public function testAddPrimaryKeyConstraint(): void
+    {
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setUnquotedColumnNames('id')
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->addPrimaryKeyConstraint($primaryKeyConstraint)
+            ->create();
+
+        self::assertSame($primaryKeyConstraint, $table->getPrimaryKeyConstraint());
+    }
+
+    public function testSetNullPrimaryKeyConstraint(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setPrimaryKeyConstraint(null)
+            ->create();
+
+        self::assertNull($table->getPrimaryKeyConstraint());
+    }
+
+    public function testAddPrimaryKeyConstraintWhenOneAlreadyExists(): void
+    {
+        $primaryKeyConstraint = PrimaryKeyConstraint::editor()
+            ->setUnquotedColumnNames('id')
+            ->create();
+
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setPrimaryKeyConstraint($primaryKeyConstraint);
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->addPrimaryKeyConstraint($primaryKeyConstraint);
+    }
+
+    public function testDropPrimaryKeyConstraint(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->dropPrimaryKeyConstraint()
+            ->create();
+
+        self::assertNull($table->getPrimaryKeyConstraint());
+    }
+
+    public function testDropNonExistingPrimaryKeyConstraint(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->dropPrimaryKeyConstraint();
+    }
+
+    public function testPrimaryKeyConstraintReplacesPrimaryIndex(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->create();
+        $table->setPrimaryKey(['id'], 'pk_id');
+
+        self::assertNotNull($table->getPrimaryKeyConstraint());
+        self::assertTrue($table->hasIndex('pk_id'));
+
+        $table = $table->edit()
+            ->dropPrimaryKeyConstraint()
+            ->addPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        self::assertFalse($table->hasIndex('pk_id'));
+    }
+
+    public function testSetUniqueConstraints(): void
+    {
+        $uniqueConstraint = UniqueConstraint::editor()
+            ->setUnquotedColumnNames('id')
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setUniqueConstraints($uniqueConstraint)
+            ->create();
+
+        self::assertSame([$uniqueConstraint], array_values($table->getUniqueConstraints()));
+    }
+
+    public function testAddExistingUniqueConstraint(): void
+    {
+        $uniqueConstraint = UniqueConstraint::editor()
+            ->setUnquotedName('uq_accounts_id')
+            ->setUnquotedColumnNames('id')
+            ->create();
+
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->addUniqueConstraint($uniqueConstraint);
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->addUniqueConstraint($uniqueConstraint);
+    }
+
+    public function testDropUniqueConstraint(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->addUniqueConstraint(
+                UniqueConstraint::editor()
+                    ->setUnquotedName('uq_accounts_id')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->dropUniqueConstraintByUnquotedName('uq_accounts_id')
+            ->create();
+
+        self::assertEmpty($table->getUniqueConstraints());
+    }
+
+    public function testDropNonExistingUniqueConstraint(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->dropUniqueConstraintByUnquotedName('uq_accounts_id');
+    }
+
+    public function testSetForeignKeyConstraints(): void
+    {
+        $foreignKeyConstraint = ForeignKeyConstraint::editor()
+            ->setUnquotedName('fk_accounts_users')
+            ->setUnquotedReferencingColumnNames('user_id')
+            ->setUnquotedReferencedTableName('users')
+            ->setUnquotedReferencedColumnNames('id')
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns(
+                $this->createColumn('id', Types::INTEGER),
+                $this->createColumn('user_id', Types::INTEGER),
+            )
+            ->setForeignKeyConstraints($foreignKeyConstraint)
+            ->create();
+
+        self::assertSame([$foreignKeyConstraint], array_values($table->getForeignKeys()));
+    }
+
+    public function testAddExistingForeignKeyConstraint(): void
+    {
+        $foreignKeyConstraint = ForeignKeyConstraint::editor()
+            ->setUnquotedName('fk_accounts_users')
+            ->setUnquotedReferencingColumnNames('user_id')
+            ->setUnquotedReferencedTableName('users')
+            ->setUnquotedReferencedColumnNames('id')
+            ->create();
+
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns(
+                $this->createColumn('user_id', Types::INTEGER),
+            )
+            ->addForeignKeyConstraint($foreignKeyConstraint);
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->addForeignKeyConstraint($foreignKeyConstraint);
+    }
+
+    public function testDropForeignKeyConstraint(): void
+    {
+        $foreignKeyConstraint = ForeignKeyConstraint::editor()
+            ->setUnquotedName('fk_accounts_users')
+            ->setUnquotedReferencingColumnNames('user_id')
+            ->setUnquotedReferencedTableName('users')
+            ->setUnquotedReferencedColumnNames('id')
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns(
+                $this->createColumn('user_id', Types::INTEGER),
+            )
+            ->addForeignKeyConstraint($foreignKeyConstraint)
+            ->dropForeignKeyConstraintByUnquotedName('fk_accounts_users')
+            ->create();
+
+        self::assertEmpty($table->getForeignKeys());
+    }
+
+    public function testDropNonExistingForeignKeyConstraint(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns($this->createColumn('id', Types::INTEGER));
+
+        $this->expectException(InvalidTableModification::class);
+
+        $editor->dropForeignKeyConstraintByUnquotedName('fk_accounts_users');
+    }
+
+    public function testSetComment(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('accounts', 'public')
+            ->setColumns($this->createColumn('id', Types::INTEGER))
+            ->setComment('This is the "accounts" table')
+            ->create();
+
+        self::assertEquals(
+            'This is the "accounts" table',
+            $table->getComment(),
+        );
+    }
+
+    /**
+     * @param non-empty-string $name
+     *
+     * @throws TypesException
+     */
+    private function createColumn(string $name, string $typeName): Column
     {
         return Column::editor()
-            ->setUnquotedName('id')
-            ->setTypeName(Types::INTEGER)
+            ->setUnquotedName($name)
+            ->setTypeName($typeName)
             ->create();
     }
 }


### PR DESCRIPTION
Currently, the API of `TableEditor` is quite rudimentary and is primarily aimed at replacing the `Table` constructor. This PR introduces the methods for actually editing tables.

### Object Collections

Unlike all other objects for which we have feature-complete editors, `Table` is the only one that internally contains
collections of other objects (columns, indexes, and so on). To manage them efficiently, I'm introducing an internal
`Schema\Collections` namespace with the following classes and interfaces:

1. `ObjectSet` – a common interface for the following two classes.
2. `NamedObjectSet` – will be used for representing table columns and indexes.
3. `OptionallyNamedObjectSet` – will be used for representing table unique and foreign key constraints.

Currently, the key of an element in the above sets is derived from the lower-case element name. Therefore, these collections, for example, cannot represent a pair of columns `id` and `ID`. This limitation is temporary and mimics the current logic of the `Table` class. Later, it will be possible to parameterize a collection with one or more `UnquotedIdentifierFolding`s, and the current case-insensitive behavior will be deprecated.

### Editor Operations

- **Column operations**:
    - Add, modify, rename, and drop columns
    - Renaming a column automatically updates references to this column in related objects (indexes, constraints)

- **Index operations**:
    - Add, rename, and drop indexes. Unlike columns, indexes cannot be modified (similar to SQL)

- **Constraint operations**:
    - Add and drop unique and foreign key constraints. Unlike columns and indexes, constraints cannot be renamed (similar to SQL)

- **Other operations**:
    - Support for editing table comments

#### API design considerations

1. For each internal object collection (e.g. columns), there is a method to set the collection to a given value (e.g.
   `setColumns()`), and there are also methods for adding or removing elements (e.g. `addColumn()` and `dropColumn()`).
   The first one is handy when creating new tables (e.g. during schema introspection or in unit tests), the other two
   are good for editing an existing table.
2. The same applies to the primary key constraints. Even though there exists the
   `setPrimaryKeyConstraint(?PrimaryKeyConstraint $primaryKeyConstraint)` method, I'm adding
   `addPrimaryKeyConstraint(PrimaryKeyConstraint $primaryKeyConstraint)` and `dropPrimaryKeyConstraint()`. They share the same implementation but express different intents.
3. Each method that accepts an element name (e.g. `modifyColumn(UnqualifiedName $columnName)`) is accompanied by a method with the "ByUnquotedName" suffix that accepts the name as string (e.g. `modifyColumnByUnquotedName(string $columnName)`). Currently, there are no "ByQuotedName" methods, because the collections do not respect the semantics of quoted identifiers, so their behavior would be identical to the one of the "ByUnquotedName" methods. We will introduce these methods once we add the support for `UnquotedIdentifierFolding`s  to the collections.

### Next steps

1. I have a pending PR that reworks most of the existing tests to use `TableEditor` and its new methods. Besides `TableEditorTest`, the editor will be covered by the existing tests.
2. This PR enables the next steps on deprecating `Column::$_platformOptions`.