### PR TITLE
Quote MySQL constraint names for foreign keys

### DIFF
--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -280,7 +280,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
                 }
 
                 $list[$row['constraint_name']] = [
-                    'name' => $row['constraint_name'],
+                    'name' => $this->getQuotedIdentifierName($row['constraint_name']),
                     'local' => [],
                     'foreign' => [],
                     'foreignTable' => $row['referenced_table_name'],
@@ -523,5 +523,15 @@ SQL,
         }
 
         return $this->defaultTableOptions;
+    }
+
+    /** Returns the quoted representation of the given identifier name. */
+    private function getQuotedIdentifierName(?string $identifier): ?string
+    {
+        if ($identifier === null) {
+            return null;
+        }
+
+        return $this->platform->quoteSingleIdentifier($identifier);
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7021 

#### Summary

MariaDB 12.1 introduces InnoDB Foreign key names
of a digit which requires quoting.