### PR TITLE
Do not hardcode allowed parameters in TestUtil

### DIFF
--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -23,6 +23,7 @@ use function file_exists;
 use function implode;
 use function in_array;
 use function is_string;
+use function str_starts_with;
 use function strlen;
 use function strpos;
 use function substr;
@@ -189,31 +190,12 @@ class TestUtil
     {
         $parameters = [];
 
-        foreach (
-            [
-                'driver',
-                'user',
-                'password',
-                'host',
-                'dbname',
-                'memory',
-                'port',
-                'server',
-                'ssl_key',
-                'ssl_cert',
-                'ssl_ca',
-                'ssl_capath',
-                'ssl_cipher',
-                'unix_socket',
-                'path',
-                'charset',
-            ] as $parameter
-        ) {
-            if (! isset($configuration[$prefix . $parameter])) {
+        foreach ($configuration as $key => $value) {
+            if (! str_starts_with($key, $prefix)) {
                 continue;
             }
 
-            $parameters[$parameter] = $configuration[$prefix . $parameter];
+            $parameters[substr($key, strlen($prefix))] = $value;
         }
 
         foreach ($configuration as $param => $value) {


### PR DESCRIPTION
The list of parameters supported by `TestUtil::mapConnectionParameters()` is not exhaustive. For instance, it doesn't support `service` and `servicename` supported by the `oci8` and `pdo_oci` drivers. If such a parameter is specified in the test suite configuration, it is silently ignored, which isn't the best user experience.