### PR TITLE
Fail PHPUnit on notice, output more failure details

### DIFF
--- a/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pdo_sqlsrv.xml
+++ b/ci/github/phpunit/pdo_sqlsrv.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -5,8 +5,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,8 +17,12 @@
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
 >
     <php>


### PR DESCRIPTION
Currently, PHPUnit doesn't fail if the code being tested triggers a notice.

Consider the following test for example:
```php
final class TestErrorReporting extends TestCase
{
    public function testNotice(): void
    {
        $arr = [new \stdClass(), 1];
        sort($arr);

        $this->expectNotToPerformAssertions();
    }
}
```

It successfully passes, and PHPUnit doesn't print the notice details:
```
➜ phpunit tests/TestErrorReporting.php && echo Success
PHPUnit 10.5.39 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.7
Configuration: /Users/morozov/Projects/dbal/phpunit.xml.dist

N                                                                                               1 / 1 (100%)

Time: 00:00.014, Memory: 14.00 MB

OK, but there were issues!
Tests: 1, Assertions: 0, Notices: 1.
Success
```

With the proposed configuration, it will fail like the following:
```
➜ phpunit tests/TestErrorReporting.php || echo Failure
PHPUnit 10.5.39 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.7
Configuration: /Users/morozov/Projects/dbal/phpunit.xml.dist

N                                                                                               1 / 1 (100%)

Time: 00:00.009, Memory: 14.00 MB

1 test triggered 1 PHP notice:

1) /Users/morozov/Projects/dbal/tests/TestErrorReporting.php:14
Object of class stdClass could not be converted to int

Triggered by:

* Doctrine\DBAL\Tests\TestErrorReporting::testNotice
  /Users/morozov/Projects/dbal/tests/TestErrorReporting.php:11

OK, but there were issues!
Tests: 1, Assertions: 0, Notices: 1.
Failure
```

Similar to displaying the details on tests that triggered a notice, it enables displaying the details of other failure scenarios.