### PR TITLE
Deprecate support for MariaDB 10.5

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 4.3
 
+## Deprecated support for MariaDB 10.5
+
+* Upgrade to MariaDB 10.6 or later.
+
 ## Deprecated `Column` methods
 
 The following `Column` methods have been deprecated:

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -46,15 +46,15 @@ abstract class AbstractMySQLDriver implements Driver
                 return new MariaDB1060Platform();
             }
 
-            if (version_compare($mariaDbVersion, '10.5.2', '>=')) {
-                return new MariaDB1052Platform();
-            }
-
             Deprecation::trigger(
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/pull/6343',
-                'Support for MariaDB < 10.5.2 is deprecated and will be removed in DBAL 5',
+                'Support for MariaDB < 10.6.0 is deprecated and will be removed in DBAL 5',
             );
+
+            if (version_compare($mariaDbVersion, '10.5.2', '>=')) {
+                return new MariaDB1052Platform();
+            }
 
             return new MariaDBPlatform();
         }

--- a/src/Platforms/MariaDB1060Platform.php
+++ b/src/Platforms/MariaDB1060Platform.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 
 /**
  * Provides the behavior, features and SQL dialect of the MariaDB 10.6 database platform.
+ *
+ * @deprecated This class will be removed once support for MariaDB 10.5 is dropped.
  */
 class MariaDB1060Platform extends MariaDB1052Platform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

MariaDB 10.5 community edition will be EOL next week and enterprise support will end next month. I believe we don't want to keep on supporting this release in DBAL 5, so we might as well deprecate the support now.

see https://mariadb.org/about/#maintenance-policy
