### PR TITLE
Mark schema classes as final

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -86,8 +86,12 @@ The following classes have been marked as final:
 
 - `StaticServerVersionProvider`
 - `ColumnDiff`
+- `Table`
 - `TableDiff`
+- `Sequence`
+- `Schema`
 - `SchemaDiff`
+- `View`
 
 ## BC BREAK: Changes in `Index` methods, properties and behavior
 

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -53,10 +53,8 @@ use function strtolower;
  * the CREATE/DROP SQL visitors will just filter this queries and do not
  * execute them. Only the queries for the currently connected database are
  * executed.
- *
- * @final
  */
-class Schema
+final class Schema
 {
     /**
      * The namespaces in this schema.
@@ -66,12 +64,12 @@ class Schema
     private array $namespaces = [];
 
     /** @var array<string, Table> */
-    protected array $_tables = [];
+    private array $tables = [];
 
     /** @var array<string, Sequence> */
-    protected array $_sequences = [];
+    private array $sequences = [];
 
-    protected SchemaConfig $_schemaConfig;
+    private SchemaConfig $schemaConfig;
 
     /**
      * The default namespace name that the schema will use as a qualifier to resolve unqualified names.
@@ -101,7 +99,7 @@ class Schema
     ) {
         $schemaConfig ??= new SchemaConfig();
 
-        $this->_schemaConfig = $schemaConfig;
+        $this->schemaConfig = $schemaConfig;
 
         $this->defaultNamespaceName = $schemaConfig->getName();
 
@@ -110,42 +108,42 @@ class Schema
         }
 
         foreach ($tables as $table) {
-            $this->_addTable($table);
+            $this->addTable($table);
         }
 
         foreach ($sequences as $sequence) {
-            $this->_addSequence($sequence);
+            $this->addSequence($sequence);
         }
     }
 
-    protected function _addTable(Table $table): void
+    private function addTable(Table $table): void
     {
         $resolvedName = $this->resolveName($table->getObjectName());
 
         $key = $this->getKeyFromResolvedName($resolvedName);
 
-        if (isset($this->_tables[$key])) {
+        if (isset($this->tables[$key])) {
             throw TableAlreadyExists::new($resolvedName->toString());
         }
 
         $this->registerQualifier($resolvedName->getQualifier());
 
-        $this->_tables[$key] = $table;
+        $this->tables[$key] = $table;
     }
 
-    protected function _addSequence(Sequence $sequence): void
+    private function addSequence(Sequence $sequence): void
     {
         $resolvedName = $this->resolveName($sequence->getObjectName());
 
         $key = $this->getKeyFromResolvedName($resolvedName);
 
-        if (isset($this->_sequences[$key])) {
+        if (isset($this->sequences[$key])) {
             throw SequenceAlreadyExists::new($resolvedName->toString());
         }
 
         $this->registerQualifier($resolvedName->getQualifier());
 
-        $this->_sequences[$key] = $sequence;
+        $this->sequences[$key] = $sequence;
     }
 
     private function registerQualifier(?Identifier $qualifier): void
@@ -186,17 +184,17 @@ class Schema
      */
     public function getTables(): array
     {
-        return array_values($this->_tables);
+        return array_values($this->tables);
     }
 
     public function getTable(string $name): Table
     {
         $key = $this->getKeyFromName($name);
-        if (! isset($this->_tables[$key])) {
+        if (! isset($this->tables[$key])) {
             throw TableDoesNotExist::new($name);
         }
 
-        return $this->_tables[$key];
+        return $this->tables[$key];
     }
 
     /**
@@ -275,30 +273,30 @@ class Schema
     {
         $key = $this->getKeyFromName($name);
 
-        return isset($this->_tables[$key]);
+        return isset($this->tables[$key]);
     }
 
     public function hasSequence(string $name): bool
     {
         $key = $this->getKeyFromName($name);
 
-        return isset($this->_sequences[$key]);
+        return isset($this->sequences[$key]);
     }
 
     public function getSequence(string $name): Sequence
     {
         $key = $this->getKeyFromName($name);
-        if (! isset($this->_sequences[$key])) {
+        if (! isset($this->sequences[$key])) {
             throw SequenceDoesNotExist::new($name);
         }
 
-        return $this->_sequences[$key];
+        return $this->sequences[$key];
     }
 
     /** @return list<Sequence> */
     public function getSequences(): array
     {
-        return array_values($this->_sequences);
+        return array_values($this->sequences);
     }
 
     /**
@@ -340,10 +338,10 @@ class Schema
      */
     public function createTable(string $name): Table
     {
-        $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
-        $this->_addTable($table);
+        $table = new Table($name, [], [], [], [], [], $this->schemaConfig->toTableConfiguration());
+        $this->addTable($table);
 
-        foreach ($this->_schemaConfig->getDefaultTableOptions() as $option => $value) {
+        foreach ($this->schemaConfig->getDefaultTableOptions() as $option => $value) {
             $table->addOption($option, $value);
         }
 
@@ -365,7 +363,7 @@ class Schema
             ->create();
 
         $this->dropTable($oldName);
-        $this->_addTable($table);
+        $this->addTable($table);
 
         return $this;
     }
@@ -378,11 +376,11 @@ class Schema
     public function dropTable(string $name): self
     {
         $key = $this->getKeyFromName($name);
-        if (! isset($this->_tables[$key])) {
+        if (! isset($this->tables[$key])) {
             throw TableDoesNotExist::new($name);
         }
 
-        unset($this->_tables[$key]);
+        unset($this->tables[$key]);
 
         return $this;
     }
@@ -393,7 +391,7 @@ class Schema
     public function createSequence(string $name, int $allocationSize = 1, int $initialValue = 1): Sequence
     {
         $seq = new Sequence($name, $allocationSize, $initialValue);
-        $this->_addSequence($seq);
+        $this->addSequence($seq);
 
         return $seq;
     }
@@ -402,7 +400,7 @@ class Schema
     public function dropSequence(string $name): self
     {
         $key = $this->getKeyFromName($name);
-        unset($this->_sequences[$key]);
+        unset($this->sequences[$key]);
 
         return $this;
     }
@@ -438,12 +436,12 @@ class Schema
      */
     public function __clone()
     {
-        foreach ($this->_tables as $k => $table) {
-            $this->_tables[$k] = clone $table;
+        foreach ($this->tables as $k => $table) {
+            $this->tables[$k] = clone $table;
         }
 
-        foreach ($this->_sequences as $k => $sequence) {
-            $this->_sequences[$k] = clone $sequence;
+        foreach ($this->sequences as $k => $sequence) {
+            $this->sequences[$k] = clone $sequence;
         }
     }
 

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -12,20 +12,19 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 /**
  * Sequence structure.
  *
- * @final
  * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
-class Sequence extends AbstractNamedObject
+final class Sequence extends AbstractNamedObject
 {
-    protected int $allocationSize = 1;
+    private int $allocationSize = 1;
 
-    protected int $initialValue = 1;
+    private int $initialValue = 1;
 
     public function __construct(
         string $name,
         int $allocationSize = 1,
         int $initialValue = 1,
-        protected ?int $cache = null,
+        private ?int $cache = null,
     ) {
         $parser = Parsers::getOptionallyQualifiedNameParser();
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -48,22 +48,21 @@ use function substr;
 /**
  * Object Representation of a table.
  *
- * @final
  * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
-class Table extends AbstractNamedObject
+final class Table extends AbstractNamedObject
 {
     /** @var Column[] */
-    protected array $_columns = [];
+    private array $columns = [];
 
     /** @var array<string, string> keys are new names, values are old names */
-    protected array $renamedColumns = [];
+    private array $renamedColumns = [];
 
     /** @var Index[] */
-    protected array $_indexes = [];
+    private array $indexes = [];
 
     /**
-     * The keys of this array are the keys of the {@see $_indexes} array that correspond to the indexes that were
+     * The keys of this array are the keys of the {@see $indexes} array that correspond to the indexes that were
      * implicitly created as backing for foreign key constraints. The values are not used but must be non-null for
      * {@link isset()} to work correctly.
      *
@@ -72,13 +71,13 @@ class Table extends AbstractNamedObject
     private array $implicitIndexKeys = [];
 
     /** @var UniqueConstraint[] */
-    protected array $uniqueConstraints = [];
+    private array $uniqueConstraints = [];
 
     /** @var ForeignKeyConstraint[] */
-    protected array $_fkConstraints = [];
+    private array $foreignKeyConstraints = [];
 
     /** @var mixed[] */
-    protected array $_options = [
+    private array $options = [
         'create_options' => [],
     ];
 
@@ -138,7 +137,7 @@ class Table extends AbstractNamedObject
             $this->_addForeignKeyConstraint($fkConstraint);
         }
 
-        $this->_options = array_merge($this->_options, $options);
+        $this->options = array_merge($this->options, $options);
     }
 
     public function addPrimaryKeyConstraint(PrimaryKeyConstraint $primaryKeyConstraint): self
@@ -165,7 +164,7 @@ class Table extends AbstractNamedObject
 
         $isClustered = in_array('clustered', $flags, true);
 
-        return $this->_addUniqueConstraint($this->_createUniqueConstraint($columnNames, $indexName, $isClustered));
+        return $this->_addUniqueConstraint($this->createUniqueConstraint($columnNames, $indexName, $isClustered));
     }
 
     /**
@@ -181,7 +180,7 @@ class Table extends AbstractNamedObject
     ): self {
         $indexName ??= $this->generateNameFromStringColumnNames('idx', $columnNames);
 
-        return $this->_addIndex($this->_createIndex($columnNames, $indexName, false, $flags, $options));
+        return $this->_addIndex($this->createIndex($columnNames, $indexName, false, $flags, $options));
     }
 
     /**
@@ -203,7 +202,7 @@ class Table extends AbstractNamedObject
             throw IndexDoesNotExist::new($this->name, $parsedName);
         }
 
-        unset($this->_indexes[$this->getObjectKey($parsedName)]);
+        unset($this->indexes[$this->getObjectKey($parsedName)]);
     }
 
     /**
@@ -214,7 +213,7 @@ class Table extends AbstractNamedObject
     {
         $indexName ??= $this->generateNameFromStringColumnNames('uniq', $columnNames);
 
-        return $this->_addIndex($this->_createIndex($columnNames, $indexName, true, [], $options));
+        return $this->_addIndex($this->createIndex($columnNames, $indexName, true, [], $options));
     }
 
     /**
@@ -260,7 +259,7 @@ class Table extends AbstractNamedObject
             ->setName($parsedNewName)
             ->create();
 
-        unset($this->_indexes[$this->getObjectKey($parsedOldName)]);
+        unset($this->indexes[$this->getObjectKey($parsedOldName)]);
 
         return $this->_addIndex($index);
     }
@@ -280,7 +279,7 @@ class Table extends AbstractNamedObject
     }
 
     /** @return array<string, string> */
-    final public function getRenamedColumns(): array
+    public function getRenamedColumns(): array
     {
         return $this->renamedColumns;
     }
@@ -291,7 +290,7 @@ class Table extends AbstractNamedObject
      *
      * @throws LogicException
      */
-    final public function renameColumn(string $oldName, string $newName): Column
+    public function renameColumn(string $oldName, string $newName): Column
     {
         $parsedOldName = $this->parseUnqualifiedName($oldName);
         $parsedNewName = $this->parseUnqualifiedName($newName);
@@ -314,7 +313,7 @@ class Table extends AbstractNamedObject
 
         $newColumn = new Column($parsedNewName->toString(), $oldColumn->getType(), $options);
 
-        unset($this->_columns[$this->getObjectKey($parsedOldName)]);
+        unset($this->columns[$this->getObjectKey($parsedOldName)]);
         $this->_addColumn($newColumn);
 
         $this->renameColumnInIndexes($oldKey, $parsedNewName);
@@ -376,7 +375,7 @@ class Table extends AbstractNamedObject
             );
         }
 
-        unset($this->_columns[$this->getObjectKey($parsedName)]);
+        unset($this->columns[$this->getObjectKey($parsedName)]);
 
         return $this;
     }
@@ -539,7 +538,7 @@ class Table extends AbstractNamedObject
 
     public function addOption(string $name, mixed $value): self
     {
-        $this->_options[$name] = $value;
+        $this->options[$name] = $value;
 
         return $this;
     }
@@ -551,7 +550,7 @@ class Table extends AbstractNamedObject
     {
         $parsedName = $this->parseUnqualifiedName($name);
 
-        return isset($this->_fkConstraints[$this->getObjectKey($parsedName)]);
+        return isset($this->foreignKeyConstraints[$this->getObjectKey($parsedName)]);
     }
 
     /**
@@ -565,7 +564,7 @@ class Table extends AbstractNamedObject
             throw ForeignKeyDoesNotExist::new($this->name, $parsedName);
         }
 
-        return $this->_fkConstraints[$this->getObjectKey($parsedName)];
+        return $this->foreignKeyConstraints[$this->getObjectKey($parsedName)];
     }
 
     /**
@@ -579,7 +578,7 @@ class Table extends AbstractNamedObject
             throw ForeignKeyDoesNotExist::new($this->name, $parsedName);
         }
 
-        unset($this->_fkConstraints[$this->getObjectKey($parsedName)]);
+        unset($this->foreignKeyConstraints[$this->getObjectKey($parsedName)]);
     }
 
     /**
@@ -628,7 +627,7 @@ class Table extends AbstractNamedObject
     public function getColumns(): array
     {
         /** @phpstan-ignore return.type */
-        return array_values($this->_columns);
+        return array_values($this->columns);
     }
 
     /**
@@ -638,7 +637,7 @@ class Table extends AbstractNamedObject
     {
         $parsedName = $this->parseUnqualifiedName($name);
 
-        return isset($this->_columns[$this->getObjectKey($parsedName)]);
+        return isset($this->columns[$this->getObjectKey($parsedName)]);
     }
 
     /**
@@ -652,7 +651,7 @@ class Table extends AbstractNamedObject
             throw ColumnDoesNotExist::new($this->name, $parsedName);
         }
 
-        return $this->_columns[$this->getObjectKey($parsedName)];
+        return $this->columns[$this->getObjectKey($parsedName)];
     }
 
     public function getPrimaryKeyConstraint(): ?PrimaryKeyConstraint
@@ -667,7 +666,7 @@ class Table extends AbstractNamedObject
     {
         $parsedName = $this->parseUnqualifiedName($name);
 
-        return isset($this->_indexes[$this->getObjectKey($parsedName)]);
+        return isset($this->indexes[$this->getObjectKey($parsedName)]);
     }
 
     /**
@@ -681,13 +680,13 @@ class Table extends AbstractNamedObject
             throw IndexDoesNotExist::new($this->name, $parsedName);
         }
 
-        return $this->_indexes[$this->getObjectKey($parsedName)];
+        return $this->indexes[$this->getObjectKey($parsedName)];
     }
 
     /** @return array<string, Index> */
     public function getIndexes(): array
     {
-        return $this->_indexes;
+        return $this->indexes;
     }
 
     /**
@@ -707,23 +706,23 @@ class Table extends AbstractNamedObject
      */
     public function getForeignKeys(): array
     {
-        return $this->_fkConstraints;
+        return $this->foreignKeyConstraints;
     }
 
     public function hasOption(string $name): bool
     {
-        return isset($this->_options[$name]);
+        return isset($this->options[$name]);
     }
 
     public function getOption(string $name): mixed
     {
-        return $this->_options[$name] ?? null;
+        return $this->options[$name] ?? null;
     }
 
     /** @return array<string, mixed> */
     public function getOptions(): array
     {
-        return $this->_options;
+        return $this->options;
     }
 
     /**
@@ -731,35 +730,35 @@ class Table extends AbstractNamedObject
      */
     public function __clone()
     {
-        foreach ($this->_columns as $k => $column) {
-            $this->_columns[$k] = clone $column;
+        foreach ($this->columns as $k => $column) {
+            $this->columns[$k] = clone $column;
         }
 
-        foreach ($this->_indexes as $k => $index) {
-            $this->_indexes[$k] = clone $index;
+        foreach ($this->indexes as $k => $index) {
+            $this->indexes[$k] = clone $index;
         }
 
-        foreach ($this->_fkConstraints as $k => $fk) {
-            $this->_fkConstraints[$k] = clone $fk;
+        foreach ($this->foreignKeyConstraints as $k => $fk) {
+            $this->foreignKeyConstraints[$k] = clone $fk;
         }
     }
 
-    protected function _addColumn(Column $column): void
+    private function _addColumn(Column $column): void
     {
         $columnName = $column->getObjectName();
         $columnKey  = $this->getObjectKey($columnName);
 
-        if (isset($this->_columns[$columnKey])) {
+        if (isset($this->columns[$columnKey])) {
             throw ColumnAlreadyExists::new($this->name, $column->getObjectName());
         }
 
-        $this->_columns[$columnKey] = $column;
+        $this->columns[$columnKey] = $column;
     }
 
     /**
      * Adds an index to the table.
      */
-    protected function _addIndex(Index $index): self
+    private function _addIndex(Index $index): self
     {
         $indexName = $index->getObjectName();
         $indexKey  = $this->getObjectKey($indexName);
@@ -767,31 +766,31 @@ class Table extends AbstractNamedObject
         $replacedImplicitIndexKeys = [];
 
         foreach ($this->implicitIndexKeys as $implicitIndexKey => $_) {
-            if (! isset($this->_indexes[$implicitIndexKey])) {
+            if (! isset($this->indexes[$implicitIndexKey])) {
                 continue;
             }
 
-            if (! $this->_indexes[$implicitIndexKey]->isFulfilledBy($index)) {
+            if (! $this->indexes[$implicitIndexKey]->isFulfilledBy($index)) {
                 continue;
             }
 
             $replacedImplicitIndexKeys[$implicitIndexKey] = true;
         }
 
-        if (isset($this->_indexes[$indexKey]) && ! isset($replacedImplicitIndexKeys[$indexKey])) {
+        if (isset($this->indexes[$indexKey]) && ! isset($replacedImplicitIndexKeys[$indexKey])) {
             throw IndexAlreadyExists::new($this->name, $index->getObjectName());
         }
 
         foreach ($replacedImplicitIndexKeys as $key => $_) {
-            unset($this->_indexes[$key], $this->implicitIndexKeys[$key]);
+            unset($this->indexes[$key], $this->implicitIndexKeys[$key]);
         }
 
-        $this->_indexes[$indexKey] = $index;
+        $this->indexes[$indexKey] = $index;
 
         return $this;
     }
 
-    protected function _addUniqueConstraint(UniqueConstraint $constraint): self
+    private function _addUniqueConstraint(UniqueConstraint $constraint): self
     {
         $constraintName = $constraint->getObjectName();
         $columnNames    = $constraint->getColumnNames();
@@ -817,7 +816,7 @@ class Table extends AbstractNamedObject
             ->setColumnNames(...$columnNames)
             ->create();
 
-        foreach ($this->_indexes as $existingIndex) {
+        foreach ($this->indexes as $existingIndex) {
             if ($indexCandidate->isFulfilledBy($existingIndex)) {
                 return $this;
             }
@@ -828,7 +827,7 @@ class Table extends AbstractNamedObject
         return $this;
     }
 
-    protected function _addForeignKeyConstraint(ForeignKeyConstraint $constraint): self
+    private function _addForeignKeyConstraint(ForeignKeyConstraint $constraint): self
     {
         $constraintName = $constraint->getObjectName();
         $columnNames    = $constraint->getReferencingColumnNames();
@@ -839,7 +838,7 @@ class Table extends AbstractNamedObject
             $key = strtolower($this->generateNameFromObjectColumnNames('fk', $columnNames));
         }
 
-        $this->_fkConstraints[$key] = $constraint;
+        $this->foreignKeyConstraints[$key] = $constraint;
 
         // add an explicit index on the foreign key columns.
         // If there is already an index that fulfills this requirements drop the request. In the case of __construct
@@ -854,7 +853,7 @@ class Table extends AbstractNamedObject
             ->setColumnNames(...$constraint->getReferencingColumnNames())
             ->create();
 
-        foreach ($this->_indexes as $existingIndex) {
+        foreach ($this->indexes as $existingIndex) {
             if ($indexCandidate->isFulfilledBy($existingIndex)) {
                 return $this;
             }
@@ -886,7 +885,7 @@ class Table extends AbstractNamedObject
 
     public function getComment(): ?string
     {
-        return $this->_options['comment'] ?? null;
+        return $this->options['comment'] ?? null;
     }
 
     /**
@@ -904,13 +903,13 @@ class Table extends AbstractNamedObject
     {
         $editor = self::editor()
             ->setName($this->getObjectName())
-            ->setColumns(...array_values($this->_columns))
-            ->setIndexes(...array_values(array_diff_key($this->_indexes, $this->implicitIndexKeys)))
+            ->setColumns(...array_values($this->columns))
+            ->setIndexes(...array_values(array_diff_key($this->indexes, $this->implicitIndexKeys)))
             ->setPrimaryKeyConstraint($this->primaryKeyConstraint)
             ->setUniqueConstraints(...array_values($this->uniqueConstraints))
-            ->setForeignKeyConstraints(...array_values($this->_fkConstraints));
+            ->setForeignKeyConstraints(...array_values($this->foreignKeyConstraints));
 
-        $options = $this->_options;
+        $options = $this->options;
 
         if (isset($options['comment'])) {
             $editor->setComment($options['comment']);
@@ -925,7 +924,7 @@ class Table extends AbstractNamedObject
     }
 
     /** @param non-empty-list<string> $columns */
-    private function _createUniqueConstraint(
+    private function createUniqueConstraint(
         array $columns,
         string $indexName,
         bool $isClustered,
@@ -951,7 +950,7 @@ class Table extends AbstractNamedObject
      * @param array<int, string>     $flags
      * @param array<string, mixed>   $options
      */
-    private function _createIndex(
+    private function createIndex(
         array $columns,
         string $indexName,
         bool $isUnique,
@@ -1108,7 +1107,7 @@ class Table extends AbstractNamedObject
 
     private function renameColumnInIndexes(string $oldKey, UnqualifiedName $newName): void
     {
-        foreach ($this->_indexes as $key => $index) {
+        foreach ($this->indexes as $key => $index) {
             $modified    = false;
             $columnNames = [];
             foreach ($index->getIndexedColumns() as $indexedColumn) {
@@ -1125,7 +1124,7 @@ class Table extends AbstractNamedObject
                 continue;
             }
 
-            $this->_indexes[$key] = $index->edit()
+            $this->indexes[$key] = $index->edit()
                 ->setColumnNames(...$columnNames)
                 ->create();
         }
@@ -1133,7 +1132,7 @@ class Table extends AbstractNamedObject
 
     private function renameColumnInForeignKeyConstraints(string $oldKey, UnqualifiedName $newName): void
     {
-        foreach ($this->_fkConstraints as $key => $constraint) {
+        foreach ($this->foreignKeyConstraints as $key => $constraint) {
             $modified    = false;
             $columnNames = [];
             foreach ($constraint->getReferencingColumnNames() as $columnName) {
@@ -1149,7 +1148,7 @@ class Table extends AbstractNamedObject
                 continue;
             }
 
-            $this->_fkConstraints[$key] = $constraint->edit()
+            $this->foreignKeyConstraints[$key] = $constraint->edit()
                 ->setReferencingColumnNames(...$columnNames)
                 ->create();
         }
@@ -1186,7 +1185,7 @@ class Table extends AbstractNamedObject
 
         $names = [];
 
-        foreach ($this->_fkConstraints as $key => $constraint) {
+        foreach ($this->foreignKeyConstraints as $key => $constraint) {
             foreach ($constraint->getReferencingColumnNames() as $referencingColumnName) {
                 if ($this->getObjectKey($referencingColumnName) === $columnKey) {
                     $names[] = $constraint->getObjectName();

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -12,10 +12,9 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 /**
  * Representation of a Database View.
  *
- * @final
  * @extends AbstractNamedObject<OptionallyQualifiedName>
  */
-class View extends AbstractNamedObject
+final class View extends AbstractNamedObject
 {
     public function __construct(string $name, private readonly string $sql)
     {


### PR DESCRIPTION
In addition to marking value object classes as final, this PR:
1. Marks all their `protected` properties and methods as `private`.
2. Removes leading underscore from the names of properties and some methods. Some methods like `_addColumn()` are left as is because there is already a method with the same name without the underscore.