### PR TITLE
Deprecate the new MariaDB110700Platform class

### DIFF
--- a/src/Platforms/MariaDB110700Platform.php
+++ b/src/Platforms/MariaDB110700Platform.php
@@ -10,6 +10,8 @@ use Doctrine\Deprecations\Deprecation;
 
 /**
  * Provides the behavior, features and SQL dialect of the MariaDB 11.7 database platform.
+ *
+ * @deprecated To be removed along with the keyword list feature.
  */
 class MariaDB110700Platform extends MariaDB1010Platform
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #7061

#### Summary

This class has been introduced by #7061, but it would be empty on 5.0 due to the removal of the keyword list feature.
