### PR TITLE
Add spatial types

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -150,6 +150,30 @@ jobs:
             extension: "pdo_pgsql"
             config-file-suffix: "-stringify_fetches"
 
+  phpunit-postgis:
+    name: "PHPUnit with PostGIS"
+    needs: "phpunit-smoke-check"
+    uses: ./.github/workflows/phpunit-postgis.yml
+    with:
+      php-version: ${{ matrix.php-version }}
+      postgis-version: ${{ matrix.postgis-version }}
+      extension: ${{ matrix.extension }}
+      postgres-locale-provider: ${{ matrix.postgres-locale-provider }}
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.5"
+        postgis-version:
+          - "17-3.5"
+        extension:
+          - "pgsql"
+          - "pdo_pgsql"
+        include:
+          - php-version: "8.2"
+            postgis-version: "17-3.5"
+            extension: "pgsql"
+
   phpunit-mariadb:
     name: >
       ${{ format('MariaDB {0} - PHP {1} - ext. {2}',
@@ -337,6 +361,7 @@ jobs:
       - "phpunit-smoke-check"
       - "phpunit-oracle"
       - "phpunit-postgres"
+      - "phpunit-postgis"
       - "phpunit-mariadb"
       - "phpunit-mysql"
       - "phpunit-mssql"

--- a/.github/workflows/phpunit-postgis.yml
+++ b/.github/workflows/phpunit-postgis.yml
@@ -1,0 +1,67 @@
+name: PHPUnit with PostGIS
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: true
+        type: string
+      postgis-version:
+        required: true
+        type: string
+      extension:
+        required: true
+        type: string
+      postgres-locale-provider:
+        required: true
+        type: string
+      config-file-suffix:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  phpunit-postgis:
+    runs-on: ubuntu-24.04
+
+    services:
+      postgres:
+        image: postgis/postgis:${{ inputs.postgis-version }}
+        ports:
+          - '5432:5432'
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_INITDB_ARGS: ${{ inputs.postgres-locale-provider == 'icu' && '--locale-provider=icu --icu-locale=en-US' || '' }}
+        options: >-
+          --health-cmd pg_isready
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          extensions: ${{ inputs.extension }}
+          coverage: pcov
+          ini-values: zend.assertions=1
+        env:
+          fail-fast: true
+
+      - name: Install dependencies with Composer
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--ignore-platform-req=php+'
+
+      - name: Enable PostGIS extension
+        run: PGPASSWORD=postgres psql -h localhost -U postgres -d template1 -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c ci/github/phpunit/${{ inputs.extension }}${{ inputs.config-file-suffix }}.xml --coverage-clover=coverage.xml
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-${{ inputs.postgis-version }}-php-${{ inputs.php-version }}-${{ inputs.extension }}${{ inputs.config-file-suffix }}.coverage
+          path: coverage.xml

--- a/docs/en/reference/spatial-types.rst
+++ b/docs/en/reference/spatial-types.rst
@@ -1,0 +1,223 @@
+.. _spatial_types:
+
+Spatial Types
+=============
+
+Doctrine DBAL provides two spatial mapping types, :ref:`geometry <geometry>` and
+:ref:`geography <geography>`, for storing and retrieving geometric data such as points,
+lines and polygons. Both are built-in types and can be retrieved through the usual
+factory method:
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\DBAL\Types\Type;
+
+    $type = Type::getType('geometry');
+
+The difference between the two mirrors the distinction made by the underlying database:
+
+- ``geometry`` operates on a planar (Euclidean) coordinate system. Distances and areas
+  are computed on a flat plane.
+- ``geography`` operates on a spherical coordinate system using longitude/latitude
+  coordinates. Distances and areas are computed on the surface of the earth.
+
+Both types convert values to and from the ``Doctrine\DBAL\Types\Geometry`` value object
+rather than to raw strings or arrays. Spatial data is transported as GeoJSON on every
+supported platform.
+
+The ``Geometry`` and ``GeoJSON`` value objects
+----------------------------------------------
+
+``Doctrine\DBAL\Types\Geometry`` is an immutable value object that wraps a single
+geometry together with its optional SRID (Spatial Reference System Identifier). You
+create one from a GeoJSON string:
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\DBAL\Types\Geometry;
+
+    $point = Geometry::fromGeoJSON('{"type":"Point","coordinates":[-122.4194,37.7749]}');
+
+    $point->toGeoJSON(); // string, the GeoJSON representation
+    (string) $point;     // same as toGeoJSON()
+    $point->getSrid();   // int|null, read from the GeoJSON "crs" property
+    $point->getGeoJSON(); // the underlying Doctrine\DBAL\Types\GeoJSON value object
+
+``Geometry::fromGeoJSON()`` throws ``InvalidArgumentException`` when the input is not
+valid GeoJSON.
+
+``Doctrine\DBAL\Types\GeoJSON`` is the validator and wrapper behind ``Geometry``. It
+parses and validates a GeoJSON string according to
+`RFC 7946 <https://datatracker.ietf.org/doc/html/rfc7946>`_ and exposes
+``GeoJSON::fromString()``, ``toString()`` and ``getSrid()``. The following geometry types
+are supported:
+
+- ``Point``, ``LineString``, ``Polygon``
+- ``MultiPoint``, ``MultiLineString``, ``MultiPolygon``
+- ``GeometryCollection``
+
+``Feature`` and ``FeatureCollection`` are intentionally not supported, as they are not
+suitable for storage in a database column.
+
+The SRID is read from the ``crs.properties.name`` member of the GeoJSON payload and is
+recognised in the EPSG (``EPSG:4326``) and URN (``urn:ogc:def:crs:EPSG::4326``) forms.
+If no ``crs`` is present, ``getSrid()`` returns ``null``.
+
+.. _spatial_types_geojson:
+
+Why GeoJSON is the wire format
+------------------------------
+
+Spatial data is always transported as GeoJSON, not WKT, on every supported platform.
+This is a constraint of the type-conversion design rather than a preference.
+
+``Type::convertToDatabaseValueSQL()`` receives exactly one placeholder and wraps it in a
+single SQL function call. A conversion function can therefore bind only one parameter.
+A WKT-based construction such as ``ST_GeomFromText(?, ?)`` needs two bind parameters —
+the WKT string *and* the SRID as separate arguments — and is not an option under this
+design. GeoJSON carries the SRID inside the payload itself via the ``crs`` property, so
+``ST_GeomFromGeoJSON(?)`` transports both the geometry and its SRID through a single
+placeholder. The read path uses ``ST_AsGeoJSON()`` accordingly.
+
+.. note::
+
+    Support for additional input formats such as WKT should be added as a PHP-side
+    conversion into the GeoJSON-backed ``Geometry`` value object (parse WKT, emit
+    GeoJSON), keeping the single-placeholder wire format intact. It must not be added by
+    switching the SQL wrapper to ``ST_GeomFromText``.
+
+Declaring a spatial column
+---------------------------
+
+Spatial columns accept two additional options:
+
+- **geometryType** (string): the geometry subtype, for example ``POINT``, ``LINESTRING``
+  or ``POLYGON``. Defaults to ``GEOMETRY`` (any geometry type) if omitted.
+- **srid** (integer): the EPSG identifier of the spatial reference system, for example
+  ``4326`` for WGS 84.
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\DBAL\Schema\Column;
+    use Doctrine\DBAL\Schema\Table;
+    use Doctrine\DBAL\Types\Types;
+
+    $table = Table::editor()
+        ->setUnquotedName('locations')
+        ->setColumns(
+            Column::editor()
+                ->setUnquotedName('id')
+                ->setTypeName(Types::INTEGER)
+                ->setAutoincrement(true)
+                ->create(),
+            Column::editor()
+                ->setUnquotedName('position')
+                ->setTypeName(Types::GEOMETRY)
+                ->setGeometryType('POINT')
+                ->setSrid(4326)
+                ->create(),
+        )
+        ->create();
+
+On PostgreSQL this produces a ``position geometry(point,4326)`` column; on MySQL/MariaDB
+it produces ``position POINT``.
+
+Writing and reading values
+--------------------------
+
+When writing, pass a ``Geometry`` instance and bind it with the spatial type. The type
+wraps the value in the platform's GeoJSON construction function:
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\DBAL\Types\Geometry;
+    use Doctrine\DBAL\Types\Types;
+
+    $connection->insert('locations', [
+        'position' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[-122.4194,37.7749]}'),
+    ], [
+        'position' => Types::GEOMETRY,
+    ]);
+
+Because the database stores spatial data in an internal binary format, a plain
+``SELECT`` of the column does not return GeoJSON. Read the column back through the
+platform's GeoJSON expression so that it can be converted to a ``Geometry`` instance:
+
+.. code-block:: php
+
+    <?php
+
+    $platform = $connection->getDatabasePlatform();
+
+    $rows = $connection->createQueryBuilder()
+        ->select($platform->getGeometryAsGeoJSONSQL('position') . ' AS position')
+        ->from('locations')
+        ->executeQuery()
+        ->fetchAllAssociative();
+
+Platform support
+----------------
+
+    +----------------+-------------------------------+------------------------------------+
+    | Platform       | geometry                      | geography                          |
+    +================+===============================+====================================+
+    | **PostgreSQL** | Yes (requires PostGIS)        | Yes (requires PostGIS)             |
+    +----------------+-------------------------------+------------------------------------+
+    | **MySQL**      | Yes (8.0+ for SRID in column) | No                                 |
+    +----------------+-------------------------------+------------------------------------+
+    | **MariaDB**    | Yes (10.2.4+)                 | No                                 |
+    +----------------+-------------------------------+------------------------------------+
+    | **SQLite**     | No                            | No                                 |
+    +----------------+-------------------------------+------------------------------------+
+    | **Oracle**     | No                            | No                                 |
+    +----------------+-------------------------------+------------------------------------+
+    | **DB2**        | No                            | No                                 |
+    +----------------+-------------------------------+------------------------------------+
+    | **SQL Server** | No                            | No                                 |
+    +----------------+-------------------------------+------------------------------------+
+
+- **PostgreSQL / PostGIS** supports both ``geometry`` and ``geography``. Values are read
+  and written via ``ST_GeomFromGeoJSON(?)`` and ``ST_AsGeoJSON(?, 15, 2)``. A
+  ``geography`` column casts the constructed value to ``::geography`` and defaults its
+  SRID to ``4326`` when none is given.
+- **MySQL 8.0+ / MariaDB 10.2.4+** supports ``geometry`` only, using the same
+  ``ST_GeomFromGeoJSON`` / ``ST_AsGeoJSON`` functions. The column declaration emits the
+  uppercased ``geometryType`` (for example ``POINT``, defaulting to ``GEOMETRY``).
+  Declaring an SRID in the column definition requires MySQL 8.0+.
+- On **SQLite, Oracle, DB2 and SQL Server** spatial types are not supported.
+
+.. note::
+
+    Using ``geography`` on MySQL or MariaDB, or using either spatial type on a platform
+    that does not support it, throws
+    ``Doctrine\DBAL\Platforms\Exception\NotSupported``.
+
+Spatial indexes
+---------------
+
+A spatial index is declared by setting the index type to
+``Doctrine\DBAL\Schema\Index\IndexType::SPATIAL``:
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\DBAL\Schema\Index;
+
+    $index = Index::editor()
+        ->setUnquotedName('position_idx')
+        ->setType(Index\IndexType::SPATIAL)
+        ->setUnquotedColumnNames('position')
+        ->create();
+
+PostgreSQL emits ``CREATE INDEX … USING GIST (…)``; MySQL and MariaDB emit
+``CREATE SPATIAL INDEX …``. Schema introspection maps the access method back to
+``IndexType::SPATIAL``, so spatial indexes round-trip through the ``SchemaManager``.

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -524,6 +524,37 @@ jsonb_object
 This type is similar to ``json_object``. On PostgreSQL, it is mapped to the ``JSONB`` data type.
 On all other platforms, it is mapped to the same type as ``json``.
 
+Spatial types
+~~~~~~~~~~~~~
+
+Types that map geometric data such as points, lines and polygons.
+
+.. _geometry:
+geometry
+++++++++
+
+Maps and converts spatial geometry data on a planar (Euclidean) coordinate system.
+Values retrieved from the database are always converted to a
+``Doctrine\DBAL\Types\Geometry`` value object or ``null`` if no data is present.
+Spatial data is transported as GeoJSON, and the column accepts ``geometryType`` and
+``srid`` options. This type is only supported on PostgreSQL (PostGIS) and
+MySQL/MariaDB.
+
+See :doc:`spatial-types` for the value objects, the GeoJSON wire format, platform
+support and spatial indexes.
+
+.. _geography:
+geography
++++++++++
+
+Maps and converts spatial geography data on a spherical coordinate system using
+longitude/latitude coordinates. Values retrieved from the database are always converted
+to a ``Doctrine\DBAL\Types\Geometry`` value object or ``null`` if no data is present.
+This type is only supported on PostgreSQL (PostGIS).
+
+See :doc:`spatial-types` for the value objects, the GeoJSON wire format, platform
+support and spatial indexes.
+
 .. _mappingMatrix:
 
 Mapping Matrix
@@ -788,6 +819,12 @@ Please also notice the mapping specific footnotes for additional information.
     |                   |                    +--------------------------+---------+----------------------------------------------------------+
     |                   |                    | **SQL Server**           | *all*   | ``VARCHAR(MAX)``                                         |
     +-------------------+--------------------+--------------------------+---------+----------------------------------------------------------+
+    | **geometry** [22] | ``Geometry``       | **PostgreSQL**           | *all*   | ``geometry(type, srid)``                                 |
+    |                   |                    +--------------------------+---------+----------------------------------------------------------+
+    |                   |                    | **MySQL**                | *all*   | ``GEOMETRY``, ``POINT``, ``POLYGON``, …                  |
+    +-------------------+--------------------+--------------------------+---------+----------------------------------------------------------+
+    | **geography** [22]| ``Geometry``       | **PostgreSQL**           | *all*   | ``geography(type, srid)``                                |
+    +-------------------+--------------------+--------------------------+---------+----------------------------------------------------------+
 
 
 **Notes**
@@ -829,6 +866,11 @@ Please also notice the mapping specific footnotes for additional information.
   attribute array or is set to ``false``.
 * [21] Chosen if the column definition contains the **jsonb** option inside the **platformOptions**
   attribute array and is set to ``true``.
+* [22] Spatial type. Requires PostGIS on PostgreSQL or MySQL 8.0+ / MariaDB 10.2.4+; ``geography`` is
+  only available on PostgreSQL. Not supported on SQLite, Oracle, DB2 and SQL Server. Values are
+  transported as GeoJSON and converted to and from the ``Doctrine\DBAL\Types\Geometry`` value object.
+  The **type** and **srid** parts of the declaration are derived from the **geometryType** and **srid**
+  column options. See :doc:`spatial-types`.
 
 Detection of Database Types
 ---------------------------

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -12,6 +12,7 @@
    /reference/transactions
    /reference/platforms
    /reference/types
+   /reference/spatial-types
    /reference/schema-manager
    /reference/schema-representation
    /reference/object-names

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -38,7 +38,9 @@ use SensitiveParameter;
 use Throwable;
 use Traversable;
 
+use function array_is_list;
 use function array_key_exists;
+use function array_keys;
 use function array_merge;
 use function count;
 use function implode;
@@ -456,10 +458,18 @@ class Connection implements ServerVersionProvider
     {
         $columns = $values = $conditions = $set = [];
 
+        $platform = $this->getDatabasePlatform();
+        $typesMap = $this->normalizeTypes($types, array_keys($data));
+
         foreach ($data as $columnName => $value) {
             $columns[] = $columnName;
             $values[]  = $value;
-            $set[]     = $columnName . ' = ?';
+            $set[]     = $columnName . ' = ' . $this->getPlaceholderForColumn(
+                $columnName,
+                $value,
+                $typesMap,
+                $platform,
+            );
         }
 
         [$criteriaColumns, $criteriaValues, $criteriaConditions] = $this->getCriteriaCondition($criteria);
@@ -503,10 +513,18 @@ class Connection implements ServerVersionProvider
         $values  = [];
         $set     = [];
 
+        $platform = $this->getDatabasePlatform();
+        $typesMap = $this->normalizeTypes($types, array_keys($data));
+
         foreach ($data as $columnName => $value) {
             $columns[] = $columnName;
             $values[]  = $value;
-            $set[]     = '?';
+            $set[]     = $this->getPlaceholderForColumn(
+                $columnName,
+                $value,
+                $typesMap,
+                $platform,
+            );
         }
 
         return $this->executeStatement(
@@ -534,6 +552,78 @@ class Connection implements ServerVersionProvider
         }
 
         return $typeValues;
+    }
+
+    /**
+     * Normalizes types array from positional or associative to associative format.
+     *
+     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     * @param list<string>                                                                          $columnNames
+     *
+     * @return array<string, string|ParameterType|Type>
+     */
+    private function normalizeTypes(array $types, array $columnNames): array
+    {
+        if (count($types) === 0) {
+            return [];
+        }
+
+        // Already associative (string keys)
+        if (! array_is_list($types)) {
+            /** @var array<string, string|ParameterType|Type> $normalizedTypes */
+            $normalizedTypes = $types;
+
+            return $normalizedTypes;
+        }
+
+        // Convert positional to associative
+        $normalizedTypes = [];
+        foreach ($columnNames as $i => $columnName) {
+            if (! isset($types[$i])) {
+                continue;
+            }
+
+            $normalizedTypes[$columnName] = $types[$i];
+        }
+
+        return $normalizedTypes;
+    }
+
+    /**
+     * Gets the SQL placeholder for a column based on its type.
+     *
+     * @param array<string, string|ParameterType|Type> $typesMap
+     *
+     * @throws Exception
+     */
+    private function getPlaceholderForColumn(
+        string $columnName,
+        mixed $value,
+        array $typesMap,
+        AbstractPlatform $platform,
+    ): string {
+        // NULL values don't need special SQL conversion
+        if ($value === null) {
+            return '?';
+        }
+
+        if (! isset($typesMap[$columnName])) {
+            return '?';
+        }
+
+        $type = $typesMap[$columnName];
+
+        // Convert string type name to Type instance
+        if (is_string($type)) {
+            $type = Type::getType($type);
+        }
+
+        // Use Type's SQL conversion if it's a Type instance
+        if ($type instanceof Type) {
+            return $type->convertToDatabaseValueSQL('?', $platform);
+        }
+
+        return '?';
     }
 
     /**

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnValuesRequired;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Platforms\MySQL\MySQLMetadataProvider;
@@ -217,6 +218,42 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     public function getBooleanTypeDeclarationSQL(array $column): string
     {
         return 'TINYINT';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeographyTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
     }
 
     /**

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -35,6 +35,7 @@ use function is_numeric;
 use function sprintf;
 use function str_replace;
 use function strtolower;
+use function strtoupper;
 
 /**
  * Provides the base implementation for the lowest versions of supported MySQL-like database platforms.
@@ -225,17 +226,20 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      */
     public function getGeometryTypeDeclarationSQL(array $column): string
     {
-        throw NotSupported::new(__METHOD__);
+        $geometryType = $column['geometryType'] ?? 'GEOMETRY';
+
+        return strtoupper($geometryType);
     }
 
     public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
     {
-        throw NotSupported::new(__METHOD__);
+        return sprintf('ST_GeomFromGeoJSON(%s)', $sqlExpr);
     }
 
     public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
     {
-        throw NotSupported::new(__METHOD__);
+        // MySQL 5.7.5+ / MariaDB 10.2.4+ - maxdecimaldigits=15 (full precision), options=2 (include SRID in CRS)
+        return sprintf('ST_AsGeoJSON(%s, 15, 2)', $sqlExpr);
     }
 
     /**
@@ -288,6 +292,19 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     public function getColumnTypeSQLSnippet(string $tableAlias, string $databaseName): string
     {
         return $tableAlias . '.DATA_TYPE';
+    }
+
+    /**
+     * Returns the SQL snippet for selecting SRID from information_schema.COLUMNS.
+     *
+     * MySQL 8.0+ supports SRS_ID column, while MariaDB does not.
+     *
+     * @internal The method should be only used from
+     * within the {@see MySQLSchemaManager, @see MySQLMetadataProvider} class hierarchy.
+     */
+    public function getSridColumnSQL(): string
+    {
+        return 'NULL AS srs_id';
     }
 
     /**
@@ -794,38 +811,47 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     protected function initializeDoctrineTypeMappings(): void
     {
         $this->doctrineTypeMapping = [
-            'bigint'     => Types::BIGINT,
-            'binary'     => Types::BINARY,
-            'blob'       => Types::BLOB,
-            'char'       => Types::STRING,
-            'date'       => Types::DATE_MUTABLE,
-            'datetime'   => Types::DATETIME_MUTABLE,
-            'decimal'    => Types::DECIMAL,
-            'double'     => Types::FLOAT,
-            'enum'       => Types::ENUM,
-            'float'      => Types::SMALLFLOAT,
-            'int'        => Types::INTEGER,
-            'integer'    => Types::INTEGER,
-            'json'       => Types::JSON,
-            'longblob'   => Types::BLOB,
-            'longtext'   => Types::TEXT,
-            'mediumblob' => Types::BLOB,
-            'mediumint'  => Types::INTEGER,
-            'mediumtext' => Types::TEXT,
-            'numeric'    => Types::DECIMAL,
-            'real'       => Types::FLOAT,
-            'set'        => Types::SIMPLE_ARRAY,
-            'smallint'   => Types::SMALLINT,
-            'string'     => Types::STRING,
-            'text'       => Types::TEXT,
-            'time'       => Types::TIME_MUTABLE,
-            'timestamp'  => Types::DATETIME_MUTABLE,
-            'tinyblob'   => Types::BLOB,
-            'tinyint'    => Types::BOOLEAN,
-            'tinytext'   => Types::TEXT,
-            'varbinary'  => Types::BINARY,
-            'varchar'    => Types::STRING,
-            'year'       => Types::DATE_MUTABLE,
+            'bigint'             => Types::BIGINT,
+            'binary'             => Types::BINARY,
+            'blob'               => Types::BLOB,
+            'char'               => Types::STRING,
+            'date'               => Types::DATE_MUTABLE,
+            'datetime'           => Types::DATETIME_MUTABLE,
+            'decimal'            => Types::DECIMAL,
+            'double'             => Types::FLOAT,
+            'enum'               => Types::ENUM,
+            'float'              => Types::SMALLFLOAT,
+            'geomcollection'     => Types::GEOMETRY,
+            'geometry'           => Types::GEOMETRY,
+            'geometrycollection' => Types::GEOMETRY,
+            'int'                => Types::INTEGER,
+            'integer'            => Types::INTEGER,
+            'json'               => Types::JSON,
+            'linestring'         => Types::GEOMETRY,
+            'longblob'           => Types::BLOB,
+            'longtext'           => Types::TEXT,
+            'mediumblob'         => Types::BLOB,
+            'mediumint'          => Types::INTEGER,
+            'mediumtext'         => Types::TEXT,
+            'multilinestring'    => Types::GEOMETRY,
+            'multipoint'         => Types::GEOMETRY,
+            'multipolygon'       => Types::GEOMETRY,
+            'numeric'            => Types::DECIMAL,
+            'point'              => Types::GEOMETRY,
+            'polygon'            => Types::GEOMETRY,
+            'real'               => Types::FLOAT,
+            'set'                => Types::SIMPLE_ARRAY,
+            'smallint'           => Types::SMALLINT,
+            'string'             => Types::STRING,
+            'text'               => Types::TEXT,
+            'time'               => Types::TIME_MUTABLE,
+            'timestamp'          => Types::DATETIME_MUTABLE,
+            'tinyblob'           => Types::BLOB,
+            'tinyint'            => Types::BOOLEAN,
+            'tinytext'           => Types::TEXT,
+            'varbinary'          => Types::BINARY,
+            'varchar'            => Types::STRING,
+            'year'               => Types::DATE_MUTABLE,
         ];
     }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -387,6 +387,44 @@ abstract class AbstractPlatform
     abstract public function getBlobTypeDeclarationSQL(array $column): string;
 
     /**
+     * Gets the SQL declaration snippet for a geometry column.
+     *
+     * @param array<string, mixed> $column
+     */
+    abstract public function getGeometryTypeDeclarationSQL(array $column): string;
+
+    /**
+     * Gets the SQL snippet to convert a geometry value
+     * from GeoJSON format to the database's internal geometry format.
+     */
+    abstract public function getGeometryFromGeoJSONSQL(string $sqlExpr): string;
+
+    /**
+     * Gets the SQL snippet to convert a geometry value
+     * from the database's internal format to GeoJSON format.
+     */
+    abstract public function getGeometryAsGeoJSONSQL(string $sqlExpr): string;
+
+    /**
+     * Gets the SQL declaration snippet for a geography column.
+     *
+     * @param array<string, mixed> $column
+     */
+    abstract public function getGeographyTypeDeclarationSQL(array $column): string;
+
+    /**
+     * Gets the SQL snippet to convert a geography value
+     * from GeoJSON format to the database's internal geography format.
+     */
+    abstract public function getGeographyFromGeoJSONSQL(string $sqlExpr): string;
+
+    /**
+     * Gets the SQL snippet to convert a geography value
+     * from the database's internal format to GeoJSON format.
+     */
+    abstract public function getGeographyAsGeoJSONSQL(string $sqlExpr): string;
+
+    /**
      * Registers a doctrine type to be used in conjunction with a column type of this platform.
      *
      * @throws Exception If the type is not found.

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1251,9 +1251,20 @@ abstract class AbstractPlatform
         }
 
         $query  = 'CREATE ' . $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name . ' ON ' . $table;
+        $query .= $this->getIndexMethodSQL($index);
         $query .= ' (' . implode(', ', $index->getQuotedColumns($this)) . ')' . $this->getPartialIndexSQL($index);
 
         return $query;
+    }
+
+    /**
+     * Returns the index method clause for platforms that support it.
+     *
+     * @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy.
+     */
+    protected function getIndexMethodSQL(Index $index): string
+    {
+        return '';
     }
 
     /**

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -203,6 +203,42 @@ class DB2Platform extends AbstractPlatform
         return 'TIME';
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeographyTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
     public function getTruncateTableSQL(string $tableName, bool $cascade = false): string
     {
         $tableIdentifier = new Identifier($tableName);

--- a/src/Platforms/MySQL/MySQLMetadataProvider.php
+++ b/src/Platforms/MySQL/MySQLMetadataProvider.php
@@ -173,7 +173,8 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
                    c.EXTRA,
                    c.COLUMN_COMMENT,
                    c.CHARACTER_SET_NAME,
-                   c.COLLATION_NAME
+                   c.COLLATION_NAME,
+                   %s
             FROM information_schema.COLUMNS c
                      INNER JOIN information_schema.TABLES t
                                 ON t.TABLE_NAME = c.TABLE_NAME
@@ -184,6 +185,7 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
                      c.ORDINAL_POSITION
             SQL,
             $this->platform->getColumnTypeSQLSnippet('c', $this->databaseName),
+            $this->platform->getSridColumnSQL(),
             implode(' AND ', $conditions),
         );
 
@@ -214,6 +216,7 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             $columnComment,
             $characterSetName,
             $collationName,
+            $srid,
         ] = $row;
 
         $editor = Column::editor()
@@ -283,6 +286,32 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
 
             case 'enum':
                 $editor->setValues($this->parseEnumExpression($columnType));
+                break;
+
+            case 'geometry':
+            case 'point':
+            case 'linestring':
+            case 'polygon':
+            case 'multipoint':
+            case 'multilinestring':
+            case 'multipolygon':
+            case 'geomcollection':
+            case 'geometrycollection':
+                // For MySQL, the dbType directly represents the geometry subtype
+                $geometryType = $dbType;
+
+                // Normalize MySQL's abbreviated "geomcollection" to "geometrycollection"
+                if ($geometryType === 'geomcollection') {
+                    $geometryType = 'geometrycollection';
+                }
+
+                $editor->setGeometryType($geometryType);
+
+                // MySQL 8.0.3+ stores SRID in information_schema.COLUMNS.SRS_ID
+                if ($srid !== null) {
+                    $editor->setSrid((int) $srid);
+                }
+
                 break;
         }
 

--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -10,6 +10,9 @@ use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\WithSQLBuilder;
 use Doctrine\Deprecations\Deprecation;
 
+use function sprintf;
+use function strtoupper;
+
 /**
  * Provides the behavior, features and SQL dialect of the MySQL 8.0 database platform.
  *
@@ -37,5 +40,27 @@ class MySQL80Platform extends MySQLPlatform
     public function createWithSQLBuilder(): WithSQLBuilder
     {
         return AbstractPlatform::createWithSQLBuilder();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        $geometryType = $column['geometryType'] ?? 'GEOMETRY';
+        $srid         = $column['srid'] ?? null;
+
+        $sql = strtoupper($geometryType);
+
+        if ($srid !== null) {
+            $sql .= sprintf(' SRID %d', $srid);
+        }
+
+        return $sql;
+    }
+
+    public function getSridColumnSQL(): string
+    {
+        return 'c.SRS_ID AS srs_id';
     }
 }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnLengthRequired;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\OracleKeywords;
 use Doctrine\DBAL\Platforms\Oracle\OracleMetadataProvider;
@@ -264,6 +265,42 @@ class OraclePlatform extends AbstractPlatform
     public function getTimeTypeDeclarationSQL(array $column): string
     {
         return 'DATE';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeographyTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
     }
 
     /**

--- a/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
+++ b/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
@@ -25,8 +25,10 @@ use Doctrine\DBAL\Schema\Metadata\UniqueConstraintColumnMetadataRow;
 use Doctrine\DBAL\Schema\Metadata\ViewMetadataRow;
 use Doctrine\DBAL\Types\Exception\TypesException;
 
+use function array_map;
 use function assert;
 use function count;
+use function ctype_digit;
 use function implode;
 use function preg_match;
 use function sprintf;
@@ -253,7 +255,7 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
             case 'varchar':
                 $parameters = $this->parseColumnTypeParameters($completeType);
                 if (count($parameters) > 0) {
-                    $editor->setLength($parameters[0]);
+                    $editor->setLength((int) $parameters[0]);
                 }
 
                 break;
@@ -264,11 +266,23 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
             case 'numeric':
                 $parameters = $this->parseColumnTypeParameters($completeType);
                 if (count($parameters) > 0) {
-                    $editor->setPrecision($parameters[0]);
+                    $editor->setPrecision((int) $parameters[0]);
                 }
 
                 if (count($parameters) > 1) {
-                    $editor->setScale($parameters[1]);
+                    $editor->setScale((int) $parameters[1]);
+                }
+
+                break;
+            case 'geometry':
+            case 'geography':
+                $parameters = $this->parseColumnTypeParameters($completeType);
+                if (count($parameters) > 0) {
+                    $editor->setGeometryType((string) $parameters[0]);
+                }
+
+                if (count($parameters) > 1) {
+                    $editor->setSrid((int) $parameters[1]);
                 }
 
                 break;
@@ -295,19 +309,24 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
     /**
      * Parses the parameters between parenthesis in the data type.
      *
-     * @return list<int>
+     * @return list<int|non-empty-string>
      */
     private function parseColumnTypeParameters(string $type): array
     {
-        if (preg_match('/\((\d+)(?:,(\d+))?\)/', $type, $matches) !== 1) {
+        if (preg_match('/\(([\w]+)(?:,([\w]+))?\)/', $type, $matches) !== 1) {
             return [];
         }
 
-        $parameters = [(int) $matches[1]];
+        $parameters = [$matches[1]];
 
         if (isset($matches[2])) {
-            $parameters[] = (int) $matches[2];
+            $parameters[] = $matches[2];
         }
+
+        // Cast numeric strings to int automatically
+        $parameters = array_map(static function ($param) {
+            return ctype_digit($param) ? (int) $param : $param;
+        }, $parameters);
 
         return $parameters;
     }

--- a/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
+++ b/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
@@ -392,11 +392,13 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
                    ic.relname,
                    i.indisunique,
                    pg_get_expr(indpred, indrelid),
-                   attname
+                   attname,
+                   am.amname
             FROM pg_index i
                      JOIN pg_class AS c ON c.oid = i.indrelid
                      JOIN pg_namespace n ON n.oid = c.relnamespace
                      JOIN pg_class AS ic ON ic.oid = i.indexrelid
+                     JOIN pg_am am ON am.oid = ic.relam
                      JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS keys(attnum, ord)
                           ON TRUE
                      JOIN pg_attribute a
@@ -413,11 +415,21 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
         );
 
         foreach ($this->connection->iterateNumeric($sql, $params) as $row) {
+            // Determine index type based on access method and uniqueness
+            // GIST indexes are used for spatial data in PostGIS
+            if ($row[6] === 'gist') {
+                $type = IndexType::SPATIAL;
+            } elseif ($row[3]) {
+                $type = IndexType::UNIQUE;
+            } else {
+                $type = IndexType::REGULAR;
+            }
+
             yield new IndexColumnMetadataRow(
                 schemaName: $row[0],
                 tableName: $row[1],
                 indexName: $row[2],
-                type: $row[3] ? IndexType::UNIQUE : IndexType::REGULAR,
+                type: $type,
                 isClustered: false,
                 predicate: $row[4],
                 columnName: $row[5],

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\PostgreSQLKeywords;
 use Doctrine\DBAL\Platforms\PostgreSQL\PostgreSQLMetadataProvider;
@@ -832,6 +833,42 @@ class PostgreSQLPlatform extends AbstractPlatform
     public function getJsonbTypeDeclarationSQL(array $column): string
     {
         return 'JSONB';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeographyTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
     }
 
     public function createMetadataProvider(Connection $connection): PostgreSQLMetadataProvider

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -899,6 +899,20 @@ class PostgreSQLPlatform extends AbstractPlatform
         return new PostgreSQLMetadataProvider($connection, $this);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * For spatial indexes on PostgreSQL/PostGIS, we need to use GIST index method.
+     */
+    protected function getIndexMethodSQL(Index $index): string
+    {
+        if ($index->getType() === Index\IndexType::SPATIAL) {
+            return ' USING GIST';
+        }
+
+        return '';
+    }
+
     public function createSchemaManager(Connection $connection): PostgreSQLSchemaManager
     {
         return new PostgreSQLSchemaManager($connection, $this);

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\PostgreSQLKeywords;
 use Doctrine\DBAL\Platforms\PostgreSQL\PostgreSQLMetadataProvider;
@@ -740,6 +739,8 @@ class PostgreSQLPlatform extends AbstractPlatform
             'float'            => Types::FLOAT,
             'float4'           => Types::SMALLFLOAT,
             'float8'           => Types::FLOAT,
+            'geography'        => Types::GEOGRAPHY,
+            'geometry'         => Types::GEOMETRY,
             'inet'             => Types::STRING,
             'int'              => Types::INTEGER,
             'int2'             => Types::SMALLINT,
@@ -840,17 +841,29 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getGeometryTypeDeclarationSQL(array $column): string
     {
-        throw NotSupported::new(__METHOD__);
+        $geometryType = $column['geometryType'] ?? null;
+        $srid         = $column['srid'] ?? null;
+
+        if ($geometryType === null && $srid === null) {
+            return 'geometry';
+        }
+
+        return sprintf(
+            'geometry(%s%s)',
+            strtolower($geometryType ?? 'geometry'),
+            $srid !== null ? ',' . $srid : '',
+        );
     }
 
     public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
     {
-        throw NotSupported::new(__METHOD__);
+        return sprintf('ST_GeomFromGeoJSON(%s)', $sqlExpr);
     }
 
     public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
     {
-        throw NotSupported::new(__METHOD__);
+        // PostGIS 1.5+ - maxdecimaldigits=15 (full precision), options=2 (include CRS/SRID)
+        return sprintf('ST_AsGeoJSON(%s, 15, 2)', $sqlExpr);
     }
 
     /**
@@ -858,17 +871,27 @@ class PostgreSQLPlatform extends AbstractPlatform
      */
     public function getGeographyTypeDeclarationSQL(array $column): string
     {
-        throw NotSupported::new(__METHOD__);
+        // geography defaults to SRID 4326 (WGS 84), unlike geometry which has no default SRID.
+        $geometryType = $column['geometryType'] ?? 'geometry';
+        $srid         = $column['srid'] ?? 4326;
+
+        return sprintf(
+            'geography(%s,%s)',
+            strtolower($geometryType),
+            $srid,
+        );
     }
 
     public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
     {
-        throw NotSupported::new(__METHOD__);
+        // First parse as geometry, then cast to geography
+        return sprintf('ST_GeomFromGeoJSON(%s)::geography', $sqlExpr);
     }
 
     public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
     {
-        throw NotSupported::new(__METHOD__);
+        // PostGIS 1.5+ - maxdecimaldigits=15 (full precision), options=2 (include CRS/SRID)
+        return sprintf('ST_AsGeoJSON(%s, 15, 2)', $sqlExpr);
     }
 
     public function createMetadataProvider(Connection $connection): PostgreSQLMetadataProvider

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\InvalidColumnType\ColumnLengthRequired;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\SQLServerKeywords;
 use Doctrine\DBAL\Platforms\SQLServer\SQL\Builder\SQLServerSelectSQLBuilder;
@@ -1035,6 +1036,42 @@ class SQLServerPlatform extends AbstractPlatform
     public function getBooleanTypeDeclarationSQL(array $column): string
     {
         return 'BIT';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeographyTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
     }
 
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -376,6 +376,42 @@ class SQLitePlatform extends AbstractPlatform
         return 'CLOB';
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeometryTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeometryAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getGeographyTypeDeclarationSQL(array $column): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyFromGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function getGeographyAsGeoJSONSQL(string $sqlExpr): string
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
     /** @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy. */
     public function getListViewsSQL(string $database): string
     {

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -30,6 +30,8 @@ use function method_exists;
  *     comment: string,
  *     charset?: ?non-empty-string,
  *     collation?: ?non-empty-string,
+ *     geometryType?: ?non-empty-string,
+ *     srid?: ?int,
  * }
  * @phpstan-type PlatformOptions = array{
  *     charset?: ?non-empty-string,
@@ -38,6 +40,8 @@ use function method_exists;
  *     enumType?: class-string,
  *     jsonb?: bool,
  *     version?: bool,
+ *     geometryType?: ?non-empty-string,
+ *     srid?: ?int,
  * }
  */
 class Column extends AbstractNamedObject
@@ -425,8 +429,26 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()}
-     *             or {@see getEnumType()} instead.
+     * Returns the geometry type for spatial columns.
+     *
+     * @return ?non-empty-string
+     */
+    public function getGeometryType(): ?string
+    {
+        return $this->_platformOptions['geometryType'] ?? null;
+    }
+
+    /**
+     * Returns the SRID (Spatial Reference System Identifier) for spatial columns.
+     */
+    public function getSrid(): ?int
+    {
+        return $this->_platformOptions['srid'] ?? null;
+    }
+
+    /**
+     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()},
+     *             {@see getEnumType()}, {@see getGeometryType()} or {@see getSrid()} instead.
      *
      * @return PlatformOptions
      */
@@ -436,8 +458,8 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()}
-     *             or {@see getEnumType()} instead.
+     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()},
+     *             {@see getEnumType()}, {@see getGeometryType()} or {@see getSrid()} instead.
      *
      * @param key-of<PlatformOptions> $name
      */
@@ -447,8 +469,8 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()}
-     *             or {@see getEnumType()} instead.
+     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()},
+     *             {@see getEnumType()}, {@see getGeometryType()} or {@see getSrid()} instead.
      *
      * @param key-of<PlatformOptions> $name
      */
@@ -579,6 +601,8 @@ class Column extends AbstractNamedObject
             ->setMinimumValue($this->getMinimumValue())
             ->setMaximumValue($this->getMaximumValue())
             ->setEnumType($this->getEnumType())
-            ->setDefaultConstraintName($this->getDefaultConstraintName());
+            ->setDefaultConstraintName($this->getDefaultConstraintName())
+            ->setGeometryType($this->getGeometryType())
+            ->setSrid($this->getSrid());
     }
 }

--- a/src/Schema/ColumnEditor.php
+++ b/src/Schema/ColumnEditor.php
@@ -56,6 +56,11 @@ final class ColumnEditor
     /** @var ?non-empty-string */
     private ?string $columnDefinition = null;
 
+    /** @var ?non-empty-string */
+    private ?string $geometryType = null;
+
+    private ?int $srid = null;
+
     /** @internal Use {@link Column::editor()} or {@link Column::edit()} to create an instance */
     public function __construct()
     {
@@ -228,6 +233,21 @@ final class ColumnEditor
         return $this;
     }
 
+    /** @param ?non-empty-string $geometryType */
+    public function setGeometryType(?string $geometryType): self
+    {
+        $this->geometryType = $geometryType;
+
+        return $this;
+    }
+
+    public function setSrid(?int $srid): self
+    {
+        $this->srid = $srid;
+
+        return $this;
+    }
+
     public function create(): Column
     {
         if ($this->name === null) {
@@ -262,6 +282,14 @@ final class ColumnEditor
 
         if ($this->defaultConstraintName !== null) {
             $platformOptions[SQLServerPlatform::OPTION_DEFAULT_CONSTRAINT_NAME] = $this->defaultConstraintName;
+        }
+
+        if ($this->geometryType !== null) {
+            $platformOptions['geometryType'] = $this->geometryType;
+        }
+
+        if ($this->srid !== null) {
+            $platformOptions['srid'] = $this->srid;
         }
 
         return new Column(

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -121,12 +121,14 @@ class MySQLSchemaManager extends AbstractSchemaManager
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        $dbType    = $tableColumn['type'];
-        $length    = null;
-        $scale     = 0;
-        $precision = null;
-        $fixed     = false;
-        $values    = [];
+        $dbType       = $tableColumn['type'];
+        $length       = null;
+        $scale        = 0;
+        $precision    = null;
+        $fixed        = false;
+        $values       = [];
+        $geometryType = null;
+        $srid         = null;
 
         $type = $this->platform->getDoctrineTypeMapping($dbType);
 
@@ -177,6 +179,30 @@ class MySQLSchemaManager extends AbstractSchemaManager
                 }
 
                 break;
+
+            case 'geometry':
+            case 'point':
+            case 'linestring':
+            case 'polygon':
+            case 'multipoint':
+            case 'multilinestring':
+            case 'multipolygon':
+            case 'geomcollection':
+            case 'geometrycollection':
+                // For MySQL, the dbType directly represents the geometry subtype
+                $geometryType = $dbType;
+
+                // Normalize MySQL's abbreviated "geomcollection" to "geometrycollection"
+                if ($geometryType === 'geomcollection') {
+                    $geometryType = 'geometrycollection';
+                }
+
+                // MySQL 8.0.3+ stores SRID in information_schema.COLUMNS.SRS_ID
+                if (isset($tableColumn['srs_id'])) {
+                    $srid = (int) $tableColumn['srs_id'];
+                }
+
+                break;
         }
 
         switch ($dbType) {
@@ -217,6 +243,14 @@ class MySQLSchemaManager extends AbstractSchemaManager
         $column = new Column($tableColumn['field'], Type::getType($type), $options);
         $column->setPlatformOption('charset', $tableColumn['characterset']);
         $column->setPlatformOption('collation', $tableColumn['collation']);
+
+        if ($geometryType !== null) {
+            $column->setPlatformOption('geometryType', $geometryType);
+        }
+
+        if ($srid !== null) {
+            $column->setPlatformOption('srid', $srid);
+        }
 
         return $column;
     }
@@ -390,7 +424,8 @@ SELECT
        c.EXTRA,
        c.COLUMN_COMMENT     AS comment,
        c.CHARACTER_SET_NAME AS characterset,
-       c.COLLATION_NAME     AS collation
+       c.COLLATION_NAME     AS collation,
+       %s
 FROM information_schema.COLUMNS c
     INNER JOIN information_schema.TABLES t
         ON t.TABLE_NAME = c.TABLE_NAME
@@ -400,6 +435,7 @@ ORDER BY c.TABLE_NAME,
          c.ORDINAL_POSITION
 SQL,
             $this->platform->getColumnTypeSQLSnippet('c', $databaseName),
+            $this->platform->getSridColumnSQL(),
             implode(' AND ', $conditions),
         );
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -179,12 +179,20 @@ SQL,
         return parent::_getPortableTableIndexesList(array_map(
             /** @param array<string, mixed> $row */
             static function (array $row): array {
+                $flags = [];
+
+                // GIST indexes are used for spatial data in PostGIS
+                if (isset($row['index_method']) && $row['index_method'] === 'gist') {
+                    $flags = ['SPATIAL'];
+                }
+
                 return [
                     'key_name' => $row['relname'],
                     'non_unique' => ! $row['indisunique'],
                     'primary' => (bool) $row['indisprimary'],
                     'where' => $row['where'],
                     'column_name' => $row['attname'],
+                    'flags' => $flags,
                 ];
             },
             $rows,
@@ -469,11 +477,13 @@ SQL;
                    i.indkey,
                    i.indrelid,
                    pg_get_expr(indpred, indrelid) AS "where",
-                   quote_ident(attname) AS attname
+                   quote_ident(attname) AS attname,
+                   am.amname AS index_method
               FROM pg_index i
                    JOIN pg_class AS c ON c.oid = i.indrelid
                    JOIN pg_namespace n ON n.oid = c.relnamespace
                    JOIN pg_class AS ic ON ic.oid = i.indexrelid
+                   JOIN pg_am am ON am.oid = ic.relam
                    JOIN LATERAL UNNEST(i.indkey) WITH ORDINALITY AS keys(attnum, ord)
                         ON TRUE
                    JOIN pg_attribute a

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -15,6 +15,7 @@ use function array_change_key_case;
 use function array_map;
 use function assert;
 use function count;
+use function ctype_digit;
 use function explode;
 use function func_get_arg;
 use function func_num_args;
@@ -219,11 +220,13 @@ SQL,
     {
         $tableColumn = array_change_key_case($tableColumn, CASE_LOWER);
 
-        $length    = null;
-        $precision = null;
-        $scale     = 0;
-        $fixed     = false;
-        $jsonb     = false;
+        $length       = null;
+        $precision    = null;
+        $scale        = 0;
+        $fixed        = false;
+        $jsonb        = false;
+        $geometryType = null;
+        $srid         = null;
 
         $dbType = $tableColumn['type'];
 
@@ -263,6 +266,18 @@ SQL,
                 }
 
                 break;
+            case 'geometry':
+            case 'geography':
+                $parameters = $this->parseColumnTypeParameters($completeType);
+                if (count($parameters) > 0) {
+                    $geometryType = $parameters[0];
+                }
+
+                if (count($parameters) > 1) {
+                    $srid = $parameters[1];
+                }
+
+                break;
         }
 
         if ($dbType === 'bpchar') {
@@ -291,6 +306,14 @@ SQL,
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }
 
+        if ($geometryType !== null) {
+            $column->setPlatformOption('geometryType', $geometryType);
+        }
+
+        if ($srid !== null) {
+            $column->setPlatformOption('srid', $srid);
+        }
+
         if ($column->getType() instanceof JsonType) {
             $column->setPlatformOption('jsonb', $jsonb);
         }
@@ -301,19 +324,24 @@ SQL,
     /**
      * Parses the parameters between parenthesis in the data type.
      *
-     * @return list<int>
+     * @return list<int|string>
      */
     private function parseColumnTypeParameters(string $type): array
     {
-        if (preg_match('/\((\d+)(?:,(\d+))?\)/', $type, $matches) !== 1) {
+        if (preg_match('/\(([\w]+)(?:,([\w]+))?\)/', $type, $matches) !== 1) {
             return [];
         }
 
-        $parameters = [(int) $matches[1]];
+        $parameters = [$matches[1]];
 
         if (isset($matches[2])) {
-            $parameters[] = (int) $matches[2];
+            $parameters[] = $matches[2];
         }
+
+        // Cast numeric strings to int automatically
+        $parameters = array_map(static function ($param) {
+            return ctype_digit($param) ? (int) $param : $param;
+        }, $parameters);
 
         return $parameters;
     }

--- a/src/Types/GeoJSON.php
+++ b/src/Types/GeoJSON.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use InvalidArgumentException;
+use JsonException;
+use RuntimeException;
+use Stringable;
+
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function preg_match;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Value object representing GeoJSON geometry data with optional SRID metadata.
+ *
+ * This class validates and wraps GeoJSON geometry data according to RFC 7946 specification.
+ * It provides a clean abstraction for transporting pure geometry data with SRID across
+ * different database platforms. Feature and FeatureCollection types are intentionally
+ * excluded as they are not suitable for database column storage.
+ *
+ * Supported geometry types:
+ * - Point, LineString, Polygon
+ * - MultiPoint, MultiLineString, MultiPolygon
+ * - GeometryCollection
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7946
+ */
+final class GeoJSON implements Stringable
+{
+    /**
+     * Valid GeoJSON geometry types according to RFC 7946.
+     *
+     * Note: Feature and FeatureCollection are not included as they are not supported
+     * for database storage. This class focuses on pure geometry transport with SRID.
+     */
+    private const VALID_TYPES = [
+        'Point' => true,
+        'LineString' => true,
+        'Polygon' => true,
+        'MultiPoint' => true,
+        'MultiLineString' => true,
+        'MultiPolygon' => true,
+        'GeometryCollection' => true,
+    ];
+
+    /** @param array<string, mixed> $data Parsed GeoJSON data as associative array */
+    private function __construct(private readonly array $data)
+    {
+    }
+
+    /**
+     * Creates a GeoJSON value object from a JSON string.
+     *
+     * Validates the JSON structure and ensures it conforms to RFC 7946 geometry types.
+     *
+     * @param string $json GeoJSON string conforming to RFC 7946
+     *
+     * @throws InvalidArgumentException If the JSON is invalid or doesn't conform to GeoJSON spec.
+     */
+    public static function fromString(string $json): self
+    {
+        try {
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid JSON string: %s', $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        if (! is_array($data)) {
+            throw new InvalidArgumentException('GeoJSON must be a JSON object, not a scalar or array');
+        }
+
+        self::validate($data);
+
+        return new self($data);
+    }
+
+    /**
+     * Validates GeoJSON data structure according to RFC 7946.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @throws InvalidArgumentException If validation fails.
+     */
+    private static function validate(array $data): void
+    {
+        if (! isset($data['type'])) {
+            throw new InvalidArgumentException('GeoJSON object must have a "type" property');
+        }
+
+        if (! is_string($data['type'])) {
+            throw new InvalidArgumentException('GeoJSON "type" must be a string');
+        }
+
+        if (! isset(self::VALID_TYPES[$data['type']])) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid GeoJSON type "%s"', $data['type']),
+            );
+        }
+
+        $type = $data['type'];
+
+        // Validate geometry objects (only pure geometries, no Features/FeatureCollections)
+        if ($type === 'GeometryCollection') {
+            if (! isset($data['geometries'])) {
+                throw new InvalidArgumentException('GeoJSON GeometryCollection must have a "geometries" property');
+            }
+
+            if (! is_array($data['geometries'])) {
+                throw new InvalidArgumentException('GeoJSON "geometries" must be an array');
+            }
+        } else {
+            // All other geometry types must have coordinates
+            if (! isset($data['coordinates'])) {
+                throw new InvalidArgumentException(
+                    sprintf('GeoJSON %s must have a "coordinates" property', $type),
+                );
+            }
+
+            if (! is_array($data['coordinates'])) {
+                throw new InvalidArgumentException(
+                    sprintf('GeoJSON %s "coordinates" must be an array', $type),
+                );
+            }
+        }
+
+        // Validate CRS if present (for SRID support)
+        if (isset($data['crs'])) {
+            self::validateCrs($data['crs']);
+        }
+
+        // Validate bbox if present
+        if (isset($data['bbox']) && ! is_array($data['bbox'])) {
+            throw new InvalidArgumentException('GeoJSON "bbox" must be an array');
+        }
+    }
+
+    /**
+     * Validates the CRS (Coordinate Reference System) property.
+     *
+     * @throws InvalidArgumentException If CRS is invalid.
+     */
+    private static function validateCrs(mixed $crs): void
+    {
+        if (! is_array($crs)) {
+            throw new InvalidArgumentException('GeoJSON "crs" must be an object');
+        }
+
+        if (! isset($crs['type']) || $crs['type'] !== 'name') {
+            throw new InvalidArgumentException('GeoJSON "crs" must have type "name"');
+        }
+
+        if (! isset($crs['properties']) || ! is_array($crs['properties'])) {
+            throw new InvalidArgumentException('GeoJSON "crs" must have a "properties" object');
+        }
+
+        if (! isset($crs['properties']['name']) || ! is_string($crs['properties']['name'])) {
+            throw new InvalidArgumentException('GeoJSON "crs.properties" must have a "name" string');
+        }
+    }
+
+    /**
+     * Returns the SRID (Spatial Reference System Identifier) if specified in CRS.
+     *
+     * Extracts SRID from CRS property in formats:
+     * - "EPSG:4326"
+     * - "urn:ogc:def:crs:EPSG::4326"
+     * - "http://www.opengis.net/def/crs/EPSG/0/4326"
+     */
+    public function getSrid(): int|null
+    {
+        if (! isset($this->data['crs']['properties']['name'])) {
+            return null;
+        }
+
+        $crsName = $this->data['crs']['properties']['name'];
+
+        // Match EPSG:4326 format
+        if (preg_match('/EPSG[:\\/](\d+)$/i', $crsName, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        // Match urn:ogc:def:crs:EPSG::4326 format
+        if (preg_match('/urn:ogc:def:crs:EPSG::(\d+)$/i', $crsName, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the GeoJSON data as a JSON string.
+     */
+    public function toString(): string
+    {
+        try {
+            return json_encode($this->data, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException(
+                sprintf('Failed to encode GeoJSON: %s', $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * Returns the GeoJSON data as a JSON string.
+     */
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/src/Types/GeographyType.php
+++ b/src/Types/GeographyType.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use function is_string;
 
 /**
- * Type that maps a database GEOGRAPHY column to a PHP string containing GeoJSON data.
+ * Type that maps a database GEOGRAPHY column to a PHP Geometry value object.
  *
  * Geography types handle spherical coordinate systems and are typically used for
  * earth-based geographic data with latitude/longitude coordinates.
@@ -38,21 +38,21 @@ class GeographyType extends Type
             return null;
         }
 
-        if (is_string($value)) {
-            return $value;
+        if ($value instanceof Geometry) {
+            return $value->toGeoJSON();
         }
 
         throw ValueNotConvertible::new($value, Types::GEOGRAPHY);
     }
 
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): Geometry|null
     {
         if ($value === null) {
             return null;
         }
 
         if (is_string($value)) {
-            return $value;
+            return Geometry::fromGeoJSON($value);
         }
 
         throw ValueNotConvertible::new($value, Types::GEOGRAPHY);

--- a/src/Types/GeographyType.php
+++ b/src/Types/GeographyType.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
+
+use function is_string;
+
+/**
+ * Type that maps a database GEOGRAPHY column to a PHP string containing GeoJSON data.
+ *
+ * Geography types handle spherical coordinate systems and are typically used for
+ * earth-based geographic data with latitude/longitude coordinates.
+ * This is distinct from geometry types which use planar/Euclidean coordinate systems.
+ */
+class GeographyType extends Type
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getGeographyTypeDeclarationSQL($column);
+    }
+
+    public function getBindingType(): ParameterType
+    {
+        return ParameterType::STRING;
+    }
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        throw ValueNotConvertible::new($value, Types::GEOGRAPHY);
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        throw ValueNotConvertible::new($value, Types::GEOGRAPHY);
+    }
+
+    public function convertToDatabaseValueSQL(string $sqlExpr, AbstractPlatform $platform): string
+    {
+        return $platform->getGeographyFromGeoJSONSQL($sqlExpr);
+    }
+
+    public function convertToPHPValueSQL(string $sqlExpr, AbstractPlatform $platform): string
+    {
+        return $platform->getGeographyAsGeoJSONSQL($sqlExpr);
+    }
+}

--- a/src/Types/Geometry.php
+++ b/src/Types/Geometry.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use InvalidArgumentException;
+use Stringable;
+
+/**
+ * Value object representing spatial geometry data using GeoJSON format.
+ *
+ * This class provides a clean abstraction for spatial data that works across different
+ * database platforms. GeoJSON is the standardized format that includes SRID information
+ * within the format itself via the CRS property.
+ */
+final class Geometry implements Stringable
+{
+    private function __construct(
+        private readonly GeoJSON $geoJson,
+        private readonly int|null $srid,
+    ) {
+    }
+
+    /**
+     * Creates a Geometry from GeoJSON string.
+     *
+     * GeoJSON format includes SRID information within the CRS property according to RFC 7946.
+     * This provides a standardized, platform-agnostic representation.
+     *
+     * @param string $json GeoJSON string representation of the geometry
+     *
+     * @throws InvalidArgumentException If the GeoJSON format is invalid.
+     */
+    public static function fromGeoJSON(string $json): self
+    {
+        $geoJson = GeoJSON::fromString($json);
+        $srid    = $geoJson->getSrid();
+
+        return new self($geoJson, $srid);
+    }
+
+    /**
+     * Returns the GeoJSON representation.
+     */
+    public function getGeoJSON(): GeoJSON
+    {
+        return $this->geoJson;
+    }
+
+    /**
+     * Returns the Spatial Reference System Identifier, if set.
+     *
+     * This is extracted from the CRS property in the GeoJSON.
+     */
+    public function getSrid(): int|null
+    {
+        return $this->srid;
+    }
+
+    /**
+     * Returns GeoJSON string representation.
+     */
+    public function toGeoJSON(): string
+    {
+        return $this->geoJson->toString();
+    }
+
+    /**
+     * Returns string representation of the geometry in GeoJSON format.
+     */
+    public function __toString(): string
+    {
+        return $this->geoJson->toString();
+    }
+}

--- a/src/Types/GeometryType.php
+++ b/src/Types/GeometryType.php
@@ -11,10 +11,10 @@ use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use function is_string;
 
 /**
- * Type that maps a database GEOMETRY column to a PHP string containing GeoJSON data.
+ * Type that maps a database GEOMETRY column to a PHP Geometry value object.
  *
  * This type handles geometric data stored in various database formats and converts
- * it to/from GeoJSON format for PHP processing.
+ * it to/from a Geometry value object that encapsulates GeoJSON.
  */
 class GeometryType extends Type
 {
@@ -37,21 +37,21 @@ class GeometryType extends Type
             return null;
         }
 
-        if (is_string($value)) {
-            return $value;
+        if ($value instanceof Geometry) {
+            return $value->toGeoJSON();
         }
 
         throw ValueNotConvertible::new($value, Types::GEOMETRY);
     }
 
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): Geometry|null
     {
         if ($value === null) {
             return null;
         }
 
         if (is_string($value)) {
-            return $value;
+            return Geometry::fromGeoJSON($value);
         }
 
         throw ValueNotConvertible::new($value, Types::GEOMETRY);

--- a/src/Types/GeometryType.php
+++ b/src/Types/GeometryType.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
+
+use function is_string;
+
+/**
+ * Type that maps a database GEOMETRY column to a PHP string containing GeoJSON data.
+ *
+ * This type handles geometric data stored in various database formats and converts
+ * it to/from GeoJSON format for PHP processing.
+ */
+class GeometryType extends Type
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getGeometryTypeDeclarationSQL($column);
+    }
+
+    public function getBindingType(): ParameterType
+    {
+        return ParameterType::STRING;
+    }
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        throw ValueNotConvertible::new($value, Types::GEOMETRY);
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        throw ValueNotConvertible::new($value, Types::GEOMETRY);
+    }
+
+    public function convertToDatabaseValueSQL(string $sqlExpr, AbstractPlatform $platform): string
+    {
+        return $platform->getGeometryFromGeoJSONSQL($sqlExpr);
+    }
+
+    public function convertToPHPValueSQL(string $sqlExpr, AbstractPlatform $platform): string
+    {
+        return $platform->getGeometryAsGeoJSONSQL($sqlExpr);
+    }
+}

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -43,6 +43,8 @@ abstract class Type
         Types::NUMBER                 => NumberType::class,
         Types::ENUM                   => EnumType::class,
         Types::FLOAT                  => FloatType::class,
+        Types::GEOGRAPHY              => GeographyType::class,
+        Types::GEOMETRY               => GeometryType::class,
         Types::GUID                   => GuidType::class,
         Types::INTEGER                => IntegerType::class,
         Types::JSON                   => JsonType::class,

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -27,6 +27,8 @@ final class Types
     public const NUMBER                 = 'number';
     public const FLOAT                  = 'float';
     public const ENUM                   = 'enum';
+    public const GEOGRAPHY              = 'geography';
+    public const GEOMETRY               = 'geometry';
     public const GUID                   = 'guid';
     public const INTEGER                = 'integer';
     public const JSON                   = 'json';

--- a/tests/Functional/Schema/MySQL/SpatialTypesTest.php
+++ b/tests/Functional/Schema/MySQL/SpatialTypesTest.php
@@ -1,0 +1,707 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\MySQL;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\GeometryType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+final class SpatialTypesTest extends SpatialTestCase
+{
+    private const TABLE_NAME = 'mysql_spatial_schema_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof AbstractMySQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('This test is MySQL-specific and should not run on other platforms.');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        if (! $schemaManager->tablesExist([self::TABLE_NAME])) {
+            return;
+        }
+
+        $schemaManager->dropTable(self::TABLE_NAME);
+    }
+
+    public function testCreateTableWithSpatialColumns(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        self::assertTrue($schemaManager->tablesExist([self::TABLE_NAME]));
+
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        self::assertSame(Type::getType(Types::GEOMETRY), $columns['geom']->getType());
+    }
+
+    public function testSpatialColumnIntrospection(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('simple_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('point_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('linestring_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('polygon_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POLYGON')
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        $simpleGeom = $columns['simple_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $simpleGeom->getType());
+        self::assertSame('geometry', $simpleGeom->getGeometryType());
+        self::assertNull($simpleGeom->getSrid());
+
+        $pointGeom = $columns['point_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $pointGeom->getType());
+        self::assertSame('point', $pointGeom->getGeometryType());
+        self::assertNull($pointGeom->getSrid());
+
+        $linestringGeom = $columns['linestring_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $linestringGeom->getType());
+        self::assertSame('linestring', $linestringGeom->getGeometryType());
+        self::assertNull($linestringGeom->getSrid());
+
+        $polygonGeom = $columns['polygon_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $polygonGeom->getType());
+        self::assertSame('polygon', $polygonGeom->getGeometryType());
+        self::assertNull($polygonGeom->getSrid());
+    }
+
+    public function testSpatialColumnIntrospectionWithSrid(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('point_srid')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('linestring_srid')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->setSrid(SpatialReferenceSystems::SRID_UTM_33N)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('polygon_srid')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POLYGON')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        $pointSrid = $columns['point_srid'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $pointSrid->getType());
+        self::assertSame('point', $pointSrid->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $pointSrid->getSrid());
+
+        $linestringSrid = $columns['linestring_srid'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $linestringSrid->getType());
+        self::assertSame('linestring', $linestringSrid->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $linestringSrid->getSrid());
+
+        $polygonSrid = $columns['polygon_srid'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $polygonSrid->getType());
+        self::assertSame('polygon', $polygonSrid->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $polygonSrid->getSrid());
+    }
+
+    public function testIntrospectTableCreatedWithRawSQLContainingSpatialColumns(): void
+    {
+        $this->connection->executeStatement(<<< 'SQL'
+            CREATE TABLE mysql_spatial_raw_sql_test (
+                id BIGINT NOT NULL PRIMARY KEY,
+                point_col POINT DEFAULT NULL,
+                linestring_col LINESTRING DEFAULT NULL,
+                polygon_col POLYGON DEFAULT NULL,
+                multipoint_col MULTIPOINT DEFAULT NULL,
+                multilinestring_col MULTILINESTRING DEFAULT NULL,
+                multipolygon_col MULTIPOLYGON DEFAULT NULL,
+                geometrycollection_col GEOMETRYCOLLECTION DEFAULT NULL
+            );
+            SQL);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $table         = $schemaManager->introspectTableByUnquotedName('mysql_spatial_raw_sql_test');
+
+        // POINT column
+        $pointCol = $table->getColumn('point_col');
+        self::assertInstanceOf(GeometryType::class, $pointCol->getType());
+        self::assertSame('point', $pointCol->getGeometryType());
+        self::assertNull($pointCol->getSrid());
+
+        // LINESTRING column
+        $linestringCol = $table->getColumn('linestring_col');
+        self::assertInstanceOf(GeometryType::class, $linestringCol->getType());
+        self::assertSame('linestring', $linestringCol->getGeometryType());
+        self::assertNull($linestringCol->getSrid());
+
+        // POLYGON column
+        $polygonCol = $table->getColumn('polygon_col');
+        self::assertInstanceOf(GeometryType::class, $polygonCol->getType());
+        self::assertSame('polygon', $polygonCol->getGeometryType());
+        self::assertNull($polygonCol->getSrid());
+
+        // MULTIPOINT column
+        $multipointCol = $table->getColumn('multipoint_col');
+        self::assertInstanceOf(GeometryType::class, $multipointCol->getType());
+        self::assertSame('multipoint', $multipointCol->getGeometryType());
+        self::assertNull($multipointCol->getSrid());
+
+        // MULTILINESTRING column
+        $multilinestringCol = $table->getColumn('multilinestring_col');
+        self::assertInstanceOf(GeometryType::class, $multilinestringCol->getType());
+        self::assertSame('multilinestring', $multilinestringCol->getGeometryType());
+        self::assertNull($multilinestringCol->getSrid());
+
+        // MULTIPOLYGON column
+        $multipolygonCol = $table->getColumn('multipolygon_col');
+        self::assertInstanceOf(GeometryType::class, $multipolygonCol->getType());
+        self::assertSame('multipolygon', $multipolygonCol->getGeometryType());
+        self::assertNull($multipolygonCol->getSrid());
+
+        // GEOMETRYCOLLECTION column
+        $geometrycollectionCol = $table->getColumn('geometrycollection_col');
+        self::assertInstanceOf(GeometryType::class, $geometrycollectionCol->getType());
+        self::assertSame('geometrycollection', $geometrycollectionCol->getGeometryType());
+        self::assertNull($geometrycollectionCol->getSrid());
+
+        // Clean up
+        $schemaManager->dropTable('mysql_spatial_raw_sql_test');
+    }
+
+    public function testIntrospectTableCreatedWithRawSQLContainingSpatialColumnsWithSrid(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
+        $this->connection->executeStatement(<<< 'SQL'
+            CREATE TABLE mysql_spatial_raw_sql_srid_test (
+                id BIGINT NOT NULL PRIMARY KEY,
+                point_col POINT SRID 4326 DEFAULT NULL,
+                linestring_col LINESTRING SRID 32633 DEFAULT NULL,
+                polygon_col POLYGON SRID 4326 DEFAULT NULL,
+                multipoint_col MULTIPOINT SRID 4326 DEFAULT NULL,
+                multilinestring_col MULTILINESTRING SRID 32633 DEFAULT NULL,
+                multipolygon_col MULTIPOLYGON SRID 4326 DEFAULT NULL,
+                geometrycollection_col GEOMETRYCOLLECTION SRID 4326 DEFAULT NULL
+            );
+            SQL);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $table         = $schemaManager->introspectTableByUnquotedName('mysql_spatial_raw_sql_srid_test');
+
+        // POINT column
+        $pointCol = $table->getColumn('point_col');
+        self::assertInstanceOf(GeometryType::class, $pointCol->getType());
+        self::assertSame('point', $pointCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $pointCol->getSrid());
+
+        // LINESTRING column
+        $linestringCol = $table->getColumn('linestring_col');
+        self::assertInstanceOf(GeometryType::class, $linestringCol->getType());
+        self::assertSame('linestring', $linestringCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $linestringCol->getSrid());
+
+        // POLYGON column
+        $polygonCol = $table->getColumn('polygon_col');
+        self::assertInstanceOf(GeometryType::class, $polygonCol->getType());
+        self::assertSame('polygon', $polygonCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $polygonCol->getSrid());
+
+        // MULTIPOINT column
+        $multipointCol = $table->getColumn('multipoint_col');
+        self::assertInstanceOf(GeometryType::class, $multipointCol->getType());
+        self::assertSame('multipoint', $multipointCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $multipointCol->getSrid());
+
+        // MULTILINESTRING column
+        $multilinestringCol = $table->getColumn('multilinestring_col');
+        self::assertInstanceOf(GeometryType::class, $multilinestringCol->getType());
+        self::assertSame('multilinestring', $multilinestringCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $multilinestringCol->getSrid());
+
+        // MULTIPOLYGON column
+        $multipolygonCol = $table->getColumn('multipolygon_col');
+        self::assertInstanceOf(GeometryType::class, $multipolygonCol->getType());
+        self::assertSame('multipolygon', $multipolygonCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $multipolygonCol->getSrid());
+
+        // GEOMETRYCOLLECTION column
+        $geometrycollectionCol = $table->getColumn('geometrycollection_col');
+        self::assertInstanceOf(GeometryType::class, $geometrycollectionCol->getType());
+        self::assertSame('geometrycollection', $geometrycollectionCol->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $geometrycollectionCol->getSrid());
+
+        // Clean up
+        $schemaManager->dropTable('mysql_spatial_raw_sql_srid_test');
+    }
+
+    public function testAlterTableAddSpatialColumn(): void
+    {
+        // Create table without spatial columns
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Add spatial column via ALTER TABLE
+        $newTable = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+        $tableDiff  = $comparator->compareTables($table, $newTable);
+        $alterSql   = $this->connection->getDatabasePlatform()->getAlterTableSQL($tableDiff);
+
+        // Execute ALTER TABLE
+        foreach ($alterSql as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+
+        // Verify spatial column was added
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+        self::assertArrayHasKey('location', $columns);
+        self::assertSame(Type::getType(Types::GEOMETRY), $columns['location']->getType());
+        self::assertSame('point', $columns['location']->getGeometryType());
+        self::assertNull($columns['location']->getSrid());
+    }
+
+    public function testAlterTableAddSpatialColumnWithSrid(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
+        // Create table without spatial columns
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Add spatial column with SRID via ALTER TABLE
+        $newTable = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+        $tableDiff  = $comparator->compareTables($table, $newTable);
+        $alterSql   = $this->connection->getDatabasePlatform()->getAlterTableSQL($tableDiff);
+
+        // Execute ALTER TABLE
+        foreach ($alterSql as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+
+        // Verify spatial column with SRID was added
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+        self::assertArrayHasKey('location', $columns);
+        self::assertSame(Type::getType(Types::GEOMETRY), $columns['location']->getType());
+        self::assertSame('point', $columns['location']->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $columns['location']->getSrid());
+    }
+
+    public function testAlterTableAlterSpatialColumn(): void
+    {
+        // Create table with spatial column
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Alter spatial column to different type
+        $newTable = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+        $tableDiff  = $comparator->compareTables($table, $newTable);
+        $alterSql   = $this->connection->getDatabasePlatform()->getAlterTableSQL($tableDiff);
+
+        // Execute ALTER TABLE
+        foreach ($alterSql as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+
+        // Verify spatial column was altered
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        $geom = $columns['geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $geom->getType());
+        self::assertSame('linestring', $geom->getGeometryType());
+        self::assertNull($geom->getSrid());
+    }
+
+    public function testAlterTableAlterSpatialColumnWithSrid(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
+        // Create table with spatial column with SRID
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Alter spatial column to different type and SRID
+        $newTable = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->setSrid(SpatialReferenceSystems::SRID_UTM_33N)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+        $tableDiff  = $comparator->compareTables($table, $newTable);
+        $alterSql   = $this->connection->getDatabasePlatform()->getAlterTableSQL($tableDiff);
+
+        // Execute ALTER TABLE
+        foreach ($alterSql as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+
+        // Verify spatial column was altered
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        $geom = $columns['geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $geom->getType());
+        self::assertSame('linestring', $geom->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $geom->getSrid());
+    }
+
+    public function testDifferentGeometryTypes(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('point_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('linestring_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('polygon_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POLYGON')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('multipoint_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('MULTIPOINT')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('multilinestring_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('MULTILINESTRING')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('multipolygon_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('MULTIPOLYGON')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geometrycollection_col')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('GEOMETRYCOLLECTION')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        self::assertSame('point', $columns['point_col']->getGeometryType());
+        self::assertSame('linestring', $columns['linestring_col']->getGeometryType());
+        self::assertSame('polygon', $columns['polygon_col']->getGeometryType());
+        self::assertSame('multipoint', $columns['multipoint_col']->getGeometryType());
+        self::assertSame('multilinestring', $columns['multilinestring_col']->getGeometryType());
+        self::assertSame('multipolygon', $columns['multipolygon_col']->getGeometryType());
+        self::assertSame('geometrycollection', $columns['geometrycollection_col']->getGeometryType());
+    }
+}

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -794,6 +794,11 @@ SQL;
         $doctrineTypes = array_keys(Type::getTypesMap());
 
         foreach ($doctrineTypes as $type) {
+            // Skip GEOGRAPHY type - MySQL doesn't support it (PostgreSQL/PostGIS only)
+            if ($type === Types::GEOGRAPHY) {
+                continue;
+            }
+
             $columnEditor = Column::editor()
                 ->setUnquotedName('col_' . $type)
                 ->setTypeName($type);

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Schema\MySQL\CustomType;
-use Doctrine\DBAL\Tests\Functional\Schema\MySQL\PointType;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
@@ -33,11 +32,6 @@ use function array_keys;
 class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
     use VerifyDeprecations;
-
-    public static function setUpBeforeClass(): void
-    {
-        Type::addType('point', PointType::class);
-    }
 
     protected function supportsPlatform(AbstractPlatform $platform): bool
     {
@@ -88,7 +82,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             ->setColumns(
                 Column::editor()
                     ->setUnquotedName('point')
-                    ->setTypeName('point')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
                     ->create(),
             )
             ->setIndexes($index)

--- a/tests/Functional/Schema/PostgreSQL/PostGISTest.php
+++ b/tests/Functional/Schema/PostgreSQL/PostGISTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\PostgreSQL;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+final class PostGISTest extends SpatialTestCase
+{
+    private const TABLE_NAME = 'postgis_schema_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof PostgreSQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('PostGIS tests require PostgreSQL with PostGIS extension.');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        if (! $schemaManager->tablesExist([self::TABLE_NAME])) {
+            return;
+        }
+
+        $schemaManager->dropTable(self::TABLE_NAME);
+    }
+
+    public function testCreateTableWithSpatialColumns(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        self::assertTrue($schemaManager->tablesExist([self::TABLE_NAME]));
+
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        self::assertSame(Type::getType(Types::GEOMETRY), $columns['geom']->getType());
+        self::assertSame(Type::getType(Types::GEOGRAPHY), $columns['geog']->getType());
+    }
+
+    public function testSpatialColumnIntrospection(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('simple_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('typed_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('srid_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setSrid(SpatialReferenceSystems::SRID_UTM_33N)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('full_geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POLYGON')
+                    ->setSrid(SpatialReferenceSystems::SRID_UTM_33N)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('simple_geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('typed_geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('LINESTRING')
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('srid_geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setSrid(SpatialReferenceSystems::SRID_NAD27)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('full_geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POLYGON')
+                    ->setSrid(SpatialReferenceSystems::SRID_NAD27)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        $simpleGeom = $columns['simple_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $simpleGeom->getType());
+        self::assertNull($simpleGeom->getGeometryType());
+        self::assertNull($simpleGeom->getSrid());
+
+        $typedGeom = $columns['typed_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $typedGeom->getType());
+        self::assertSame('LineString', $typedGeom->getGeometryType());
+        self::assertNull($typedGeom->getSrid());
+
+        $sridGeom = $columns['srid_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $sridGeom->getType());
+        self::assertSame('Geometry', $sridGeom->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $sridGeom->getSrid());
+
+        $fullGeom = $columns['full_geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $fullGeom->getType());
+        self::assertSame('Polygon', $fullGeom->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $fullGeom->getSrid());
+
+        $simpleGeog = $columns['simple_geog'];
+        self::assertSame(Type::getType(Types::GEOGRAPHY), $simpleGeog->getType());
+        self::assertSame('Geometry', $simpleGeog->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $simpleGeog->getSrid());
+
+        $typedGeog = $columns['typed_geog'];
+        self::assertSame(Type::getType(Types::GEOGRAPHY), $typedGeog->getType());
+        self::assertSame('LineString', $typedGeog->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $typedGeog->getSrid());
+
+        $sridGeog = $columns['srid_geog'];
+        self::assertSame(Type::getType(Types::GEOGRAPHY), $sridGeog->getType());
+        self::assertSame('Geometry', $sridGeog->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_NAD27, $sridGeog->getSrid());
+
+        $fullGeog = $columns['full_geog'];
+        self::assertSame(Type::getType(Types::GEOGRAPHY), $fullGeog->getType());
+        self::assertSame('Polygon', $fullGeog->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_NAD27, $fullGeog->getSrid());
+    }
+
+    public function testAlterTableAddSpatialColumn(): void
+    {
+        // Create table without spatial columns
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Add spatial column via ALTER TABLE
+        $newTable = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+        $tableDiff  = $comparator->compareTables($table, $newTable);
+
+        $schemaManager->alterTable($tableDiff);
+
+        // Verify spatial column was added
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+        self::assertArrayHasKey('location', $columns);
+        self::assertSame(Type::getType(Types::GEOMETRY), $columns['location']->getType());
+    }
+
+    public function testAlterTableAlterSpatialColumn(): void
+    {
+        // Create table without spatial columns
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Add spatial column via ALTER TABLE
+        $newTable = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geom')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('LINESTRING')
+                    ->setSrid(SpatialReferenceSystems::SRID_UTM_33N)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('geog')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POLYGON')
+                    ->setSrid(SpatialReferenceSystems::SRID_NAD27)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+        $tableDiff  = $comparator->compareTables($table, $newTable);
+
+        $schemaManager->alterTable($tableDiff);
+
+        // Verify spatial column was added
+        $columns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        $geom = $columns['geom'];
+        self::assertSame(Type::getType(Types::GEOMETRY), $geom->getType());
+        self::assertSame('LineString', $geom->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_UTM_33N, $geom->getSrid());
+
+        $geog = $columns['geog'];
+        self::assertSame(Type::getType(Types::GEOGRAPHY), $geog->getType());
+        self::assertSame('Polygon', $geog->getGeometryType());
+        self::assertSame(SpatialReferenceSystems::SRID_NAD27, $geog->getSrid());
+    }
+}

--- a/tests/Functional/Schema/PostgreSQL/PostGISTest.php
+++ b/tests/Functional/Schema/PostgreSQL/PostGISTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\DBAL\Tests\Functional\Schema\PostgreSQL;
 
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
@@ -338,5 +340,56 @@ final class PostGISTest extends SpatialTestCase
         self::assertSame(Type::getType(Types::GEOGRAPHY), $geog->getType());
         self::assertSame('Polygon', $geog->getGeometryType());
         self::assertSame(SpatialReferenceSystems::SRID_NAD27, $geog->getSrid());
+    }
+
+    public function testSpatialIndex(): void
+    {
+        $index = Index::editor()
+            ->setUnquotedName('spatial_idx')
+            ->setType(IndexType::SPATIAL)
+            ->setUnquotedColumnNames('location')
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(4326)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setIndexes($index)
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $onlineTable = $schemaManager->introspectTableByUnquotedName(self::TABLE_NAME);
+
+        // Verify the table structure is maintained
+        self::assertTrue(
+            $schemaManager->createComparator()
+                ->compareTables($table, $onlineTable)
+                ->isEmpty(),
+        );
+
+        // Verify the spatial index exists
+        self::assertTrue($onlineTable->hasIndex('spatial_idx'));
+
+        // Verify the index type is SPATIAL
+        $spatialIndex = $onlineTable->getIndex('spatial_idx');
+        self::assertSame(IndexType::SPATIAL, $spatialIndex->getType());
     }
 }

--- a/tests/Functional/SpatialTestCase.php
+++ b/tests/Functional/SpatialTestCase.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+
+/**
+ * Base class for spatial tests that require PostGIS extension.
+ */
+abstract class SpatialTestCase extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('PostGIS is only available as an extension in PostgreSQL.');
+        }
+
+        $this->requiresPostGIS();
+    }
+
+    private function requiresPostGIS(): void
+    {
+        $installed = $this->connection->fetchOne('
+            SELECT extname
+            FROM pg_extension
+            WHERE extname = \'postgis\'
+        ');
+
+        if ($installed !== false) {
+            return;
+        }
+
+        $available = $this->connection->fetchOne('
+            SELECT name
+            FROM pg_available_extensions
+            WHERE name = \'postgis\'
+        ');
+
+        if ($available !== false) {
+            self::fail(
+                'PostGIS extension is available but not installed. ' .
+                'Please install PostGIS: CREATE EXTENSION postgis;',
+            );
+        } else {
+            self::markTestSkipped(
+                'PostGIS extension is not available in this PostgreSQL installation. ' .
+                'Skipping spatial tests.',
+            );
+        }
+    }
+}

--- a/tests/Functional/SpatialTestCase.php
+++ b/tests/Functional/SpatialTestCase.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 
 /**
- * Base class for spatial tests that require PostGIS extension.
+ * Base class for spatial tests.
+ *
+ * Supports both PostgreSQL (with PostGIS extension) and MySQL (native spatial support).
  */
 abstract class SpatialTestCase extends FunctionalTestCase
 {
@@ -16,11 +19,19 @@ abstract class SpatialTestCase extends FunctionalTestCase
     {
         parent::setUp();
 
-        if (! $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-            self::markTestSkipped('PostGIS is only available as an extension in PostgreSQL.');
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            $this->requiresPostGIS();
+
+            return;
         }
 
-        $this->requiresPostGIS();
+        if ($platform instanceof AbstractMySQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('Spatial types are only supported on PostgreSQL (PostGIS) and MySQL platforms.');
     }
 
     private function requiresPostGIS(): void

--- a/tests/Functional/Types/GeographyTest.php
+++ b/tests/Functional/Types/GeographyTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\Types;
+use Throwable;
+
+/**
+ * Tests for GEOGRAPHY type data operations and conversions.
+ * GEOGRAPHY is only supported on PostgreSQL with PostGIS extension.
+ */
+class GeographyTest extends SpatialTestCase
+{
+    private const TABLE_NAME = 'geography_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof PostgreSQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('GEOGRAPHY type is only supported on PostgreSQL with PostGIS.');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        if (! $schemaManager->tablesExist([self::TABLE_NAME])) {
+            return;
+        }
+
+        $schemaManager->dropTable(self::TABLE_NAME);
+    }
+
+    public function testGeographyDataConversion(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $locations = [
+            ['name' => 'London', 'location' => '{"type":"Point","coordinates":[-0.1276,51.5074]}'],
+            ['name' => 'Paris', 'location' => '{"type":"Point","coordinates":[2.3522,48.8566]}'],
+            ['name' => 'Berlin', 'location' => '{"type":"Point","coordinates":[13.4050,52.5200]}'],
+        ];
+
+        foreach ($locations as $location) {
+            $this->connection->insert(self::TABLE_NAME, $location, [
+                'name' => Types::STRING,
+                'location' => Types::GEOGRAPHY,
+            ]);
+        }
+
+        // Retrieve and verify data conversion
+        $platform = $this->connection->getDatabasePlatform();
+
+        $geographyAsGeoJSON = $platform->getGeographyAsGeoJSONSQL('location');
+
+        $results = $this->connection->createQueryBuilder()
+            ->select('name', $geographyAsGeoJSON . ' as location')
+            ->from(self::TABLE_NAME)
+            ->orderBy('name')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        self::assertCount(3, $results);
+        self::assertSame('Berlin', $results[0]['name']);
+        self::assertStringContainsString('"coordinates":[13.405,52.52]', $results[0]['location']);
+    }
+
+    public function testGeographyWithInvalidSRID(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage('Only lon/lat coordinate systems are supported in geography');
+
+        // UTM Zone 33N coordinates - should fail because GEOGRAPHY requires spherical coordinates
+        $utmGeoJSON = '{"type":"Point","coordinates":[551490,5181640],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_UTM_33N . '"}}}';
+
+        $this->connection->insert(
+            self::TABLE_NAME,
+            ['location' => $utmGeoJSON], // UTM Zone 33N - should fail
+            ['location' => Types::GEOGRAPHY],
+        );
+    }
+
+    public function testGeographyNullValues(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setNotNull(false)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $this->connection->insert(self::TABLE_NAME, [
+            'name' => 'Unknown Location',
+            'location' => null,
+        ], [
+            'name' => Types::STRING,
+            'location' => Types::GEOGRAPHY,
+        ]);
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        $geographyAsGeoJSON = $platform->getGeographyAsGeoJSONSQL('location');
+
+        $results = $this->connection->createQueryBuilder()
+            ->select('name', $geographyAsGeoJSON . ' AS location')
+            ->from(self::TABLE_NAME)
+            ->orderBy('name')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        self::assertCount(1, $results);
+        self::assertSame('Unknown Location', $results[0]['name']);
+        self::assertNull($results[0]['location']);
+    }
+}

--- a/tests/Functional/Types/GeographyTest.php
+++ b/tests/Functional/Types/GeographyTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
 use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\Geometry;
 use Doctrine\DBAL\Types\Types;
 use Throwable;
 
@@ -78,9 +79,18 @@ class GeographyTest extends SpatialTestCase
         $schemaManager->createTable($table);
 
         $locations = [
-            ['name' => 'London', 'location' => '{"type":"Point","coordinates":[-0.1276,51.5074]}'],
-            ['name' => 'Paris', 'location' => '{"type":"Point","coordinates":[2.3522,48.8566]}'],
-            ['name' => 'Berlin', 'location' => '{"type":"Point","coordinates":[13.4050,52.5200]}'],
+            [
+                'name' => 'London',
+                'location' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[-0.1276,51.5074]}'),
+            ],
+            [
+                'name' => 'Paris',
+                'location' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[2.3522,48.8566]}'),
+            ],
+            [
+                'name' => 'Berlin',
+                'location' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[13.4050,52.5200]}'),
+            ],
         ];
 
         foreach ($locations as $location) {
@@ -143,7 +153,7 @@ class GeographyTest extends SpatialTestCase
 
         $this->connection->insert(
             self::TABLE_NAME,
-            ['location' => $utmGeoJSON], // UTM Zone 33N - should fail
+            ['location' => Geometry::fromGeoJSON($utmGeoJSON)], // UTM Zone 33N - should fail
             ['location' => Types::GEOGRAPHY],
         );
     }

--- a/tests/Functional/Types/GeometryTest.php
+++ b/tests/Functional/Types/GeometryTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
 use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\Geometry;
 use Doctrine\DBAL\Types\Types;
 use Throwable;
 
@@ -73,9 +74,18 @@ class GeometryTest extends SpatialTestCase
         $schemaManager->createTable($table);
 
         $locations = [
-            ['name' => 'San Francisco', 'location' => '{"type":"Point","coordinates":[-122.4194,37.7749]}'],
-            ['name' => 'Los Angeles', 'location' => '{"type":"Point","coordinates":[-118.2437,34.0522]}'],
-            ['name' => 'New York', 'location' => '{"type":"Point","coordinates":[-74.0060,40.7128]}'],
+            [
+                'name' => 'San Francisco',
+                'location' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[-122.4194,37.7749]}'),
+            ],
+            [
+                'name' => 'Los Angeles',
+                'location' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[-118.2437,34.0522]}'),
+            ],
+            [
+                'name' => 'New York',
+                'location' => Geometry::fromGeoJSON('{"type":"Point","coordinates":[-74.0060,40.7128]}'),
+            ],
         ];
 
         foreach ($locations as $location) {
@@ -152,8 +162,8 @@ class GeometryTest extends SpatialTestCase
             . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_UTM_33N . '"}}}';
 
         $this->connection->insert(self::TABLE_NAME, [
-            'wgs84_point' => $wgs84GeoJSON,
-            'utm_point' => $utmGeoJSON,
+            'wgs84_point' => Geometry::fromGeoJSON($wgs84GeoJSON),
+            'utm_point' => Geometry::fromGeoJSON($utmGeoJSON),
         ], [
             'wgs84_point' => Types::GEOMETRY,
             'utm_point' => Types::GEOMETRY,
@@ -214,7 +224,7 @@ class GeometryTest extends SpatialTestCase
 
         $this->connection->insert(
             self::TABLE_NAME,
-            ['location' => $wrongSridGeoJSON], // Wrong SRID - should fail
+            ['location' => Geometry::fromGeoJSON($wrongSridGeoJSON)], // Wrong SRID - should fail
             ['location' => Types::GEOMETRY],
         );
     }

--- a/tests/Functional/Types/GeometryTest.php
+++ b/tests/Functional/Types/GeometryTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\Functional\SpatialTestCase;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\Types;
+use Throwable;
+
+/**
+ * Tests for GEOMETRY type data operations and conversions.
+ */
+class GeometryTest extends SpatialTestCase
+{
+    private const TABLE_NAME = 'geometry_test';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        if (! $schemaManager->tablesExist([self::TABLE_NAME])) {
+            return;
+        }
+
+        $schemaManager->dropTable(self::TABLE_NAME);
+    }
+
+    public function testGeometryDataConversion(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $locations = [
+            ['name' => 'San Francisco', 'location' => '{"type":"Point","coordinates":[-122.4194,37.7749]}'],
+            ['name' => 'Los Angeles', 'location' => '{"type":"Point","coordinates":[-118.2437,34.0522]}'],
+            ['name' => 'New York', 'location' => '{"type":"Point","coordinates":[-74.0060,40.7128]}'],
+        ];
+
+        foreach ($locations as $location) {
+            $this->connection->insert(self::TABLE_NAME, $location, [
+                'name' => Types::STRING,
+                'location' => Types::GEOMETRY,
+            ]);
+        }
+
+        // Retrieve and verify data conversion
+        $platform = $this->connection->getDatabasePlatform();
+
+        $geometryAsGeoJSON = $platform->getGeometryAsGeoJSONSQL('location');
+
+        $results = $this->connection->createQueryBuilder()
+            ->select('name', $geometryAsGeoJSON . ' as location')
+            ->from(self::TABLE_NAME)
+            ->orderBy('name')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        self::assertCount(3, $results);
+        self::assertSame('Los Angeles', $results[0]['name']);
+        // Verify coordinates are present (format may vary by database - MySQL includes spaces and bbox)
+        self::assertStringContainsString('"coordinates"', $results[0]['location']);
+        self::assertStringContainsString('-118.2437', $results[0]['location']);
+        self::assertStringContainsString('34.0522', $results[0]['location']);
+    }
+
+    public function testGeometryWithDifferentSRIDs(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('wgs84_point')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('utm_point')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_UTM_33N)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Insert points with different SRIDs
+        $wgs84GeoJSON = '{"type":"Point","coordinates":[-122.4194,37.7749],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+        $utmGeoJSON   = '{"type":"Point","coordinates":[551490,5181640],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_UTM_33N . '"}}}';
+
+        $this->connection->insert(self::TABLE_NAME, [
+            'wgs84_point' => $wgs84GeoJSON,
+            'utm_point' => $utmGeoJSON,
+        ], [
+            'wgs84_point' => Types::GEOMETRY,
+            'utm_point' => Types::GEOMETRY,
+        ]);
+
+        // Verify SRID preservation in data operations
+        $result = $this->connection->createQueryBuilder()
+            ->select('ST_SRID(wgs84_point) as wgs84_srid', 'ST_SRID(utm_point) as utm_srid')
+            ->from(self::TABLE_NAME)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        self::assertIsArray($result);
+        self::assertEquals(SpatialReferenceSystems::SRID_WGS84, $result['wgs84_srid']);
+        self::assertEquals(SpatialReferenceSystems::SRID_UTM_33N, $result['utm_srid']);
+    }
+
+    public function testGeometryWithInvalidSRID(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage('Geometry SRID (32633) does not match column SRID (4326)');
+
+        // Wrong SRID (UTM 33N instead of WGS84) - should fail
+        $wrongSridGeoJSON = '{"type":"Point","coordinates":[551490,5181640],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_UTM_33N . '"}}}';
+
+        $this->connection->insert(
+            self::TABLE_NAME,
+            ['location' => $wrongSridGeoJSON], // Wrong SRID - should fail
+            ['location' => Types::GEOMETRY],
+        );
+    }
+
+    public function testGeometryNullValues(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName(self::TABLE_NAME)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setAutoincrement(true)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setNotNull(false)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(255)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($table);
+
+        // Insert row with null geometry
+        $this->connection->insert(self::TABLE_NAME, [
+            'name' => 'Unknown Location',
+            'location' => null,
+        ], [
+            'name' => Types::STRING,
+            'location' => Types::GEOMETRY,
+        ]);
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        $geometryAsGeoJSON = $platform->getGeometryAsGeoJSONSQL('location');
+
+        $results = $this->connection->createQueryBuilder()
+            ->select('name', $geometryAsGeoJSON . ' AS location')
+            ->from(self::TABLE_NAME)
+            ->orderBy('name')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        self::assertCount(1, $results);
+        self::assertSame('Unknown Location', $results[0]['name']);
+        self::assertNull($results[0]['location']);
+    }
+}

--- a/tests/Functional/Types/GeometryTest.php
+++ b/tests/Functional/Types/GeometryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
@@ -33,6 +35,13 @@ class GeometryTest extends SpatialTestCase
 
     public function testGeometryDataConversion(): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        // MySQL < 8.0 and MariaDB do not support SRID in column definitions
+        if ($platform instanceof AbstractMySQLPlatform && ! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
         $table = Table::editor()
             ->setUnquotedName(self::TABLE_NAME)
             ->setColumns(
@@ -98,6 +107,13 @@ class GeometryTest extends SpatialTestCase
 
     public function testGeometryWithDifferentSRIDs(): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        // MySQL < 8.0 and MariaDB do not support SRID in column definitions
+        if ($platform instanceof AbstractMySQLPlatform && ! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
         $table = Table::editor()
             ->setUnquotedName(self::TABLE_NAME)
             ->setColumns(
@@ -157,6 +173,13 @@ class GeometryTest extends SpatialTestCase
 
     public function testGeometryWithInvalidSRID(): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        // MySQL < 8.0 and MariaDB do not support SRID in column definitions
+        if ($platform instanceof AbstractMySQLPlatform && ! $platform instanceof MySQL80Platform) {
+            self::markTestSkipped('This test requires MySQL 8.0+ for SRID support in column definitions.');
+        }
+
         $table = Table::editor()
             ->setUnquotedName(self::TABLE_NAME)
             ->setColumns(
@@ -183,7 +206,7 @@ class GeometryTest extends SpatialTestCase
         $schemaManager->createTable($table);
 
         $this->expectException(Throwable::class);
-        $this->expectExceptionMessage('Geometry SRID (32633) does not match column SRID (4326)');
+        $this->expectExceptionMessageMatches('/SRID.*does not match/i');
 
         // Wrong SRID (UTM 33N instead of WGS84) - should fail
         $wrongSridGeoJSON = '{"type":"Point","coordinates":[551490,5181640],'

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -652,4 +652,68 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
             'multiple values and lower length' => [['foo', 'bar1'], 2, "ENUM('foo', 'bar1')"],
         ];
     }
+
+    public function testGeometryTypeDeclarationSQL(): void
+    {
+        self::assertEquals(
+            'GEOMETRY',
+            $this->platform->getGeometryTypeDeclarationSQL([]),
+        );
+    }
+
+    public function testGeometryTypeDeclarationWithGeometryTypeSQL(): void
+    {
+        self::assertEquals(
+            'POINT',
+            $this->platform->getGeometryTypeDeclarationSQL(['geometryType' => 'POINT']),
+        );
+
+        self::assertEquals(
+            'LINESTRING',
+            $this->platform->getGeometryTypeDeclarationSQL(['geometryType' => 'linestring']),
+        );
+    }
+
+    public function testGeometryFromGeoJSONSQL(): void
+    {
+        self::assertEquals(
+            'ST_GeomFromGeoJSON(?)',
+            $this->platform->getGeometryFromGeoJSONSQL('?'),
+        );
+    }
+
+    public function testGeometryAsGeoJSONSQL(): void
+    {
+        self::assertEquals(
+            'ST_AsGeoJSON(location, 15, 2)',
+            $this->platform->getGeometryAsGeoJSONSQL('location'),
+        );
+    }
+
+    public function testGeometryTypeMappings(): void
+    {
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('geometry'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('geometry'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('point'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('point'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('linestring'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('linestring'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('polygon'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('polygon'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('multipoint'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('multipoint'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('multilinestring'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('multilinestring'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('multipolygon'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('multipolygon'));
+
+        self::assertTrue($this->platform->hasDoctrineTypeMappingFor('geometrycollection'));
+        self::assertSame(Types::GEOMETRY, $this->platform->getDoctrineTypeMapping('geometrycollection'));
+    }
 }

--- a/tests/Platforms/MySQL80PlatformTest.php
+++ b/tests/Platforms/MySQL80PlatformTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+
+class MySQL80PlatformTest extends MySQLPlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MySQL80Platform();
+    }
+
+    public function testGeometryTypeDeclarationWithSRIDSQL(): void
+    {
+        self::assertEquals(
+            'POINT SRID 4326',
+            $this->platform->getGeometryTypeDeclarationSQL([
+                'geometryType' => 'POINT',
+                'srid' => SpatialReferenceSystems::SRID_WGS84,
+            ]),
+        );
+
+        self::assertEquals(
+            'GEOMETRY SRID 32633',
+            $this->platform->getGeometryTypeDeclarationSQL([
+                'srid' => SpatialReferenceSystems::SRID_UTM_33N,
+            ]),
+        );
+    }
+}

--- a/tests/Platforms/MySQL84PlatformTest.php
+++ b/tests/Platforms/MySQL84PlatformTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Tests\Platforms;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQL84Platform;
 
-class MySQL84PlatformTest extends MySQLPlatformTest
+class MySQL84PlatformTest extends MySQL80PlatformTest
 {
     public function createPlatform(): AbstractPlatform
     {

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
@@ -1387,6 +1388,20 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertSame(
             'ST_AsGeoJSON(geog_col, 15, 2)',
             $this->platform->getGeographyAsGeoJSONSQL('geog_col'),
+        );
+    }
+
+    public function testCreateSpatialIndexSQL(): void
+    {
+        $index = Index::editor()
+            ->setUnquotedName('spatial_idx')
+            ->setType(Index\IndexType::SPATIAL)
+            ->setUnquotedColumnNames('location')
+            ->create();
+
+        self::assertSame(
+            'CREATE INDEX spatial_idx ON spatial_table USING GIST (location)',
+            $this->platform->getCreateIndexSQL($index, 'spatial_table'),
         );
     }
 }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -1171,6 +1172,221 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertSame(
             ['ALTER TABLE mytable ALTER payload TYPE JSON'],
             $this->platform->getAlterTableSQL($tableDiff),
+        );
+    }
+
+    public function testCreateTableWithGeometryColumns(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('spatial_table')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('point_location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('polygon_area')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POLYGON')
+                    ->create(),
+            )
+            ->create();
+
+        self::assertSame(
+            [
+                'CREATE TABLE spatial_table (id INT NOT NULL, '
+                . 'location geometry NOT NULL, '
+                . 'point_location geometry(point,4326) NOT NULL, '
+                . 'polygon_area geometry(polygon) NOT NULL)',
+            ],
+            $this->platform->getCreateTableSQL($table),
+        );
+    }
+
+    public function testCreateTableWithGeographyColumns(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('geo_table')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('point_location')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('line_path')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('LINESTRING')
+                    ->create(),
+            )
+            ->create();
+
+        self::assertSame(
+            [
+                'CREATE TABLE geo_table (id INT NOT NULL, '
+                . 'location geography(geometry,4326) NOT NULL, '
+                . 'point_location geography(point,4326) NOT NULL, '
+                . 'line_path geography(linestring,4326) NOT NULL)',
+            ],
+            $this->platform->getCreateTableSQL($table),
+        );
+    }
+
+    public function testAlterTableChangeColumnToGeometry(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('spatial_table')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::TEXT)
+                    ->create(),
+            )
+            ->create();
+
+        $tableDiff = new TableDiff($table, changedColumns: [
+            'location' => new ColumnDiff(
+                $table->getColumn('location'),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOMETRY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            ),
+        ]);
+
+        self::assertSame(
+            ['ALTER TABLE spatial_table ALTER location TYPE geometry(point,4326)'],
+            $this->platform->getAlterTableSQL($tableDiff),
+        );
+    }
+
+    public function testAlterTableChangeColumnToGeography(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('geo_table')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::TEXT)
+                    ->create(),
+            )
+            ->create();
+
+        $tableDiff = new TableDiff($table, changedColumns: [
+            'location' => new ColumnDiff(
+                $table->getColumn('location'),
+                Column::editor()
+                    ->setUnquotedName('location')
+                    ->setTypeName(Types::GEOGRAPHY)
+                    ->setGeometryType('POINT')
+                    ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+                    ->create(),
+            ),
+        ]);
+
+        self::assertSame(
+            ['ALTER TABLE geo_table ALTER location TYPE geography(point,4326)'],
+            $this->platform->getAlterTableSQL($tableDiff),
+        );
+    }
+
+    public function testReturnsGeometryTypeDeclarationSQL(): void
+    {
+        self::assertSame(
+            'geometry',
+            $this->platform->getGeometryTypeDeclarationSQL([]),
+        );
+
+        self::assertSame(
+            'geometry(point)',
+            $this->platform->getGeometryTypeDeclarationSQL(['geometryType' => 'POINT']),
+        );
+
+        self::assertSame(
+            'geometry(geometry,4326)',
+            $this->platform->getGeometryTypeDeclarationSQL(['srid' => SpatialReferenceSystems::SRID_WGS84]),
+        );
+
+        self::assertSame(
+            'geometry(polygon,4326)',
+            $this->platform->getGeometryTypeDeclarationSQL([
+                'geometryType' => 'POLYGON',
+                'srid' => SpatialReferenceSystems::SRID_WGS84,
+            ]),
+        );
+    }
+
+    public function testReturnsGeometryFromGeoJSONSQL(): void
+    {
+        self::assertSame(
+            'ST_GeomFromGeoJSON(?)',
+            $this->platform->getGeometryFromGeoJSONSQL('?'),
+        );
+    }
+
+    public function testReturnsGeometryAsGeoJSONSQL(): void
+    {
+        self::assertSame(
+            'ST_AsGeoJSON(geom_col, 15, 2)',
+            $this->platform->getGeometryAsGeoJSONSQL('geom_col'),
+        );
+    }
+
+    public function testReturnsGeographyTypeDeclarationSQL(): void
+    {
+        self::assertSame(
+            'geography(geometry,4326)',
+            $this->platform->getGeographyTypeDeclarationSQL([]),
+        );
+
+        self::assertSame(
+            'geography(point,4326)',
+            $this->platform->getGeographyTypeDeclarationSQL(['geometryType' => 'POINT']),
+        );
+
+        self::assertSame(
+            'geography(point,3857)',
+            $this->platform->getGeographyTypeDeclarationSQL([
+                'geometryType' => 'POINT',
+                'srid' => SpatialReferenceSystems::SRID_WEB_MERCATOR,
+            ]),
+        );
+    }
+
+    public function testReturnsGeographyFromGeoJSONSQL(): void
+    {
+        self::assertSame(
+            'ST_GeomFromGeoJSON(?)::geography',
+            $this->platform->getGeographyFromGeoJSONSQL('?'),
+        );
+    }
+
+    public function testReturnsGeographyAsGeoJSONSQL(): void
+    {
+        self::assertSame(
+            'ST_AsGeoJSON(geog_col, 15, 2)',
+            $this->platform->getGeographyAsGeoJSONSQL('geog_col'),
         );
     }
 }

--- a/tests/Schema/ColumnEditorTest.php
+++ b/tests/Schema/ColumnEditorTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\InvalidColumnDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -121,5 +122,27 @@ class ColumnEditorTest extends TestCase
         $this->expectException(InvalidColumnDefinition::class);
 
         $editor->create();
+    }
+
+    public function testSetGeometryType(): void
+    {
+        $column = Column::editor()
+            ->setUnquotedName('location')
+            ->setTypeName(Types::GEOMETRY)
+            ->setGeometryType('POINT')
+            ->create();
+
+        self::assertSame('POINT', $column->getGeometryType());
+    }
+
+    public function testSetSrid(): void
+    {
+        $column = Column::editor()
+            ->setUnquotedName('location')
+            ->setTypeName(Types::GEOMETRY)
+            ->setSrid(SpatialReferenceSystems::SRID_WGS84)
+            ->create();
+
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $column->getSrid());
     }
 }

--- a/tests/SpatialReferenceSystems.php
+++ b/tests/SpatialReferenceSystems.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests;
+
+/**
+ * Common SRID (Spatial Reference System Identifier) constants for spatial type tests.
+ *
+ * These EPSG codes define coordinate reference systems used across spatial functionality tests.
+ */
+final class SpatialReferenceSystems
+{
+    /**
+     * EPSG:4326 - WGS 84 coordinate system.
+     *
+     * The most commonly used geographic coordinate system (latitude/longitude).
+     * Used by GPS and most web mapping applications.
+     */
+    public const SRID_WGS84 = 4326;
+}

--- a/tests/SpatialReferenceSystems.php
+++ b/tests/SpatialReferenceSystems.php
@@ -20,6 +20,22 @@ final class SpatialReferenceSystems
     public const SRID_WGS84 = 4326;
 
     /**
+     * EPSG:32633 - WGS 84 / UTM zone 33N.
+     *
+     * A projected coordinate system for central Europe.
+     * Used to test different SRID values in the same table.
+     */
+    public const SRID_UTM_33N = 32633;
+
+    /**
+     * EPSG:4267 - NAD27 coordinate system.
+     *
+     * North American Datum 1927, a geodetic datum for North America.
+     * Used to test different SRID values for GEOGRAPHY columns.
+     */
+    public const SRID_NAD27 = 4267;
+
+    /**
      * EPSG:3857 - WGS 84 / Pseudo-Mercator (Web Mercator).
      *
      * Used by web mapping services like Google Maps, OpenStreetMap, and Bing Maps.

--- a/tests/SpatialReferenceSystems.php
+++ b/tests/SpatialReferenceSystems.php
@@ -18,4 +18,12 @@ final class SpatialReferenceSystems
      * Used by GPS and most web mapping applications.
      */
     public const SRID_WGS84 = 4326;
+
+    /**
+     * EPSG:3857 - WGS 84 / Pseudo-Mercator (Web Mercator).
+     *
+     * Used by web mapping services like Google Maps, OpenStreetMap, and Bing Maps.
+     * Projects the spherical earth onto a flat surface for web display.
+     */
+    public const SRID_WEB_MERCATOR = 3857;
 }

--- a/tests/Types/GeoJSONTest.php
+++ b/tests/Types/GeoJSONTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\GeoJSON;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\TestCase;
+
+class GeoJSONTest extends TestCase
+{
+    #[DoesNotPerformAssertions]
+    #[DataProvider('validGeoJSONStringProvider')]
+    public function testFromStringWithValidGeoJSON(string $json): void
+    {
+        GeoJSON::fromString($json);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function validGeoJSONStringProvider(): iterable
+    {
+        yield 'Point' => ['{"type":"Point","coordinates":[100.0,0.0]}'];
+        yield 'Point with whitespace' => ['  {"type": "Point", "coordinates": [100.0, 0.0]}  '];
+        yield 'LineString' => ['{"type":"LineString","coordinates":[[100.0,0.0],[101.0,1.0]]}'];
+        yield 'Polygon' => ['{"type":"Polygon",' .
+        '"coordinates":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}',
+        ];
+
+        yield 'MultiPoint' => ['{"type":"MultiPoint",' .
+        '"coordinates":[[100.0,0.0],[101.0,1.0]]}',
+        ];
+
+        yield 'MultiLineString' => ['{"type":"MultiLineString",' .
+        '"coordinates":[[[100.0,0.0],[101.0,1.0]],[[102.0,2.0],[103.0,3.0]]]}',
+        ];
+
+        yield 'MultiPolygon' => ['{"type":"MultiPolygon",' .
+        '"coordinates":[[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]]}',
+        ];
+
+        yield 'GeometryCollection' => ['{"type":"GeometryCollection",' .
+        '"geometries":[{"type":"Point","coordinates":[100.0,0.0]}]}',
+        ];
+    }
+
+    #[DataProvider('invalidGeoJSONStringProvider')]
+    public function testFromStringWithInvalidGeoJSON(string $invalidJSON): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        GeoJSON::fromString($invalidJSON);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function invalidGeoJSONStringProvider(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'whitespace only' => ['   '];
+        yield 'not JSON' => ['not json'];
+        yield 'invalid JSON' => ['{invalid json}'];
+        yield 'missing type' => ['{"coordinates":[100.0,0.0]}'];
+        yield 'invalid type' => ['{"type":"InvalidType","coordinates":[100.0,0.0]}'];
+        yield 'Point without coordinates' => ['{"type":"Point"}'];
+        yield 'Point with invalid coordinates' => ['{"type":"Point","coordinates":"invalid"}'];
+        yield 'Feature not supported' => ['{"type":"Feature",' .
+        '"geometry":{"type":"Point","coordinates":[0,0]},"properties":{}}',
+        ];
+
+        yield 'FeatureCollection not supported' => ['{"type":"FeatureCollection","features":[]}'];
+    }
+
+    public function testGetSridFromCrsProperty(): void
+    {
+        $json = '{"type":"Point","coordinates":[100.0,0.0],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+
+        $geoJSON = GeoJSON::fromString($json);
+
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $geoJSON->getSrid());
+    }
+
+    public function testGetSridFromCrsPropertyWithUrn(): void
+    {
+        $json = '{"type":"Point","coordinates":[100.0,0.0],"crs":{' .
+            '"type":"name","properties":{' .
+                '"name":"urn:ogc:def:crs:EPSG::' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+
+        $geoJSON = GeoJSON::fromString($json);
+
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $geoJSON->getSrid());
+    }
+
+    public function testGetSridReturnsNullWhenNoCrs(): void
+    {
+        $geoJSON = GeoJSON::fromString('{"type":"Point","coordinates":[100.0,0.0]}');
+
+        self::assertNull($geoJSON->getSrid());
+    }
+
+    public function testToString(): void
+    {
+        $json    = '{"type":"Point","coordinates":[100.0,0.0]}';
+        $geoJSON = GeoJSON::fromString($json);
+
+        self::assertJsonStringEqualsJsonString($json, $geoJSON->toString());
+    }
+
+    public function testStringable(): void
+    {
+        $json    = '{"type":"Point","coordinates":[100.0,0.0]}';
+        $geoJSON = GeoJSON::fromString($json);
+
+        self::assertJsonStringEqualsJsonString($json, (string) $geoJSON);
+    }
+
+    public function testRoundTripPreservesData(): void
+    {
+        $json = '{"type":"Point","coordinates":[100.5,50.25],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+
+        $geoJSON = GeoJSON::fromString($json);
+        $output  = $geoJSON->toString();
+
+        self::assertJsonStringEqualsJsonString($json, $output);
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $geoJSON->getSrid());
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testGeometryCollectionValidation(): void
+    {
+        $json = '{"type":"GeometryCollection","geometries":[' .
+        '{"type":"Point","coordinates":[100.0,0.0]},' .
+        '{"type":"LineString","coordinates":[[101.0,0.0],[102.0,1.0]]}]}';
+
+        GeoJSON::fromString($json);
+    }
+}

--- a/tests/Types/GeographyTypeTest.php
+++ b/tests/Types/GeographyTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\GeographyType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GeographyTypeTest extends TestCase
+{
+    private GeographyType $type;
+    private AbstractPlatform&MockObject $platform;
+
+    protected function setUp(): void
+    {
+        $this->type     = new GeographyType();
+        $this->platform = $this->createMock(AbstractPlatform::class);
+    }
+
+    public function testDelegatesToPlatformForSQLDeclaration(): void
+    {
+        $columnDefinitions = [
+            ['geometryType' => 'point', 'srid' => SpatialReferenceSystems::SRID_WGS84],
+            ['geometryType' => 'geometry'],
+            ['srid' => SpatialReferenceSystems::SRID_WGS84],
+        ];
+
+        foreach ($columnDefinitions as $column) {
+            $platform = $this->createMock(AbstractPlatform::class);
+            $platform->expects(self::once())
+                ->method('getGeographyTypeDeclarationSQL')
+                ->with($column);
+
+            $this->type->getSQLDeclaration($column, $platform);
+        }
+    }
+
+    public function testReturnsCorrectBindingType(): void
+    {
+        self::assertSame(ParameterType::STRING, $this->type->getBindingType());
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        self::assertIsString($this->type->convertToPHPValue(
+            '{"type":"Point","coordinates":[-122.4194,37.7749]}',
+            $this->platform,
+        ));
+    }
+
+    public function testNullConversion(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertToPHPValueFailsOnInvalidValue(): void
+    {
+        $this->expectException(ConversionException::class);
+        $this->expectExceptionMessage('Could not convert database value "123" to Doctrine Type "geography"');
+
+        $this->type->convertToPHPValue(123, $this->platform);
+    }
+
+    public function testConvertToDatabaseValueFailsOnInvalidValue(): void
+    {
+        $this->expectException(ConversionException::class);
+        $this->expectExceptionMessage('Could not convert database value "123" to Doctrine Type "geography"');
+
+        $this->type->convertToDatabaseValue(123, $this->platform);
+    }
+
+    public function testDelegatesToPlatformForConvertToDatabaseValueSQL(): void
+    {
+        $this->platform->expects(self::once())
+            ->method('getGeographyFromGeoJSONSQL')
+            ->with('?');
+
+        $this->type->convertToDatabaseValueSQL('?', $this->platform);
+    }
+
+    public function testDelegatesToPlatformForConvertToPHPValueSQL(): void
+    {
+        $this->platform->expects(self::once())
+            ->method('getGeographyAsGeoJSONSQL')
+            ->with('geog_column');
+
+        $this->type->convertToPHPValueSQL('geog_column', $this->platform);
+    }
+}

--- a/tests/Types/GeographyTypeTest.php
+++ b/tests/Types/GeographyTypeTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Tests\SpatialReferenceSystems;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\GeographyType;
+use Doctrine\DBAL\Types\Geometry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -48,16 +49,24 @@ class GeographyTypeTest extends TestCase
 
     public function testConvertToPHPValue(): void
     {
-        self::assertIsString($this->type->convertToPHPValue(
-            '{"type":"Point","coordinates":[-122.4194,37.7749]}',
-            $this->platform,
-        ));
+        $geoJson = '{"type":"Point","coordinates":[-122.4194,37.7749]}';
+        $result  = $this->type->convertToPHPValue($geoJson, $this->platform);
+        self::assertInstanceOf(Geometry::class, $result);
+        self::assertSame($geoJson, $result->toGeoJSON());
     }
 
     public function testNullConversion(): void
     {
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertToDatabaseValueWithGeometryObject(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[-122.4194,37.7749]}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+        $result   = $this->type->convertToDatabaseValue($geometry, $this->platform);
+        self::assertSame($geoJson, $result);
     }
 
     public function testConvertToPHPValueFailsOnInvalidValue(): void

--- a/tests/Types/GeometryTest.php
+++ b/tests/Types/GeometryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\Geometry;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class GeometryTest extends TestCase
+{
+    public function testFromGeoJSONCreatesGeometryWithoutSrid(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[1,2]}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+
+        self::assertSame($geoJson, $geometry->getGeoJSON()->toString());
+        self::assertNull($geometry->getSrid());
+    }
+
+    public function testFromGeoJSONCreatesGeometryWithSrid(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[1,2],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+
+        self::assertSame($geoJson, $geometry->getGeoJSON()->toString());
+        self::assertSame(SpatialReferenceSystems::SRID_WGS84, $geometry->getSrid());
+    }
+
+    public function testToGeoJSON(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[1,2],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+
+        self::assertSame($geoJson, $geometry->toGeoJSON());
+    }
+
+    public function testToStringReturnsGeoJSON(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[1,2],'
+            . '"crs":{"type":"name","properties":{"name":"EPSG:' . SpatialReferenceSystems::SRID_WGS84 . '"}}}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+
+        self::assertSame($geoJson, (string) $geometry);
+    }
+
+    public function testFromGeoJSONValidatesFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid JSON string');
+
+        Geometry::fromGeoJSON('INVALID JSON');
+    }
+
+    public function testSupportsVariousGeometryTypes(): void
+    {
+        $geometries = [
+            '{"type":"Point","coordinates":[1,2]}',
+            '{"type":"LineString","coordinates":[[0,0],[1,1],[2,2]]}',
+            '{"type":"Polygon","coordinates":[[[0,0],[4,0],[4,4],[0,4],[0,0]]]}',
+            '{"type":"MultiPoint","coordinates":[[0,0],[1,1]]}',
+            '{"type":"MultiLineString","coordinates":[[[0,0],[1,1]],[[2,2],[3,3]]]}',
+            '{"type":"MultiPolygon","coordinates":[[[[0,0],[4,0],[4,4],[0,4],[0,0]]]]}',
+            '{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1,1]},'
+                . '{"type":"LineString","coordinates":[[0,0],[1,1]]}]}',
+        ];
+
+        foreach ($geometries as $geoJson) {
+            $geometry = Geometry::fromGeoJSON($geoJson);
+            self::assertSame($geoJson, $geometry->getGeoJSON()->toString());
+        }
+    }
+
+    public function testGetGeoJSONReturnsGeoJSONObject(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[1,2]}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+        $result   = $geometry->getGeoJSON();
+
+        self::assertSame($geoJson, $result->toString());
+    }
+}

--- a/tests/Types/GeometryTypeTest.php
+++ b/tests/Types/GeometryTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Tests\SpatialReferenceSystems;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\GeometryType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GeometryTypeTest extends TestCase
+{
+    private GeometryType $type;
+    private AbstractPlatform&MockObject $platform;
+
+    protected function setUp(): void
+    {
+        $this->type     = new GeometryType();
+        $this->platform = $this->createMock(AbstractPlatform::class);
+    }
+
+    public function testDelegatesToPlatformForSQLDeclaration(): void
+    {
+        $columnDefinitions = [
+            ['geometryType' => 'point', 'srid' => SpatialReferenceSystems::SRID_WGS84],
+            ['geometryType' => 'geometry'],
+            ['srid' => SpatialReferenceSystems::SRID_WGS84],
+        ];
+
+        foreach ($columnDefinitions as $column) {
+            $platform = $this->createMock(AbstractPlatform::class);
+            $platform->expects(self::once())
+                ->method('getGeometryTypeDeclarationSQL')
+                ->with($column);
+
+            $this->type->getSQLDeclaration($column, $platform);
+        }
+    }
+
+    public function testReturnsCorrectBindingType(): void
+    {
+        self::assertSame(ParameterType::STRING, $this->type->getBindingType());
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        self::assertIsString($this->type->convertToPHPValue(
+            '{"type":"Point","coordinates":[-122.4194,37.7749]}',
+            $this->platform,
+        ));
+    }
+
+    public function testNullConversion(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertToPHPValueFailsOnInvalidValue(): void
+    {
+        $this->expectException(ConversionException::class);
+        $this->expectExceptionMessage('Could not convert database value "123" to Doctrine Type "geometry"');
+
+        $this->type->convertToPHPValue(123, $this->platform);
+    }
+
+    public function testConvertToDatabaseValueFailsOnInvalidValue(): void
+    {
+        $this->expectException(ConversionException::class);
+        $this->expectExceptionMessage('Could not convert database value "123" to Doctrine Type "geometry"');
+
+        $this->type->convertToDatabaseValue(123, $this->platform);
+    }
+
+    public function testDelegatesToPlatformForConvertToDatabaseValueSQL(): void
+    {
+        $this->platform->expects(self::once())
+            ->method('getGeometryFromGeoJSONSQL')
+            ->with('?');
+
+        $this->type->convertToDatabaseValueSQL('?', $this->platform);
+    }
+
+    public function testDelegatesToPlatformForConvertToPHPValueSQL(): void
+    {
+        $this->platform->expects(self::once())
+            ->method('getGeometryAsGeoJSONSQL')
+            ->with('geom_column');
+
+        $this->type->convertToPHPValueSQL('geom_column', $this->platform);
+    }
+}

--- a/tests/Types/GeometryTypeTest.php
+++ b/tests/Types/GeometryTypeTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Tests\SpatialReferenceSystems;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Geometry;
 use Doctrine\DBAL\Types\GeometryType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,16 +49,24 @@ class GeometryTypeTest extends TestCase
 
     public function testConvertToPHPValue(): void
     {
-        self::assertIsString($this->type->convertToPHPValue(
-            '{"type":"Point","coordinates":[-122.4194,37.7749]}',
-            $this->platform,
-        ));
+        $geoJson = '{"type":"Point","coordinates":[-122.4194,37.7749]}';
+        $result  = $this->type->convertToPHPValue($geoJson, $this->platform);
+        self::assertInstanceOf(Geometry::class, $result);
+        self::assertSame($geoJson, $result->toGeoJSON());
     }
 
     public function testNullConversion(): void
     {
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
         self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertToDatabaseValueWithGeometryObject(): void
+    {
+        $geoJson  = '{"type":"Point","coordinates":[-122.4194,37.7749]}';
+        $geometry = Geometry::fromGeoJSON($geoJson);
+        $result   = $this->type->convertToDatabaseValue($geometry, $this->platform);
+        self::assertSame($geoJson, $result);
     }
 
     public function testConvertToPHPValueFailsOnInvalidValue(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #7081 

#### Summary

This PR introduces spatial data type support for DBAL, starting with PostgreSQL/PostGIS and MySQL. This implementation is intended to serve as a reference and guide for adding support for other database platforms in the future.

#### Core Spatial Types

- **GeometryType** (`Types::GEOMETRY`) - For planar coordinate systems
- **GeographyType** (`Types::GEOGRAPHY`) - For spherical earth coordinates
- Both types handle GeoJSON format for data exchange

#### Schema API Integration

- Extended `Column` and `ColumnEditor` with `geometryType` and `srid` properties
- Clean fluent API: `Column::editor()->setGeometryType('POINT')->setSrid(4326)`
- Full PostgreSQL platform support with PostGIS-specific SQL generation
- Schema introspection and table creation/modification support

#### What's next

- [x] Discuss the PR
- [X] Add other platforms (PostgreSQL/PostGIS, MySQL)
- [X] Add spatial index (PostgreSQL/PostGIS, MySQL already support creation of spatial indexes)
