### PR TITLE
Unconditionally update vcredist140 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,11 +42,10 @@ init:
 install:
     - sc config wuauserv start=auto
     - net start wuauserv
+    - choco install --no-progress -y vcredist140
     - ps: |
         # Check if installation is cached
         if (!(Test-Path c:\tools\php)) {
-          choco upgrade --no-progress chocolatey
-          choco install --no-progress -y vcredist140
           appveyor-retry choco install --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
           # install sqlite
           appveyor-retry choco install --no-progress -y sqlite


### PR DESCRIPTION
The fix implemented in https://github.com/doctrine/dbal/pull/7114 worked, but now the build is [failing again](https://ci.appveyor.com/project/doctrine/dbal/builds/52646628/job/ds6dukwp7krfbypj). The reason is that on subsequent builds after the successful one the PHP binary is cached but the DLL is not.

Not sure how to cache it together with PHP, so let's update it unconditionally. An even better approach might be to use a newer OS version/build (likely it's outdated, while PHP was built on a newer version/build), but I don't know how to do that.

I'm removing `choco upgrade --no-progress chocolatey` since now we need to use it not only in order to install PHP, and I don't think we want to update it on every build. At the end, AppVeyor manages Chocolatey itself, and I don't remember a case where the out-of-the-box version wasn't sufficient.

UPD: updating the DLL adds almost a minute to the build time, which sucks. But it's still better than a failing build.