### PR TITLE
Add the `ComparatorConfig` parameter

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -29,8 +29,6 @@ use function array_map;
 use function array_values;
 use function assert;
 use function count;
-use function func_get_arg;
-use function func_num_args;
 use function strtolower;
 
 /**
@@ -1204,9 +1202,9 @@ abstract class AbstractSchemaManager
         return $database;
     }
 
-    public function createComparator(/* ComparatorConfig $config = new ComparatorConfig() */): Comparator
+    public function createComparator(ComparatorConfig $config = new ComparatorConfig()): Comparator
     {
-        return new Comparator($this->platform, func_num_args() > 0 ? func_get_arg(0) : new ComparatorConfig());
+        return new Comparator($this->platform, $config);
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -21,8 +21,6 @@ use function array_change_key_case;
 use function array_map;
 use function assert;
 use function explode;
-use function func_get_arg;
-use function func_num_args;
 use function implode;
 use function preg_match;
 use function preg_match_all;
@@ -275,7 +273,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
     }
 
     /** @throws Exception */
-    public function createComparator(/* ComparatorConfig $config = new ComparatorConfig() */): Comparator
+    public function createComparator(ComparatorConfig $config = new ComparatorConfig()): Comparator
     {
         return new MySQL\Comparator(
             $this->platform,
@@ -286,7 +284,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
                 new ConnectionCollationMetadataProvider($this->connection),
             ),
             $this->getDefaultTableOptions(),
-            func_num_args() > 0 ? func_get_arg(0) : new ComparatorConfig(),
+            $config,
         );
     }
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -12,8 +12,6 @@ use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 
 use function assert;
-use function func_get_arg;
-use function func_num_args;
 use function implode;
 use function is_string;
 use function preg_match;
@@ -220,12 +218,12 @@ SQL,
     }
 
     /** @throws Exception */
-    public function createComparator(/* ComparatorConfig $config = new ComparatorConfig() */): Comparator
+    public function createComparator(ComparatorConfig $config = new ComparatorConfig()): Comparator
     {
         return new SQLServer\Comparator(
             $this->platform,
             $this->getDatabaseCollation(),
-            func_num_args() > 0 ? func_get_arg(0) : new ComparatorConfig(),
+            $config,
         );
     }
 

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -19,8 +19,6 @@ use function array_map;
 use function array_merge;
 use function assert;
 use function count;
-use function func_get_arg;
-use function func_num_args;
 use function implode;
 use function is_string;
 use function preg_match;
@@ -334,9 +332,9 @@ SQL
         return $sql;
     }
 
-    public function createComparator(/* ComparatorConfig $config = new ComparatorConfig() */): Comparator
+    public function createComparator(ComparatorConfig $config = new ComparatorConfig()): Comparator
     {
-        return new SQLite\Comparator($this->platform, func_num_args() > 0 ? func_get_arg(0) : new ComparatorConfig());
+        return new SQLite\Comparator($this->platform, $config);
     }
 
     protected function selectTableNames(string $databaseName): Result


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #6300

#### Summary

This PR materializes the previously virtual `ComparatorConfig` parameter in `AbstractSchemaManager::createComparator()`.
