### PR TITLE
Adding context information when requesting invalid column type

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -7,13 +7,13 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseRequired;
-use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Types\Exception\TypesException;
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
@@ -24,7 +24,6 @@ use function array_values;
 use function count;
 use function func_get_arg;
 use function func_num_args;
-use function sprintf;
 use function strtolower;
 
 /**
@@ -817,7 +816,7 @@ abstract class AbstractSchemaManager
             try {
                 $column = $this->_getPortableTableColumnDefinition($row);
             } catch (UnknownColumnType $unknownTypeException) {
-                throw UnknownColumnType::withContext($unknownTypeException->getType(), sprintf('table %s', $table));
+                throw UnknownColumnType::newWithContext($unknownTypeException->getRequestedType(), $table);
             }
 
             $name        = strtolower($column->getQuotedName($this->platform));

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseRequired;
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Result;
@@ -23,6 +24,7 @@ use function array_values;
 use function count;
 use function func_get_arg;
 use function func_num_args;
+use function sprintf;
 use function strtolower;
 
 /**
@@ -812,7 +814,11 @@ abstract class AbstractSchemaManager
     {
         $list = [];
         foreach ($rows as $row) {
-            $column = $this->_getPortableTableColumnDefinition($row);
+            try {
+                $column = $this->_getPortableTableColumnDefinition($row);
+            } catch (UnknownColumnType $unknownTypeException) {
+                throw UnknownColumnType::withContext($unknownTypeException->getType(), sprintf('table %s', $table));
+            }
 
             $name        = strtolower($column->getQuotedName($this->platform));
             $list[$name] = $column;

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -816,7 +816,11 @@ abstract class AbstractSchemaManager
             try {
                 $column = $this->_getPortableTableColumnDefinition($row);
             } catch (UnknownColumnType $unknownTypeException) {
-                throw UnknownColumnType::newWithContext($unknownTypeException->getRequestedType(), $table);
+                throw UnknownColumnType::newWithContext(
+                    $unknownTypeException->getRequestedType(),
+                    $table,
+                    $unknownTypeException,
+                );
             }
 
             $name        = strtolower($column->getQuotedName($this->platform));

--- a/src/Types/Exception/UnknownColumnType.php
+++ b/src/Types/Exception/UnknownColumnType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types\Exception;
 
 use Exception;
+use Throwable;
 
 use function sprintf;
 
@@ -35,19 +36,22 @@ final class UnknownColumnType extends Exception implements TypesException
         return $object;
     }
 
-    public static function newWithContext(string $name, string $tableName): self
+    public static function newWithContext(string $name, string $tableName, ?Throwable $previous): self
     {
-        $object = new self(sprintf(
-            'Unknown column type "%s" requested for table "%s". Any Doctrine type that you use has '
+        $object = new self(
+            sprintf(
+                'Unknown column type "%s" requested for table "%s". Any Doctrine type that you use has '
                     . 'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the '
                     . 'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database '
                     . 'introspection then you might have forgotten to register all database types for a Doctrine Type. '
                     . 'Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement '
                     . 'Type#getMappedDatabaseTypes(). If the type name is empty you might '
                     . 'have a problem with the cache or forgot some mapping information.',
-            $name,
-            $tableName,
-        ));
+                $name,
+                $tableName,
+            ),
+            previous: $previous,
+        );
 
         $object->requestedType = $name;
 

--- a/src/Types/Exception/UnknownColumnType.php
+++ b/src/Types/Exception/UnknownColumnType.php
@@ -5,24 +5,45 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types\Exception;
 
 use Exception;
+use Throwable;
 
 use function sprintf;
 
 final class UnknownColumnType extends Exception implements TypesException
 {
-    public static function new(string $name): self
-    {
-        return new self(
-            sprintf(
-                'Unknown column type "%s" requested. Any Doctrine type that you use has '
+    private function __construct(
+        private string $requestedType,
+        ?string $context,
+        int $code = 0,
+        ?Throwable $throwable = null,
+    ) {
+        $message = sprintf(
+            'Unknown column type "%s" requested%s. Any Doctrine type that you use has '
                     . 'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the '
                     . 'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database '
                     . 'introspection then you might have forgotten to register all database types for a Doctrine Type. '
                     . 'Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement '
                     . 'Type#getMappedDatabaseTypes(). If the type name is empty you might '
                     . 'have a problem with the cache or forgot some mapping information.',
-                $name,
-            ),
+            $this->requestedType,
+            $context !== null ? ' for ' . $context : '',
         );
+
+        parent::__construct($message, $code, $throwable);
+    }
+
+    public function getType(): string
+    {
+        return $this->requestedType;
+    }
+
+    public static function new(string $name): self
+    {
+        return new self($name, null);
+    }
+
+    public static function withContext(string $name, string $context): self
+    {
+        return new self($name, $context);
     }
 }

--- a/src/Types/Exception/UnknownColumnType.php
+++ b/src/Types/Exception/UnknownColumnType.php
@@ -5,45 +5,52 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types\Exception;
 
 use Exception;
-use Throwable;
 
 use function sprintf;
 
 final class UnknownColumnType extends Exception implements TypesException
 {
-    private function __construct(
-        private string $requestedType,
-        ?string $context,
-        int $code = 0,
-        ?Throwable $throwable = null,
-    ) {
-        $message = sprintf(
-            'Unknown column type "%s" requested%s. Any Doctrine type that you use has '
-                    . 'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the '
-                    . 'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database '
-                    . 'introspection then you might have forgotten to register all database types for a Doctrine Type. '
-                    . 'Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement '
-                    . 'Type#getMappedDatabaseTypes(). If the type name is empty you might '
-                    . 'have a problem with the cache or forgot some mapping information.',
-            $this->requestedType,
-            $context !== null ? ' for ' . $context : '',
-        );
+    private string $requestedType;
 
-        parent::__construct($message, $code, $throwable);
-    }
-
-    public function getType(): string
+    public function getRequestedType(): string
     {
         return $this->requestedType;
     }
 
     public static function new(string $name): self
     {
-        return new self($name, null);
+        $object = new self(sprintf(
+            'Unknown column type "%s" requested. Any Doctrine type that you use has '
+                    . 'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the '
+                    . 'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database '
+                    . 'introspection then you might have forgotten to register all database types for a Doctrine Type. '
+                    . 'Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement '
+                    . 'Type#getMappedDatabaseTypes(). If the type name is empty you might '
+                    . 'have a problem with the cache or forgot some mapping information.',
+            $name,
+        ));
+
+        $object->requestedType = $name;
+
+        return $object;
     }
 
-    public static function withContext(string $name, string $context): self
+    public static function newWithContext(string $name, string $tableName): self
     {
-        return new self($name, $context);
+        $object = new self(sprintf(
+            'Unknown column type "%s" requested for table "%s". Any Doctrine type that you use has '
+                    . 'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the '
+                    . 'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database '
+                    . 'introspection then you might have forgotten to register all database types for a Doctrine Type. '
+                    . 'Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement '
+                    . 'Type#getMappedDatabaseTypes(). If the type name is empty you might '
+                    . 'have a problem with the cache or forgot some mapping information.',
+            $name,
+            $tableName,
+        ));
+
+        $object->requestedType = $name;
+
+        return $object;
     }
 }

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -37,6 +37,7 @@ use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\DateType;
 use Doctrine\DBAL\Types\DecimalType;
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Types\FloatType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\SmallFloatType;
@@ -379,6 +380,40 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         );
         self::assertEquals(true, $columns['baz3']->getNotnull());
         self::assertEquals(null, $columns['baz3']->getDefault());
+    }
+
+    public function testUnknownColumnType(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('test_list_table_with_unkown_doctrine_type')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('column_char')
+                    ->setTypeName(Types::STRING)
+                    ->create(),
+            )
+            ->create();
+
+        $this->schemaManager->createTable($table);
+
+        $platform = $this->connection->getDatabasePlatform();
+        $mappings = [
+            'varchar' => 'doctrine_type',
+        ];
+        (new \ReflectionObject($platform))->getProperty('doctrineTypeMapping')->setValue($platform, $mappings);
+
+        $exception = null;
+        try {
+            $this->schemaManager->listTableColumns('test_list_table_with_unkown_doctrine_type');
+        } catch (\Throwable $t) {
+            $exception = $t;
+        }
+
+        self::assertInstanceOf(UnknownColumnType::class, $exception);
+        self::assertSame('Unknown column type "doctrine_type" requested for table "test_list_table_with_unkown_doctrine_type". Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information.', $exception->getMessage());
+
+        // Reverting back to the standard
+        (new \ReflectionObject($platform))->getProperty('doctrineTypeMapping')->setValue($platform, null);
     }
 
     public function testListTableColumnsWithFixedStringColumn(): void

--- a/tests/Schema/ColumnEditorTest.php
+++ b/tests/Schema/ColumnEditorTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\InvalidColumnDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -77,5 +78,18 @@ class ColumnEditorTest extends TestCase
         $this->expectException(InvalidColumnDefinition::class);
 
         $editor->create();
+    }
+
+    public function testInvalidType(): void
+    {
+        $this->expectException(UnknownColumnType::class);
+        $this->expectExceptionMessage('Unknown column type "unknown_type"');
+
+        Column::editor()
+            ->setUnquotedName('column_char')
+            ->setTypeName('unknown_type')
+            ->setFixed(true)
+            ->setLength(2)
+            ->create();
     }
 }

--- a/tests/Types/Exception/UnknownColumnTypeTest.php
+++ b/tests/Types/Exception/UnknownColumnTypeTest.php
@@ -13,7 +13,7 @@ class UnknownColumnTypeTest extends TestCase
     {
         $exception = UnknownColumnType::new('custom_type');
 
-        self::assertSame('custom_type', $exception->getType());
+        self::assertSame('custom_type', $exception->getRequestedType());
         self::assertStringContainsString(
             'Unknown column type "custom_type" requested.',
             $exception->getMessage(),
@@ -22,9 +22,9 @@ class UnknownColumnTypeTest extends TestCase
 
     public function testWithContext(): void
     {
-        $exception = UnknownColumnType::withContext('custom_type', 'table "some_table"');
+        $exception = UnknownColumnType::newWithContext('custom_type', 'some_table');
 
-        self::assertSame('custom_type', $exception->getType());
+        self::assertSame('custom_type', $exception->getRequestedType());
         self::assertStringContainsString(
             'Unknown column type "custom_type" requested for table "some_table".',
             $exception->getMessage(),

--- a/tests/Types/Exception/UnknownColumnTypeTest.php
+++ b/tests/Types/Exception/UnknownColumnTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types\Exception;
+
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
+use PHPUnit\Framework\TestCase;
+
+class UnknownColumnTypeTest extends TestCase
+{
+    public function testNew(): void
+    {
+        $exception = UnknownColumnType::new('custom_type');
+
+        self::assertSame('custom_type', $exception->getType());
+        self::assertStringContainsString(
+            'Unknown column type "custom_type" requested.',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testWithContext(): void
+    {
+        $exception = UnknownColumnType::withContext('custom_type', 'table "some_table"');
+
+        self::assertSame('custom_type', $exception->getType());
+        self::assertStringContainsString(
+            'Unknown column type "custom_type" requested for table "some_table".',
+            $exception->getMessage(),
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | closes #7012

#### Summary
Adding a way to set context on the `UnkownColumnType`. However in the place where I've added it there is no easy way to also get the name of the column, so I'm just providing the table, which should also already help.