### PR TITLE
Return table-scoped object sets as lists

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Changes in `Table` method return types
+
+The following `Table` methods no longer return associative arrays of objects. Instead, they return lists:
+- `Table::getIndexes()`
+- `Table::getUniqueConstraints()`
+- `Table::getForeignKeys()`
+
 ## BC BREAK: Changes in `Sequence` API
 
 The following `Sequence` methods have been removed:

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Platforms;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Exception\UnsupportedTableDefinition;
+use Doctrine\DBAL\Schema\Collections\UnqualifiedNamedObjectSet;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -799,17 +800,17 @@ class SQLitePlatform extends AbstractPlatform
     private function getIndexesInAlteredTable(TableDiff $diff): array
     {
         $oldTable = $diff->getOldTable();
-        $indexes  = $oldTable->getIndexes();
+        $indexes  = new UnqualifiedNamedObjectSet(...$oldTable->getIndexes());
         $nameMap  = $this->getDiffColumnNameMap($diff);
 
         foreach ($indexes as $key => $index) {
-            $indexName = $index->getObjectName()->getIdentifier()->getValue();
+            $indexName = $index->getObjectName();
             foreach ($diff->getRenamedIndexes() as $oldIndexName => $renamedIndex) {
-                if (strtolower($indexName) !== strtolower($oldIndexName)) {
+                if (strtolower($indexName->getIdentifier()->getValue()) !== strtolower($oldIndexName)) {
                     continue;
                 }
 
-                unset($indexes[$key]);
+                $indexes->remove($indexName);
             }
 
             $changed     = false;
@@ -817,7 +818,7 @@ class SQLitePlatform extends AbstractPlatform
             foreach ($index->getIndexedColumns() as $column) {
                 $name = $column->getColumnName()->getIdentifier()->getValue();
                 if (! isset($nameMap[$name])) {
-                    unset($indexes[$key]);
+                    $indexes->remove($indexName);
                     continue 2;
                 }
 
@@ -833,19 +834,14 @@ class SQLitePlatform extends AbstractPlatform
                 continue;
             }
 
-            $indexes[$key] = $index->edit()
+            $indexes->modify($indexName, static fn (Index $index): Index => $index
+                ->edit()
                 ->setUnquotedColumnNames(...$columnNames)
-                ->create();
+                ->create());
         }
 
         foreach ($diff->getDroppedIndexes() as $index) {
-            $indexKey = strtolower(
-                $index->getObjectName()
-                    ->getIdentifier()
-                    ->getValue(),
-            );
-
-            unset($indexes[$indexKey]);
+            $indexes->remove($index->getObjectName());
         }
 
         foreach (
@@ -854,16 +850,10 @@ class SQLitePlatform extends AbstractPlatform
                 $diff->getRenamedIndexes(),
             ) as $index
         ) {
-            $indexKey = strtolower(
-                $index->getObjectName()
-                    ->getIdentifier()
-                    ->getValue(),
-            );
-
-            $indexes[$indexKey] = $index;
+            $indexes->add($index);
         }
 
-        return $indexes;
+        return $indexes->toList();
     }
 
     /** @return array<ForeignKeyConstraint> */

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -683,30 +683,30 @@ final class Table extends AbstractNamedObject
         return $this->indexes[$this->getObjectKey($parsedName)];
     }
 
-    /** @return array<string, Index> */
+    /** @return list<Index> */
     public function getIndexes(): array
     {
-        return $this->indexes;
+        return array_values($this->indexes);
     }
 
     /**
      * Returns the unique constraints.
      *
-     * @return array<string, UniqueConstraint>
+     * @return list<UniqueConstraint>
      */
     public function getUniqueConstraints(): array
     {
-        return $this->uniqueConstraints;
+        return array_values($this->uniqueConstraints);
     }
 
     /**
      * Returns the foreign key constraints.
      *
-     * @return array<string, ForeignKeyConstraint>
+     * @return list<ForeignKeyConstraint>
      */
     public function getForeignKeys(): array
     {
-        return $this->foreignKeyConstraints;
+        return array_values($this->foreignKeyConstraints);
     }
 
     public function hasOption(string $name): bool

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -32,7 +32,6 @@ use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use ValueError;
 
-use function array_keys;
 use function array_values;
 
 class TableTest extends TestCase
@@ -1520,17 +1519,7 @@ class TableTest extends TestCase
             ->setUniqueConstraints(...$uniqueConstraints)
             ->create();
 
-        $constraints = $table->getUniqueConstraints();
-
-        self::assertCount(2, $constraints);
-
-        $constraintNames = array_keys($constraints);
-
-        self::assertSame('fk_d87f7e0c341ce00bad15b1b1', $constraintNames[0]);
-        self::assertSame('fk_d87f7e0cda12812744761484', $constraintNames[1]);
-
-        self::assertSame($uniqueConstraints[0], $constraints['fk_d87f7e0c341ce00bad15b1b1']);
-        self::assertSame($uniqueConstraints[1], $constraints['fk_d87f7e0cda12812744761484']);
+        self::assertSame($uniqueConstraints, $table->getUniqueConstraints());
     }
 
     public function testDropUniqueConstraint(): void


### PR DESCRIPTION
Using keys of table-scoped object collections as names was deprecated in https://github.com/doctrine/dbal/pull/7102.

The implementation of `SQLitePlatform#getIndexesInAlteredTable()` involves lookup of index by name, which is no longer possible on a list returned by `Table#getIndexes()`. To mitigate that, it represents indexes as `UnqualifiedNamedObjectSet`, which allows lookup. This is a temporary solution. A proper solution would be to drop all the `strtolower()` logic and compare the SQL representation of the index names, but that will be done later as it will increase the area of the BC break.