### PR TITLE
Add a nice way to create a builder for subqueries

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -204,6 +204,14 @@ class QueryBuilder
     }
 
     /**
+     * Returns a fresh query builder instance that can be used to build a subquery.
+     */
+    public function sub(): self
+    {
+        return $this->connection->createQueryBuilder();
+    }
+
+    /**
      * Prepares and executes an SQL query and returns the first row of the result
      * as an associative array.
      *

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -247,14 +247,14 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['id' => 2], ['id' => 1], ['id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $subQueryBuilder1 = $this->connection->createQueryBuilder();
-        $subQueryBuilder1->select('id')->from('for_update')->where($qb->expr()->eq('id', '1'));
+        $subQueryBuilder1 = $qb->sub()
+            ->select('id')->from('for_update')->where($qb->expr()->eq('id', '1'));
 
-        $subQueryBuilder2 = $this->connection->createQueryBuilder();
-        $subQueryBuilder2->select('id')->from('for_update')->where($qb->expr()->eq('id', '2'));
+        $subQueryBuilder2 = $qb->sub()
+            ->select('id')->from('for_update')->where($qb->expr()->eq('id', '2'));
 
-        $subQueryBuilder3 = $this->connection->createQueryBuilder();
-        $subQueryBuilder3->select('id')->from('for_update')->where($qb->expr()->eq('id', '1'));
+        $subQueryBuilder3 = $qb->sub()
+            ->select('id')->from('for_update')->where($qb->expr()->eq('id', '1'));
 
         $qb->union($subQueryBuilder1)
             ->addUnion($subQueryBuilder2, UnionType::ALL)
@@ -269,18 +269,18 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['id' => 2], ['id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $subQueryBuilder1 = $this->connection->createQueryBuilder();
-        $subQueryBuilder1->select('id')
+        $subQueryBuilder1 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
 
-        $subQueryBuilder2 = $this->connection->createQueryBuilder();
-        $subQueryBuilder2->select('id')
+        $subQueryBuilder2 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(2, ParameterType::INTEGER)));
 
-        $subQueryBuilder3 = $this->connection->createQueryBuilder();
-        $subQueryBuilder3->select('id')
+        $subQueryBuilder3 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
 
@@ -297,18 +297,18 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 1], ['id' => 2]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $subQueryBuilder1 = $this->connection->createQueryBuilder();
-        $subQueryBuilder1->select('id')
+        $subQueryBuilder1 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
 
-        $subQueryBuilder2 = $this->connection->createQueryBuilder();
-        $subQueryBuilder2->select('id')
+        $subQueryBuilder2 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(2, ParameterType::INTEGER)));
 
-        $subQueryBuilder3 = $this->connection->createQueryBuilder();
-        $subQueryBuilder3->select('id')
+        $subQueryBuilder3 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
 
@@ -325,18 +325,18 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 2]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $subQueryBuilder1 = $this->connection->createQueryBuilder();
-        $subQueryBuilder1->select('id')
+        $subQueryBuilder1 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
 
-        $subQueryBuilder2 = $this->connection->createQueryBuilder();
-        $subQueryBuilder2->select('id')
+        $subQueryBuilder2 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(2, ParameterType::INTEGER)));
 
-        $subQueryBuilder3 = $this->connection->createQueryBuilder();
-        $subQueryBuilder3->select('id')
+        $subQueryBuilder3 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', $qb->createNamedParameter(1, ParameterType::INTEGER)));
 
@@ -361,8 +361,8 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['virtual_id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $cteQueryBuilder = $this->connection->createQueryBuilder();
-        $cteQueryBuilder->select('id AS virtual_id')
+        $cteQueryBuilder = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where('id = :id');
 
@@ -387,14 +387,14 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['virtual_id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $cteQueryBuilder1 = $this->connection->createQueryBuilder();
-        $cteQueryBuilder1->select('id AS virtual_id')
+        $cteQueryBuilder1 = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', '?'));
         $qb->setParameter(0, 1, ParameterType::INTEGER);
 
-        $cteQueryBuilder2 = $this->connection->createQueryBuilder();
-        $cteQueryBuilder2->select('id AS virtual_id')
+        $cteQueryBuilder2 = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where($qb->expr()->in('id', ':id'));
         $qb->setParameter('id', [1, 2], ArrayParameterType::INTEGER);
@@ -425,16 +425,16 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['virtual_id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $cteQueryBuilder1 = $this->connection->createQueryBuilder();
-        $cteQueryBuilder1->select('id AS virtual_id')
+        $cteQueryBuilder1 = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where($qb->expr()->eq(
                 'id',
                 $qb->createNamedParameter(1, ParameterType::INTEGER, ':id1'),
             ));
 
-        $cteQueryBuilder2 = $this->connection->createQueryBuilder();
-        $cteQueryBuilder2->select('id AS virtual_id')
+        $cteQueryBuilder2 = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where($qb->expr()->in(
                 'id',
@@ -467,16 +467,16 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['virtual_id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $cteQueryBuilder1 = $this->connection->createQueryBuilder();
-        $cteQueryBuilder1->select('id AS virtual_id')
+        $cteQueryBuilder1 = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where($qb->expr()->eq(
                 'id',
                 $qb->createPositionalParameter(1, ParameterType::INTEGER),
             ));
 
-        $cteQueryBuilder2 = $this->connection->createQueryBuilder();
-        $cteQueryBuilder2->select('id AS virtual_id')
+        $cteQueryBuilder2 = $qb->sub()
+            ->select('id AS virtual_id')
             ->from('for_update')
             ->where($qb->expr()->in(
                 'id',
@@ -505,18 +505,18 @@ final class QueryBuilderTest extends FunctionalTestCase
         $expectedRows = $this->prepareExpectedRows([['id' => 2], ['id' => 1]]);
         $qb           = $this->connection->createQueryBuilder();
 
-        $subQueryBuilder1 = $this->connection->createQueryBuilder();
-        $subQueryBuilder1->select('id')
+        $subQueryBuilder1 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', '?'));
 
-        $subQueryBuilder2 = $this->connection->createQueryBuilder();
-        $subQueryBuilder2->select('id')
+        $subQueryBuilder2 = $qb->sub()
+            ->select('id')
             ->from('for_update')
             ->where($qb->expr()->eq('id', '?'));
 
-        $subQueryBuilder3 = $this->connection->createQueryBuilder();
-        $subQueryBuilder3->union($subQueryBuilder1)
+        $subQueryBuilder3 = $qb->sub()
+            ->union($subQueryBuilder1)
             ->addUnion($subQueryBuilder2);
 
         $qb->with('cte_a', $subQueryBuilder3)
@@ -536,8 +536,8 @@ final class QueryBuilderTest extends FunctionalTestCase
 
         $qb = $this->connection->createQueryBuilder();
 
-        $cteQueryBuilder = $this->connection->createQueryBuilder();
-        $cteQueryBuilder->select('id')
+        $cteQueryBuilder = $qb->sub()
+            ->select('id')
             ->from('for_update');
 
         $qb->with('cte_a', $cteQueryBuilder)


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | N/A

#### Summary

In DBAL 3, we could ask q query builder for its database connection. That accessor has been removed in DBAL 4 which is a good thing.

Currently, I'm migrating a codebase that used the `QueryBuilder::getConnection()` method in order to create a fresh builder for constructing a subquery.

```php
$subQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
```

I believe this is a valid requirement, especially given that we allow query builders for unions and CTEs.

This PR proposes a new method `sub()` which creates a fresh builder for the same connection, pretty much like the already existing method `expr()` does for the expression builder.

```php
$subQueryBuilder = $queryBuilder->sub();
```