### PR TITLE
Bump doctrine/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "doctrine/cache": "^1.11|^2.0",
-        "doctrine/coding-standard": "13.0.0",
+        "doctrine/coding-standard": "13.0.1",
         "fig/log-test": "^1",
         "jetbrains/phpstorm-stubs": "2023.1",
         "phpstan/phpstan": "2.1.22",


### PR DESCRIPTION
Currently, running phpcs on this repository produces a warning, the upgrade makes it vanish:

>  Squiz.WhiteSpace.LanguageConstructSpacing
>  This sniff has been deprecated since v3.3.0 and will be removed in v4.0.0. Use the
>  Generic.WhiteSpace.LanguageConstructSpacing sniff instead.
