### PR TITLE
Clean up SQL Server LIKE wildcard characters

### DIFF
--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1276,9 +1276,14 @@ class SQLServerPlatform extends AbstractPlatform
             === $this->getDefaultValueDeclarationSQL($column2->toArray());
     }
 
+    /**
+     * The <code>[</code> character is used in SQL Server's extended pattern syntax to define character ranges or sets.
+     *
+     * @link https://learn.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql#pattern
+     */
     protected function getLikeWildcardCharacters(): string
     {
-        return parent::getLikeWildcardCharacters() . '[]^';
+        return parent::getLikeWildcardCharacters() . '[';
     }
 
     protected function getCommentOnTableSQL(string $tableName, string $comment): string


### PR DESCRIPTION
I was working on implementing escaping for the SQL Server LIKE wildcard characters in a different project and realized that the implementation in the DBAL might be cleaned up.

The set of SQL Server LIKE wildcard characters was originally defined in https://github.com/doctrine/dbal/pull/3013. Even though the `^` and the `]` characters are indeed special in a LIKE expression, they are only special within a `[...]` expression (see the [documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql#pattern)). So if the opening `[` is escaped, there's no need to escape, `^` and `]`. By the same token, we don't escape `-`, even though it has a special meaning in an expression like this `[a-z]`.

Handling of these characters is covered by an existing integration test: https://github.com/doctrine/dbal/blob/47dd669806bd2cc76c8c12511e524576988fbe4a/tests/Functional/LikeWildcardsEscapingTest.php#L15