### PR TITLE
Update outdated examples in documentation (schema-representation)

### DIFF
--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -34,7 +34,10 @@ example shows:
     $myForeign = $schema->createTable("my_foreign");
     $myForeign->addColumn("id", "integer");
     $myForeign->addColumn("user_id", "integer");
-    $myForeign->addForeignKeyConstraint($myTable, ["user_id"], ["id"], ["onUpdate" => "CASCADE"]);
+    $myForeign->addForeignKeyConstraint($myTable->getName(), ["user_id"], ["id"], ["onUpdate" => "CASCADE"]);
+
+    $connection = \Doctrine\DBAL\DriverManager::getConnection([/*...*/]);
+    $myPlatform = $connection->getDatabasePlatform();
 
     $queries = $schema->toSql($myPlatform); // get queries to create this schema.
     $dropSchema = $schema->toDropSql($myPlatform); // get queries to safely delete this schema.
@@ -45,19 +48,11 @@ use the ``Comparator`` class to get instances of ``SchemaDiff``,
 foreign key, sequence and index changes.
 
 .. code-block:: php
-
     <?php
+    /*...*/
     $schemaManager = $connection->createSchemaManager();
     $comparator = $schemaManager->createComparator();
-    $schemaDiff = $comparator->compare($fromSchema, $toSchema);
-
-    $queries = $schemaDiff->toSql($myPlatform); // queries to get from one to another schema.
-    $saveQueries = $schemaDiff->toSaveSql($myPlatform);
-
-The Save Diff mode is a specific mode that prevents the deletion of
-tables and sequences that might occur when making a diff of your
-schema. This is often necessary when your target schema is not
-complete but only describes a subset of your application.
+    $schemaDiff = $comparator->compareSchemas($fromSchema, $toSchema);
 
 All methods that generate SQL queries for you make much effort to
 get the order of generation correct, so that no problems will ever


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #6968

#### Summary

Fixed:
- First argument of `Table::addForeignKeyConstraint` must be string
- Comparator example fully outdated - `Comparator::compare`, `SchemaDiff::toSql` and `SchemaDiff::toSaveSql` not exists

Recreate PR #6969 to push single commit
