### PR TITLE
Deprecate using keys of table-scoped object collections as names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated features of `Table::getIndexes()`, `Table::getUniqueConstraints()` and `Table::getForeignKeys()`
+
+Using the keys of the arrays returned by `Table::getIndexes()`, `Table::getUniqueConstraints()` and
+`Table::getForeignKeys()` as index or constraint names is deprecated. Instead, retrieve the name from the index or
+constraint object using `NamedObject::getObjectName()` or `OptionallyNamedObject::getObjectName()`. In order to retrieve
+an object by name, use `Table::getIndex()`, `Table::getUniqueConstraint()` or `Table::getForeignKey()` respectively.
+
 ## Deprecated `AbstractAsset::getName()`
 
 The `AbstractAsset::getName()` method has been deprecated. Instead, use `NamedObject::getObjectName()` or 

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -824,8 +824,9 @@ class SQLitePlatform extends AbstractPlatform
         $nameMap  = $this->getDiffColumnNameMap($diff);
 
         foreach ($indexes as $key => $index) {
+            $indexName = $index->getName();
             foreach ($diff->getRenamedIndexes() as $oldIndexName => $renamedIndex) {
-                if (strtolower($key) !== strtolower($oldIndexName)) {
+                if (strtolower($indexName) !== strtolower($oldIndexName)) {
                     continue;
                 }
 


### PR DESCRIPTION
The array returned by `Table::getColumns()` doesn't contain column names as keys since https://github.com/doctrine/dbal/pull/3583 (4.0.0). This PR deprecates using keys as names in other collections.

Keys as lower-case names is the source of various issues:

1. Potential collisions (elements are keyed by lower-case name not taking if the name is quoted into account):
   1. The returned array cannot contain two elements if their names are equal but in a different case.
   2. It cannot contain two elements if their names are equal, but one is quoted while the other is not.
2. For unnamed constraints, the DBAL will auto-generate the key but not the name, so when the object hits the database, a different name will be generated. Essentially, in this case the auto-generated name is not used anywhere and doesn't match anything.
3. This is just redundant. Right now there is probably a bug that when a table column is renamed, it's put to the end of column list. Solving this bug while preserving its key in the array of columns would require rebuilding the array.

Besides the deprecation, this PR reworks that code that would use the keys as names such that the keys are used only as pointers to elements in the collection, but without any specific meaning.