### PR TITLE
Avoid useless extra query in Psql

### DIFF
--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -805,6 +805,34 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
     }
 
+    public function testTypeChangeWithTheSameSQLGenerationWhileChangingAComment(): void
+    {
+        $table1 = Table::editor()
+            ->setQuotedName('Foo')
+            ->setColumns(Column::editor()
+                ->setQuotedName('Bar')
+                ->setTypeName(Types::DATETIMETZ_MUTABLE)
+                ->create())
+            ->create();
+
+        $table2 = Table::editor()
+            ->setQuotedName('Foo')
+            ->setColumns(Column::editor()
+                ->setQuotedName('Bar')
+                ->setTypeName(Types::DATETIMETZ_IMMUTABLE)
+                ->setComment('Baz')
+                ->create())
+            ->create();
+
+        $tableDiff = $this->createComparator()
+            ->compareTables($table1, $table2);
+
+        self::assertSame(
+            ['COMMENT ON COLUMN "Foo"."Bar" IS \'Baz\''],
+            $this->platform->getAlterTableSQL($tableDiff),
+        );
+    }
+
     protected function getQuotesReservedKeywordInUniqueConstraintDeclarationSQL(): string
     {
         return 'CONSTRAINT "select" UNIQUE (foo)';


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7033

#### Summary

When modifying a field form DateTime to DateTimeImmutable, the comparator + platform correctly detect "nothing" really change and no sql query is necessary. 

But if we're doing this modification while changing another thing like a comment, the platform generate 
- A useless alter table
- A query to change the comment

This is because the type has changed but the `Type::getSQLDeclaration` value is the same.
