### PR TITLE
Remove redundant PHPUnit 11 configuration

### DIFF
--- a/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.pdo_sqlsrv.appveyor.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="pdo_sqlsrv"/>

--- a/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
+++ b/ci/appveyor/mssql.sql2017.sqlsrv.appveyor.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <var name="db_driver" value="sqlsrv"/>

--- a/ci/github/phpunit/ibm_db2.xml
+++ b/ci/github/phpunit/ibm_db2.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli-tls.xml
+++ b/ci/github/phpunit/mysqli-tls.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/mysqli.xml
+++ b/ci/github/phpunit/mysqli.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_mysql.xml
+++ b/ci/github/phpunit/pdo_mysql.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_pgsql.xml
+++ b/ci/github/phpunit/pdo_pgsql.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlite.xml
+++ b/ci/github/phpunit/pdo_sqlite.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pdo_sqlsrv.xml
+++ b/ci/github/phpunit/pdo_sqlsrv.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/pgsql.xml
+++ b/ci/github/phpunit/pgsql.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlite3.xml
+++ b/ci/github/phpunit/sqlite3.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/ci/github/phpunit/sqlsrv.xml
+++ b/ci/github/phpunit/sqlsrv.xml
@@ -8,10 +8,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,10 +20,7 @@
          failOnNotice="true"
          failOnPhpunitDeprecation="true"
          displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
As pointed out in https://github.com/doctrine/dbal/pull/6978#discussion_r2118061020, starting PHPUnit 11.3 (https://github.com/sebastianbergmann/phpunit/issues/5856), PHPUnit displays the details on the tests that cause failures by default, so if there is `failOnSomething` enabled, there is no need to enable `displayDetailsOnTestsThatTriggerSomethings`.