### PR TITLE
Extend the detection of connection lost in the PostgreSQL ExceptionConverter

### DIFF
--- a/src/Driver/API/PostgreSQL/ExceptionConverter.php
+++ b/src/Driver/API/PostgreSQL/ExceptionConverter.php
@@ -78,7 +78,10 @@ final class ExceptionConverter implements ExceptionConverterInterface
                 return new ConnectionException($exception, $query);
         }
 
-        if (str_contains($exception->getMessage(), 'terminating connection')) {
+        if (
+            str_contains($exception->getMessage(), 'terminating connection')
+            || str_contains($exception->getMessage(), 'server closed the connection')
+        ) {
             return new ConnectionLost($exception, $query);
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | 

#### Summary

In some cases I'm getting the following exception:
`Doctrine\DBAL\Exception\DriverException #7
An exception occurred while executing a query: SQLSTATE[HY000]: General error: 7 server closed the connection unexpectedly
This probably means the server terminated abnormally before or while processing the request. `

I think this exception should be converted to the ConnectionLost exception.
