### PR TITLE
Introduce sequence editor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated `Sequence` features
+
+1. The `Sequence` constructor has been marked as internal. Use `Sequence::editor()` to instantiate an editor and
+   `SequenceEditor::create()` to create a sequence.
+2. Passing a negative value as sequence cache size has been deprecated.
+3. The `Sequence::getCache()` method has been deprecated. Use `Sequence::getCacheSize()` instead.
+
 ## Deprecated extension of schema classes
 
 Extending the following classes has been deprecated. Use them directly.

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -155,31 +155,27 @@ class OraclePlatform extends AbstractPlatform
                ' START WITH ' . $sequence->getInitialValue() .
                ' MINVALUE ' . $sequence->getInitialValue() .
                ' INCREMENT BY ' . $sequence->getAllocationSize() .
-               $this->getSequenceCacheSQL($sequence);
+               $this->getSequenceCacheSQL($sequence->getCacheSize());
     }
 
     public function getAlterSequenceSQL(Sequence $sequence): string
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
                ' INCREMENT BY ' . $sequence->getAllocationSize()
-               . $this->getSequenceCacheSQL($sequence);
+               . $this->getSequenceCacheSQL($sequence->getCacheSize());
     }
 
     /**
      * Cache definition for sequences
      */
-    private function getSequenceCacheSQL(Sequence $sequence): string
+    private function getSequenceCacheSQL(?int $cacheSize): string
     {
-        if ($sequence->getCache() === 0) {
+        if ($cacheSize === 0 || $cacheSize === 1) {
             return ' NOCACHE';
         }
 
-        if ($sequence->getCache() === 1) {
-            return ' NOCACHE';
-        }
-
-        if ($sequence->getCache() > 1) {
-            return ' CACHE ' . $sequence->getCache();
+        if ($cacheSize > 1) {
+            return ' CACHE ' . $cacheSize;
         }
 
         return '';

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -330,23 +330,23 @@ class PostgreSQLPlatform extends AbstractPlatform
             ' INCREMENT BY ' . $sequence->getAllocationSize() .
             ' MINVALUE ' . $sequence->getInitialValue() .
             ' START ' . $sequence->getInitialValue() .
-            $this->getSequenceCacheSQL($sequence);
+            $this->getSequenceCacheSQL($sequence->getCacheSize());
     }
 
     public function getAlterSequenceSQL(Sequence $sequence): string
     {
         return 'ALTER SEQUENCE ' . $sequence->getQuotedName($this) .
             ' INCREMENT BY ' . $sequence->getAllocationSize() .
-            $this->getSequenceCacheSQL($sequence);
+            $this->getSequenceCacheSQL($sequence->getCacheSize());
     }
 
     /**
      * Cache definition for sequences
      */
-    private function getSequenceCacheSQL(Sequence $sequence): string
+    private function getSequenceCacheSQL(?int $cacheSize): string
     {
-        if ($sequence->getCache() > 1) {
-            return ' CACHE ' . $sequence->getCache();
+        if ($cacheSize > 1) {
+            return ' CACHE ' . $cacheSize;
         }
 
         return '';

--- a/src/Schema/Exception/InvalidSequenceDefinition.php
+++ b/src/Schema/Exception/InvalidSequenceDefinition.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+final class InvalidSequenceDefinition extends LogicException implements SchemaException
+{
+    public static function nameNotSet(): self
+    {
+        return new self('Sequence name is not set.');
+    }
+
+    public static function fromNegativeCacheSize(int $cacheSize): self
+    {
+        return new self(sprintf('Sequence cache size must be a non-negative integer, %d given.', $cacheSize));
+    }
+}

--- a/src/Schema/SequenceEditor.php
+++ b/src/Schema/SequenceEditor.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidSequenceDefinition;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+
+final class SequenceEditor
+{
+    private ?OptionallyQualifiedName $name = null;
+
+    private int $allocationSize = 1;
+
+    private int $initialValue = 1;
+
+    /** @var ?non-negative-int */
+    private ?int $cacheSize = null;
+
+    /** @internal Use {@link Sequence::editor()} or {@link Sequence::edit()} to create an instance */
+    public function __construct()
+    {
+    }
+
+    public function setName(OptionallyQualifiedName $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
+     */
+    public function setUnquotedName(string $unqualifiedName, ?string $qualifier = null): self
+    {
+        $this->name = OptionallyQualifiedName::unquoted($unqualifiedName, $qualifier);
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
+     */
+    public function setQuotedName(string $unqualifiedName, ?string $qualifier = null): self
+    {
+        $this->name = OptionallyQualifiedName::quoted($unqualifiedName, $qualifier);
+
+        return $this;
+    }
+
+    public function setAllocationSize(int $allocationSize): self
+    {
+        $this->allocationSize = $allocationSize;
+
+        return $this;
+    }
+
+    public function setInitialValue(int $initialValue): self
+    {
+        $this->initialValue = $initialValue;
+
+        return $this;
+    }
+
+    /** @param ?non-negative-int $cacheSize */
+    public function setCacheSize(?int $cacheSize): self
+    {
+        if ($cacheSize < 0) {
+            throw InvalidSequenceDefinition::fromNegativeCacheSize($cacheSize);
+        }
+
+        $this->cacheSize = $cacheSize;
+
+        return $this;
+    }
+
+    public function create(): Sequence
+    {
+        if ($this->name === null) {
+            throw InvalidSequenceDefinition::nameNotSet();
+        }
+
+        return new Sequence(
+            $this->name->toString(),
+            $this->allocationSize,
+            $this->initialValue,
+            $this->cacheSize,
+        );
+    }
+}

--- a/tests/Functional/Schema/PostgreSQL/SchemaTest.php
+++ b/tests/Functional/Schema/PostgreSQL/SchemaTest.php
@@ -35,7 +35,9 @@ final class SchemaTest extends FunctionalTestCase
             )
             ->create();
 
-        $sequence = new Sequence('my_table_id_seq');
+        $sequence = Sequence::editor()
+            ->setUnquotedName('my_table_id_seq')
+            ->create();
 
         $schema = new Schema([$table], [$sequence]);
         foreach ($schema->toSql($platform) as $sql) {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -107,7 +107,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $name = 'create_sequences_test_seq';
 
-        $this->schemaManager->createSequence(new Sequence($name));
+        $this->schemaManager->createSequence(
+            Sequence::editor()
+                ->setUnquotedName($name)
+                ->create(),
+        );
 
         self::assertNotNull($this->findObjectByShortestName($this->schemaManager->listSequences(), $name));
     }
@@ -157,7 +161,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         }
 
         $this->schemaManager->createSequence(
-            new Sequence('list_sequences_test_seq', 20, 10),
+            Sequence::editor()
+                ->setUnquotedName('list_sequences_test_seq')
+                ->setAllocationSize(20)
+                ->setInitialValue(10)
+                ->create(),
         );
 
         $createdSequence = $this->findObjectByShortestName(
@@ -1429,8 +1437,18 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $sequence2Name           = 'sequence_2';
         $sequence2AllocationSize = 3;
         $sequence2InitialValue   = 4;
-        $sequence1               = new Sequence($sequence1Name, $sequence1AllocationSize, $sequence1InitialValue);
-        $sequence2               = new Sequence($sequence2Name, $sequence2AllocationSize, $sequence2InitialValue);
+
+        $sequence1 = Sequence::editor()
+            ->setUnquotedName($sequence1Name)
+            ->setAllocationSize($sequence1AllocationSize)
+            ->setInitialValue($sequence1InitialValue)
+            ->create();
+
+        $sequence2 = Sequence::editor()
+            ->setUnquotedName($sequence2Name)
+            ->setAllocationSize($sequence2AllocationSize)
+            ->setInitialValue($sequence2InitialValue)
+            ->create();
 
         $this->schemaManager->createSequence($sequence1);
         $this->schemaManager->createSequence($sequence2);
@@ -1459,7 +1477,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $sequenceName           = 'sequence_auto_detect_test';
         $sequenceAllocationSize = 5;
         $sequenceInitialValue   = 10;
-        $sequence               = new Sequence($sequenceName, $sequenceAllocationSize, $sequenceInitialValue);
+
+        $sequence = Sequence::editor()
+            ->setUnquotedName($sequenceName)
+            ->setAllocationSize($sequenceAllocationSize)
+            ->setInitialValue($sequenceInitialValue)
+            ->create();
 
         try {
             $this->schemaManager->dropSequence(

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -407,14 +407,19 @@ SQL
         );
     }
 
+    /** @param non-negative-int $cacheSize */
     #[DataProvider('dataCreateSequenceWithCache')]
     public function testCreateSequenceWithCache(int $cacheSize, string $expectedSql): void
     {
-        $sequence = new Sequence('foo', 1, 1, $cacheSize);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('foo')
+            ->setCacheSize($cacheSize)
+            ->create();
+
         self::assertStringContainsString($expectedSql, $this->platform->getCreateSequenceSQL($sequence));
     }
 
-    /** @return mixed[][] */
+    /** @return iterable<array{non-negative-int, string}> */
     public static function dataCreateSequenceWithCache(): iterable
     {
         return [

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -310,7 +310,11 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 
     public function testGeneratesSequenceSqlCommands(): void
     {
-        $sequence = new Sequence('myseq', 20, 1);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('myseq')
+            ->setAllocationSize(20)
+            ->create();
+
         self::assertEquals(
             'CREATE SEQUENCE myseq INCREMENT BY 20 MINVALUE 1 START 1',
             $this->platform->getCreateSequenceSQL($sequence),
@@ -575,14 +579,19 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         ];
     }
 
+    /** @param non-negative-int $cacheSize */
     #[DataProvider('dataCreateSequenceWithCache')]
     public function testCreateSequenceWithCache(int $cacheSize, string $expectedSql): void
     {
-        $sequence = new Sequence('foo', 1, 1, $cacheSize);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('foo')
+            ->setCacheSize($cacheSize)
+            ->create();
+
         self::assertStringContainsString($expectedSql, $this->platform->getCreateSequenceSQL($sequence));
     }
 
-    /** @return mixed[][] */
+    /** @return iterable<array{non-negative-int, string}> */
     public static function dataCreateSequenceWithCache(): iterable
     {
         return [

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -1140,7 +1140,11 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
 
     public function testGeneratesSequenceSqlCommands(): void
     {
-        $sequence = new Sequence('myseq', 20, 1);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('myseq')
+            ->setAllocationSize(20)
+            ->create();
+
         self::assertEquals(
             'CREATE SEQUENCE myseq START WITH 1 INCREMENT BY 20 MINVALUE 1',
             $this->platform->getCreateSequenceSQL($sequence),

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -278,12 +278,22 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testCompareSequences(): void
     {
-        $seq1 = new Sequence('foo', 1, 1);
-        $seq2 = new Sequence('foo', 1, 2);
-        $seq3 = new Sequence('foo', 2, 1);
+        $sequence1 = Sequence::editor()
+            ->setUnquotedName('foo')
+            ->create();
 
-        self::assertTrue($this->comparator->diffSequence($seq1, $seq2));
-        self::assertTrue($this->comparator->diffSequence($seq1, $seq3));
+        $sequence2 = Sequence::editor()
+            ->setUnquotedName('foo')
+            ->setInitialValue(2)
+            ->create();
+
+        $sequence3 = Sequence::editor()
+            ->setUnquotedName('foo')
+            ->setAllocationSize(2)
+            ->create();
+
+        self::assertTrue($this->comparator->diffSequence($sequence1, $sequence2));
+        self::assertTrue($this->comparator->diffSequence($sequence1, $sequence3));
     }
 
     public function testRemovedSequence(): void

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -123,7 +123,9 @@ class SchemaTest extends TestCase
 
     public function testAddSequences(): void
     {
-        $sequence = new Sequence('a_seq', 1, 1);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('a_seq')
+            ->create();
 
         $schema = new Schema([], [$sequence]);
 
@@ -138,7 +140,9 @@ class SchemaTest extends TestCase
 
     public function testSequenceAccessCaseInsensitive(): void
     {
-        $sequence = new Sequence('a_Seq');
+        $sequence = Sequence::editor()
+            ->setUnquotedName('a_Seq')
+            ->create();
 
         $schema = new Schema([], [$sequence]);
         self::assertTrue($schema->hasSequence('a_seq'));
@@ -181,7 +185,9 @@ class SchemaTest extends TestCase
 
     public function testDropSequence(): void
     {
-        $sequence = new Sequence('a_seq', 1, 1);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('a_seq')
+            ->create();
 
         $schema = new Schema([], [$sequence]);
 
@@ -193,7 +199,9 @@ class SchemaTest extends TestCase
     {
         $this->expectException(SchemaException::class);
 
-        $sequence = new Sequence('a_seq', 1, 1);
+        $sequence = Sequence::editor()
+            ->setUnquotedName('a_seq')
+            ->create();
 
         new Schema([], [$sequence, $sequence]);
     }

--- a/tests/Schema/SequenceEditorTest.php
+++ b/tests/Schema/SequenceEditorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Exception\InvalidSequenceDefinition;
+use Doctrine\DBAL\Schema\Sequence;
+use PHPUnit\Framework\TestCase;
+
+class SequenceEditorTest extends TestCase
+{
+    public function testNameNotSet(): void
+    {
+        $editor = Sequence::editor();
+
+        $this->expectException(InvalidSequenceDefinition::class);
+
+        $editor->create();
+    }
+
+    public function testNegativeCacheSize(): void
+    {
+        $editor = Sequence::editor();
+
+        $this->expectException(InvalidSequenceDefinition::class);
+
+        /** @phpstan-ignore argument.type */
+        $editor->setCacheSize(-1);
+    }
+}

--- a/tests/Schema/SequenceTest.php
+++ b/tests/Schema/SequenceTest.php
@@ -36,11 +36,19 @@ class SequenceTest extends TestCase
             )
             ->create();
 
-        $sequence  = new Sequence('foo_id_seq');
-        $sequence2 = new Sequence('bar_id_seq');
-        $sequence3 = new Sequence('other.foo_id_seq');
+        $sequence1 = Sequence::editor()
+            ->setUnquotedName('foo_id_seq')
+            ->create();
 
-        self::assertTrue($sequence->isAutoIncrementsFor($table));
+        $sequence2 = Sequence::editor()
+            ->setUnquotedName('bar_id_seq')
+            ->create();
+
+        $sequence3 = Sequence::editor()
+            ->setUnquotedName('foo_id_seq', 'other')
+            ->create();
+
+        self::assertTrue($sequence1->isAutoIncrementsFor($table));
         self::assertFalse($sequence2->isAutoIncrementsFor($table));
         self::assertFalse($sequence3->isAutoIncrementsFor($table));
     }
@@ -63,11 +71,25 @@ class SequenceTest extends TestCase
             )
             ->create();
 
-        $sequence  = new Sequence('foo_id_seq');
-        $sequence1 = new Sequence('foo_ID_seq');
-        $sequence2 = new Sequence('bar_id_seq');
-        $sequence3 = new Sequence('bar_ID_seq');
-        $sequence4 = new Sequence('other.foo_id_seq');
+        $sequence = Sequence::editor()
+            ->setUnquotedName('foo_id_seq')
+            ->create();
+
+        $sequence1 = Sequence::editor()
+            ->setUnquotedName('foo_ID_seq')
+            ->create();
+
+        $sequence2 = Sequence::editor()
+            ->setUnquotedName('bar_id_seq')
+            ->create();
+
+        $sequence3 = Sequence::editor()
+            ->setUnquotedName('bar_ID_seq')
+            ->create();
+
+        $sequence4 = Sequence::editor()
+            ->setUnquotedName('foo_id_seq', 'other')
+            ->create();
 
         self::assertTrue($sequence->isAutoIncrementsFor($table));
         self::assertTrue($sequence1->isAutoIncrementsFor($table));


### PR DESCRIPTION
Even though users don’t edit sequences as often as other objects, introducing an editor still makes sense:
1. To ensure a consistent DX across all schema objects.
2. To provide an upgrade path toward using object names as objects across the codebase.