### PR TITLE
Improve driver error message

### DIFF
--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -26,7 +26,7 @@ class DriverException extends \Exception implements Exception, Driver\Exception
         if ($query !== null) {
             $message = 'An exception occurred while executing a query: ' . $driverException->getMessage();
         } else {
-            $message = 'An exception occurred in the driver: ' . $driverException->getMessage();
+            $message = 'An exception occurred in the database driver: ' . $driverException->getMessage();
         }
 
         parent::__construct($message, $driverException->getCode(), $driverException);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- |-----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

While working on a Symfony 7.4 project using PHP 8.3, I encountered the following error when trying to run database migrations on a PostgreSQL database:
```
In ExceptionConverter.php line 92:

An exception occurred in the driver: could not find driver
```
At first, the message was unclear and didn't indicate the root cause. It also didn't reference PostgreSQL or the database layer explicitly, which made it harder to debug. After further investigation, I discovered that the `pdo_pgsql` extension was not installed for PHP 8.3.

To improve clarity and developer experience, I updated the exception.
This wording makes it clearer that the issue is related to the database driver and may help developers diagnose the problem more quickly.
