### PR TITLE
feat: add withComment method to add comments

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -403,7 +403,8 @@ Values of parameters used in a CTE should be defined in the main QueryBuilder.
 Comments
 ~~~~~~~~~~~
 
-To add comments to the query you can use the ``withComment()`` method which will add the comment at the top of the query:
+To add comments to the query you can use the ``withComment()`` method
+which will add the comment at the top of the query:
 
 .. code-block:: php
 
@@ -428,8 +429,9 @@ Multiple comments can be added by calling the method multiple times:
         ->withComment('Comment 2');
     // /* Comment 1 */ /* Comment 2 */ SELECT id, name FROM users
 
-Comments containing `/*` and `*/` will be sanitized in order to prevent comment injection. Each occurrence of aforementioned
-tokens will be replaced by an empty string and trimmed.
+Comments containing ``/*`` and ``*/`` will be sanitized in order to prevent
+comment injection. Each occurrence of aforementioned tokens will be replaced
+by an empty string and trimmed.
 
 .. code-block:: php
 

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -400,6 +400,34 @@ Multiple CTEs can be defined by calling the with method multiple times.
 
 Values of parameters used in a CTE should be defined in the main QueryBuilder.
 
+Comments
+~~~~~~~~~~~
+
+To add comments to the query you can use the ``withComment()`` method which will add the comment at the top of the query:
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->withComment('This is a comment');
+    // /* This is a comment */ SELECT id, name FROM users
+
+Multiple comments can be added by calling the method multiple times:
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->withComment('Comment 1')
+        ->withComment('Comment 2');
+    // /* Comment 1 */ /* Comment 2 */ SELECT id, name FROM users
+
 Building Expressions
 --------------------
 

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -401,9 +401,9 @@ Multiple CTEs can be defined by calling the with method multiple times.
 Values of parameters used in a CTE should be defined in the main QueryBuilder.
 
 Comments
-~~~~~~~~~~~
+~~~~~~~~
 
-To add comments to the query you can use the ``withComment()`` method
+To add comments to the query you can use the ``addComment()`` method
 which will add the comment at the top of the query:
 
 .. code-block:: php
@@ -413,7 +413,7 @@ which will add the comment at the top of the query:
     $queryBuilder
         ->select('id', 'name')
         ->from('users')
-        ->withComment('This is a comment');
+        ->addComment('This is a comment');
     // /* This is a comment */ SELECT id, name FROM users
 
 Multiple comments can be added by calling the method multiple times:
@@ -425,8 +425,8 @@ Multiple comments can be added by calling the method multiple times:
     $queryBuilder
         ->select('id', 'name')
         ->from('users')
-        ->withComment('Comment 1')
-        ->withComment('Comment 2');
+        ->addComment('Comment 1')
+        ->addComment('Comment 2');
     // /* Comment 1 */ /* Comment 2 */ SELECT id, name FROM users
 
 Comments containing ``/*`` and ``*/`` will be sanitized in order to prevent
@@ -440,7 +440,7 @@ by an empty string and trimmed.
     $queryBuilder
         ->select('id', 'name')
         ->from('users')
-        ->withComment('*/ drop table users; /*');
+        ->addComment('*/ drop table users; /*');
     // /* drop table users; */ SELECT id, name FROM users
 
 Building Expressions

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -403,8 +403,8 @@ Values of parameters used in a CTE should be defined in the main QueryBuilder.
 Comments
 ~~~~~~~~
 
-To add comments to the query you can use the ``addComment()`` method
-which will add the comment at the top of the query:
+To add comments to the query, use the ``addComment()`` method which
+will add the comment before the query:
 
 .. code-block:: php
 

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -428,6 +428,19 @@ Multiple comments can be added by calling the method multiple times:
         ->withComment('Comment 2');
     // /* Comment 1 */ /* Comment 2 */ SELECT id, name FROM users
 
+Comments containing `/*` and `*/` will be sanitized in order to prevent comment injection. Each occurrence of aforementioned
+tokens will be replaced by an empty string and trimmed.
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->withComment('*/ drop table users; /*');
+    // /* drop table users; */ SELECT id, name FROM users
+
 Building Expressions
 --------------------
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -366,11 +366,7 @@ class QueryBuilder
      */
     public function getSQL(): string
     {
-        if ($this->sql) {
-            return $this->sql;
-        }
-
-        return $this->getComments() . match ($this->type) {
+        return $this->sql ??= $this->getComments() . match ($this->type) {
             QueryType::INSERT => $this->getSQLForInsert(),
             QueryType::DELETE => $this->getSQLForDelete(),
             QueryType::UPDATE => $this->getSQLForUpdate(),

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -28,7 +28,9 @@ use function count;
 use function implode;
 use function is_object;
 use function sprintf;
+use function str_replace;
 use function substr;
+use function trim;
 
 /**
  * QueryBuilder class is responsible to dynamically create SQL queries.

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -27,7 +27,6 @@ use function array_unshift;
 use function count;
 use function implode;
 use function is_object;
-use function preg_replace;
 use function sprintf;
 use function str_replace;
 use function substr;
@@ -1638,12 +1637,7 @@ class QueryBuilder
 
     public function addComment(string $comment): self
     {
-        $sanitizedComment = $this->sanitizeComment($comment);
-        if ($sanitizedComment === '') {
-            return $this;
-        }
-
-        $this->comments[] = $sanitizedComment;
+        $this->comments[] = $this->sanitizeComment($comment);
 
         $this->sql = null;
 
@@ -1662,10 +1656,6 @@ class QueryBuilder
 
     private function sanitizeComment(string $comment): string
     {
-        $comment = str_replace(['*/', '/*'], '', $comment);
-        $comment = preg_replace('/[[:cntrl:]]+/u', ' ', $comment) ?? $comment;
-        $comment = preg_replace('/\s+/u', ' ', $comment) ?? $comment;
-
-        return trim($comment);
+        return trim(str_replace(['*/', '/*'], '', $comment));
     }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -22,6 +22,7 @@ use function array_filter;
 use function array_intersect;
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function array_merge;
 use function array_unshift;
 use function count;
@@ -169,6 +170,13 @@ class QueryBuilder
      * @var CommonTableExpression[]
      */
     private array $commonTableExpressions = [];
+
+    /**
+     * Comments that will be added to the query.
+     *
+     * @var string[]
+     */
+    private array $comments = [];
 
     /**
      * The query cache profile used for caching results.
@@ -358,7 +366,11 @@ class QueryBuilder
      */
     public function getSQL(): string
     {
-        return $this->sql ??= match ($this->type) {
+        if ($this->sql) {
+            return $this->sql;
+        }
+
+        return $this->getComments() . match ($this->type) {
             QueryType::INSERT => $this->getSQLForInsert(),
             QueryType::DELETE => $this->getSQLForDelete(),
             QueryType::UPDATE => $this->getSQLForUpdate(),
@@ -1624,5 +1636,21 @@ class QueryBuilder
         $this->resultCacheProfile = null;
 
         return $this;
+    }
+
+    public function withComment(string $comment): self
+    {
+        $this->comments[] = $comment;
+
+        $this->sql = null;
+
+        return $this;
+    }
+
+    private function getComments(): string
+    {
+        return implode('', array_map(static function ($comment) {
+            return sprintf('/* %s */ ', $comment);
+        }, $this->comments));
     }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1635,7 +1635,7 @@ class QueryBuilder
 
     public function withComment(string $comment): self
     {
-        $this->comments[] = $comment;
+        $this->comments[] = $this->sanitizeComment($comment);
 
         $this->sql = null;
 
@@ -1650,5 +1650,10 @@ class QueryBuilder
         }
 
         return $comments;
+    }
+
+    private function sanitizeComment(string $comment): string
+    {
+        return trim(str_replace(['*/', '/*'], '', $comment));
     }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -1633,7 +1633,7 @@ class QueryBuilder
         return $this;
     }
 
-    public function withComment(string $comment): self
+    public function addComment(string $comment): self
     {
         $this->comments[] = $this->sanitizeComment($comment);
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -27,6 +27,7 @@ use function array_unshift;
 use function count;
 use function implode;
 use function is_object;
+use function preg_replace;
 use function sprintf;
 use function str_replace;
 use function substr;
@@ -1637,7 +1638,12 @@ class QueryBuilder
 
     public function addComment(string $comment): self
     {
-        $this->comments[] = $this->sanitizeComment($comment);
+        $sanitizedComment = $this->sanitizeComment($comment);
+        if ($sanitizedComment === '') {
+            return $this;
+        }
+
+        $this->comments[] = $sanitizedComment;
 
         $this->sql = null;
 
@@ -1656,6 +1662,10 @@ class QueryBuilder
 
     private function sanitizeComment(string $comment): string
     {
-        return trim(str_replace(['*/', '/*'], '', $comment));
+        $comment = str_replace(['*/', '/*'], '', $comment);
+        $comment = preg_replace('/[[:cntrl:]]+/u', ' ', $comment) ?? $comment;
+        $comment = preg_replace('/\s+/u', ' ', $comment) ?? $comment;
+
+        return trim($comment);
     }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -22,7 +22,6 @@ use function array_filter;
 use function array_intersect;
 use function array_key_exists;
 use function array_keys;
-use function array_map;
 use function array_merge;
 use function array_unshift;
 use function count;
@@ -1645,8 +1644,11 @@ class QueryBuilder
 
     private function getComments(): string
     {
-        return implode('', array_map(static function ($comment) {
-            return sprintf('/* %s */ ', $comment);
-        }, $this->comments));
+        $comments = '';
+        foreach ($this->comments as $comment) {
+            $comments .= sprintf('/* %s */ ', $comment);
+        }
+
+        return $comments;
     }
 }

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -538,9 +538,10 @@ final class QueryBuilderTest extends FunctionalTestCase
             ->from('for_update')
             ->where('id IN (?, ?)')
             ->setParameters([1, 2], [ParameterType::INTEGER, ParameterType::INTEGER])
+            ->addComment('Test comment')
             ->addComment('*/ drop table users; /*');
 
-        self::assertSame('/* drop table users; */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
+        self::assertSame('/* Test comment */ /* drop table users; */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
         self::assertSame($expectedRows, $select->executeQuery()->fetchAllAssociative());
     }
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -528,6 +528,22 @@ final class QueryBuilderTest extends FunctionalTestCase
         self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
     }
 
+    public function testSelectWithComment(): void
+    {
+        $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 2]]);
+        $qb           = $this->connection->createQueryBuilder();
+
+        $select = $qb
+            ->select('id')
+            ->from('for_update')
+            ->where('id IN (?, ?)')
+            ->setParameters([1, 2], [ParameterType::INTEGER, ParameterType::INTEGER])
+            ->withComment('Test comment');
+
+        self::assertSame('/* Test comment */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
+        self::assertSame($expectedRows, $select->executeQuery()->fetchAllAssociative());
+    }
+
     public function testPlatformDoesNotSupportCTE(): void
     {
         if ($this->platformSupportsCTEs()) {

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -541,7 +541,10 @@ final class QueryBuilderTest extends FunctionalTestCase
             ->addComment('Test comment')
             ->addComment('*/ drop table users; /*');
 
-        self::assertSame('/* Test comment */ /* drop table users; */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
+        self::assertSame(
+            '/* Test comment */ /* drop table users; */ SELECT id FROM for_update WHERE id IN (?, ?)',
+            $select->getSQL(),
+        );
         self::assertSame($expectedRows, $select->executeQuery()->fetchAllAssociative());
     }
 

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -528,7 +528,7 @@ final class QueryBuilderTest extends FunctionalTestCase
         self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
     }
 
-    public function testSelectWithCommentIsSanitized(): void
+    public function testSelectAddCommentIsSanitized(): void
     {
         $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 2]]);
         $qb           = $this->connection->createQueryBuilder();
@@ -538,7 +538,7 @@ final class QueryBuilderTest extends FunctionalTestCase
             ->from('for_update')
             ->where('id IN (?, ?)')
             ->setParameters([1, 2], [ParameterType::INTEGER, ParameterType::INTEGER])
-            ->withComment('*/ drop table users; /*');
+            ->addComment('*/ drop table users; /*');
 
         self::assertSame('/* drop table users; */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
         self::assertSame($expectedRows, $select->executeQuery()->fetchAllAssociative());

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -528,7 +528,7 @@ final class QueryBuilderTest extends FunctionalTestCase
         self::assertSame($expectedRows, $qb->executeQuery()->fetchAllAssociative());
     }
 
-    public function testSelectWithComment(): void
+    public function testSelectWithCommentIsSanitized(): void
     {
         $expectedRows = $this->prepareExpectedRows([['id' => 1], ['id' => 2]]);
         $qb           = $this->connection->createQueryBuilder();
@@ -538,9 +538,9 @@ final class QueryBuilderTest extends FunctionalTestCase
             ->from('for_update')
             ->where('id IN (?, ?)')
             ->setParameters([1, 2], [ParameterType::INTEGER, ParameterType::INTEGER])
-            ->withComment('Test comment');
+            ->withComment('*/ drop table users; /*');
 
-        self::assertSame('/* Test comment */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
+        self::assertSame('/* drop table users; */ SELECT id FROM for_update WHERE id IN (?, ?)', $select->getSQL());
         self::assertSame($expectedRows, $select->executeQuery()->fetchAllAssociative());
     }
 

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -70,9 +70,29 @@ class QueryBuilderTest extends TestCase
         $qb = new QueryBuilder($this->conn);
 
         $qb->select('some_function()')
-           ->addComment('Test comment');
+           ->addComment('Test  comment');
 
         self::assertEquals('/* Test comment */ SELECT some_function()', (string) $qb);
+    }
+
+    public function testEmptyCommentAfterSanitizationIsIgnored(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->addComment('/* */');
+        $qb->select('1');
+
+        self::assertSame('SELECT 1', (string) $qb);
+    }
+
+    public function testControlCharactersAreNormalizedToSpaces(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->addComment("route=read\nshard=2\ttrace=abc");
+        $qb->select('1');
+
+        self::assertSame('/* route=read shard=2 trace=abc */ SELECT 1', (string) $qb);
     }
 
     public function testSimpleSelect(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -70,29 +70,9 @@ class QueryBuilderTest extends TestCase
         $qb = new QueryBuilder($this->conn);
 
         $qb->select('some_function()')
-           ->addComment('Test  comment');
+           ->addComment('Test comment');
 
         self::assertEquals('/* Test comment */ SELECT some_function()', (string) $qb);
-    }
-
-    public function testEmptyCommentAfterSanitizationIsIgnored(): void
-    {
-        $qb = new QueryBuilder($this->conn);
-
-        $qb->addComment('/* */');
-        $qb->select('1');
-
-        self::assertSame('SELECT 1', (string) $qb);
-    }
-
-    public function testControlCharactersAreNormalizedToSpaces(): void
-    {
-        $qb = new QueryBuilder($this->conn);
-
-        $qb->addComment("route=read\nshard=2\ttrace=abc");
-        $qb->select('1');
-
-        self::assertSame('/* route=read shard=2 trace=abc */ SELECT 1', (string) $qb);
     }
 
     public function testSimpleSelect(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -65,6 +65,16 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('SELECT some_function()', (string) $qb);
     }
 
+    public function testSimpleSelectWithComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('some_function()')
+           ->withComment('Test comment');
+
+        self::assertEquals('/* Test comment */ SELECT some_function()', (string) $qb);
+    }
+
     public function testSimpleSelect(): void
     {
         $qb = new QueryBuilder($this->conn);
@@ -414,6 +424,17 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('UPDATE users SET foo = ?, bar = ?', (string) $qb);
     }
 
+    public function testUpdateWithComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->update('users')
+           ->set('foo', '?')
+           ->set('bar', '?')
+           ->withComment('Test comment');
+
+        self::assertEquals('/* Test comment */ UPDATE users SET foo = ?, bar = ?', (string) $qb);
+    }
+
     public function testUpdateWhere(): void
     {
         $qb = new QueryBuilder($this->conn);
@@ -430,6 +451,15 @@ class QueryBuilderTest extends TestCase
         $qb->delete('users');
 
         self::assertEquals('DELETE FROM users', (string) $qb);
+    }
+
+    public function testDeleteWithComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->delete('users');
+        $qb->withComment('Test comment');
+
+        self::assertEquals('/* Test comment */ DELETE FROM users', (string) $qb);
     }
 
     public function testDeleteWhere(): void
@@ -453,6 +483,21 @@ class QueryBuilderTest extends TestCase
             );
 
         self::assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
+    }
+
+    public function testInsertValuesWithComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert('users')
+            ->values(
+                [
+                    'foo' => '?',
+                    'bar' => '?',
+                ],
+            )
+            ->withComment('Test comment');
+
+        self::assertEquals('/* Test comment */ INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }
 
     public function testInsertReplaceValues(): void

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -65,12 +65,12 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('SELECT some_function()', (string) $qb);
     }
 
-    public function testSimpleSelectWithComment(): void
+    public function testSimpleSelectAddComment(): void
     {
         $qb = new QueryBuilder($this->conn);
 
         $qb->select('some_function()')
-           ->withComment('Test comment');
+           ->addComment('Test comment');
 
         self::assertEquals('/* Test comment */ SELECT some_function()', (string) $qb);
     }
@@ -424,13 +424,13 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('UPDATE users SET foo = ?, bar = ?', (string) $qb);
     }
 
-    public function testUpdateWithComment(): void
+    public function testUpdateAddComment(): void
     {
         $qb = new QueryBuilder($this->conn);
         $qb->update('users')
            ->set('foo', '?')
            ->set('bar', '?')
-           ->withComment('Test comment');
+           ->addComment('Test comment');
 
         self::assertEquals('/* Test comment */ UPDATE users SET foo = ?, bar = ?', (string) $qb);
     }
@@ -453,11 +453,11 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('DELETE FROM users', (string) $qb);
     }
 
-    public function testDeleteWithComment(): void
+    public function testDeleteAddComment(): void
     {
         $qb = new QueryBuilder($this->conn);
         $qb->delete('users');
-        $qb->withComment('Test comment');
+        $qb->addComment('Test comment');
 
         self::assertEquals('/* Test comment */ DELETE FROM users', (string) $qb);
     }
@@ -485,7 +485,7 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }
 
-    public function testInsertValuesWithComment(): void
+    public function testInsertValuesAddComment(): void
     {
         $qb = new QueryBuilder($this->conn);
         $qb->insert('users')
@@ -495,7 +495,7 @@ class QueryBuilderTest extends TestCase
                     'bar' => '?',
                 ],
             )
-            ->withComment('Test comment');
+            ->addComment('Test comment');
 
         self::assertEquals('/* Test comment */ INSERT INTO users (foo, bar) VALUES(?, ?)', (string) $qb);
     }

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -75,6 +75,27 @@ class QueryBuilderTest extends TestCase
         self::assertEquals('/* Test comment */ SELECT some_function()', (string) $qb);
     }
 
+    public function testSimpleSelectAddMultilineComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+
+        $qb->select('some_function()')
+           ->addComment(
+               <<<'COMMENT'
+               This is a multiline comment.
+               It can span multiple lines.
+               COMMENT,
+           );
+
+        self::assertEquals(
+            <<<'SQL'
+            /* This is a multiline comment.
+            It can span multiple lines. */ SELECT some_function()
+            SQL,
+            (string) $qb,
+        );
+    }
+
     public function testSimpleSelect(): void
     {
         $qb = new QueryBuilder($this->conn);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #4168 

#### Summary

This PR provides new `withComment` method that adds a comment at the top of query. It works for queries and statements.

Support for different database engines is shown in the table below. As you can see, both `/* */` (slash-star) and `--` (double-hyphen) comment styles are supported across all engines. We can use either, but since double-hyphen comments terminate at the end of a line, I personally find the slash-star style more flexible and a better fit.

| Engine           | `/* */` support | `--` support |
| ------------- | -------------- | ------------- |
| SQL Server    | ✅ [^1]           | ✅ [^8]           |
| MySQL           | ✅ [^2]          | ✅ [^9]           |
|  SQLite           | ✅ [^3]          | ✅ [^10]           |
| PostgreSQL   | ✅ [^4]          | ✅ [^11]           |
| MariaDB         | ✅ [^5]          | ✅ [^12]           |
| Oracle            | ✅ [^6]          | ✅ [^13]           |
| IBM DB2         | ✅ [^7]          | ✅ [^14]           |


[^1]: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/slash-star-comment-transact-sql?view=sql-server-ver17#syntax
[^2]: https://dev.mysql.com/doc/refman/5.7/en/comments.html#:~:text=From%20a%20/*%20sequence
[^3]: https://www.sqlite.org/lang_comment.html#:~:text=C-style%20comments%20begin%20with%20"/*"
[^4]: https://www.postgresql.org/docs/7.0/syntax519.htm#:~:text=We%20also%20support%20C-style%20block%20comments,%20e.g.:
[^5]: https://mariadb.com/docs/server/reference/sql-statements/comment-syntax#:~:text=C%20style%20comments%20from
[^6]: https://docs.oracle.com/cd/E24693_01/server.11203/e17118/sql_elements006.htm#:~:text=Begin%20the%20comment%20with%20a,a%20slash%20(*/).
[^7]: https://www.ibm.com/docs/en/db2-for-zos/12.0.0?topic=statements-sql-comments#:~:text=Bracketed%20comments%20are%20introduced
[^8]: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/comment-transact-sql?view=sql-server-ver17
[^9]: https://dev.mysql.com/doc/refman/5.7/en/comments.html#:~:text=From%20a%20--%20sequence
[^10]: https://www.sqlite.org/lang_comment.html#:~:text=SQL%20comments%20begin%20with%20two%20consecutive%20%22-%22
[^11]: https://www.postgresql.org/docs/7.0/syntax519.htm#:~:text=A%20comment%20is%20an%20arbitrary%20sequence%20of%20characters%20beginning%20with%20double%20dashes
[^12]: https://mariadb.com/docs/server/reference/sql-statements/comment-syntax#:~:text=From%20a%20'--'%20to%20the%20end%20of%20a%20line
[^13]: https://docs.oracle.com/cd/E24693_01/server.11203/e17118/sql_elements006.htm#:~:text=Begin%20the%20comment%20with%20--
[^14]: https://www.ibm.com/docs/en/db2-for-zos/12.0.0?topic=statements-sql-comments#:~:text=Simple%20comments%20are%20introduced%20with%20two%20consecutive%20hyphens