### PR TITLE
Update outdated examples in documentation (schema-representation)

### DIFF
--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -52,7 +52,7 @@ foreign key, sequence and index changes.
     /*...*/
     $schemaManager = $connection->createSchemaManager();
     $comparator = $schemaManager->createComparator();
-    $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+    $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
 
 All methods that generate SQL queries for you make much effort to
 get the order of generation correct, so that no problems will ever

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -55,8 +55,8 @@ foreign key, sequence and index changes.
     $comparator = $schemaManager->createComparator();
     $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
 
-    $createdSchemas = $schemaDiff->getCreatedSchemas($myPlatform);
-    $droppedSchemas = $schemaDiff->getDroppedSchemas($myPlatform);
+    $createdSchemas = $schemaDiff->getCreatedSchemas();
+    $droppedSchemas = $schemaDiff->getDroppedSchemas();
 
 The Save Diff mode is a specific mode that prevents the deletion of
 tables and sequences that might occur when making a diff of your

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -42,31 +42,6 @@ example shows:
     $queries = $schema->toSql($myPlatform); // get queries to create this schema.
     $dropSchema = $schema->toDropSql($myPlatform); // get queries to safely delete this schema.
 
-Now if you want to compare this schema with another schema, you can
-use the ``Comparator`` class to get instances of ``SchemaDiff``,
-``TableDiff`` and ``ColumnDiff``, as well as information about other
-foreign key, sequence and index changes.
-
-.. code-block:: php
-
-    <?php
-    /*...*/
-    $schemaManager = $connection->createSchemaManager();
-    $comparator = $schemaManager->createComparator();
-    $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
-
-    $createdSchemas = $schemaDiff->getCreatedSchemas();
-    $droppedSchemas = $schemaDiff->getDroppedSchemas();
-
-The Save Diff mode is a specific mode that prevents the deletion of
-tables and sequences that might occur when making a diff of your
-schema. This is often necessary when your target schema is not
-complete but only describes a subset of your application.
-
-All methods that generate SQL queries for you make much effort to
-get the order of generation correct, so that no problems will ever
-occur with missing links of foreign keys.
-
 Schema Assets
 -------------
 

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -34,7 +34,10 @@ example shows:
     $myForeign = $schema->createTable("my_foreign");
     $myForeign->addColumn("id", "integer");
     $myForeign->addColumn("user_id", "integer");
-    $myForeign->addForeignKeyConstraint($myTable, ["user_id"], ["id"], ["onUpdate" => "CASCADE"]);
+    $myForeign->addForeignKeyConstraint($myTable->getName(), ["user_id"], ["id"], ["onUpdate" => "CASCADE"]);
+
+    $connection = \Doctrine\DBAL\DriverManager::getConnection([/*...*/]);
+    $myPlatform = $connection->getDatabasePlatform();
 
     $queries = $schema->toSql($myPlatform); // get queries to create this schema.
     $dropSchema = $schema->toDropSql($myPlatform); // get queries to safely delete this schema.
@@ -47,12 +50,13 @@ foreign key, sequence and index changes.
 .. code-block:: php
 
     <?php
+    /*...*/
     $schemaManager = $connection->createSchemaManager();
     $comparator = $schemaManager->createComparator();
-    $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+    $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
 
-    $queries = $schemaDiff->toSql($myPlatform); // queries to get from one to another schema.
-    $saveQueries = $schemaDiff->toSaveSql($myPlatform);
+    $createdSchemas = $schemaDiff->getCreatedSchemas($myPlatform);
+    $droppedSchemas = $schemaDiff->getDroppedSchemas($myPlatform);
 
 The Save Diff mode is a specific mode that prevents the deletion of
 tables and sequences that might occur when making a diff of your

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -42,6 +42,22 @@ example shows:
     $queries = $schema->toSql($myPlatform); // get queries to create this schema.
     $dropSchema = $schema->toDropSql($myPlatform); // get queries to safely delete this schema.
 
+Now if you want to compare this schema with another schema, you can
+use the ``Comparator`` class to get instances of ``SchemaDiff``,
+``TableDiff`` and ``ColumnDiff``, as well as information about other
+foreign key, sequence and index changes.
+
+.. code-block:: php
+    <?php
+    /*...*/
+    $schemaManager = $connection->createSchemaManager();
+    $comparator = $schemaManager->createComparator();
+    $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+
+All methods that generate SQL queries for you make much effort to
+get the order of generation correct, so that no problems will ever
+occur with missing links of foreign keys.
+
 Schema Assets
 -------------
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6968

#### Summary

Fixed:
- First argument of `Table::addForeignKeyConstraint` must be string
- Comparator example fully outdated - `Comparator::compare`, `SchemaDiff::toSql` and `SchemaDiff::toSaveSql` not exists
