### PR TITLE
Fix NULL handling when binding boolean parameter for native pgsql driver

### DIFF
--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -86,7 +86,7 @@ final class Statement implements StatementInterface
             if ($value !== null) {
                 $booleanValue = (bool) $value === false ? 'f' : 't';
             }
-            
+
             $this->parameters[$this->parameterMap[$param]]     = $booleanValue;
             $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;
         } else {

--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -82,7 +82,12 @@ final class Statement implements StatementInterface
         }
 
         if ($type === ParameterType::BOOLEAN) {
-            $this->parameters[$this->parameterMap[$param]]     = (bool) $value === false ? 'f' : 't';
+            $booleanValue = null;
+            if ($value !== null) {
+                $booleanValue = (bool) $value === false ? 'f' : 't';
+            }
+            
+            $this->parameters[$this->parameterMap[$param]]     = $booleanValue;
             $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;
         } else {
             $this->parameters[$this->parameterMap[$param]]     = $value;

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -9,6 +9,9 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
+use function assert;
+use function is_bool;
+
 class BooleanBindingTest extends FunctionalTestCase
 {
     protected function setUp(): void
@@ -37,12 +40,12 @@ class BooleanBindingTest extends FunctionalTestCase
         ])->executeStatement();
 
         self::assertSame(1, $result);
-        
+
         $valueFromDatabase = $this->connection->createQueryBuilder()
             ->select('val')->from('boolean_test_table')
             ->executeQuery()->fetchOne();
 
-        assert(is_null($valueFromDatabase) || is_bool($valueFromDatabase));
+        assert($valueFromDatabase === null || is_bool($valueFromDatabase));
 
         self::assertSame(
             $input,

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -18,7 +18,7 @@ class BooleanBindingTest extends FunctionalTestCase
         }
 
         $table = new Table('boolean_test_table');
-        $table->addColumn('val', 'boolean');
+        $table->addColumn('val', 'boolean', ['notnull' => false]);
         $this->dropAndCreateTable($table);
     }
 
@@ -28,7 +28,7 @@ class BooleanBindingTest extends FunctionalTestCase
     }
 
     /** @dataProvider booleanProvider */
-    public function testBooleanInsert(bool $input): void
+    public function testBooleanInsert(?bool $input): void
     {
         $queryBuilder = $this->connection->createQueryBuilder();
 
@@ -37,11 +37,23 @@ class BooleanBindingTest extends FunctionalTestCase
         ])->executeStatement();
 
         self::assertSame(1, $result);
+
+        /** @var boolean|null $valueFromDatabase */
+        $valueFromDatabase = $this->connection->createQueryBuilder()
+            ->select('val')->from('boolean_test_table')
+            ->executeQuery()->fetchOne();
+        assert($valueFromDatabase !== false);
+
+        self::assertSame(
+            $input,
+            $this->connection->convertToPHPValue($valueFromDatabase, 'boolean'),
+            'Must return from database the same value inserted.',
+        );
     }
 
-    /** @return bool[][] */
+    /** @return array<int, list<bool|null>> */
     public static function booleanProvider(): array
     {
-        return [[true], [false]];
+        return [[true], [false], [null]];
     }
 }

--- a/tests/Functional/BooleanBindingTest.php
+++ b/tests/Functional/BooleanBindingTest.php
@@ -37,12 +37,12 @@ class BooleanBindingTest extends FunctionalTestCase
         ])->executeStatement();
 
         self::assertSame(1, $result);
-
-        /** @var boolean|null $valueFromDatabase */
+        
         $valueFromDatabase = $this->connection->createQueryBuilder()
             ->select('val')->from('boolean_test_table')
             ->executeQuery()->fetchOne();
-        assert($valueFromDatabase !== false);
+
+        assert(is_null($valueFromDatabase) || is_bool($valueFromDatabase));
 
         self::assertSame(
             $input,


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | #7022

#### Summary

PostgreSQL allows 3 values in a boolean column: TRUE, FALSE and NULL.

Previously, when binding NULL to a boolean column, it passed the value as FALSE to the database. It prevents having NULL values in the nullable boolean column.

This PR involves the changes below.

- It fixes this issue by forwarding NULL to the database.
- The test has been modified to guarantee correct behavior in this scenario.
