### PR TITLE
Fix PHP 8.4 installation on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,7 @@ install:
         # Check if installation is cached
         if (!(Test-Path c:\tools\php)) {
           choco upgrade chocolatey
+          choco install --no-progress -y vcredist140
           appveyor-retry choco install --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
           # install sqlite
           appveyor-retry choco install --no-progress -y sqlite

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ install:
     - ps: |
         # Check if installation is cached
         if (!(Test-Path c:\tools\php)) {
-          choco upgrade chocolatey
+          choco upgrade --no-progress chocolatey
           choco install --no-progress -y vcredist140
           appveyor-retry choco install --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
           # install sqlite


### PR DESCRIPTION
The 5.0.x build has been [failing](https://ci.appveyor.com/project/doctrine/dbal/builds/52644296/job/2699d5946exvuwg7#L73) for a while on AppVeyor due to the following error:
> appveyor-retry composer self-update
> PHP Warning:  'C:\windows\SYSTEM32\VCRUNTIME140.dll' 14.22 is not compatible with this PHP build linked with 14.44 in Unknown on line 0
> Command "composer self-update" failed with exit code 1.

It looks like we need to update the DLL before running PHP.

Additionally, I added `--no-progress` to `choco upgrade chocolatey`, since otherwise it produces a ton of useless output.