### PR TITLE
Remove deprecated Sequence features

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,17 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Changes in `Sequence` API
+
+The following `Sequence` methods have been removed:
+
+- `Sequence::getCache()`
+- `Sequence::setAllocationSize()`
+- `Sequence::setInitialValue()`
+- `Sequence::setCache()`
+
+Additionally, the `Sequence` class has been declared as final.
+
 ## BC BREAK: Removed `AbstractAsset` class
 
 The `AbstractAsset` class has been removed.
@@ -88,7 +99,6 @@ The following classes have been marked as final:
 - `ColumnDiff`
 - `Table`
 - `TableDiff`
-- `Sequence`
 - `Schema`
 - `SchemaDiff`
 - `View`

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -363,8 +363,12 @@ class OraclePlatform extends AbstractPlatform
 
         $triggerName  = $this->generateAutoincrementTriggerName($tableName->getUnqualifiedName());
         $sequenceName = $this->generateAutoincrementSequenceName($tableName);
-        $sequence     = new Sequence($sequenceName->toString());
-        $sql[]        = $this->getCreateSequenceSQL($sequence);
+
+        $sequence = Sequence::editor()
+            ->setName($sequenceName)
+            ->create();
+
+        $sql[] = $this->getCreateSequenceSQL($sequence);
 
         $sql[] = sprintf(
             <<<'SQL'

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -149,10 +149,10 @@ class PostgreSQLPlatform extends AbstractPlatform
     /** @internal The method should be only used from within the {@see AbstractSchemaManager} class hierarchy. */
     public function getListSequencesSQL(string $database): string
     {
-        return 'SELECT sequence_name AS relname,
-                       sequence_schema AS schemaname,
-                       minimum_value AS min_value,
-                       increment AS increment_by
+        return 'SELECT sequence_name,
+                       sequence_schema,
+                       minimum_value,
+                       increment
                 FROM   information_schema.sequences
                 WHERE  sequence_catalog = ' . $this->quoteStringLiteral($database) . "
                 AND    sequence_schema NOT LIKE 'pg\_%'

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -153,13 +153,16 @@ class SQLServerPlatform extends AbstractPlatform
     public function getListSequencesSQL(string $database): string
     {
         return 'SELECT seq.name,
+                       scm.name AS schema_name,
                        CAST(
                            seq.increment AS VARCHAR(MAX)
                        ) AS increment, -- CAST avoids driver error for sql_variant type
                        CAST(
                            seq.start_value AS VARCHAR(MAX)
                        ) AS start_value -- CAST avoids driver error for sql_variant type
-                FROM   sys.sequences AS seq';
+                FROM   sys.sequences AS seq
+                JOIN   sys.schemas AS scm
+                ON     scm.schema_id = seq.schema_id';
     }
 
     public function getSequenceNextValSQL(string $sequence): string

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -212,11 +212,11 @@ class OracleSchemaManager extends AbstractSchemaManager
     {
         $sequence = array_change_key_case($sequence, CASE_LOWER);
 
-        return new Sequence(
-            $this->getQuotedIdentifierName($sequence['sequence_name']),
-            (int) $sequence['increment_by'],
-            (int) $sequence['min_value'],
-        );
+        return Sequence::editor()
+            ->setQuotedName($sequence['sequence_name'])
+            ->setAllocationSize((int) $sequence['increment_by'])
+            ->setInitialValue((int) $sequence['min_value'])
+            ->create();
     }
 
     /**

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -166,13 +166,17 @@ SQL,
     protected function _getPortableSequenceDefinition(array $sequence): Sequence
     {
         // @phpstan-ignore missingType.checkedException
-        if ($sequence['schemaname'] !== $this->getCurrentSchemaName()) {
-            $sequenceName = $sequence['schemaname'] . '.' . $sequence['relname'];
+        if ($sequence['sequence_schema'] !== $this->getCurrentSchemaName()) {
+            $name = OptionallyQualifiedName::quoted($sequence['sequence_name'], $sequence['sequence_schema']);
         } else {
-            $sequenceName = $sequence['relname'];
+            $name = OptionallyQualifiedName::quoted($sequence['sequence_name']);
         }
 
-        return new Sequence($sequenceName, (int) $sequence['increment_by'], (int) $sequence['min_value']);
+        return Sequence::editor()
+            ->setName($name)
+            ->setAllocationSize((int) $sequence['increment'])
+            ->setInitialValue((int) $sequence['minimum_value'])
+            ->create();
     }
 
     /**

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -46,7 +46,18 @@ SQL,
      */
     protected function _getPortableSequenceDefinition(array $sequence): Sequence
     {
-        return new Sequence($sequence['name'], (int) $sequence['increment'], (int) $sequence['start_value']);
+        // @phpstan-ignore missingType.checkedException
+        if ($sequence['schema_name'] !== $this->getCurrentSchemaName()) {
+            $name = OptionallyQualifiedName::quoted($sequence['name'], $sequence['schema_name']);
+        } else {
+            $name = OptionallyQualifiedName::quoted($sequence['name']);
+        }
+
+        return Sequence::editor()
+            ->setName($name)
+            ->setAllocationSize((int) $sequence['increment'])
+            ->setInitialValue((int) $sequence['start_value'])
+            ->create();
     }
 
     /**

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -390,7 +390,20 @@ final class Schema
      */
     public function createSequence(string $name, int $allocationSize = 1, int $initialValue = 1): Sequence
     {
-        $seq = new Sequence($name, $allocationSize, $initialValue);
+        $parser = Parsers::getOptionallyQualifiedNameParser();
+
+        try {
+            $parsedName = $parser->parse($name);
+        } catch (Parser\Exception $e) {
+            throw InvalidName::fromParserException($name, $e);
+        }
+
+        $seq = Sequence::editor()
+            ->setName($parsedName)
+            ->setAllocationSize($allocationSize)
+            ->setInitialValue($initialValue)
+            ->create();
+
         $this->addSequence($seq);
 
         return $seq;

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\Schema\Exception\InvalidName;
+use Doctrine\DBAL\Schema\Exception\InvalidSequenceDefinition;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
-use Doctrine\DBAL\Schema\Name\Parser;
-use Doctrine\DBAL\Schema\Name\Parsers;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * Sequence structure.
@@ -17,42 +14,23 @@ use Doctrine\Deprecations\Deprecation;
  */
 final class Sequence extends AbstractNamedObject
 {
-    private int $allocationSize = 1;
-
-    private int $initialValue = 1;
-
     /**
      * @internal Use {@link Sequence::editor()} to instantiate an editor and {@link SequenceEditor::create()} to create
      *           a sequence.
      *
-     * @param ?non-negative-int $cache
+     * @param ?non-negative-int $cacheSize
      */
     public function __construct(
-        string $name,
-        int $allocationSize = 1,
-        int $initialValue = 1,
-        private ?int $cache = null,
+        OptionallyQualifiedName $name,
+        private readonly int $allocationSize,
+        private readonly int $initialValue,
+        private readonly ?int $cacheSize = null,
     ) {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
+        parent::__construct($name);
 
-        try {
-            $parsedName = $parser->parse($name);
-        } catch (Parser\Exception $e) {
-            throw InvalidName::fromParserException($name, $e);
+        if ($cacheSize < 0) {
+            throw InvalidSequenceDefinition::fromNegativeCacheSize($cacheSize);
         }
-
-        parent::__construct($parsedName);
-
-        if ($cache < 0) {
-            Deprecation::triggerIfCalledFromOutside(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/7108',
-                'Passing a negative value as sequence cache size is deprecated.',
-            );
-        }
-
-        $this->setAllocationSize($allocationSize);
-        $this->setInitialValue($initialValue);
     }
 
     public function getAllocationSize(): int
@@ -65,49 +43,10 @@ final class Sequence extends AbstractNamedObject
         return $this->initialValue;
     }
 
-    /**
-     * @deprecated Use {@see getCacheSize()} instead.
-     *
-     * @return ?non-negative-int
-     */
-    public function getCache(): ?int
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7108',
-            '%s is deprecated, use `getCacheSize()` instead.',
-            __METHOD__,
-        );
-
-        return $this->cache;
-    }
-
     /** @return ?non-negative-int */
     public function getCacheSize(): ?int
     {
-        return $this->getCache();
-    }
-
-    public function setAllocationSize(int $allocationSize): self
-    {
-        $this->allocationSize = $allocationSize;
-
-        return $this;
-    }
-
-    public function setInitialValue(int $initialValue): self
-    {
-        $this->initialValue = $initialValue;
-
-        return $this;
-    }
-
-    /** @param non-negative-int $cache */
-    public function setCache(int $cache): self
-    {
-        $this->cache = $cache;
-
-        return $this;
+        return $this->cacheSize;
     }
 
     /**
@@ -124,9 +63,9 @@ final class Sequence extends AbstractNamedObject
     public function edit(): SequenceEditor
     {
         return self::editor()
-            ->setName($this->getObjectName())
-            ->setAllocationSize($this->getAllocationSize())
-            ->setInitialValue($this->getInitialValue())
-            ->setCacheSize($this->getCacheSize());
+            ->setName($this->name)
+            ->setAllocationSize($this->allocationSize)
+            ->setInitialValue($this->initialValue)
+            ->setCacheSize($this->cacheSize);
     }
 }

--- a/src/Schema/SequenceEditor.php
+++ b/src/Schema/SequenceEditor.php
@@ -85,7 +85,7 @@ final class SequenceEditor
         }
 
         return new Sequence(
-            $this->name->toString(),
+            $this->name,
             $this->allocationSize,
             $this->initialValue,
             $this->cacheSize,

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -893,21 +893,6 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         self::assertEquals(Types::JSONB, $this->platform->getDoctrineTypeMapping('jsonb'));
     }
 
-    public function testGetListSequencesSQL(): void
-    {
-        self::assertSame(
-            "SELECT sequence_name AS relname,
-                       sequence_schema AS schemaname,
-                       minimum_value AS min_value,
-                       increment AS increment_by
-                FROM   information_schema.sequences
-                WHERE  sequence_catalog = 'test_db'
-                AND    sequence_schema NOT LIKE 'pg\_%'
-                AND    sequence_schema != 'information_schema'",
-            $this->platform->getListSequencesSQL('test_db'),
-        );
-    }
-
     public function testAlterTableChangeJsonToJsonb(): void
     {
         $table = Table::editor()

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -976,8 +976,8 @@ abstract class AbstractComparatorTestCase extends TestCase
         $oldSchema = new Schema();
         $oldSchema->createSequence('baz');
 
-        $newSchema = clone $oldSchema;
-        $newSchema->getSequence('baz')->setAllocationSize(20);
+        $newSchema = new Schema();
+        $newSchema->createSequence('baz', 20);
 
         $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 

--- a/tests/Schema/SequenceTest.php
+++ b/tests/Schema/SequenceTest.php
@@ -4,45 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
-use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Schema\Exception\InvalidName;
-use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Exception\InvalidSequenceDefinition;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Sequence;
 use PHPUnit\Framework\TestCase;
 
 class SequenceTest extends TestCase
 {
-    public function testEmptyName(): void
+    public function testNegativeCacheSize(): void
     {
-        $this->expectException(InvalidName::class);
+        $this->expectException(InvalidSequenceDefinition::class);
 
-        new Sequence('');
-    }
-
-    public function testOverqualifiedName(): void
-    {
-        $this->expectException(InvalidName::class);
-
-        new Sequence('identity.auth.user_id_seq');
-    }
-
-    /** @throws Exception */
-    public function testGetUnqualifiedObjectName(): void
-    {
-        $sequence = new Sequence('user_id_seq');
-        $name     = $sequence->getObjectName();
-
-        self::assertEquals(Identifier::unquoted('user_id_seq'), $name->getUnqualifiedName());
-        self::assertNull($name->getQualifier());
-    }
-
-    /** @throws Exception */
-    public function testGetQualifiedObjectName(): void
-    {
-        $sequence = new Sequence('auth.user_id_seq');
-        $name     = $sequence->getObjectName();
-
-        self::assertEquals(Identifier::unquoted('user_id_seq'), $name->getUnqualifiedName());
-        self::assertEquals(Identifier::unquoted('auth'), $name->getQualifier());
+        /** @phpstan-ignore argument.type */
+        new Sequence(OptionallyQualifiedName::unquoted('id'), 1, 1, -1);
     }
 }


### PR DESCRIPTION
The affected methods were deprecated in https://github.com/doctrine/dbal/pull/7108. Note, I forgot to deprecate the setters. Will do it later.

Additionally, the PR contains the following changes:
1. Column aliases have been removed from the sequence introspection queries. They are redundant.
2. The introspection logic on SQL Server has been modified such that the schema name of the sequence is also selected. Otherwise, the DBAL will likely introspect the database schema where sequences with the same name exist in more than one schema. The fix could be backported, and the correct behavior enforced with an integration test, but sequences are used such rarely that I don't think it's a priority.
