### PR TITLE
Fix binding null as a boolean parameter on pgsql

### DIFF
--- a/src/Driver/PgSQL/Statement.php
+++ b/src/Driver/PgSQL/Statement.php
@@ -81,6 +81,10 @@ final class Statement implements StatementInterface
             throw UnknownParameter::new((string) $param);
         }
 
+        if ($value === null) {
+            $type = ParameterType::NULL;
+        }
+
         if ($type === ParameterType::BOOLEAN) {
             $this->parameters[$this->parameterMap[$param]]     = (bool) $value === false ? 'f' : 't';
             $this->parameterTypes[$this->parameterMap[$param]] = ParameterType::STRING;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | Replace #7024

#### Summary

This PR fixes an issue where `null` is turned into `false` in prepared statements with the `pgsql` driver.
