### PR TITLE
Fix introspection on PDO_pgsql with `PDO::STRINGIFY_FETCHES` enabled

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,6 +35,7 @@ jobs:
       php-version: ${{ matrix.php-version }}
       extension: ${{ matrix.extension }}
       dependency-versions: ${{ matrix.dependency-versions }}
+      config-file-suffix: ${{ matrix.config-file-suffix }}
 
     strategy:
       matrix:
@@ -61,7 +62,7 @@ jobs:
             php-version: "8.2"
             dependency-versions: "highest"
             extension: "pdo_sqlite"
-            config-file-suffix: ${{ matrix.config-file-suffix }}
+            config-file-suffix: "-stringify_fetches"
 
   phpunit-oracle:
     name: "PHPUnit with Oracle"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,6 +57,11 @@ jobs:
             php-version: "8.4"
             dependency-versions: "highest"
             extension: "sqlite3"
+          - os: "ubuntu-22.04"
+            php-version: "8.2"
+            dependency-versions: "highest"
+            extension: "pdo_sqlite"
+            config-file-suffix: ${{ matrix.config-file-suffix }}
 
   phpunit-oracle:
     name: "PHPUnit with Oracle"
@@ -95,6 +100,7 @@ jobs:
       postgres-version: ${{ matrix.postgres-version }}
       extension: ${{ matrix.extension }}
       postgres-locale-provider: ${{ matrix.postgres-locale-provider }}
+      config-file-suffix: ${{ matrix.config-file-suffix }}
 
     strategy:
       matrix:
@@ -121,6 +127,10 @@ jobs:
             postgres-version: "15"
             extension: "pdo_pgsql"
             postgres-locale-provider: "icu"
+          - php-version: "8.2"
+            postgres-version: "17"
+            extension: "pdo_pgsql"
+            config-file-suffix: "-stringify_fetches"
 
   phpunit-mariadb:
     name: "PHPUnit with MariaDB"
@@ -130,6 +140,7 @@ jobs:
       php-version: ${{ matrix.php-version }}
       mariadb-version: ${{ matrix.mariadb-version }}
       extension: ${{ matrix.extension }}
+      config-file-suffix: ${{ matrix.config-file-suffix }}
 
     strategy:
       matrix:
@@ -152,6 +163,10 @@ jobs:
             mariadb-version: "11.4"
             extension: "mysqli"
           - php-version: "8.2"
+            mariadb-version: "11.4"
+            extension: "pdo_mysql"
+          - config-file-suffix: "-stringify_fetches"
+            php-version: "8.2"
             mariadb-version: "11.4"
             extension: "pdo_mysql"
 

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -57,5 +57,5 @@ jobs:
       - name: Upload coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}-${{ inputs.mariadb-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}.coverage
+          name: ${{ github.job }}-${{ inputs.mariadb-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}${{ inputs.config-file-suffix }}.coverage
           path: coverage.xml

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -12,6 +12,10 @@ on:
       extension:
         required: true
         type: string
+      config-file-suffix:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   phpunit-mariadb:

--- a/.github/workflows/phpunit-postgres.yml
+++ b/.github/workflows/phpunit-postgres.yml
@@ -15,6 +15,10 @@ on:
       postgres-locale-provider:
         required: true
         type: string
+      config-file-suffix:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   phpunit-postgres:
@@ -51,10 +55,10 @@ jobs:
           composer-options: '--ignore-platform-req=php+'
 
       - name: Run PHPUnit
-        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}.xml --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}${{ inputs.config-file-suffix }}.xml --coverage-clover=coverage.xml
 
       - name: Upload coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}-${{ inputs.postgres-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}.coverage
+          name: ${{ github.job }}-${{ inputs.postgres-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}${{ inputs.config-file-suffix }}.coverage
           path: coverage.xml

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -15,6 +15,10 @@ on:
       dependency-versions:
         required: true
         type: string
+      config-file-suffix:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   phpunit-sqlite:
@@ -50,10 +54,10 @@ jobs:
         if: ${{ inputs.extension == 'sqlite3' }}
 
       - name: Run PHPUnit
-        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}.xml --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}${{ inputs.config-file-suffix }}.xml --coverage-clover=coverage.xml
 
       - name: Upload coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}-php-${{ inputs.php-version }}-${{ inputs.extension }}-${{ inputs.dependency-versions }}.coverage
+          name: ${{ github.job }}-php-${{ inputs.php-version }}-${{ inputs.extension }}${{ inputs.config-file-suffix }}-${{ inputs.dependency-versions }}.coverage
           path: coverage.xml

--- a/ci/github/phpunit/pdo_pgsql-stringify_fetches.xml
+++ b/ci/github/phpunit/pdo_pgsql-stringify_fetches.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <var name="db_driver" value="pdo_pgsql"/>
+        <!-- see \PDO::ATTR_STRINGIFY_FETCHES-->
+        <var name="db_driver_option_17" value="true"/>
+        <var name="db_host" value="localhost" />
+        <var name="db_user" value="postgres" />
+        <var name="db_password" value="postgres" />
+        <var name="db_dbname" value="doctrine_tests" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../../../tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>../../../src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/ci/github/phpunit/pdo_sqlite-stringify_fetches.xml
+++ b/ci/github/phpunit/pdo_sqlite-stringify_fetches.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <var name="db_driver" value="pdo_sqlite"/>
+        <!-- see \PDO::ATTR_STRINGIFY_FETCHES-->
+        <var name="db_driver_option_17" value="true"/>
+        <var name="db_memory" value="true"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine DBAL Test Suite">
+            <directory>../../../tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>../../../src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -128,8 +128,8 @@ SQL,
             [
                 'onUpdate' => $onUpdate,
                 'onDelete' => $onDelete,
-                'deferrable' => $tableForeignKey['condeferrable'],
-                'deferred' => $tableForeignKey['condeferred'],
+                'deferrable' => (bool) $tableForeignKey['condeferrable'],
+                'deferred' => (bool) $tableForeignKey['condeferred'],
             ],
         );
     }

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -170,7 +170,7 @@ SQL,
                 return [
                     'key_name' => $row['relname'],
                     'non_unique' => ! $row['indisunique'],
-                    'primary' => $row['indisprimary'],
+                    'primary' => (bool) $row['indisprimary'],
                     'where' => $row['where'],
                     'column_name' => $row['attname'],
                 ];

--- a/tests/Functional/Driver/DBAL6044Test.php
+++ b/tests/Functional/Driver/DBAL6044Test.php
@@ -16,7 +16,7 @@ class DBAL6044Test extends FunctionalTestCase
     {
         parent::setUp();
 
-        if (TestUtil::isDriverOneOf('pdo_pgsql', 'pgsql')) {
+        if (TestUtil::isDriverOneOf('pdo_pgsql', 'pgsql') && ! TestUtil::isPdoStringifyFetchesEnabled()) {
             return;
         }
 

--- a/tests/Functional/FetchBooleanTest.php
+++ b/tests/Functional/FetchBooleanTest.php
@@ -20,7 +20,7 @@ class FetchBooleanTest extends FunctionalTestCase
             return;
         }
 
-        self::markTestSkipped('Only PostgreSQL supports boolean values natively');
+        self::markTestSkipped('Only PostgreSQL supports boolean values natively, as long as PDO does not stringify them.');
     }
 
     #[DataProvider('booleanLiteralProvider')]

--- a/tests/Functional/FetchBooleanTest.php
+++ b/tests/Functional/FetchBooleanTest.php
@@ -6,13 +6,17 @@ namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class FetchBooleanTest extends FunctionalTestCase
 {
     protected function setUp(): void
     {
-        if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+        if (
+            $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform
+            && !TestUtil::isPdoStringifyFetchesEnabled()
+        ) {
             return;
         }
 

--- a/tests/Functional/FetchBooleanTest.php
+++ b/tests/Functional/FetchBooleanTest.php
@@ -20,7 +20,9 @@ class FetchBooleanTest extends FunctionalTestCase
             return;
         }
 
-        self::markTestSkipped('Only PostgreSQL supports boolean values natively, as long as PDO does not stringify them.');
+        self::markTestSkipped(
+            'Only PostgreSQL supports boolean values natively, as long as PDO does not stringify them.'
+        );
     }
 
     #[DataProvider('booleanLiteralProvider')]

--- a/tests/Functional/FetchBooleanTest.php
+++ b/tests/Functional/FetchBooleanTest.php
@@ -15,7 +15,7 @@ class FetchBooleanTest extends FunctionalTestCase
     {
         if (
             $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform
-            && !TestUtil::isPdoStringifyFetchesEnabled()
+            && ! TestUtil::isPdoStringifyFetchesEnabled()
         ) {
             return;
         }

--- a/tests/Functional/FetchBooleanTest.php
+++ b/tests/Functional/FetchBooleanTest.php
@@ -21,7 +21,7 @@ class FetchBooleanTest extends FunctionalTestCase
         }
 
         self::markTestSkipped(
-            'Only PostgreSQL supports boolean values natively, as long as PDO does not stringify them.'
+            'Only PostgreSQL supports boolean values natively, as long as PDO does not stringify them.',
         );
     }
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -24,7 +24,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Types;
-use PDO;
 
 use function array_change_key_case;
 
@@ -558,7 +557,7 @@ final class QueryBuilderTest extends FunctionalTestCase
     {
         if (
             TestUtil::isDriverOneOf('pdo_oci', 'pdo_sqlsrv', 'oci8')
-            || (TestUtil::getConnectionParams()['driverOptions'][PDO::ATTR_STRINGIFY_FETCHES] ?? false) === true
+            || TestUtil::isPdoStringifyFetchesEnabled()
         ) {
             foreach ($rows as &$row) {
                 foreach ($row as &$value) {

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -11,10 +11,16 @@ class ParserTest extends FunctionalTestCase
 {
     public function testPostgreSQLJSONBQuestionOperator(): void
     {
-        if (! TestUtil::isDriverOneOf('pdo_pgsql') || TestUtil::isPdoStringifyFetchesEnabled()) {
-            self::markTestSkipped('This test requires the pdo_pgsql driver without PDO::STRINGIFY_FETCHES option.');
+        if (! TestUtil::isDriverOneOf('pdo_pgsql')) {
+            self::markTestSkipped('This test requires the pdo_pgsql driver.');
         }
 
-        self::assertTrue($this->connection->fetchOne('SELECT \'{"a":null}\'::jsonb ?? :key', ['key' => 'a']));
+        $result = $this->connection->fetchOne('SELECT \'{"a":null}\'::jsonb ?? :key', ['key' => 'a']);
+
+        if (TestUtil::isPdoStringifyFetchesEnabled()) {
+            self::assertSame('1', $result);
+        } else {
+            self::assertTrue($result);
+        }
     }
 }

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -11,8 +11,8 @@ class ParserTest extends FunctionalTestCase
 {
     public function testPostgreSQLJSONBQuestionOperator(): void
     {
-        if (! TestUtil::isDriverOneOf('pdo_pgsql')) {
-            self::markTestSkipped('This test requires the pdo_pgsql driver.');
+        if ((! TestUtil::isDriverOneOf('pdo_pgsql')) || TestUtil::isPdoStringifyFetchesEnabled()) {
+            self::markTestSkipped('This test requires the pdo_pgsql driver without PDO::STRINGIFY_FETCHES option.');
         }
 
         self::assertTrue($this->connection->fetchOne('SELECT \'{"a":null}\'::jsonb ?? :key', ['key' => 'a']));

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -11,7 +11,7 @@ class ParserTest extends FunctionalTestCase
 {
     public function testPostgreSQLJSONBQuestionOperator(): void
     {
-        if ((! TestUtil::isDriverOneOf('pdo_pgsql')) || TestUtil::isPdoStringifyFetchesEnabled()) {
+        if (! TestUtil::isDriverOneOf('pdo_pgsql') || TestUtil::isPdoStringifyFetchesEnabled()) {
             self::markTestSkipped('This test requires the pdo_pgsql driver without PDO::STRINGIFY_FETCHES option.');
         }
 

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use InvalidArgumentException;
+use PDO;
 use PHPUnit\Framework\Assert;
 
 use function array_map;
@@ -239,6 +240,11 @@ class TestUtil
         assert(isset($params['driver']));
 
         return in_array($params['driver'], $names, true);
+    }
+
+    public static function isPdoStringifyFetchesEnabled(): bool
+    {
+        return (self::getConnectionParams()['driverOptions'][PDO::ATTR_STRINGIFY_FETCHES] ?? false) === true;
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Add more unit test jobs that use the PDO::STRINGIFY_FETCHES option, as discussed in this PR: https://github.com/doctrine/dbal/pull/7028#pullrequestreview-3042233545

I didn't add a job for `pdo_oci` and `pdo_sqlsrv` as for those drivers the result in `QueryBuilderTest` was already stringified, therefore I assume those drivers always stringify the fetches, therefore a separate job is not needed