### PR TITLE
Run tests on MySQL 9.3 instead of 9.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -161,7 +161,7 @@ jobs:
         mysql-version:
           - "5.7"
           - "8.0" # We have code specific to ^8.0
-          - "9.1"
+          - "9.3"
         extension:
           - "mysqli"
           - "pdo_mysql"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

MySQL 9.3 is the latest release. We should test against it.
