### PR TITLE
Deprecate overwriting existing foreign key constraints

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated overwriting foreign key constraints
+
+Adding a foreign key constraint with a name that matches an existing one, whether explicitly specified or
+auto-generated, has been deprecated. In order to replace an existing constraint, drop it first
+via `dropForeignKey()`.
+
 ## Deprecated `View` features
 
 The `View` constructor has been marked as internal. Use `View::editor()` to instantiate an editor and

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -938,6 +938,14 @@ class Table extends AbstractNamedObject
             );
 
         $name = $this->normalizeIdentifier($name);
+        if (isset($this->_fkConstraints[$name])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7125',
+                'Overwriting an existing foreign key constraint ("%s") is deprecated.',
+                $name,
+            );
+        }
 
         $this->_fkConstraints[$name] = $constraint;
 

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -1768,4 +1768,22 @@ class TableTest extends TestCase
         $this->expectException(InvalidState::class);
         $table->getPrimaryKeyConstraint();
     }
+
+    public function testOverwritingForeignKeyConstraint(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $table->addForeignKeyConstraint('bar', ['id'], ['id']);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7125');
+        $table->addForeignKeyConstraint('baz', ['id'], ['id']);
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7123

This PR introduces a deprecation notice when overwriting an existing foreign key constraint.

### Summary
- Adds a deprecation warning when a foreign key constraint with the same name already exists.
- In Doctrine DBAL 5.0, this behavior will throw an exception instead of silently overwriting the constraint.
