### PR TITLE
Deprecate Sequence setters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,7 +18,13 @@ The `View` constructor has been marked as internal. Use `View::editor()` to inst
 1. The `Sequence` constructor has been marked as internal. Use `Sequence::editor()` to instantiate an editor and
    `SequenceEditor::create()` to create a sequence.
 2. Passing a negative value as sequence cache size has been deprecated.
-3. The `Sequence::getCache()` method has been deprecated. Use `Sequence::getCacheSize()` instead.
+
+The following `Sequence` methods have been deprecated:
+
+- `Sequence::getCache()` - use `Sequence::getCacheSize()` instead.
+- `Sequence::setAllocationSize()`, `Sequence::setInitialValue()` and `Sequence::setCache()` - use
+   `SequenceEditor::setAllocationSize()`, `SequenceEditor::setInitialValue()` and `SequenceEditor::setCacheSize()`
+   instead.
 
 ## Deprecated extension of schema classes
 

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -88,23 +88,50 @@ class Sequence extends AbstractNamedObject
         return $this->getCache();
     }
 
+    /** @deprecated Use {@see edit()} and {@see SequenceEditor::setAllocationSize()} instead. */
     public function setAllocationSize(int $allocationSize): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7115',
+            '%s is deprecated. Use Sequence::edit() and SequenceEditor::setAllocationSize() instead.',
+            __METHOD__,
+        );
+
         $this->allocationSize = $allocationSize;
 
         return $this;
     }
 
+    /** @deprecated Use {@see edit()} and {@see SequenceEditor::setInitialValue()} instead. */
     public function setInitialValue(int $initialValue): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7115',
+            '%s is deprecated. Use Sequence::edit() and SequenceEditor::setInitialValue() instead.',
+            __METHOD__,
+        );
+
         $this->initialValue = $initialValue;
 
         return $this;
     }
 
-    /** @param non-negative-int $cache */
+    /**
+     * @deprecated Use {@see edit()} and {@see SequenceEditor::setCacheSize()} instead.
+     *
+     * @param non-negative-int $cache
+     */
     public function setCache(int $cache): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7115',
+            '%s is deprecated. Use Sequence::edit() and SequenceEditor::setCacheSize() instead.',
+            __METHOD__,
+        );
+
         $this->cache = $cache;
 
         return $this;


### PR DESCRIPTION
These deprecations should have been made as part of https://github.com/doctrine/dbal/pull/7108.