### PR TITLE
Deprecate extending schema classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated extension of schema classes
+
+Extending the following classes has been deprecated. Use them directly.
+
+- `Schema`
+- `Sequence`
+- `Table`
+- `View`
+
 ## Deprecated features of `Table::getIndexes()`, `Table::getUniqueConstraints()` and `Table::getForeignKeys()`
 
 Using the keys of the arrays returned by `Table::getIndexes()`, `Table::getUniqueConstraints()` and

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,7 +18,7 @@ an object by name, use `Table::getIndex()`, `Table::getUniqueConstraint()` or `T
 ## Deprecated `AbstractAsset::getName()`
 
 The `AbstractAsset::getName()` method has been deprecated. Instead, use `NamedObject::getObjectName()` or 
-`OptionallyQualifiedName::getObjectName()` to get the object representation of the name. SQL context, convert the
+`OptionallyQualifiedName::getObjectName()` to get the object representation of the name. In SQL context, convert the
 resulting `Name` to SQL using `Name::toSQL()`. In other contexts, convert the resulting name to string using
 `Name::toString()`.
 

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -52,6 +52,7 @@ use function strtolower;
  * execute them. Only the queries for the currently connected database are
  * executed.
  *
+ * @final
  * @extends AbstractAsset<UnqualifiedName>
  */
 class Schema extends AbstractAsset

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -15,6 +15,7 @@ use function sprintf;
 /**
  * Sequence structure.
  *
+ * @final
  * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
 class Sequence extends AbstractNamedObject

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -38,6 +38,7 @@ use function strtolower;
 /**
  * Object Representation of a table.
  *
+ * @final
  * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
 class Table extends AbstractNamedObject

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 /**
  * Representation of a Database View.
  *
+ * @final
  * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
 class View extends AbstractNamedObject


### PR DESCRIPTION
Similar to the `Column`, `ForeignKeyConstraint`, `Index` and `UniqueConstraint` classes soft-marked as `@final`, I'm marking the rest of schema-related classes as `@final` as well. They are value objects and are not meant to be extended.

Making them final in 5.0.x will allow to rework their internal implementation w/o breaking BC.