### PR TITLE
Omit implicit indexes in Table::edit()

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
 
+use function array_diff_key;
 use function array_map;
 use function array_merge;
 use function array_values;
@@ -1002,7 +1003,7 @@ class Table extends AbstractNamedObject
         $editor = self::editor()
             ->setName($this->getObjectName())
             ->setColumns(...array_values($this->_columns))
-            ->setIndexes(...array_values($this->_indexes))
+            ->setIndexes(...array_values(array_diff_key($this->_indexes, $this->implicitIndexNames)))
             ->setPrimaryKeyConstraint($this->primaryKeyConstraint)
             ->setUniqueConstraints(...array_values($this->uniqueConstraints))
             ->setForeignKeyConstraints(...array_values($this->_fkConstraints));

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -716,7 +717,15 @@ class TableTest extends TestCase
 
         self::assertCount(1, $localTable->getIndexes());
 
-        $localTable->addUniqueIndex(['id'], 'explicit_idx');
+        $localTable = $localTable->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('explicit_idx')
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
 
         self::assertCount(1, $localTable->getIndexes());
         self::assertTrue($localTable->hasIndex('explicit_idx'));


### PR DESCRIPTION
Currently, when `Table::edit()` instantiates a `TableEditor`, it passes all its indexes, including the implicit ones. As a result, the indexes that were implicit in the original table become explicit in the table created by the editor, which is a bug.

The modified test demonstrates the issue. Without the changes in `src/`, adding a new explicit index wouldn't replace the existing implicit one, so the total number of indexes would be 2, not 1.