### PR TITLE
Fix NULL handling when binding boolean parameter for native pgsql driver

### DIFF
--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -82,7 +82,11 @@ final class Statement implements StatementInterface
         }
 
         if ($type === ParameterType::BOOLEAN) {
-            $this->parameters[$this->parameterMap[$param]]     = (bool) $value === false ? 'f' : 't';
+            $booleanValue = null;
+            if ($value !== null) {
+                $booleanValue = (bool) $value === false ? 'f' : 't';
+            }
+            $this->parameters[$this->parameterMap[$param]]     = $booleanValue;
             $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;
         } else {
             $this->parameters[$this->parameterMap[$param]]     = $value;

--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -86,6 +86,7 @@ final class Statement implements StatementInterface
             if ($value !== null) {
                 $booleanValue = (bool) $value === false ? 'f' : 't';
             }
+            
             $this->parameters[$this->parameterMap[$param]]     = $booleanValue;
             $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;
         } else {

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -18,7 +18,7 @@ class BooleanBindingTest extends FunctionalTestCase
         }
 
         $table = new Table('boolean_test_table');
-        $table->addColumn('val', 'boolean');
+        $table->addColumn('val', 'boolean', ['notnull' => false]);
         $this->dropAndCreateTable($table);
     }
 
@@ -28,7 +28,7 @@ class BooleanBindingTest extends FunctionalTestCase
     }
 
     /** @dataProvider booleanProvider */
-    public function testBooleanInsert(bool $input): void
+    public function testBooleanInsert(?bool $input): void
     {
         $queryBuilder = $this->connection->createQueryBuilder();
 
@@ -37,11 +37,21 @@ class BooleanBindingTest extends FunctionalTestCase
         ])->executeStatement();
 
         self::assertSame(1, $result);
+
+        $row = $this->connection->createQueryBuilder()
+            ->select('val')->from('boolean_test_table')
+            ->executeQuery()->fetchAssociative();
+
+        self::assertSame(
+            $input,
+            $this->connection->convertToPHPValue($row['val'], 'boolean'),
+            'Must return from database the same value inserted.'
+        );
     }
 
     /** @return bool[][] */
     public static function booleanProvider(): array
     {
-        return [[true], [false]];
+        return [[true], [false], [null]];
     }
 }

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -38,18 +38,20 @@ class BooleanBindingTest extends FunctionalTestCase
 
         self::assertSame(1, $result);
 
-        $row = $this->connection->createQueryBuilder()
+        /** @var boolean|null $valueFromDatabase */
+        $valueFromDatabase = $this->connection->createQueryBuilder()
             ->select('val')->from('boolean_test_table')
-            ->executeQuery()->fetchAssociative();
+            ->executeQuery()->fetchOne();
+        assert($valueFromDatabase !== false);
 
         self::assertSame(
             $input,
-            $this->connection->convertToPHPValue($row['val'], 'boolean'),
-            'Must return from database the same value inserted.'
+            $this->connection->convertToPHPValue($valueFromDatabase, 'boolean'),
+            'Must return from database the same value inserted.',
         );
     }
 
-    /** @return bool[][] */
+    /** @return array<int, list<bool|null>> */
     public static function booleanProvider(): array
     {
         return [[true], [false], [null]];


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7022 

#### Summary

PostgreSQL allows 3 values in a boolean column: TRUE, FALSE and NULL.

Previously, when binding `NULL` to a boolean column, it passed the value as FALSE to the database. It prevents having NULL values in the nullable boolean column.

This PR involves the changes below.

- It fixes this issue by forwarding `NULL` to the database.
- The test has been modified to guarantee correct behavior in this scenario.

