### PR TITLE
Fixed missing schema on MySQL table names

### DIFF
--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -279,7 +279,6 @@ class MySQLSchemaManager extends AbstractSchemaManager
                     $row['update_rule'] = null;
                 }
 
-                dump($row['referenced_table_name']);
                 $list[$row['constraint_name']] = [
                     'name' => $this->getQuotedIdentifierName($row['constraint_name']),
                     'local' => [],

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -279,6 +279,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
                     $row['update_rule'] = null;
                 }
 
+                dump($row['referenced_table_name']);
                 $list[$row['constraint_name']] = [
                     'name' => $this->getQuotedIdentifierName($row['constraint_name']),
                     'local' => [],
@@ -332,7 +333,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
     protected function selectTableNames(string $databaseName): Result
     {
         $sql = <<<'SQL'
-SELECT TABLE_NAME
+SELECT CONCAT(TABLE_SCHEMA, '.', TABLE_NAME) AS TABLE_NAME
 FROM information_schema.TABLES
 WHERE TABLE_SCHEMA = ?
   AND TABLE_TYPE = 'BASE TABLE'
@@ -358,7 +359,7 @@ SQL;
         $sql = sprintf(
             <<<'SQL'
 SELECT
-       c.TABLE_NAME,
+       CONCAT(c.TABLE_SCHEMA, '.', c.TABLE_NAME) AS TABLE_NAME,
        c.COLUMN_NAME        AS field,
        %s                   AS type,
        c.COLUMN_TYPE,
@@ -401,7 +402,7 @@ SQL,
         $sql = sprintf(
             <<<'SQL'
 SELECT
-        TABLE_NAME,
+        CONCAT(TABLE_SCHEMA, '.', TABLE_NAME) AS TABLE_NAME,
         NON_UNIQUE  AS Non_Unique,
         INDEX_NAME  AS Key_name,
         COLUMN_NAME AS Column_Name,
@@ -434,7 +435,7 @@ SQL,
         $sql = sprintf(
             <<<'SQL'
 SELECT
-            k.TABLE_NAME,
+            CONCAT(k.TABLE_SCHEMA, '.', k.TABLE_NAME) AS TABLE_NAME,
             k.CONSTRAINT_NAME,
             k.COLUMN_NAME,
             k.REFERENCED_TABLE_NAME,

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -65,7 +65,7 @@ class NoneTest extends FunctionalTestCase
             $this->connection2->createSchemaManager()->tableExists(
                 $this->connection2->getDatabasePlatform() instanceof AbstractMySQLPlatform
                 ? 'doctrine_tests.users'
-                : 'users'
+                : 'users',
             )
         ) {
             return;

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -60,7 +60,7 @@ class NoneTest extends FunctionalTestCase
 
         $this->connection2 = DriverManager::getConnection($params);
 
-        if ($this->connection2->createSchemaManager()->tableExists('users')) {
+        if ($this->connection2->createSchemaManager()->tableExists('doctrine_tests.users')) {
             return;
         }
 

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -60,7 +61,13 @@ class NoneTest extends FunctionalTestCase
 
         $this->connection2 = DriverManager::getConnection($params);
 
-        if ($this->connection2->createSchemaManager()->tableExists('doctrine_tests.users')) {
+        if (
+            $this->connection2->createSchemaManager()->tableExists(
+                $this->connection2->getDatabasePlatform() instanceof MySQLPlatform
+                ? 'doctrine_tests.users'
+                : 'users',
+            )
+        ) {
             return;
         }
 

--- a/tests/Functional/LockMode/NoneTest.php
+++ b/tests/Functional/LockMode/NoneTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -63,9 +63,9 @@ class NoneTest extends FunctionalTestCase
 
         if (
             $this->connection2->createSchemaManager()->tableExists(
-                $this->connection2->getDatabasePlatform() instanceof MySQLPlatform
+                $this->connection2->getDatabasePlatform() instanceof AbstractMySQLPlatform
                 ? 'doctrine_tests.users'
-                : 'users',
+                : 'users'
             )
         ) {
             return;

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
@@ -163,7 +164,11 @@ class NamedParametersTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        if ($this->connection->createSchemaManager()->tableExists('doctrine_tests.ddc1372_foobar')) {
+        if ($this->connection->createSchemaManager()->tableExists(
+            $this->connection->getDatabasePlatform() instanceof MySQLPlatform
+                ? 'doctrine_tests.ddc1372_foobar'
+                : 'ddc1372_foobar'
+        )) {
             return;
         }
 

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -163,7 +163,7 @@ class NamedParametersTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        if ($this->connection->createSchemaManager()->tableExists('ddc1372_foobar')) {
+        if ($this->connection->createSchemaManager()->tableExists('doctrine_tests.ddc1372_foobar')) {
             return;
         }
 

--- a/tests/Functional/NamedParametersTest.php
+++ b/tests/Functional/NamedParametersTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
@@ -164,11 +164,13 @@ class NamedParametersTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
-        if ($this->connection->createSchemaManager()->tableExists(
-            $this->connection->getDatabasePlatform() instanceof MySQLPlatform
-                ? 'doctrine_tests.ddc1372_foobar'
-                : 'ddc1372_foobar'
-        )) {
+        if (
+            $this->connection->createSchemaManager()->tableExists(
+                $this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform
+                    ? 'doctrine_tests.ddc1372_foobar'
+                    : 'ddc1372_foobar',
+            )
+        ) {
             return;
         }
 

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -875,6 +875,84 @@ SQL;
         );
     }
 
+    public function testListTables(): void
+    {
+        $this->createTestTable('list_tables_test');
+        $tables = $this->schemaManager->listTables();
+
+        $table = $this->findTableByName($tables, 'doctrine_tests.list_tables_test');
+        self::assertNotNull($table);
+
+        self::assertTrue($table->hasColumn('id'));
+        self::assertTrue($table->hasColumn('test'));
+        self::assertTrue($table->hasColumn('foreign_key_test'));
+    }
+
+    /** @return iterable<string, array{string, int}> */
+    public static function tableFilterProvider(): iterable
+    {
+        yield 'One table' => ['doctrine_tests.filter_test_1', 1];
+        yield 'Two tables' => ['doctrine_tests.filter_test_', 2];
+    }
+
+    public function testRenameTable(): void
+    {
+        $this->createTestTable('old_name');
+        $this->schemaManager->renameTable('old_name', 'new_name');
+
+        self::assertFalse($this->schemaManager->tablesExist(['doctrine_tests.old_name']));
+        self::assertTrue($this->schemaManager->tablesExist(['doctrine_tests.new_name']));
+    }
+
+    public function testSchemaIntrospection(): void
+    {
+        $this->createTestTable('test_table');
+
+        $schema = $this->schemaManager->introspectSchema();
+        self::assertTrue($schema->hasTable('doctrine_tests.test_table'));
+    }
+
+    public function testMigrateSchema(): void
+    {
+        $this->createTestTable('table_to_alter');
+        $this->createTestTable('table_to_drop');
+
+        $schema = $this->schemaManager->introspectSchema();
+
+        $tableToAlter = $schema->getTable('doctrine_tests.table_to_alter');
+        $tableToAlter->dropColumn('foreign_key_test');
+        $tableToAlter->addColumn('number', Types::INTEGER);
+
+        $schema->dropTable('doctrine_tests.table_to_drop');
+
+        $tableToCreate = $schema->createTable('table_to_create');
+        $tableToCreate->addColumn('id', Types::INTEGER, ['notnull' => true]);
+        $tableToCreate->setPrimaryKey(['id']);
+
+        $this->schemaManager->migrateSchema($schema);
+
+        $schema = $this->schemaManager->introspectSchema();
+
+        self::assertTrue($schema->hasTable('doctrine_tests.table_to_alter'));
+        self::assertFalse($schema->getTable('doctrine_tests.table_to_alter')->hasColumn('foreign_key_test'));
+        self::assertTrue($schema->getTable('doctrine_tests.table_to_alter')->hasColumn('number'));
+        self::assertFalse($schema->hasTable('doctrine_tests.table_to_drop'));
+        self::assertTrue($schema->hasTable('doctrine_tests.table_to_create'));
+    }
+
+    public function testIntrospectReservedKeywordTableViaListTables(): void
+    {
+        $this->createReservedKeywordTables();
+
+        $tables = $this->schemaManager->listTables();
+
+        $user = $this->findTableByName($tables, 'doctrine_tests.user');
+        self::assertNotNull($user);
+        self::assertCount(2, $user->getColumns());
+        self::assertCount(2, $user->getIndexes());
+        self::assertCount(1, $user->getForeignKeys());
+    }
+
     public function getExpectedDefaultSchemaName(): ?string
     {
         return null;

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -207,7 +207,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('list_tables_test');
         $tables = $this->schemaManager->listTables();
 
-        $table = $this->findTableByName($tables, 'doctrine_tests.list_tables_test');
+        $table = $this->findTableByName($tables, 'list_tables_test');
         self::assertNotNull($table);
 
         self::assertTrue($table->hasColumn('id'));
@@ -250,8 +250,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     /** @return iterable<string, array{string, int}> */
     public static function tableFilterProvider(): iterable
     {
-        yield 'One table' => ['doctrine_tests.filter_test_1', 1];
-        yield 'Two tables' => ['doctrine_tests.filter_test_', 2];
+        yield 'One table' => ['filter_test_1', 1];
+        yield 'Two tables' => ['filter_test_', 2];
     }
 
     public function testRenameTable(): void
@@ -259,8 +259,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('old_name');
         $this->schemaManager->renameTable('old_name', 'new_name');
 
-        self::assertFalse($this->schemaManager->tablesExist(['doctrine_tests.old_name']));
-        self::assertTrue($this->schemaManager->tablesExist(['doctrine_tests.new_name']));
+        self::assertFalse($this->schemaManager->tablesExist(['old_name']));
+        self::assertTrue($this->schemaManager->tablesExist(['new_name']));
     }
 
     public function createListTableColumns(): Table
@@ -539,7 +539,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('test_table');
 
         $schema = $this->schemaManager->introspectSchema();
-        self::assertTrue($schema->hasTable('doctrine_tests.test_table'));
+        self::assertTrue($schema->hasTable('test_table'));
     }
 
     public function testMigrateSchema(): void
@@ -549,11 +549,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $schema = $this->schemaManager->introspectSchema();
 
-        $tableToAlter = $schema->getTable('doctrine_tests.table_to_alter');
+        $tableToAlter = $schema->getTable('table_to_alter');
         $tableToAlter->dropColumn('foreign_key_test');
         $tableToAlter->addColumn('number', Types::INTEGER);
 
-        $schema->dropTable('doctrine_tests.table_to_drop');
+        $schema->dropTable('table_to_drop');
 
         $tableToCreate = $schema->createTable('table_to_create');
         $tableToCreate->addColumn('id', Types::INTEGER, ['notnull' => true]);
@@ -563,11 +563,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $schema = $this->schemaManager->introspectSchema();
 
-        self::assertTrue($schema->hasTable('doctrine_tests.table_to_alter'));
-        self::assertFalse($schema->getTable('doctrine_tests.table_to_alter')->hasColumn('foreign_key_test'));
-        self::assertTrue($schema->getTable('doctrine_tests.table_to_alter')->hasColumn('number'));
-        self::assertFalse($schema->hasTable('doctrine_tests.table_to_drop'));
-        self::assertTrue($schema->hasTable('doctrine_tests.table_to_create'));
+        self::assertTrue($schema->hasTable('table_to_alter'));
+        self::assertFalse($schema->getTable('table_to_alter')->hasColumn('foreign_key_test'));
+        self::assertTrue($schema->getTable('table_to_alter')->hasColumn('number'));
+        self::assertFalse($schema->hasTable('table_to_drop'));
+        self::assertTrue($schema->hasTable('table_to_create'));
     }
 
     /** @throws Exception */
@@ -1555,14 +1555,14 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tables = $this->schemaManager->listTables();
 
-        $user = $this->findTableByName($tables, 'doctrine_tests.user');
+        $user = $this->findTableByName($tables, 'user');
         self::assertNotNull($user);
         self::assertCount(2, $user->getColumns());
         self::assertCount(2, $user->getIndexes());
         self::assertCount(1, $user->getForeignKeys());
     }
 
-    private function createReservedKeywordTables(): void
+    protected function createReservedKeywordTables(): void
     {
         $platform = $this->connection->getDatabasePlatform();
 

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -207,7 +207,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('list_tables_test');
         $tables = $this->schemaManager->listTables();
 
-        $table = $this->findTableByName($tables, 'list_tables_test');
+        $table = $this->findTableByName($tables, 'doctrine_tests.list_tables_test');
         self::assertNotNull($table);
 
         self::assertTrue($table->hasColumn('id'));
@@ -250,8 +250,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     /** @return iterable<string, array{string, int}> */
     public static function tableFilterProvider(): iterable
     {
-        yield 'One table' => ['filter_test_1', 1];
-        yield 'Two tables' => ['filter_test_', 2];
+        yield 'One table' => ['doctrine_tests.filter_test_1', 1];
+        yield 'Two tables' => ['doctrine_tests.filter_test_', 2];
     }
 
     public function testRenameTable(): void
@@ -259,8 +259,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('old_name');
         $this->schemaManager->renameTable('old_name', 'new_name');
 
-        self::assertFalse($this->schemaManager->tablesExist(['old_name']));
-        self::assertTrue($this->schemaManager->tablesExist(['new_name']));
+        self::assertFalse($this->schemaManager->tablesExist(['doctrine_tests.old_name']));
+        self::assertTrue($this->schemaManager->tablesExist(['doctrine_tests.new_name']));
     }
 
     public function createListTableColumns(): Table
@@ -539,7 +539,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('test_table');
 
         $schema = $this->schemaManager->introspectSchema();
-        self::assertTrue($schema->hasTable('test_table'));
+        self::assertTrue($schema->hasTable('doctrine_tests.test_table'));
     }
 
     public function testMigrateSchema(): void
@@ -549,11 +549,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $schema = $this->schemaManager->introspectSchema();
 
-        $tableToAlter = $schema->getTable('table_to_alter');
+        $tableToAlter = $schema->getTable('doctrine_tests.table_to_alter');
         $tableToAlter->dropColumn('foreign_key_test');
         $tableToAlter->addColumn('number', Types::INTEGER);
 
-        $schema->dropTable('table_to_drop');
+        $schema->dropTable('doctrine_tests.table_to_drop');
 
         $tableToCreate = $schema->createTable('table_to_create');
         $tableToCreate->addColumn('id', Types::INTEGER, ['notnull' => true]);
@@ -563,11 +563,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $schema = $this->schemaManager->introspectSchema();
 
-        self::assertTrue($schema->hasTable('table_to_alter'));
-        self::assertFalse($schema->getTable('table_to_alter')->hasColumn('foreign_key_test'));
-        self::assertTrue($schema->getTable('table_to_alter')->hasColumn('number'));
-        self::assertFalse($schema->hasTable('table_to_drop'));
-        self::assertTrue($schema->hasTable('table_to_create'));
+        self::assertTrue($schema->hasTable('doctrine_tests.table_to_alter'));
+        self::assertFalse($schema->getTable('doctrine_tests.table_to_alter')->hasColumn('foreign_key_test'));
+        self::assertTrue($schema->getTable('doctrine_tests.table_to_alter')->hasColumn('number'));
+        self::assertFalse($schema->hasTable('doctrine_tests.table_to_drop'));
+        self::assertTrue($schema->hasTable('doctrine_tests.table_to_create'));
     }
 
     /** @throws Exception */
@@ -1555,7 +1555,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $tables = $this->schemaManager->listTables();
 
-        $user = $this->findTableByName($tables, 'user');
+        $user = $this->findTableByName($tables, 'doctrine_tests.user');
         self::assertNotNull($user);
         self::assertCount(2, $user->getColumns());
         self::assertCount(2, $user->getIndexes());


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | (https://github.com/doctrine/migrations/issues/1460)

#### Summary

The schema was missing on the table name for MySQL.

Because of that "bin/console doctrine:migrations:diff" did not generate correct diffs and always detected the whole table as changed.

See:
https://github.com/doctrine/migrations/issues/1460