### PR TITLE
Quote Oracle user password

### DIFF
--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -270,7 +270,7 @@ class OracleSchemaManager extends AbstractSchemaManager
         $params = $this->connection->getParams();
 
         if (isset($params['password'])) {
-            $statement .= ' IDENTIFIED BY ' . $params['password'];
+            $statement .= ' IDENTIFIED BY ' . $this->connection->quoteSingleIdentifier($params['password']);
         }
 
         $this->connection->executeStatement($statement);


### PR DESCRIPTION
The DBAL, when building a `CREATE USER` statement, uses the password as is w/o any escaping. This way, it will fail to create the user if the password contains special characters. For example:
```
SQL> create user bob identified by Password!;
create user bob identified by Password!
                                      *
ERROR at line 1:
ORA-00922: missing or invalid option
Help: https://docs.oracle.com/error-help/db/ora-00922/
```

Per the [documentation](https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_8003.htm),
> Passwords must follow the rules described in the section ["Schema Object Naming Rules"](https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements008.htm#i27570) [...]

Which documents the common quoting rules:
> Nonquoted identifiers can contain only alphanumeric characters [...]
>
> Quoted identifiers can contain any characters and punctuations marks as well as spaces  [...]

Which basically means that we need to quote the password:
```
SQL> create user bob identified by "Passw0rd!";
User created.
```

In my understanding, unlike other database objects, passwords are always case-sensitive, even if declared as unquoted. So it's not a breaking change. Furthermore, I very much doubt that this method is used for anything else than testing (the method creates a new user with the same password as the password of the current user).