### PR TITLE
Remove internal from comparator-related classes constructor

### DIFF
--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -24,7 +24,6 @@ use function array_diff_assoc;
  */
 class Comparator extends BaseComparator
 {
-    /** @internal The comparator can be only instantiated by a schema manager. */
     public function __construct(
         AbstractMySQLPlatform $platform,
         private readonly CharsetMetadataProvider $charsetMetadataProvider,

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\TableDiff;
  */
 class Comparator extends BaseComparator
 {
-    /** @internal The comparator can be only instantiated by a schema manager. */
     public function __construct(
         SQLServerPlatform $platform,
         private readonly string $databaseCollation,

--- a/src/Platforms/SQLite/Comparator.php
+++ b/src/Platforms/SQLite/Comparator.php
@@ -19,7 +19,6 @@ use function strcasecmp;
  */
 class Comparator extends BaseComparator
 {
-    /** @internal The comparator can be only instantiated by a schema manager. */
     public function __construct(SQLitePlatform $platform, ComparatorConfig $config = new ComparatorConfig())
     {
         parent::__construct($platform, $config);

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -13,7 +13,6 @@ use function strcasecmp;
  */
 class ColumnDiff
 {
-    /** @internal The diff can be only instantiated by a {@see Comparator}. */
     public function __construct(private readonly Column $oldColumn, private readonly Column $newColumn)
     {
     }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -17,7 +17,6 @@ use function strtolower;
  */
 class Comparator
 {
-    /** @internal The comparator can be only instantiated by a schema manager. */
     public function __construct(
         private readonly AbstractPlatform $platform,
         private readonly ComparatorConfig $config = new ComparatorConfig(),

--- a/src/Schema/SchemaDiff.php
+++ b/src/Schema/SchemaDiff.php
@@ -20,8 +20,6 @@ class SchemaDiff
     /**
      * Constructs an SchemaDiff object.
      *
-     * @internal The diff can be only instantiated by a {@see Comparator}.
-     *
      * @param array<string>    $createdSchemas
      * @param array<string>    $droppedSchemas
      * @param array<Table>     $createdTables

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -20,8 +20,6 @@ class TableDiff
     /**
      * Constructs a TableDiff object.
      *
-     * @internal The diff can be only instantiated by a {@see Comparator}.
-     *
      * @param array<ForeignKeyConstraint> $droppedForeignKeys
      * @param array<Column>               $addedColumns
      * @param array<string, ColumnDiff>   $changedColumns


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | 

1) The comparator constructor say
```
@internal The comparator can be only instantiated by a schema manager.
```
but when we're writing an own custom schemaManager, extending AbstractSchemaManager, we'll need still need a way with BC to instantiate a Comparator in order to implement/override the `createComparator` method.

2) When writing our custom Comparator, we should be able to implements `compareSchemas` or `compareTable` so we need a way with BC to instantiate a SchemaDiff/TableDiff/ColumnDiff classes (It doesn't forbid those class to be final @morozov)

3) Another reason to allows instantiate a SchemaDiff/TableDiff/ColumnDiff classes is to write tests when implementing our own Platform and we want to unit tests the methods `getAlterSchemaSQL` or `getAlterTableSQL`.