### PR TITLE
Fix case sensitivity in SQLite column types

### DIFF
--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -32,6 +32,7 @@ use function str_contains;
 use function str_replace;
 use function strcasecmp;
 use function strtolower;
+use function strtoupper;
 
 use const CASE_LOWER;
 
@@ -73,7 +74,11 @@ class SQLiteSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableColumnDefinition(array $tableColumn): Column
     {
-        $matchResult = preg_match('/^([A-Z\s]+?)(?:\s*\((\d+)(?:,\s*(\d+))?\))?$/', $tableColumn['type'], $matches);
+        $matchResult = preg_match(
+            '/^([A-Z\s]+?)(?:\s*\((\d+)(?:,\s*(\d+))?\))?$/',
+            strtoupper($tableColumn['type']),
+            $matches,
+        );
         assert($matchResult === 1);
 
         $dbType = strtolower($matches[1]);

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -32,7 +32,6 @@ use function str_contains;
 use function str_replace;
 use function strcasecmp;
 use function strtolower;
-use function strtoupper;
 
 use const CASE_LOWER;
 
@@ -74,11 +73,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
      */
     protected function _getPortableTableColumnDefinition(array $tableColumn): Column
     {
-        $matchResult = preg_match(
-            '/^([A-Z\s]+?)(?:\s*\((\d+)(?:,\s*(\d+))?\))?$/',
-            strtoupper($tableColumn['type']),
-            $matches,
-        );
+        $matchResult = preg_match('/^([A-Z\s]+?)(?:\s*\((\d+)(?:,\s*(\d+))?\))?$/i', $tableColumn['type'], $matches);
         assert($matchResult === 1);
 
         $dbType = strtolower($matches[1]);

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -191,6 +191,28 @@ SQL;
         self::assertSame(100, $columns['bar']->getLength());
     }
 
+    public function testListTableColumnsWithMixedCaseInTypeDeclarations(): void
+    {
+        $sql = <<<'SQL'
+CREATE TABLE dbal_mixed (
+    foo VarChar (64),
+    bar Text (100)
+)
+SQL;
+
+        $this->connection->executeStatement($sql);
+
+        $columns = $this->schemaManager->listTableColumns('dbal_mixed');
+
+        self::assertCount(2, $columns);
+
+        self::assertArrayHasKey('foo', $columns);
+        self::assertArrayHasKey('bar', $columns);
+
+        self::assertSame(Type::getType(Types::STRING), $columns['foo']->getType());
+        self::assertSame(Type::getType(Types::TEXT), $columns['bar']->getType());
+    }
+
     public function testPrimaryKeyAutoIncrement(): void
     {
         $table = Table::editor()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7049

#### Summary

This change makes the regular expression case-insensitive so it matches the original casing in the definition.