### PR TITLE
Remove "minimal" dependency setting

### DIFF
--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Remove optional dependencies
-        run: composer remove --no-update --dev doctrine/cache
-        if: ${{ matrix.dependency-versions == 'minimal' }}
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

This seems to be a leftover from a 3.x merge-up. We don't use doctrine/cache anymore in the 4.x branches.
