### PR TITLE
Deprecate AbstractAsset::getName()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated `AbstractAsset::getName()`
+
+The `AbstractAsset::getName()` method has been deprecated. Instead, use `NamedObject::getObjectName()` or 
+`OptionallyQualifiedName::getObjectName()` to get the object representation of the name. SQL context, convert the
+resulting `Name` to SQL using `Name::toSQL()`. In other contexts, convert the resulting name to string using
+`Name::toString()`.
+
 ## Deprecated `AbstractAsset::isQuoted()`
 
 The `AbstractAsset::isQuoted()` method has been deprecated. The recommended approach depends on the object class:
@@ -326,7 +333,7 @@ The `Table::__construct()` method has been marked as internal. Use `Table::edito
 
 ## Deprecated `AbstractAsset::getShortestName()`
 
-The `AbstractAsset::getShortestName()` method has been deprecated. Use `AbstractAsset::getName()` instead.
+The `AbstractAsset::getShortestName()` method has been deprecated. Use `NamedObject::getObjectName()` instead.
 
 ## Deprecated `Sequence::isAutoIncrementsFor()`
 

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -59,7 +59,7 @@ Now you can loop over the array inspecting each sequence object:
 
     <?php
     foreach ($sequences as $sequence) {
-        echo $sequence->getName() . "\n";
+        echo $sequence->getObjectName()->toString() . "\n";
     }
 
 listTableColumns()
@@ -79,7 +79,7 @@ Now you can loop over the array inspecting each column object:
 
     <?php
     foreach ($columns as $column) {
-        echo $column->getName() . ': ' . $column->getType() . "\n";
+        echo $column->getObjectName()->toString() . ': ' . $column->getType() . "\n";
     }
 
 introspectTable()
@@ -119,7 +119,7 @@ object:
 
     <?php
     foreach ($foreignKeys as $foreignKey) {
-        echo $foreignKey->getName() ."\n";
+        echo $foreignKey->getObjectName()->toString() . "\n";
     }
 
 listTableIndexes()
@@ -139,7 +139,7 @@ Now you can loop over the array inspecting each index object:
 
     <?php
     foreach ($indexes as $index) {
-        echo $index->getName() . ': ' . ($index->isUnique() ? 'unique' : 'not unique') . "\n";
+        echo $index->getObjectName()->toString() . ': ' . ($index->isUnique() ? 'unique' : 'not unique') . "\n";
     }
 
 listTables()
@@ -162,9 +162,9 @@ retrieved with the ``getColumns()`` method:
 
     <?php
     foreach ($tables as $table) {
-        echo $table->getName() . " columns:\n\n";
+        echo $table->getObjectName()->toString() . " columns:\n\n";
         foreach ($table->getColumns() as $column) {
-            echo ' - ' . $column->getName() . "\n";
+            echo ' - ' . $column->getObjectName()->toString() . "\n";
         }
     }
 
@@ -185,7 +185,7 @@ Now you can loop over the array inspecting each view object:
 
     <?php
     foreach ($views as $view) {
-        echo $view->getName() . ': ' . $view->getSql() . "\n";
+        echo $view->getObjectName()->toString() . ': ' . $view->getSql() . "\n";
     }
 
 introspectSchema()

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -59,7 +59,7 @@ Now you can loop over the array inspecting each sequence object:
 
     <?php
     foreach ($sequences as $sequence) {
-        echo $sequence->getObjectName()->toString() . "\n";
+        echo $sequence->getObjectName()->toString() . PHP_EOL;
     }
 
 listTableColumns()
@@ -79,7 +79,7 @@ Now you can loop over the array inspecting each column object:
 
     <?php
     foreach ($columns as $column) {
-        echo $column->getObjectName()->toString() . ': ' . $column->getType() . "\n";
+        echo $column->getObjectName()->toString() . ': ' . $column->getType() . PHP_EOL;
     }
 
 introspectTable()
@@ -119,7 +119,7 @@ object:
 
     <?php
     foreach ($foreignKeys as $foreignKey) {
-        echo $foreignKey->getObjectName()->toString() . "\n";
+        echo $foreignKey->getObjectName()->toString() . PHP_EOL;
     }
 
 listTableIndexes()
@@ -139,7 +139,7 @@ Now you can loop over the array inspecting each index object:
 
     <?php
     foreach ($indexes as $index) {
-        echo $index->getObjectName()->toString() . ': ' . ($index->isUnique() ? 'unique' : 'not unique') . "\n";
+        echo $index->getObjectName()->toString() . ': ' . ($index->isUnique() ? 'unique' : 'not unique') . PHP_EOL;
     }
 
 listTables()
@@ -162,9 +162,9 @@ retrieved with the ``getColumns()`` method:
 
     <?php
     foreach ($tables as $table) {
-        echo $table->getObjectName()->toString() . " columns:\n\n";
+        echo $table->getObjectName()->toString() . " columns:" . PHP_EOL;
         foreach ($table->getColumns() as $column) {
-            echo ' - ' . $column->getObjectName()->toString() . "\n";
+            echo ' - ' . $column->getObjectName()->toString() . PHP_EOL;
         }
     }
 
@@ -185,7 +185,7 @@ Now you can loop over the array inspecting each view object:
 
     <?php
     foreach ($views as $view) {
-        echo $view->getObjectName()->toString() . ': ' . $view->getSql() . "\n";
+        echo $view->getObjectName()->toString() . ': ' . $view->getSql() . PHP_EOL;
     }
 
 introspectSchema()

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -139,7 +139,12 @@ Now you can loop over the array inspecting each index object:
 
     <?php
     foreach ($indexes as $index) {
-        echo $index->getObjectName()->toString() . ': ' . ($index->isUnique() ? 'unique' : 'not unique') . PHP_EOL;
+        echo $index->getObjectName()->toString() . ': ' . match($index->getType()) {
+            IndexType::REGULAR  => 'regular',
+            IndexType::UNIQUE   => 'unique',
+            IndexType::FULLTEXT => 'fulltext',
+            IndexType::SPATIAL  => 'spatial',
+        } . PHP_EOL;
     }
 
 listTables()

--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -272,7 +272,7 @@ abstract class AbstractAsset
      * The shortest name is stripped of the default namespace. All other
      * namespaced elements are returned as full-qualified names.
      *
-     * @deprecated Use {@link getName()} instead.
+     * @deprecated Use {@see NamedObject::getObjectName()} instead.
      */
     public function getShortestName(?string $defaultNamespaceName): string
     {
@@ -340,9 +340,20 @@ abstract class AbstractAsset
 
     /**
      * Returns the name of this schema asset.
+     *
+     * @deprecated Use {@see NamedObject::getObjectName()} or {@see OptionallyQualifiedName::getObjectName()} instead.
+     *             In SQL context, convert the resulting {@see Name} to SQL using {@see Name::toSQL()}. In other
+     *             contexts, convert the resulting name to string using {@see Name::toString()}.
      */
     public function getName(): string
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7094',
+            '%s is deprecated and will be removed in 5.0.',
+            __METHOD__,
+        );
+
         if ($this->_namespace !== null) {
             return $this->_namespace . '.' . $this->_name;
         }

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -88,7 +88,7 @@ abstract class AbstractSchemaManager
     /**
      * Lists the available sequences for this connection.
      *
-     * @return array<int, Sequence>
+     * @return list<Sequence>
      *
      * @throws Exception
      */
@@ -177,7 +177,7 @@ abstract class AbstractSchemaManager
     /**
      * Returns a list of all tables in the current database.
      *
-     * @return array<int, non-empty-string>
+     * @return list<non-empty-string>
      *
      * @throws Exception
      */
@@ -196,9 +196,11 @@ abstract class AbstractSchemaManager
      * Filters asset names if they are configured to return only a subset of all
      * the found elements.
      *
-     * @param array<int, mixed> $assetNames
+     * @param list<N> $assetNames
      *
-     * @return array<int, mixed>
+     * @return list<N>
+     *
+     * @template N
      */
     private function filterAssetNames(array $assetNames): array
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -643,10 +643,11 @@ class Table extends AbstractNamedObject
     /**
      * Returns the list of table columns.
      *
-     * @return list<Column>
+     * @return non-empty-list<Column>
      */
     public function getColumns(): array
     {
+        /** @phpstan-ignore return.type */
         return array_values($this->_columns);
     }
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -412,7 +412,7 @@ class Table extends AbstractNamedObject
         if ($oldName === $newName) {
             throw new LogicException(sprintf(
                 'Attempt to rename column "%s.%s" to the same name.',
-                $this->getName(),
+                $this->name->toString(),
                 $oldName,
             ));
         }

--- a/tests/Functional/Driver/DBAL6024Test.php
+++ b/tests/Functional/Driver/DBAL6024Test.php
@@ -54,7 +54,7 @@ class DBAL6024Test extends FunctionalTestCase
         }
 
         $validationSchema = $schemaManager->introspectSchema();
-        $validationTable  = $validationSchema->getTable($table->getName());
+        $validationTable  = $validationSchema->getTable($table->getObjectName()->toString());
 
         self::assertNull($validationTable->getPrimaryKey());
     }

--- a/tests/Functional/Driver/DBAL6044Test.php
+++ b/tests/Functional/Driver/DBAL6044Test.php
@@ -53,19 +53,19 @@ class DBAL6044Test extends FunctionalTestCase
         $schemaManager = $this->connection->createSchemaManager();
 
         $validationSchema        = $schemaManager->introspectSchema();
-        $validationUnloggedTable = $validationSchema->getTable($unloggedTable->getName());
+        $validationUnloggedTable = $validationSchema->getTable($unloggedTable->getObjectName()->toString());
         self::assertTrue($validationUnloggedTable->getOption('unlogged'));
-        $validationLoggedTable = $validationSchema->getTable($loggedTable->getName());
+        $validationLoggedTable = $validationSchema->getTable($loggedTable->getObjectName()->toString());
         self::assertFalse($validationLoggedTable->getOption('unlogged'));
 
         $sql  = 'SELECT relpersistence FROM pg_class WHERE relname = ?';
         $stmt = $this->connection->prepare($sql);
 
-        $stmt->bindValue(1, $unloggedTable->getName());
+        $stmt->bindValue(1, $unloggedTable->getObjectName()->toString());
         $unloggedTablePersistenceType = $stmt->executeQuery()->fetchOne();
         self::assertEquals('u', $unloggedTablePersistenceType);
 
-        $stmt->bindValue(1, $loggedTable->getName());
+        $stmt->bindValue(1, $loggedTable->getObjectName()->toString());
         $loggedTablePersistenceType = $stmt->executeQuery()->fetchOne();
         self::assertEquals('p', $loggedTablePersistenceType);
     }

--- a/tests/Functional/Platform/AlterColumnTest.php
+++ b/tests/Functional/Platform/AlterColumnTest.php
@@ -7,9 +7,12 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
+
+use function array_map;
 
 class AlterColumnTest extends FunctionalTestCase
 {
@@ -45,12 +48,15 @@ class AlterColumnTest extends FunctionalTestCase
 
         $sm->alterTable($diff);
 
-        $table   = $sm->introspectTable('test_alter');
-        $columns = $table->getColumns();
+        $table = $sm->introspectTable('test_alter');
 
-        self::assertCount(2, $columns);
-        self::assertEqualsIgnoringCase('c1', $columns[0]->getName());
-        self::assertEqualsIgnoringCase('c2', $columns[1]->getName());
+        $this->assertUnqualifiedNameListEquals([
+            UnqualifiedName::unquoted('c1'),
+            UnqualifiedName::unquoted('c2'),
+        ], array_map(
+            static fn (Column $column): UnqualifiedName => $column->getObjectName(),
+            $table->getColumns(),
+        ));
     }
 
     public function testSupportsCollations(): void

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -413,7 +413,10 @@ class AlterTableTest extends FunctionalTestCase
 
         $schemaManager->alterTable($diff);
 
-        $introspectedTable = $schemaManager->introspectTable($newTable->getName());
+        $introspectedTable = $schemaManager->introspectTable(
+            $newTable->getObjectName()
+                ->toString(),
+        );
 
         $diff = $schemaManager->createComparator()
             ->compareTables($newTable, $introspectedTable);

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Platform\RenameColumnTest;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -113,11 +114,19 @@ class ComparatorTest extends FunctionalTestCase
         $renamedAndModified = $compareResult->getChangedColumns()['test'];
         $modifiedOnly       = $compareResult->getChangedColumns()['test3'];
 
-        self::assertEquals('foo', $renamedOnly->getNewColumn()->getName());
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('test2'),
+            $renamedOnly->getNewColumn()->getObjectName(),
+        );
+
         self::assertTrue($renamedOnly->hasNameChanged());
         self::assertEquals(1, $renamedOnly->countChangedProperties());
 
-        self::assertEquals('baz', $renamedAndModified->getNewColumn()->getName());
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('test'),
+            $renamedAndModified->getNewColumn()->getObjectName(),
+        );
+
         self::assertTrue($renamedAndModified->hasNameChanged());
         self::assertTrue($renamedAndModified->hasLengthChanged());
         self::assertTrue($renamedAndModified->hasCommentChanged());

--- a/tests/Functional/Schema/ComparatorTestUtils.php
+++ b/tests/Functional/Schema/ComparatorTestUtils.php
@@ -21,7 +21,10 @@ final class ComparatorTestUtils
         Table $desiredTable,
     ): TableDiff {
         return $comparator->compareTables(
-            $schemaManager->introspectTable($desiredTable->getName()),
+            $schemaManager->introspectTable(
+                $desiredTable->getObjectName()
+                    ->toString(),
+            ),
             $desiredTable,
         );
     }
@@ -34,7 +37,10 @@ final class ComparatorTestUtils
     ): TableDiff {
         return $comparator->compareTables(
             $desiredTable,
-            $schemaManager->introspectTable($desiredTable->getName()),
+            $schemaManager->introspectTable(
+                $desiredTable->getObjectName()
+                    ->toString(),
+            ),
         );
     }
 

--- a/tests/Functional/Schema/CustomIntrospectionTest.php
+++ b/tests/Functional/Schema/CustomIntrospectionTest.php
@@ -66,14 +66,13 @@ class CustomIntrospectionTest extends FunctionalTestCase
 
         $onlineTable = $schemaManager->introspectTable('test_custom_column_introspection');
         $diff        = $schemaManager->createComparator()->compareTables($onlineTable, $table);
-        $changedCols = array_map(
-            static fn (ColumnDiff $columnDiff): string => $columnDiff->getOldColumn()->getName(),
-            $diff->getChangedColumns(),
-        );
 
         self::assertTrue($diff->isEmpty(), sprintf(
             'Tables should be identical. Differences detected in %s.',
-            implode(', ', $changedCols),
+            implode(', ', array_map(
+                static fn (ColumnDiff $columnDiff): string => $columnDiff->getOldColumn()->getObjectName()->toString(),
+                $diff->getChangedColumns(),
+            )),
         ));
     }
 }

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -114,14 +114,21 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $schemaManager = $connection->createSchemaManager();
 
         try {
-            $schemaManager->dropTable($otherTable->getName());
+            $schemaManager->dropTable(
+                $otherTable->getObjectName()
+                    ->toSQL($connection->getDatabasePlatform()),
+            );
         } catch (DatabaseObjectNotFoundException) {
         }
 
         $schemaManager->createTable($otherTable);
         $connection->close();
 
-        $columns = $this->schemaManager->listTableColumns($table->getName());
+        $columns = $this->schemaManager->listTableColumns(
+            $table->getObjectName()
+                ->toString(),
+        );
+
         self::assertCount(7, $columns);
     }
 

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -25,7 +25,6 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 use function sprintf;
-use function strtolower;
 use function version_compare;
 
 class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
@@ -406,16 +405,9 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $tables = $this->schemaManager->listTables();
 
-        $foundTable = false;
-        foreach ($tables as $table) {
-            if (strtolower($table->getName()) !== 'list_tables_excludes_views_test_view') {
-                continue;
-            }
+        $foundTable = $this->findObjectByShortestName($tables, 'list_tables_excludes_views_test_view');
 
-            $foundTable = true;
-        }
-
-        self::assertFalse($foundTable, 'View "list_tables_excludes_views_test_view" must not be found in table list');
+        self::assertNull($foundTable, 'View "list_tables_excludes_views_test_view" must not be found in table list');
     }
 
     public function testPartialIndexes(): void

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -236,7 +236,10 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($testTable);
 
-        $databaseTable = $this->schemaManager->introspectTable($testTable->getName());
+        $databaseTable = $this->schemaManager->introspectTable(
+            $testTable->getObjectName()
+                ->toString(),
+        );
 
         self::assertEquals('foo', $databaseTable->getColumn('def')->getDefault());
     }
@@ -281,7 +284,10 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $databaseTable = $this->schemaManager->introspectTable($table->getName());
+        $databaseTable = $this->schemaManager->introspectTable(
+            $table->getObjectName()
+                ->toString(),
+        );
 
         self::assertTrue(
             $this->schemaManager->createComparator()
@@ -314,7 +320,10 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
-        $databaseTable = $this->schemaManager->introspectTable($table->getName());
+        $databaseTable = $this->schemaManager->introspectTable(
+            $table->getObjectName()
+                ->toString(),
+        );
 
         self::assertTrue(
             $this->schemaManager->createComparator()

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -394,13 +394,13 @@ SQL;
         self::assertCount(2, $foreignKeys);
 
         $foreignKey1 = $foreignKeys[0];
-        self::assertEmpty($foreignKey1->getName());
+        self::assertNull($foreignKey1->getObjectName());
 
         self::assertSame(['album_id'], $foreignKey1->getLocalColumns());
         self::assertSame(['id'], $foreignKey1->getForeignColumns());
 
         $foreignKey2 = $foreignKeys[1];
-        self::assertEmpty($foreignKey2->getName());
+        self::assertNull($foreignKey2->getObjectName());
 
         self::assertSame(['artist_id'], $foreignKey2->getLocalColumns());
         self::assertSame(['id'], $foreignKey2->getForeignColumns());
@@ -467,7 +467,7 @@ SQL;
         self::assertCount(1, $foreignKeys);
 
         $foreignKey1 = $foreignKeys[0];
-        self::assertEmpty($foreignKey1->getName());
+        self::assertNull($foreignKey1->getObjectName());
 
         self::assertSame(['trackartist'], $foreignKey1->getLocalColumns());
         self::assertSame(['artistid'], $foreignKey1->getForeignColumns());

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -328,7 +328,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertArrayHasKey('id', $columns);
         self::assertEquals(0, array_search('id', $columnsKeys, true));
-        self::assertEquals('id', strtolower($columns['id']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('id'),
+            $columns['id']->getObjectName(),
+        );
         self::assertInstanceOf(IntegerType::class, $columns['id']->getType());
         self::assertEquals(false, $columns['id']->getUnsigned());
         self::assertEquals(true, $columns['id']->getNotnull());
@@ -336,14 +339,20 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         self::assertArrayHasKey('test', $columns);
         self::assertEquals(1, array_search('test', $columnsKeys, true));
-        self::assertEquals('test', strtolower($columns['test']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('test'),
+            $columns['test']->getObjectName(),
+        );
         self::assertInstanceOf(StringType::class, $columns['test']->getType());
         self::assertEquals(255, $columns['test']->getLength());
         self::assertEquals(false, $columns['test']->getFixed());
         self::assertEquals(false, $columns['test']->getNotnull());
         self::assertEquals('expected default', $columns['test']->getDefault());
 
-        self::assertEquals('foo', strtolower($columns['foo']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('foo'),
+            $columns['foo']->getObjectName(),
+        );
         self::assertEquals(2, array_search('foo', $columnsKeys, true));
         self::assertInstanceOf(TextType::class, $columns['foo']->getType());
         self::assertEquals(false, $columns['foo']->getUnsigned());
@@ -351,7 +360,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals(true, $columns['foo']->getNotnull());
         self::assertEquals(null, $columns['foo']->getDefault());
 
-        self::assertEquals('bar', strtolower($columns['bar']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('bar'),
+            $columns['bar']->getObjectName(),
+        );
         self::assertEquals(3, array_search('bar', $columnsKeys, true));
         self::assertInstanceOf(DecimalType::class, $columns['bar']->getType());
         self::assertEquals(null, $columns['bar']->getLength());
@@ -362,13 +374,19 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals(false, $columns['bar']->getNotnull());
         self::assertEquals(null, $columns['bar']->getDefault());
 
-        self::assertEquals('baz1', strtolower($columns['baz1']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('baz1'),
+            $columns['baz1']->getObjectName(),
+        );
         self::assertEquals(4, array_search('baz1', $columnsKeys, true));
         self::assertInstanceOf(DateTimeType::class, $columns['baz1']->getType());
         self::assertEquals(true, $columns['baz1']->getNotnull());
         self::assertEquals(null, $columns['baz1']->getDefault());
 
-        self::assertEquals('baz2', strtolower($columns['baz2']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('baz2'),
+            $columns['baz2']->getObjectName(),
+        );
         self::assertEquals(5, array_search('baz2', $columnsKeys, true));
         self::assertContains(
             $columns['baz2']->getType()::class,
@@ -377,7 +395,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals(true, $columns['baz2']->getNotnull());
         self::assertEquals(null, $columns['baz2']->getDefault());
 
-        self::assertEquals('baz3', strtolower($columns['baz3']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('baz3'),
+            $columns['baz3']->getObjectName(),
+        );
         self::assertEquals(6, array_search('baz3', $columnsKeys, true));
         self::assertContains(
             $columns['baz3']->getType()::class,
@@ -461,12 +482,18 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertTrue($tableIndexes['primary']->isUnique());
         self::assertTrue($tableIndexes['primary']->isPrimary());
 
-        self::assertEquals('test_index_name', strtolower($tableIndexes['test_index_name']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('test_index_name'),
+            $tableIndexes['test_index_name']->getObjectName(),
+        );
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test_index_name']->getColumns()));
         self::assertTrue($tableIndexes['test_index_name']->isUnique());
         self::assertFalse($tableIndexes['test_index_name']->isPrimary());
 
-        self::assertEquals('test_composite_idx', strtolower($tableIndexes['test_composite_idx']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('test_composite_idx'),
+            $tableIndexes['test_composite_idx']->getObjectName(),
+        );
         self::assertEquals(['id', 'test'], array_map('strtolower', $tableIndexes['test_composite_idx']->getColumns()));
         self::assertFalse($tableIndexes['test_composite_idx']->isUnique());
         self::assertFalse($tableIndexes['test_composite_idx']->isPrimary());
@@ -487,12 +514,24 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
+        $platform = $this->connection->getDatabasePlatform();
+
         $index = $table->getIndex('test');
-        $this->schemaManager->dropIndex($index->getName(), $table->getName());
-        $this->schemaManager->createIndex($index, $table->getName());
+        $this->schemaManager->dropIndex(
+            $index->getObjectName()->toSQL($platform),
+            $table->getObjectName()->toSQL($platform),
+        );
+
+        $this->schemaManager->createIndex(
+            $index,
+            $table->getObjectName()->toSQL($platform),
+        );
         $tableIndexes = $this->schemaManager->listTableIndexes('test_create_index');
 
-        self::assertEquals('test', strtolower($tableIndexes['test']->getName()));
+        $this->assertUnqualifiedNameEquals(
+            UnqualifiedName::unquoted('test'),
+            $tableIndexes['test']->getObjectName(),
+        );
         self::assertEquals(['test'], array_map('strtolower', $tableIndexes['test']->getColumns()));
         self::assertTrue($tableIndexes['test']->isUnique());
         self::assertFalse($tableIndexes['test']->isPrimary());
@@ -516,12 +555,19 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->dropAndCreateTable($table);
 
+        $constraintName = UnqualifiedName::quoted('uniq_id');
+
         $uniqueConstraint = UniqueConstraint::editor()
-            ->setUnquotedName('uniq_id')
+            ->setName($constraintName)
             ->setUnquotedColumnNames('id')
             ->create();
 
-        $this->schemaManager->createUniqueConstraint($uniqueConstraint, $table->getName());
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->schemaManager->createUniqueConstraint(
+            $uniqueConstraint,
+            $table->getObjectName()->toSQL($platform),
+        );
 
         // there's currently no API for introspecting unique constraints,
         // so introspect the underlying indexes instead
@@ -534,7 +580,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEqualsIgnoringCase('uniq_id', $index->getName());
         self::assertTrue($index->isUnique());
 
-        $this->schemaManager->dropUniqueConstraint($uniqueConstraint->getName(), $table->getName());
+        $this->schemaManager->dropUniqueConstraint(
+            $constraintName->toSQL($platform),
+            $table->getObjectName()->toSQL($platform),
+        );
 
         $indexes = $this->schemaManager->listTableIndexes('test_unique_constraint');
         self::assertEmpty($indexes);
@@ -795,8 +844,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->create();
 
-        $this->dropTableIfExists($tableFK->getName());
-        $this->dropTableIfExists($table->getName());
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->dropTableIfExists($tableFK->getObjectName()->toSQL($platform));
+        $this->dropTableIfExists($table->getObjectName()->toSQL($platform));
 
         $this->schemaManager->createTable($table);
         $this->schemaManager->createTable($tableFK);
@@ -838,7 +889,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $diff = $this->schemaManager->createComparator()
             ->compareTables(
-                $this->schemaManager->introspectTable($tableFK->getName()),
+                $this->schemaManager->introspectTable($tableFK->getObjectName()->toString()),
                 $tableFKNew,
             );
 
@@ -896,8 +947,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->create();
 
-        $this->dropTableIfExists($foreignTable->getName());
-        $this->dropTableIfExists($primaryTable->getName());
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->dropTableIfExists($foreignTable->getObjectName()->toSQL($platform));
+        $this->dropTableIfExists($primaryTable->getObjectName()->toSQL($platform));
 
         $this->schemaManager->createTable($primaryTable);
         $this->schemaManager->createTable($foreignTable);
@@ -1409,7 +1462,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $sequence               = new Sequence($sequenceName, $sequenceAllocationSize, $sequenceInitialValue);
 
         try {
-            $this->schemaManager->dropSequence($sequence->getName());
+            $this->schemaManager->dropSequence(
+                $sequence->getObjectName()
+                    ->toSQL($platform),
+            );
         } catch (DatabaseObjectNotFoundException) {
         }
 

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -517,7 +517,7 @@ class DB2PlatformTest extends AbstractPlatformTestCase
             ->create();
 
         $tableDiff = new TableDiff($table, changedColumns: [
-            $oldColumn->getName() => new ColumnDiff($oldColumn, $newColumn),
+            $oldColumn->getObjectName()->toString() => new ColumnDiff($oldColumn, $newColumn),
         ]);
 
         $expectedSQL = [];

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -563,7 +563,7 @@ SQL
             ->create();
 
         self::assertTrue($table->isQuoted());
-        self::assertEquals('test', $table->getName());
+        self::assertEquals('test', $table->getObjectName()->getUnqualifiedName()->getValue());
         self::assertEquals('"test"', $table->getQuotedName($this->platform));
 
         $sql = $this->platform->getCreateTableSQL($table);

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -205,7 +205,7 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
             (new class () extends SqlitePlatform {
                 public function getCreatePrimaryKeySQL(Index $index, string $table): string
                 {
-                    return 'TEST: ' . $table . ', ' . $index->getName()
+                    return 'TEST: ' . $table . ', ' . $index->getObjectName()->toString()
                         . ' - ' . implode(', ', $index->getColumns());
                 }
             })->getCreateIndexSQL($primaryIndexDef, 'main.mytable'),

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
-use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
@@ -14,6 +13,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
@@ -270,7 +270,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         $renamedColumns = RenameColumnTest::getRenamedColumns($tableDiff);
         self::assertCount(1, $renamedColumns);
         self::assertArrayHasKey('datecolumn1', $renamedColumns);
-        self::assertEquals(['new_datecolumn2'], $this->getAssetNames($tableDiff->getAddedColumns()));
+        self::assertEquals(['new_datecolumn2'], $this->getObjectNames($tableDiff->getAddedColumns()));
 
         self::assertCount(0, $tableDiff->getDroppedColumns());
         self::assertCount(1, $tableDiff->getChangedColumns());
@@ -669,7 +669,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $renamedColumns = RenameColumnTest::getRenamedColumns($tableDiff);
         self::assertArrayHasKey('foo', $renamedColumns);
-        self::assertEquals('bar', $renamedColumns['foo']->getName());
+        self::assertEquals('bar', $renamedColumns['foo']->getObjectName()->toString());
     }
 
     public function testDetectRenameColumnDisabled(): void
@@ -735,8 +735,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($tableA, $tableB);
 
-        self::assertEquals(['baz'], $this->getAssetNames($tableDiff->getAddedColumns()));
-        self::assertEquals(['foo', 'bar'], $this->getAssetNames($tableDiff->getDroppedColumns()));
+        self::assertEquals(['baz'], $this->getObjectNames($tableDiff->getAddedColumns()));
+        self::assertEquals(['foo', 'bar'], $this->getObjectNames($tableDiff->getDroppedColumns()));
         self::assertCount(0, RenameColumnTest::getRenamedColumns($tableDiff));
     }
 
@@ -777,7 +777,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $renamedIndexes = $tableDiff->getRenamedIndexes();
         self::assertArrayHasKey('idx_foo', $renamedIndexes);
-        self::assertEquals('idx_bar', $renamedIndexes['idx_foo']->getName());
+        self::assertEquals('idx_bar', $renamedIndexes['idx_foo']->getObjectName()->toString());
     }
 
     public function testDetectRenameIndexDisabled(): void
@@ -861,8 +861,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($table1, $table2);
 
-        self::assertEquals(['idx_baz'], $this->getAssetNames($tableDiff->getAddedIndexes()));
-        self::assertEquals(['idx_foo', 'idx_bar'], $this->getAssetNames($tableDiff->getDroppedIndexes()));
+        self::assertEquals(['idx_baz'], $this->getObjectNames($tableDiff->getAddedIndexes()));
+        self::assertEquals(['idx_foo', 'idx_bar'], $this->getObjectNames($tableDiff->getDroppedIndexes()));
         self::assertCount(0, $tableDiff->getRenamedIndexes());
     }
 
@@ -895,7 +895,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertCount(1, $modifiedColumns);
         /** @var ColumnDiff $modifiedColumn */
         $modifiedColumn = current($modifiedColumns);
-        self::assertEquals('id', $modifiedColumn->getOldColumn()->getName());
+        self::assertEquals('id', $modifiedColumn->getOldColumn()->getObjectName()->toString());
     }
 
     public function testReportModifiedIndexesEnabled(): void
@@ -1013,7 +1013,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         $tableDiff = $this->comparator->compareTables($table, $newtable);
 
         self::assertEquals(['twitterId', 'displayName'], array_keys(RenameColumnTest::getRenamedColumns($tableDiff)));
-        self::assertEquals(['logged_in_at'], $this->getAssetNames($tableDiff->getAddedColumns()));
+        self::assertEquals(['logged_in_at'], $this->getObjectNames($tableDiff->getAddedColumns()));
         self::assertCount(0, $tableDiff->getDroppedColumns());
     }
 
@@ -1324,16 +1324,16 @@ abstract class AbstractComparatorTestCase extends TestCase
     }
 
     /**
-     * @param array<AbstractAsset<UnqualifiedName>> $assets
+     * @param array<NamedObject<UnqualifiedName>> $objects
      *
      * @return array<string>
      */
-    protected function getAssetNames(array $assets): array
+    protected function getObjectNames(array $objects): array
     {
         $names = [];
 
-        foreach ($assets as $asset) {
-            $names[] = $asset->getName();
+        foreach ($objects as $asset) {
+            $names[] = $asset->getObjectName()->toString();
         }
 
         return $names;

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -25,7 +26,7 @@ class ColumnTest extends TestCase
     {
         $column = $this->createColumn();
 
-        self::assertEquals('foo', $column->getName());
+        self::assertEquals(UnqualifiedName::unquoted('foo'), $column->getObjectName());
         self::assertSame(Type::getType(Types::STRING), $column->getType());
 
         self::assertEquals(200, $column->getLength());
@@ -110,7 +111,7 @@ class ColumnTest extends TestCase
         $mysqlPlatform  = new MySQLPlatform();
         $sqlitePlatform = new SQLitePlatform();
 
-        self::assertEquals('bar', $column->getName());
+        self::assertEquals('"bar"', $column->getObjectName()->toString());
         self::assertEquals('`bar`', $column->getQuotedName($mysqlPlatform));
         self::assertEquals('"bar"', $column->getQuotedName($sqlitePlatform));
 
@@ -121,7 +122,7 @@ class ColumnTest extends TestCase
 
         $sqlServerPlatform = new SQLServerPlatform();
 
-        self::assertEquals('bar', $column->getName());
+        self::assertEquals('"bar"', $column->getObjectName()->toString());
         self::assertEquals('[bar]', $column->getQuotedName($sqlServerPlatform));
     }
 

--- a/tests/Schema/IndexEditorTest.php
+++ b/tests/Schema/IndexEditorTest.php
@@ -102,7 +102,7 @@ class IndexEditorTest extends TestCase
         $index2 = $index1->edit()
             ->create();
 
-        self::assertSame('idx_user_name', $index2->getName());
+        self::assertEquals(UnqualifiedName::unquoted('idx_user_name'), $index2->getObjectName());
         self::assertSame(['user_name'], $index2->getColumns());
         self::assertFalse($index2->isUnique());
         self::assertFalse($index2->isPrimary());

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -28,7 +28,7 @@ class IndexTest extends TestCase
     public function testCreateIndex(): void
     {
         $idx = $this->createIndex();
-        self::assertEquals('foo', $idx->getName());
+        self::assertEquals(UnqualifiedName::unquoted('foo'), $idx->getObjectName());
         $columns = $idx->getColumns();
         self::assertCount(2, $columns);
         self::assertEquals(['bar', 'baz'], $columns);

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -116,7 +117,7 @@ class SchemaTest extends TestCase
 
         $table = $schema->createTable('foo');
 
-        self::assertEquals('foo', $table->getName());
+        self::assertEquals(OptionallyQualifiedName::unquoted('foo'), $table->getObjectName());
         self::assertTrue($schema->hasTable('foo'));
     }
 
@@ -127,7 +128,10 @@ class SchemaTest extends TestCase
         $schema = new Schema([], [$sequence]);
 
         self::assertTrue($schema->hasSequence('a_seq'));
-        self::assertSame('a_seq', $schema->getSequence('a_seq')->getName());
+        self::assertEquals(
+            OptionallyQualifiedName::unquoted('a_seq'),
+            $schema->getSequence('a_seq')->getObjectName(),
+        );
 
         self::assertEquals([$sequence], $schema->getSequences());
     }
@@ -159,12 +163,18 @@ class SchemaTest extends TestCase
         $schema   = new Schema();
         $sequence = $schema->createSequence('a_seq', 10, 20);
 
-        self::assertEquals('a_seq', $sequence->getName());
+        self::assertEquals(
+            OptionallyQualifiedName::unquoted('a_seq'),
+            $sequence->getObjectName(),
+        );
         self::assertEquals(10, $sequence->getAllocationSize());
         self::assertEquals(20, $sequence->getInitialValue());
 
         self::assertTrue($schema->hasSequence('a_seq'));
-        self::assertSame('a_seq', $schema->getSequence('a_seq')->getName());
+        self::assertEquals(
+            OptionallyQualifiedName::unquoted('a_seq'),
+            $schema->getSequence('a_seq')->getObjectName(),
+        );
 
         self::assertEquals([$sequence], $schema->getSequences());
     }
@@ -203,7 +213,7 @@ class SchemaTest extends TestCase
 
         $index = array_shift($indexes);
         self::assertNotNull($index);
-        self::assertEquals(5, strlen($index->getName()));
+        self::assertEquals(5, strlen($index->getObjectName()->toString()));
     }
 
     public function testDeepClone(): void

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -15,6 +15,8 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
@@ -52,7 +54,10 @@ class TableTest extends TestCase
             )
             ->create();
 
-        self::assertEquals('foo', $table->getName());
+        self::assertEquals(
+            OptionallyQualifiedName::unquoted('foo'),
+            $table->getObjectName(),
+        );
     }
 
     public function testColumns(): void
@@ -75,8 +80,15 @@ class TableTest extends TestCase
         self::assertTrue($table->hasColumn('bar'));
         self::assertFalse($table->hasColumn('baz'));
 
-        self::assertSame('foo', $table->getColumn('foo')->getName());
-        self::assertSame('bar', $table->getColumn('bar')->getName());
+        self::assertEquals(
+            UnqualifiedName::unquoted('foo'),
+            $table->getColumn('foo')->getObjectName(),
+        );
+
+        self::assertEquals(
+            UnqualifiedName::unquoted('foo'),
+            $table->getColumn('foo')->getObjectName(),
+        );
 
         self::assertCount(2, $table->getColumns());
     }
@@ -424,8 +436,16 @@ class TableTest extends TestCase
         self::assertFalse($table->hasIndex('some_idx'));
 
         self::assertNotNull($table->getPrimaryKey());
-        self::assertSame('the_primary', $table->getIndex('the_primary')->getName());
-        self::assertSame('bar_idx', $table->getIndex('bar_idx')->getName());
+
+        self::assertEquals(
+            UnqualifiedName::unquoted('the_primary'),
+            $table->getIndex('the_primary')->getObjectName(),
+        );
+
+        self::assertEquals(
+            UnqualifiedName::unquoted('bar_idx'),
+            $table->getIndex('bar_idx')->getObjectName(),
+        );
     }
 
     public function testGetUnknownIndexThrowsException(): void
@@ -1063,7 +1083,7 @@ class TableTest extends TestCase
         $mysqlPlatform  = new MySQLPlatform();
         $sqlitePlatform = new SQLitePlatform();
 
-        self::assertEquals('bar', $table->getName());
+        self::assertEquals('bar', $table->getObjectName()->getUnqualifiedName()->getValue());
         self::assertEquals('`bar`', $table->getQuotedName($mysqlPlatform));
         self::assertEquals('"bar"', $table->getQuotedName($sqlitePlatform));
     }
@@ -1141,7 +1161,7 @@ class TableTest extends TestCase
             )
             ->create();
 
-        self::assertEquals('test.test', $table->getName());
+        self::assertEquals('"test"."test"', $table->getObjectName()->toString());
         self::assertEquals('`test`.`test`', $table->getQuotedName(new MySQLPlatform()));
     }
 


### PR DESCRIPTION
The logic of `AbstractAsset::getName()` is lossy. If the returned value contains a dot, it is not clear whether the dot is part of the name or a separator of the qualifier and the unqualified name.

The API being developed starting with https://github.com/doctrine/dbal/pull/6646 is the proper way to deal with object names.