### PR TITLE
Make sure column length is a nullable integer

### DIFF
--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -194,7 +194,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
         }
 
         $options = [
-            'length'        => $length,
+            'length'        => $length !== null ? (int) $length : null,
             'unsigned'      => str_contains($tableColumn['column_type'], 'unsigned'),
             'fixed'         => $fixed,
             'default'       => $columnDefault,


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

I got the following exception when running migrations in a symfony project:

```txt
In Column.php line 115:
                                                                                                                                                                               
  [TypeError]                                                                                                                                                                  
  Doctrine\DBAL\Schema\Column::setLength(): Argument #1 ($length) must be of type ?int, string given, called in /app/vendor/doctrine/dbal/src/Schema/Column.php   
  on line 102                                                                                                                                                                  
                                                                                                                                                                               

Exception trace:
  at /app/vendor/doctrine/dbal/src/Schema/Column.php:115
 Doctrine\DBAL\Schema\Column->setLength() at /app/vendor/doctrine/dbal/src/Schema/Column.php:102
 Doctrine\DBAL\Schema\Column->setOptions() at /app/vendor/doctrine/dbal/src/Schema/Column.php:84
 Doctrine\DBAL\Schema\Column->__construct() at /app/vendor/doctrine/dbal/src/Schema/MySQLSchemaManager.php:212
 Doctrine\DBAL\Schema\MySQLSchemaManager->_getPortableTableColumnDefinition() at /app/vendor/doctrine/dbal/src/Schema/AbstractSchemaManager.php:815
 Doctrine\DBAL\Schema\AbstractSchemaManager->_getPortableTableColumnList() at /app/vendor/doctrine/dbal/src/Schema/AbstractSchemaManager.php:128
 Doctrine\DBAL\Schema\AbstractSchemaManager->listTableColumns() at /app/vendor/doctrine/dbal/src/Schema/AbstractSchemaManager.php:460
 Doctrine\DBAL\Schema\AbstractSchemaManager->introspectTable() at /app/vendor/doctrine/migrations/src/Metadata/Storage/TableMetadataStorage.php:199
 Doctrine\Migrations\Metadata\Storage\TableMetadataStorage->needsUpdate() at /app/vendor/doctrine/migrations/src/Metadata/Storage/TableMetadataStorage.php:181
 Doctrine\Migrations\Metadata\Storage\TableMetadataStorage->ensureInitialized() at /app/vendor/doctrine/migrations/src/Tools/Console/Command/MigrateCommand.php:158
 Doctrine\Migrations\Tools\Console\Command\MigrateCommand->execute() at /app/vendor/symfony/console/Command/Command.php:318
 Symfony\Component\Console\Command\Command->run() at /app/vendor/symfony/console/Application.php:1092
 Symfony\Component\Console\Application->doRunCommand() at /app/vendor/symfony/framework-bundle/Console/Application.php:123
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /app/vendor/symfony/console/Application.php:341
 Symfony\Component\Console\Application->doRun() at /app/vendor/symfony/framework-bundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /app/vendor/symfony/console/Application.php:192
 Symfony\Component\Console\Application->run() at /app/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:49
 Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner->run() at /app/vendor/autoload_runtime.php:29
 require_once() at /app/bin/console:16
```

I ended up tracking it down to the following problem. When `PDO::ATTR_STRINGIFY_FETCHES` is set to true on the mysql connection, all results are cast to string. 

In the code for getting the correct collumn length we see the following, where `$tableColumn` is the result of  a query.
Since the `setLenght` method expects `?int`, we get a type error because we pass a string.

```php
 case 'char':
case 'varchar':
    $length = $tableColumn['character_maximum_length'];
    break;
case 'binary':
case 'varbinary':
    $length = $tableColumn['character_octet_length'];
break;
```


