### PR TITLE
Deprecate AbstractAsset::isQuoted()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated `AbstractAsset::isQuoted()`
+
+The `AbstractAsset::isQuoted()` method has been deprecated. The recommended approach depends on the object class:
+
+1. Get the object name using `NamedObject::getObjectName()` or `OptionallyNamedObject::getObjectName()`.
+2. Depending on the type of the name, use one or a combination of the following methods to get the identifier(s):
+   - For unqualified names, use `UnqualifiedName::getIdentifier()`
+   - For optionally qualified names, use `OptionallyQualifiedName::getQualifier()` and/or
+     `OptionallyQualifiedName::getUnqualifiedName()`.
+3. Use `Identifier::isQuoted()` to check if corresponding identifier(s) is (are) quoted.
+
 ## Deprecated `service` connection parameter for `oci8` and `pdo_oci` connections.
 
 Using the `service` connection parameter to indicate that the value of the `dbname` parameter is the service name has

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -54,6 +54,7 @@ abstract class AbstractAsset
      */
     protected ?string $_namespace = null;
 
+    /** @deprecated */
     protected bool $_quoted = false;
 
     /** @var list<Identifier> */
@@ -292,9 +293,22 @@ abstract class AbstractAsset
 
     /**
      * Checks if this asset's name is quoted.
+     *
+     * @deprecated Depending on the concrete class of the object, use {@see NamedObject::getObjectName()} or
+     *             {@see OptionallyNamedObject::getObjectName()} to get the name. Then, depending on the type of the
+     *             name, use {@see UnqualifiedName::getIdentifier()}, {@see OptionallyQualifiedName::getQualifier()},
+     *             or {@see OptionallyQualifiedName::getUnqualifiedName()} to get the corresponding identifiers. Then,
+     *             use {@see Identifier::$isQuoted()}.
      */
     public function isQuoted(): bool
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7084',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         return $this->_quoted;
     }
 


### PR DESCRIPTION
The `isQuoted()` method doesn't make sense applied to a database object (e.g. table). A table cannot be quoted, only an identifier can. A table name may be qualified and consist of multiple identifiers, and each of them individually may be quoted or unquoted.

The API being developed starting with https://github.com/doctrine/dbal/pull/6646 is the proper way to deal with object names and identifiers representing them.