### PR TITLE
CI MariaDB: add 11.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,6 +131,7 @@ jobs:
           - "10.6"  # LTS (Jul 2026) We have code specific to 10.6.0-10.10.0
           - "10.11" # LTS (Feb 2028) We have code specific to ^10.10
           - "11.4"  # LTS (May 2029)
+          - "11.8"  # LTS (Jun 2028)
         extension:
           - "mysqli"
           - "pdo_mysql"


### PR DESCRIPTION
Add the latest LTS version of MariaDB.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Improve the CI to cover newer versions of MariaDB 11.8+.

https://mariadb.org/about/#maintenance-policy