### PR TITLE
Add support of new reserved word `VECTOR` (MariaDB 11.7+)

### DIFF
--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MariaDb1060Platform;
+use Doctrine\DBAL\Platforms\MariaDb110700Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQL84Platform;
@@ -42,6 +43,10 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '11.7.0', '>=')) {
+                return new MariaDb110700Platform();
+            }
+
             if (version_compare($mariaDbVersion, '10.10.0', '>=')) {
                 return new MariaDb1010Platform();
             }

--- a/src/Platforms/Keywords/MariaDb102Keywords.php
+++ b/src/Platforms/Keywords/MariaDb102Keywords.php
@@ -11,7 +11,7 @@ use Doctrine\Deprecations\Deprecation;
  *
  * @link https://mariadb.com/kb/en/the-mariadb-library/reserved-words/
  */
-final class MariaDb102Keywords extends MariaDBKeywords
+class MariaDb102Keywords extends MariaDBKeywords
 {
     /** @deprecated */
     public function getName(): string

--- a/src/Platforms/Keywords/MariaDb117Keywords.php
+++ b/src/Platforms/Keywords/MariaDb117Keywords.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+use Doctrine\Deprecations\Deprecation;
+
+use function array_merge;
+
+/**
+ * MariaDB 11.7 reserved keywords list.
+ */
+class MariaDb117Keywords extends MariaDb102Keywords
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated
+     */
+    public function getName(): string
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MariaDb117Keywords::getName() is deprecated.',
+        );
+
+        return 'MariaDb117';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @link https://mariadb.com/docs/server/reference/sql-structure/sql-language-structure/reserved-words
+     */
+    protected function getKeywords(): array
+    {
+        $keywords = parent::getKeywords();
+
+        // New Keywords and Reserved Words
+        $keywords = array_merge($keywords, ['VECTOR']);
+
+        return $keywords;
+    }
+}

--- a/src/Platforms/MariaDb110700Platform.php
+++ b/src/Platforms/MariaDb110700Platform.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\Deprecations\Deprecation;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 11.7 database platform.
+ */
+class MariaDb110700Platform extends MariaDb1010Platform
+{
+/** @deprecated Implement {@see createReservedKeywordsList()} instead. */
+    protected function getReservedKeywordsClass(): string
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4510',
+            'MariaDb110700Platform::getReservedKeywordsClass() is deprecated,'
+                . ' use MariaDb110700Platform::createReservedKeywordsList() instead.',
+        );
+
+        return Keywords\MariaDb117Keywords::class;
+    }
+}

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\Keywords\DB2Keywords;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MariaDb102Keywords;
+use Doctrine\DBAL\Platforms\Keywords\MariaDb117Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL84Keywords;
@@ -57,6 +58,7 @@ class ReservedWordsCommand extends Command
         $this->keywordLists = [
             'db2'        => new DB2Keywords(),
             'mariadb102' => new MariaDb102Keywords(),
+            'mariadb117' => new MariaDb117Keywords(),
             'mysql'      => new MySQLKeywords(),
             'mysql57'    => new MySQL57Keywords(),
             'mysql80'    => new MySQL80Keywords(),
@@ -128,6 +130,7 @@ The following keyword lists are currently shipped with Doctrine:
 
     * db2
     * mariadb102
+    * mariadb117
     * mysql
     * mysql57
     * mysql80

--- a/tests/Platforms/MariaDb110700PlatformTest.php
+++ b/tests/Platforms/MariaDb110700PlatformTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Keywords\KeywordList;
+use Doctrine\DBAL\Platforms\MariaDb110700Platform;
+
+class MariaDb110700PlatformTest extends MariaDb1052PlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MariaDb110700Platform();
+    }
+
+    public function testMariaDb117KeywordList(): void
+    {
+        $keywordList = $this->platform->getReservedKeywordsList();
+        self::assertInstanceOf(KeywordList::class, $keywordList);
+
+        self::assertTrue($keywordList->isKeyword('vector'));
+        self::assertTrue($keywordList->isKeyword('distinctrow'));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | https://github.com/doctrine/dbal/issues/7060

#### Summary

Since MariaDb 11.7 there is a new reserved word `VECTOR` which needs to be quoted for e.g. table names. Otherwise dbal will not work with MariaDb LTS 11.8.

