### PR TITLE
Fix/sqlite column comment parsing

### DIFF
--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -390,7 +390,7 @@ CREATE\sTABLE' . $this->buildIdentifierPattern($table) . '
     private function parseColumnCommentFromSQL(string $column, string $sql): string
     {
         $pattern = '{[\s(,]' . $this->buildIdentifierPattern($column)
-            . '(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i';
+            . '\s(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s+--[^\n]*\n?)+)}i';
 
         if (preg_match($pattern, $sql, $match) !== 1) {
             return '';

--- a/tests/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Schema/SQLiteSchemaManagerTest.php
@@ -201,6 +201,14 @@ class SQLiteSchemaManagerTest extends TestCase
                     PRIMARY KEY(id)
                 )',
             ],
+            'Column name equals table name and both have a comment' => [
+                'column comment',
+                'user',
+                'CREATE TABLE "user" --table comment
+                    (
+                        "user" INT --column comment
+                )'
+            ]
         ];
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Issue found in https://github.com/doctrine/dbal/pull/6897#issuecomment-2784637201

When a table and its column share the same name and they both have a comment DBAL will return the table comment instead of the column comment.

Example:
```sql
CREATE TABLE "user" --table comment
(
    "user" INT --column comment
)
```

From the above link, here is the change:
```diff
-{[\s(,](?:\Wuser\W|\W"user"\W)(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s*--[^\n]*\n?)+)}i
+{[\s(,](?:\Wuser\W|\W"user"\W)\s(?:\([^)]*?\)|[^,(])*?,?((?:(?!\n))(?:\s+--[^\n]*\n?)+)}i
                               ^^ require a space                        ^ require at least a space
```

~~Note that I made the fix for DBAL 5.0 but the issue also exists in 4.2:~~ This now targets 4.2
https://github.com/doctrine/dbal/blob/5bbe0265c12ff34a30035cc277ee65a1bbb91955/src/Schema/SQLiteSchemaManager.php#L393