### PR TITLE
Use latest stable sqlsrv extensions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,7 @@ on:
       - "*.x"
     paths:
       - .github/workflows/continuous-integration.yml
+      - .github/workflows/phpunit-*.yml
       - ci/**
       - composer.*
       - phpunit.xml.dist
@@ -16,6 +17,7 @@ on:
       - "*.x"
     paths:
       - .github/workflows/continuous-integration.yml
+      - .github/workflows/phpunit-*.yml
       - ci/**
       - composer.*
       - phpunit.xml.dist

--- a/.github/workflows/phpunit-sqlserver.yml
+++ b/.github/workflows/phpunit-sqlserver.yml
@@ -37,7 +37,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
-          extensions: ${{ inputs.extension }}-5.10.0beta1
+          extensions: ${{ inputs.extension }}
           coverage: pcov
           ini-values: zend.assertions=1
           tools: pecl


### PR DESCRIPTION
The nightly builds are currently [failing](https://github.com/doctrine/dbal/actions/runs/15600950037/job/43940629815) on PHP 8.5-dev and `pdo_sqlsrv`:
> Could not install pdo_sqlsrv-5.12.0beta1 on PHP 8.5.0-dev

This PR attempts to relax the `sqlsrv` and `pdo_sqlsrv` version constraints on CI to allow installing the latest stable version (which is currently 5.12.0). The extension version was last pinned in https://github.com/doctrine/dbal/pull/4875 but we should un-pin them once a newer stable release is available.

The above nightly build output is actually weird:
```
Run shivammathur/setup-php@v2
  with:
    php-version: 8.5
    extensions: pdo_sqlsrv-5.10.0beta1
    coverage: pcov
    ini-values: zend.assertions=1
    tools: pecl
    ini-file: production
  env:
    fail-fast: true
/usr/bin/bash /home/runner/work/_actions/shivammathur/setup-php/v2/src/scripts/run.sh

==> Setup PHP
✓ PHP Installed PHP 8.5.0-dev (32c6ac9133d586c9c259cf98bf88037da80fcb9a)

==> Setup Extensions

==> Setup pdo_sqlsrv-5.12.0beta1
```

The requested extension version is `5.10.0beta1` but the one being installed is `5.12.0beta1`.

We want to remove this constraint anyways. But if it doesn't help, I will file an issue with [shivammathur/setup-php](https://github.com/shivammathur/setup-php).