### PR TITLE
Remove obsolete todo

### DIFF
--- a/src/Types/ArrayType.php
+++ b/src/Types/ArrayType.php
@@ -35,7 +35,6 @@ class ArrayType extends Type
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        // @todo 3.0 - $value === null check to save real NULL in database
         return serialize($value);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

This type has been removed in DBAL 4. Nobody's going to work on that `@todo`, so let's remove it.
