### PR TITLE
Remove column platform option getters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `Column` methods
+
+The following `Column` methods have been removed:
+
+- `Column::getPlatformOption()`
+- `Column::getPlatformOptions()`
+- `Column::hasPlatformOption()`
+
 ## BC BREAK: Removed support for the `version` column platform option
 
 The `version` column platform option is no longer supported.

--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms\MySQL;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
-use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 
-use function array_diff_assoc;
+use function count;
 
 /**
  * Compares schemas in the context of MySQL platform.
@@ -19,8 +19,6 @@ use function array_diff_assoc;
  * In MySQL, unless specified explicitly, the column's character set and collation are inherited from its containing
  * table. So during comparison, an omitted value and the value that matches the default value of table in the
  * desired schema must be considered equal.
- *
- * @phpstan-import-type PlatformOptions from Column
  */
 class Comparator extends BaseComparator
 {
@@ -57,43 +55,55 @@ class Comparator extends BaseComparator
             $collation = $this->defaultTableOptions->getCollation();
         }
 
-        $tableOptions = [
-            'charset'   => $charset,
-            'collation' => $collation,
-        ];
-
-        $table = clone $table;
+        $editor = null;
 
         foreach ($table->getColumns() as $column) {
-            $originalOptions   = $column->getPlatformOptions();
-            $normalizedOptions = $this->normalizeOptions($originalOptions);
+            $originalCharset   = $column->getCharset();
+            $originalCollation = $column->getCollation();
 
-            $overrideOptions = array_diff_assoc($normalizedOptions, $tableOptions);
+            $normalizedCharset   = $originalCharset;
+            $normalizedCollation = $originalCollation;
 
-            if ($overrideOptions === $originalOptions) {
+            if ($originalCharset !== null && $originalCollation === null) {
+                $normalizedCollation = $this->charsetMetadataProvider->getDefaultCharsetCollation($originalCharset);
+            } elseif ($originalCollation !== null && $originalCharset === null) {
+                $normalizedCharset = $this->collationMetadataProvider->getCollationCharset($originalCollation);
+            }
+
+            $modifications = [];
+
+            if ($normalizedCharset === $charset) {
+                $modifications[] = static function (ColumnEditor $editor): void {
+                    $editor->setCharset(null);
+                };
+            } elseif ($normalizedCharset !== $originalCharset) {
+                $modifications[] = static function (ColumnEditor $editor) use ($normalizedCharset): void {
+                    $editor->setCharset($normalizedCharset);
+                };
+            }
+
+            if ($normalizedCollation === $collation) {
+                $modifications[] = static function (ColumnEditor $editor): void {
+                    $editor->setCollation(null);
+                };
+            } elseif ($normalizedCollation !== $originalCollation) {
+                $modifications[] = static function (ColumnEditor $editor) use ($normalizedCollation): void {
+                    $editor->setCollation($normalizedCollation);
+                };
+            }
+
+            if (count($modifications) === 0) {
                 continue;
             }
 
-            /** @phpstan-ignore argument.type */
-            $column->setPlatformOptions($overrideOptions);
+            $editor ??= $table->edit();
+            $name     = $column->getObjectName();
+
+            foreach ($modifications as $modification) {
+                $editor->modifyColumn($name, $modification);
+            }
         }
 
-        return $table;
-    }
-
-    /**
-     * @param PlatformOptions $options
-     *
-     * @return PlatformOptions
-     */
-    private function normalizeOptions(array $options): array
-    {
-        if (isset($options['charset']) && ! isset($options['collation'])) {
-            $options['collation'] = $this->charsetMetadataProvider->getDefaultCharsetCollation($options['charset']);
-        } elseif (isset($options['collation']) && ! isset($options['charset'])) {
-            $options['charset'] = $this->collationMetadataProvider->getCollationCharset($options['collation']);
-        }
-
-        return $options;
+        return $editor === null ? $table : $editor->create();
     }
 }

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms\SQLServer;
 
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Table;
@@ -36,19 +37,21 @@ class Comparator extends BaseComparator
 
     private function normalizeColumns(Table $table): Table
     {
-        $table = clone $table;
+        $editor = null;
 
         foreach ($table->getColumns() as $column) {
-            $options = $column->getPlatformOptions();
+            $collation = $column->getCollation();
 
-            if (! isset($options['collation']) || $options['collation'] !== $this->databaseCollation) {
+            if ($collation !== $this->databaseCollation) {
                 continue;
             }
 
-            unset($options['collation']);
-            $column->setPlatformOptions($options);
+            ($editor ??= $table->edit())
+                ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
+                    $editor->setCollation(null);
+                });
         }
 
-        return $table;
+        return $editor === null ? $table : $editor->create();
     }
 }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -494,16 +494,16 @@ class SQLServerPlatform extends AbstractPlatform
      */
     private function getAlterTableDropDefaultConstraintClause(Column $column): string
     {
-        if (! $column->hasPlatformOption(self::OPTION_DEFAULT_CONSTRAINT_NAME)) {
+        $constraintName = $column->getDefaultConstraintName();
+
+        if ($constraintName === null) {
             throw new InvalidArgumentException(
                 'Column ' . $column->getName() . ' was not properly introspected as it has a default value'
                     . ' but does not have the default constraint name.',
             );
         }
 
-        return 'DROP CONSTRAINT ' . $this->quoteSingleIdentifier(
-            $column->getPlatformOption(self::OPTION_DEFAULT_CONSTRAINT_NAME),
-        );
+        return 'DROP CONSTRAINT ' . $this->quoteSingleIdentifier($constraintName);
     }
 
     /**

--- a/src/Platforms/SQLite/Comparator.php
+++ b/src/Platforms/SQLite/Comparator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms\SQLite;
 
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\Comparator as BaseComparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Table;
@@ -35,19 +36,21 @@ class Comparator extends BaseComparator
 
     private function normalizeColumns(Table $table): Table
     {
-        $table = clone $table;
+        $editor = null;
 
         foreach ($table->getColumns() as $column) {
-            $options = $column->getPlatformOptions();
+            $collation = $column->getCollation();
 
-            if (! isset($options['collation']) || strcasecmp($options['collation'], 'binary') !== 0) {
+            if ($collation === null || strcasecmp($collation, 'binary') !== 0) {
                 continue;
             }
 
-            unset($options['collation']);
-            $column->setPlatformOptions($options);
+            ($editor ??= $table->edit())
+                ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
+                    $editor->setCollation(null);
+                });
         }
 
-        return $table;
+        return $editor === null ? $table : $editor->create();
     }
 }

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -270,40 +270,6 @@ class Column extends AbstractNamedObject
         return $this->_platformOptions[SQLServerPlatform::OPTION_DEFAULT_CONSTRAINT_NAME] ?? null;
     }
 
-    /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()} or {@see getMaximumValue()}
-     *             instead.
-     *
-     * @return PlatformOptions
-     */
-    public function getPlatformOptions(): array
-    {
-        return $this->_platformOptions;
-    }
-
-    /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()} or {@see getMaximumValue()}
-     *             instead.
-     *
-     * @param key-of<PlatformOptions> $name
-     */
-    public function hasPlatformOption(string $name): bool
-    {
-        return isset($this->_platformOptions[$name]);
-    }
-
-    /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()} or {@see getMaximumValue()}
-     *             instead.
-     *
-     * @param key-of<PlatformOptions> $name
-     */
-    public function getPlatformOption(string $name): mixed
-    {
-        /** @phpstan-ignore offsetAccess.notFound */
-        return $this->_platformOptions[$name];
-    }
-
     public function getColumnDefinition(): ?string
     {
         return $this->_columnDefinition;

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -127,9 +127,20 @@ final readonly class ColumnDiff
 
     public function hasPlatformOptionsChanged(): bool
     {
-        return $this->hasPropertyChanged(static function (Column $column): array {
-            return $column->getPlatformOptions();
-        });
+        foreach (
+            [
+                static fn (Column $column): ?string => $column->getCharset(),
+                static fn (Column $column): ?string => $column->getCollation(),
+                static fn (Column $column): mixed => $column->getMinimumValue(),
+                static fn (Column $column): mixed => $column->getMaximumValue(),
+            ] as $property
+        ) {
+            if ($this->hasPropertyChanged($property)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function hasPropertyChanged(callable $property): bool

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -35,10 +35,8 @@ class ColumnTest extends TestCase
         self::assertTrue($column->getFixed());
         self::assertEquals('baz', $column->getDefault());
 
-        self::assertEquals(['charset' => 'utf8'], $column->getPlatformOptions());
-        self::assertTrue($column->hasPlatformOption('charset'));
-        self::assertEquals('utf8', $column->getPlatformOption('charset'));
-        self::assertFalse($column->hasPlatformOption('collation'));
+        self::assertEquals('utf8', $column->getCharset());
+        self::assertNull($column->getCollation());
     }
 
     public function testToArray(): void


### PR DESCRIPTION
This PR removes the methods deprecated in https://github.com/doctrine/dbal/pull/6945. We cannot remove the setters yet (they are not yet deprecated) because there is yet no way to modify a column, which is a part of a table, which is a part of a schema (we need a schema editor).

I'm also leaving `ColumnDiff::hasPlatformOptionsChanged()` in place for now. I believe that replacing it with one more new method per property would be overkill. We can approach replacing it with something else separately.

As a side note / observation, the logic of normalizing tables in comparators in order to account for some default charset/collation behavior, even though it is correct, might be inefficient. We construct a new graph of objects only in order to compare it with another one as is. From the CPU/memory usage perspective, it would be more efficient to actually make the comparison more intelligent w/o creating intermediate/normalized values.