### PR TITLE
Deprecate "service" connection parameter

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 4.4
+
+## Deprecated `service` connection parameter for `oci8` and `pdo_oci` connections.
+
+Using the `service` connection parameter to indicate that the value of the `dbname` parameter is the service name has
+been deprecated. Use the `servicename` parameter instead.
+
 # Upgrade to 4.3
 
 ## Deprecated support for MariaDB 10.5

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -303,12 +303,11 @@ pdo_oci / oci8
 -  ``dbname`` (string): Name of the database/schema to connect to.
 -  ``servicename`` (string): Optional name by which clients can
    connect to the database instance. Will be used as Oracle's
-   ``SID`` connection parameter if given and defaults to Doctrine's
-   ``dbname`` connection parameter value.
+   ``SERVICE_NAME`` connection parameter if given.
 -  ``service`` (boolean): Whether to use Oracle's ``SERVICE_NAME``
    connection parameter in favour of ``SID`` when connecting. The
    value for this will be read from Doctrine's ``servicename`` if
-   given, ``dbname`` otherwise.
+   given, ``dbname`` otherwise. Using this parameter is deprecated.
 -  ``pooled`` (boolean): Whether to enable database resident
    connection pooling.
 -  ``charset`` (string): The charset used when connecting to the

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\AbstractOracleDriver;
 
+use Doctrine\Deprecations\Deprecation;
+
 use function implode;
 use function is_array;
 use function sprintf;
@@ -51,10 +53,19 @@ final class EasyConnectString
 
         $connectData = [];
 
+        if (isset($params['service'])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7042',
+                'Using the "service" parameter to indicate that the value of the "dbname" parameter is the'
+                    . ' service name is deprecated. Use the "servicename" parameter instead.',
+            );
+        }
+
         if (isset($params['servicename']) || isset($params['dbname'])) {
             $serviceKey = 'SID';
 
-            if (isset($params['service'])) {
+            if (isset($params['service']) || isset($params['servicename'])) {
                 $serviceKey = 'SERVICE_NAME';
             }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/improvement

Even though the current behavior is explicitly documented, it looks nonsensical to me. If I specify the `servicename` parameter in connection configuration but don't add `service = true`, instead of being interpreted as `SERVICE_NAME`, `servicename` will be interpreted as `SID`:
```php
echo EasyConnectString::fromConnectionParameters([
    'host' => 'localhost',
    'port' => 1521,
    'servicename' => 'BILLING',
]);

// (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SID=BILLING)))
```

Technically, the addition of `|| isset($params['servicename'])` might be considered a BC break (`servicename` which  was previously interpreted as `SID` will be interpreted as `SERVICE_NAME`), but I'd consider it a bug fix. If the user expects that the connection will use `SID`, they can use `dbname`.

In the short future, I want to deprecate the usage of `dbname` for Oracle connections in favor of introducing an explicit `sid` parameter. The "database" term is too vague in the context of Oracle.