### PR TITLE
Implement IteratorAggregate in ObjectSet subclasses

### DIFF
--- a/src/Schema/Collections/ObjectSet.php
+++ b/src/Schema/Collections/ObjectSet.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Schema\Collections;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use IteratorAggregate;
 
 /**
  * A set of objects where each object is uniquely identified by its {@link UnqualifiedName}.
@@ -14,8 +15,9 @@ use Doctrine\DBAL\Schema\Name\UnqualifiedName;
  * @internal
  *
  * @template E of object
+ * @template-extends IteratorAggregate<int, E>
  */
-interface ObjectSet
+interface ObjectSet extends IteratorAggregate
 {
     /**
      * Checks if the set is empty.

--- a/src/Schema/Collections/OptionallyUnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/OptionallyUnqualifiedNamedObjectSet.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Collections;
 
+use ArrayIterator;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\OptionallyNamedObject;
+use Traversable;
 
 use function array_splice;
 use function count;
@@ -108,6 +110,12 @@ final class OptionallyUnqualifiedNamedObjectSet implements ObjectSet
     public function toList(): array
     {
         return $this->elements;
+    }
+
+    /** {@inheritDoc} */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->elements);
     }
 
     /**

--- a/src/Schema/Collections/OptionallyUnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/OptionallyUnqualifiedNamedObjectSet.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Collections;
 
-use ArrayIterator;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -115,7 +114,7 @@ final class OptionallyUnqualifiedNamedObjectSet implements ObjectSet
     /** {@inheritDoc} */
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this->elements);
+        yield from $this->elements;
     }
 
     /**

--- a/src/Schema/Collections/UnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/UnqualifiedNamedObjectSet.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Collections;
 
-use ArrayIterator;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -102,7 +101,9 @@ final class UnqualifiedNamedObjectSet implements ObjectSet
     /** {@inheritDoc} */
     public function getIterator(): Traversable
     {
-        return new ArrayIterator(array_values($this->elements));
+        foreach ($this->elements as $element) {
+            yield $element;
+        }
     }
 
     /**

--- a/src/Schema/Collections/UnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/UnqualifiedNamedObjectSet.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Collections;
 
+use ArrayIterator;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
+use Traversable;
 
 use function array_combine;
 use function array_keys;
@@ -95,6 +97,12 @@ final class UnqualifiedNamedObjectSet implements ObjectSet
     public function toList(): array
     {
         return array_values($this->elements);
+    }
+
+    /** {@inheritDoc} */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator(array_values($this->elements));
     }
 
     /**

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -156,7 +156,7 @@ final class TableEditor
 
     private function renameColumnInIndexes(UnqualifiedName $oldColumnName, UnqualifiedName $newColumnName): void
     {
-        foreach ($this->indexes->toList() as $index) {
+        foreach ($this->indexes as $index) {
             $modified = false;
             $columns  = [];
 
@@ -264,7 +264,7 @@ final class TableEditor
         $constraints = [];
         $anyModified = false;
 
-        foreach ($collection->toList() as $constraint) {
+        foreach ($collection as $constraint) {
             $newColumnNames = [];
             $modified       = false;
 


### PR DESCRIPTION
Object sets may need to be iterated, but right now this is done by converting them to a list. This can be avoided if the set itself is made traversable.

This change is backward compatible, since since the `ObjectSet` interface being extended is `@internal`.