### PR TITLE
Use provided length for enum type if given for non-mysql platform

### DIFF
--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -210,8 +210,8 @@ Maps and converts a string which is one of a set of predefined values. This
 type is specifically designed for MySQL and MariaDB, where it is mapped to
 the native ``ENUM`` type. For other database vendors, this type is mapped to
 a string field (``VARCHAR``) with the maximum length being the length of the
-longest value in the set. Values retrieved from the database are always
-converted to PHP's ``string`` type or ``null`` if no data is present.
+longest value in the set if none was configured. Values retrieved from the database
+are always converted to PHP's ``string`` type or ``null`` if no data is present.
 
 Binary string types
 ^^^^^^^^^^^^^^^^^^^

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -244,12 +244,21 @@ abstract class AbstractPlatform
             throw ColumnValuesRequired::new($this, 'ENUM');
         }
 
-        $configuredLength = $column['length'] ?? 0;
-        $neededLength     = count($column['values']) > 1
+        $length = count($column['values']) > 1
             ? max(...array_map(mb_strlen(...), $column['values']))
             : mb_strlen($column['values'][key($column['values'])]);
 
-        $length = max($configuredLength, $neededLength);
+        if (isset($column['length'])) {
+            if ($length > $column['length']) {
+                throw new InvalidArgumentException(sprintf(
+                    'Specified column length (%d) is less than the maximum length of provided values (%d).',
+                    $column['length'],
+                    $length,
+                ));
+            }
+
+            $length = $column['length'];
+        }
 
         return $this->getStringTypeDeclarationSQL(['length' => $length]);
     }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -244,9 +244,12 @@ abstract class AbstractPlatform
             throw ColumnValuesRequired::new($this, 'ENUM');
         }
 
-        $length = count($column['values']) > 1
+        $configuredLength = $column['length'] ?? 0;
+        $neededLength     = count($column['values']) > 1
             ? max(...array_map(mb_strlen(...), $column['values']))
             : mb_strlen($column['values'][key($column['values'])]);
+
+        $length = max($configuredLength, $neededLength);
 
         return $this->getStringTypeDeclarationSQL(['length' => $length]);
     }

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_shift;
 
@@ -622,6 +623,13 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         );
     }
 
+    /** @param array<string> $values */
+    #[DataProvider('getEnumDeclarationExceptionWithLengthSQLProvider')]
+    public function testGetEnumDeclarationExceptionWithLengthSQL(array $values, int $length): void
+    {
+        self::markTestSkipped('There is no exception thrown on MySQL.');
+    }
+
     /** @return array<string, array{array<string>, string}> */
     public static function getEnumDeclarationSQLProvider(): array
     {
@@ -631,7 +639,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
-    /** @return array<string, array{array<string>, int, string|null}> */
+    /** @return array<string, array{array<string>, int, string}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -630,4 +630,15 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             'multiple values' => [['foo', 'bar1'], "ENUM('foo', 'bar1')"],
         ];
     }
+
+    /** @return array<string, array{array<string>, int, string}> */
+    public static function getEnumDeclarationWithLengthSQLProvider(): array
+    {
+        return [
+            'single value and bigger length' => [['foo'], 42, "ENUM('foo')"],
+            'single value and lower length' => [['foo'], 1, "ENUM('foo')"],
+            'multiple values and bigger length' => [['foo', 'bar1'], 42, "ENUM('foo', 'bar1')"],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, "ENUM('foo', 'bar1')"],
+        ];
+    }
 }

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -631,7 +631,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
         ];
     }
 
-    /** @return array<string, array{array<string>, int, string}> */
+    /** @return array<string, array{array<string>, int, string|null}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1220,32 +1220,43 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     /** @param array<string> $values */
     #[DataProvider('getEnumDeclarationWithLengthSQLProvider')]
-    public function testGetEnumDeclarationWithLengthSQL(array $values, int $length, ?string $expectedSQL = null): void
+    public function testGetEnumDeclarationWithLengthSQL(array $values, int $length, string $expectedSQL): void
     {
-        if ($expectedSQL === null) {
-            $this->expectException(InvalidArgumentException::class);
-        }
-
         $result = $this->platform->getEnumDeclarationSQL([
             'values' => $values,
             'length' => $length,
         ]);
 
-        if ($expectedSQL === null) {
-            return;
-        }
-
         self::assertSame($expectedSQL, $result);
     }
 
-    /** @return array<string, array{array<string>, int, string|null}> */
+    /** @param array<string> $values */
+    #[DataProvider('getEnumDeclarationExceptionWithLengthSQLProvider')]
+    public function testGetEnumDeclarationExceptionWithLengthSQL(array $values, int $length): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->platform->getEnumDeclarationSQL([
+            'values' => $values,
+            'length' => $length,
+        ]);
+    }
+
+    /** @return array<string, array{array<string>, int, string}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [
             'single value and bigger length' => [['foo'], 42, 'VARCHAR(42)'],
-            'single value and lower length' => [['foo'], 1, null],
             'multiple values and bigger length' => [['foo', 'bar1'], 42, 'VARCHAR(42)'],
-            'multiple values and lower length' => [['foo', 'bar1'], 2, null],
+        ];
+    }
+
+    /** @return array<string, array{array<string>, int}> */
+    public static function getEnumDeclarationExceptionWithLengthSQLProvider(): array
+    {
+        return [
+            'single value and lower length' => [['foo'], 1],
+            'multiple values and lower length' => [['foo', 'bar1'], 2],
         ];
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1220,22 +1220,32 @@ abstract class AbstractPlatformTestCase extends TestCase
 
     /** @param array<string> $values */
     #[DataProvider('getEnumDeclarationWithLengthSQLProvider')]
-    public function testGetEnumDeclarationWithLengthSQL(array $values, int $length, string $expectedSQL): void
+    public function testGetEnumDeclarationWithLengthSQL(array $values, int $length, ?string $expectedSQL = null): void
     {
-        self::assertSame($expectedSQL, $this->platform->getEnumDeclarationSQL([
+        if ($expectedSQL === null) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+
+        $result = $this->platform->getEnumDeclarationSQL([
             'values' => $values,
             'length' => $length,
-        ]));
+        ]);
+
+        if ($expectedSQL === null) {
+            return;
+        }
+
+        self::assertSame($expectedSQL, $result);
     }
 
-    /** @return array<string, array{array<string>, int, string}> */
+    /** @return array<string, array{array<string>, int, string|null}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [
             'single value and bigger length' => [['foo'], 42, 'VARCHAR(42)'],
-            'single value and lower length' => [['foo'], 1, 'VARCHAR(3)'],
+            'single value and lower length' => [['foo'], 1, null],
             'multiple values and bigger length' => [['foo', 'bar1'], 42, 'VARCHAR(42)'],
-            'multiple values and lower length' => [['foo', 'bar1'], 2, 'VARCHAR(4)'],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, null],
         ];
     }
 

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -1218,6 +1218,27 @@ abstract class AbstractPlatformTestCase extends TestCase
         ];
     }
 
+    /** @param array<string> $values */
+    #[DataProvider('getEnumDeclarationWithLengthSQLProvider')]
+    public function testGetEnumDeclarationWithLengthSQL(array $values, int $length, string $expectedSQL): void
+    {
+        self::assertSame($expectedSQL, $this->platform->getEnumDeclarationSQL([
+            'values' => $values,
+            'length' => $length,
+        ]));
+    }
+
+    /** @return array<string, array{array<string>, int, string}> */
+    public static function getEnumDeclarationWithLengthSQLProvider(): array
+    {
+        return [
+            'single value and bigger length' => [['foo'], 42, 'VARCHAR(42)'],
+            'single value and lower length' => [['foo'], 1, 'VARCHAR(3)'],
+            'multiple values and bigger length' => [['foo', 'bar1'], 42, 'VARCHAR(42)'],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, 'VARCHAR(4)'],
+        ];
+    }
+
     /** @param array<mixed> $column */
     #[DataProvider('getEnumDeclarationSQLWithInvalidValuesProvider')]
     public function testGetEnumDeclarationSQLWithInvalidValues(array $column): void

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -651,4 +651,15 @@ EOD;
             'multiple values' => [['foo', 'bar1'], 'VARCHAR2(4)'],
         ];
     }
+
+    /** @return array<string, array{array<string>, int, string}> */
+    public static function getEnumDeclarationWithLengthSQLProvider(): array
+    {
+        return [
+            'single value and bigger length' => [['foo'], 42, 'VARCHAR2(42)'],
+            'single value and lower length' => [['foo'], 1, 'VARCHAR2(3)'],
+            'multiple values and bigger length' => [['foo', 'bar1'], 42, 'VARCHAR2(42)'],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, 'VARCHAR2(4)'],
+        ];
+    }
 }

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -652,14 +652,14 @@ EOD;
         ];
     }
 
-    /** @return array<string, array{array<string>, int, string}> */
+    /** @return array<string, array{array<string>, int, string|null}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [
             'single value and bigger length' => [['foo'], 42, 'VARCHAR2(42)'],
-            'single value and lower length' => [['foo'], 1, 'VARCHAR2(3)'],
+            'single value and lower length' => [['foo'], 1, null],
             'multiple values and bigger length' => [['foo', 'bar1'], 42, 'VARCHAR2(42)'],
-            'multiple values and lower length' => [['foo', 'bar1'], 2, 'VARCHAR2(4)'],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, null],
         ];
     }
 }

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -652,14 +652,12 @@ EOD;
         ];
     }
 
-    /** @return array<string, array{array<string>, int, string|null}> */
+    /** @return array<string, array{array<string>, int, string}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [
             'single value and bigger length' => [['foo'], 42, 'VARCHAR2(42)'],
-            'single value and lower length' => [['foo'], 1, null],
             'multiple values and bigger length' => [['foo', 'bar1'], 42, 'VARCHAR2(42)'],
-            'multiple values and lower length' => [['foo', 'bar1'], 2, null],
         ];
     }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1226,14 +1226,14 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         ];
     }
 
-    /** @return array<string, array{array<string>, int, string}> */
+    /** @return array<string, array{array<string>, int, string|null}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [
             'single value and bigger length' => [['foo'], 42, 'NVARCHAR(42)'],
-            'single value and lower length' => [['foo'], 1, 'NVARCHAR(3)'],
+            'single value and lower length' => [['foo'], 1, null],
             'multiple values and bigger length' => [['foo', 'bar1'], 42, 'NVARCHAR(42)'],
-            'multiple values and lower length' => [['foo', 'bar1'], 2, 'NVARCHAR(4)'],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, null],
         ];
     }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1225,4 +1225,15 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
             'multiple values' => [['foo', 'bar1'], 'NVARCHAR(4)'],
         ];
     }
+
+    /** @return array<string, array{array<string>, int, string}> */
+    public static function getEnumDeclarationWithLengthSQLProvider(): array
+    {
+        return [
+            'single value and bigger length' => [['foo'], 42, 'NVARCHAR(42)'],
+            'single value and lower length' => [['foo'], 1, 'NVARCHAR(3)'],
+            'multiple values and bigger length' => [['foo', 'bar1'], 42, 'NVARCHAR(42)'],
+            'multiple values and lower length' => [['foo', 'bar1'], 2, 'NVARCHAR(4)'],
+        ];
+    }
 }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1226,14 +1226,12 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
         ];
     }
 
-    /** @return array<string, array{array<string>, int, string|null}> */
+    /** @return array<string, array{array<string>, int, string}> */
     public static function getEnumDeclarationWithLengthSQLProvider(): array
     {
         return [
             'single value and bigger length' => [['foo'], 42, 'NVARCHAR(42)'],
-            'single value and lower length' => [['foo'], 1, null],
             'multiple values and bigger length' => [['foo', 'bar1'], 42, 'NVARCHAR(42)'],
-            'multiple values and lower length' => [['foo', 'bar1'], 2, null],
         ];
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement ? fix ?
| Fixed issues |

#### Summary

When a Type Enum is used AND a length
```
#[ORM\Column(name: 'role', type: Types::Enum, length: 50)
```
the length is not used at all when generating the sql.

This makes sens for MysqlPlatform which list all the possible case, but for non-mysql platform it could be a way to reserved more length in advance in order to avoid futur ALTER TABLE.
The current strategy is too look at the max length of all the existing values, which means that adding new enum values might trigger every time an ALTER table just to use a bigger length.