### PR TITLE
Remove AbstractAsset::isQuoted()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractAsset::isQuoted()`
+
+The `AbstractAsset::isQuoted()` method has been removed.
+
 ## BC BREAK: Removed support for the `service` connection parameter.
 
 The `service` parameter of the `oci8` and `pdo_oci` connections is no longer supported.

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -33,7 +33,6 @@ use function implode;
 use function sprintf;
 use function str_contains;
 use function strlen;
-use function strtoupper;
 use function substr;
 
 /**

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -309,9 +309,7 @@ class OraclePlatform extends AbstractPlatform
     public function getListSequencesSQL(string $database): string
     {
         return 'SELECT SEQUENCE_NAME, MIN_VALUE, INCREMENT_BY FROM SYS.ALL_SEQUENCES WHERE SEQUENCE_OWNER = '
-            . $this->quoteStringLiteral(
-                $this->normalizeIdentifier($database)->getName(),
-            );
+            . $this->quoteStringLiteral($database);
     }
 
     /**
@@ -432,21 +430,6 @@ SQL,
             'DROP TRIGGER ' . $triggerName->toSQL($this),
             $this->getDropSequenceSQL($sequenceName->toSQL($this)),
         ];
-    }
-
-    /**
-     * Normalizes the given identifier.
-     *
-     * Uppercases the given identifier if it is not quoted by intention
-     * to reflect Oracle's internal auto uppercasing strategy of unquoted identifiers.
-     *
-     * @param string $name The identifier to normalize.
-     */
-    private function normalizeIdentifier(string $name): Identifier
-    {
-        $identifier = new Identifier($name);
-
-        return $identifier->isQuoted() ? $identifier : new Identifier(strtoupper($name));
     }
 
     /**

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function assert;
@@ -109,27 +108,6 @@ abstract class AbstractAsset
     protected function setName(?Name $name): void
     {
         throw NotImplemented::fromMethod(static::class, __FUNCTION__);
-    }
-
-    /**
-     * Checks if this asset's name is quoted.
-     *
-     * @deprecated Depending on the concrete class of the object, use {@see NamedObject::getObjectName()} or
-     *             {@see OptionallyNamedObject::getObjectName()} to get the name. Then, depending on the type of the
-     *             name, use {@see UnqualifiedName::getIdentifier()}, {@see OptionallyQualifiedName::getQualifier()},
-     *             or {@see OptionallyQualifiedName::getUnqualifiedName()} to get the corresponding identifiers. Then,
-     *             use {@see Identifier::$isQuoted()}.
-     */
-    public function isQuoted(): bool
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7084',
-            '%s is deprecated and will be removed in 5.0.',
-            __METHOD__,
-        );
-
-        return $this->_quoted;
     }
 
     /**

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -179,24 +179,6 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue($anotherSchemaTable->hasColumn('email'));
     }
 
-    public function testReturnQuotedAssets(): void
-    {
-        $this->connection->executeStatement('DROP TABLE IF EXISTS dbal91_something');
-
-        $sql = 'create table dbal91_something'
-            . ' (id integer CONSTRAINT id_something PRIMARY KEY NOT NULL, "table" integer)';
-        $this->connection->executeStatement($sql);
-
-        $sql = 'ALTER TABLE dbal91_something ADD CONSTRAINT something_input'
-            . ' FOREIGN KEY( "table" ) REFERENCES dbal91_something ON UPDATE CASCADE;';
-        $this->connection->executeStatement($sql);
-
-        $table  = $this->schemaManager->introspectTable('dbal91_something');
-        $column = $table->getColumn('table');
-
-        self::assertTrue($column->isQuoted());
-    }
-
     public function testDefaultValueCharacterVarying(): void
     {
         $testTable = Table::editor()

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -513,7 +513,6 @@ SQL
             )
             ->create();
 
-        self::assertTrue($table->isQuoted());
         self::assertEquals('test', $table->getName());
         self::assertEquals('"test"', $table->getObjectName()->toSQL($this->platform));
 

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ColumnTest extends TestCase
@@ -120,26 +119,6 @@ class ColumnTest extends TestCase
 
         self::assertEquals('bar', $column->getName());
         self::assertEquals('[bar]', $column->getObjectName()->toSQL($sqlServerPlatform));
-    }
-
-    #[DataProvider('getIsQuoted')]
-    public function testIsQuoted(string $columnName, bool $isQuoted): void
-    {
-        $type   = Type::getType(Types::STRING);
-        $column = new Column($columnName, $type);
-
-        self::assertSame($isQuoted, $column->isQuoted());
-    }
-
-    /** @return mixed[][] */
-    public static function getIsQuoted(): iterable
-    {
-        return [
-            ['bar', false],
-            ['`bar`', true],
-            ['"bar"', true],
-            ['[bar]', true],
-        ];
     }
 
     public function testColumnComment(): void


### PR DESCRIPTION
The method being removed was deprecated in https://github.com/doctrine/dbal/pull/7084.

Additionally, do not "normalize" database name in `OraclePlatform::getListSequencesSQL()`:
1. This method is internal and is only invoked from `AbstractSchemaManager::listSequences()`.
2. The `$database` argument is always the return value of `AbstractSchemaManager::getDatabase()`, which is always a _value_, not a user-provided SQL expression that may be quoted.
3. This is consistent with `PostgreSQLPlatform::getListSequencesSQL()`, where the `$database` parameter is also interpreted as a value, not as SQL: https://github.com/doctrine/dbal/blob/c6d905bfedb8224eb2010fe608599050485d0994/src/Platforms/PostgreSQLPlatform.php#L157