### PR TITLE
Fix schema comparison on tables with multiple foreign keys referencing the same tables and columns

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -275,14 +275,17 @@ class Comparator
             foreach ($newForeignKeys as $newKey => $newForeignKey) {
                 if ($this->diffForeignKey($oldForeignKey, $newForeignKey) === false) {
                     unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
-                } else {
-                    if (strtolower($oldForeignKey->getName()) === strtolower($newForeignKey->getName())) {
-                        $droppedForeignKeys[$oldKey] = $oldForeignKey;
-                        $addedForeignKeys[$newKey]   = $newForeignKey;
-
-                        unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
-                    }
+                    continue 2;
                 }
+
+                if (strtolower($oldForeignKey->getName()) !== strtolower($newForeignKey->getName())) {
+                    continue;
+                }
+
+                $droppedForeignKeys[$oldKey] = $oldForeignKey;
+                $addedForeignKeys[$newKey]   = $newForeignKey;
+
+                unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
             }
         }
 

--- a/tests/Functional/Schema/DoubleForeignKeyConstraintTest.php
+++ b/tests/Functional/Schema/DoubleForeignKeyConstraintTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+
+class DoubleForeignKeyConstraintTest extends FunctionalTestCase
+{
+    private AbstractSchemaManager $schemaManager;
+
+    protected function setUp(): void
+    {
+        $this->schemaManager = $this->connection->createSchemaManager();
+    }
+
+    public function testDoubleForeignKeyConstraint(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof DB2Platform || $platform instanceof OraclePlatform) {
+            self::markTestSkipped('DB2 and Oracle do not allow multiple FKs with the same columns.');
+        }
+
+        $articles = Table::editor()
+            ->setUnquotedName('articles')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $orders = Table::editor()
+            ->setUnquotedName('orders')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('article_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('articles_fk')
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setUnquotedReferencedTableName('articles')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('articles_fk_2')
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setUnquotedReferencedTableName('articles')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropTableIfExists('orders');
+        $this->dropTableIfExists('articles');
+
+        $this->connection->createSchemaManager()
+            ->createTable($articles);
+        $this->connection->createSchemaManager()
+            ->createTable($orders);
+
+        $ordersActual = $this->schemaManager->introspectTable('orders');
+
+        self::assertTrue(
+            $this->schemaManager->createComparator()
+                ->compareTables($ordersActual, $orders)
+                ->isEmpty(),
+        );
+    }
+
+    public function testDoubleForeignKeyConstraintComparedToSingle(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof DB2Platform || $platform instanceof OraclePlatform) {
+            self::markTestSkipped('DB2 and Oracle do not allow multiple FKs with the same columns.');
+        }
+
+        $articles = Table::editor()
+            ->setUnquotedName('articles')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $orders = Table::editor()
+            ->setUnquotedName('orders')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('article_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('articles_fk')
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setUnquotedReferencedTableName('articles')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('articles_fk_2')
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setUnquotedReferencedTableName('articles')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $ordersCompare = Table::editor()
+            ->setUnquotedName('orders')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('article_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('articles_fk')
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setUnquotedReferencedTableName('articles')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropTableIfExists('orders');
+        $this->dropTableIfExists('articles');
+
+        $this->connection->createSchemaManager()
+            ->createTable($articles);
+        $this->connection->createSchemaManager()
+            ->createTable($orders);
+
+        $ordersActual = $this->schemaManager->introspectTable('orders');
+
+        $diff = $this->schemaManager->createComparator()
+            ->compareTables($ordersActual, $ordersCompare);
+
+        self::assertFalse($diff->isEmpty());
+        self::assertCount(0, $diff->getAddedForeignKeys());
+        self::assertCount(1, $diff->getDroppedForeignKeys());
+        self::assertSame('articles_fk_2', $diff->getDroppedForeignKeys()[0]->getName());
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Version | `4.3.2`

#### Summary

<!-- Provide a summary of your change. -->

When attempting to run a single migration, I encountered the following MySQL error:

```bash
php bin/console doctrine:migrations:execute 'DoctrineMigrations\Version00000008000000'

 WARNING! You are about to execute a migration in database "development" that could result in schema changes and data loss. Are you sure you wish to continue? (yes/no) [yes]:
 > 

[notice] Executing DoctrineMigrations\Version00000008000000 up
[error] Migration DoctrineMigrations\Version00000008000000 failed during Execution. Error: "An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-table DROP FOREIGN KEY `FK_redacted`' at line 1"

In ExceptionConverter.php line 67:
                                                                                                                                                                                                                                                                                                                              
  An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-table DROP FOREIGN KEY `FK_redacted`' at line 1    
                                                                                                                                                                                                                                                                                                                              

In Exception.php line 24:

  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-table DROP FOREIGN KEY `FK_redacted`' at line 1  


In Connection.php line 57:

  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-table DROP FOREIGN KEY `FK_redacted`' at line 1  


doctrine:migrations:execute [--write-sql [WRITE-SQL]] [--dry-run] [--up] [--down] [--query-time] [--configuration CONFIGURATION] [--em EM] [--conn CONN] [--] <versions>...
```

This error is not caused by the migration itself, but by a table name that was not properly escaped.

```sql
-- Failing query:
ALTER TABLE users-table DROP FOREIGN KEY `FK_redacted`

-- Correct query:
ALTER TABLE `users-table` DROP FOREIGN KEY `FK_redacted`
```

This query wasn't even defined in the migration, it was introduced during execution of the migration via the following code: [DbalExecutor.php#L144](https://github.com/doctrine/migrations/blob/1b88fcb812f2cd6e77c83d16db60e3cf1e35c66c/src/Version/DbalExecutor.php#L144)

In this case, the `users-table` table had two foreign keys (`FK_redacted` and `FK_redacted_2`) pointing to the same referenced table and columns.

I implemented a small fix in the foreign key change detection and added a test case to cover this scenario.

**Note:** I acknowledge that double foreign keys and table names with `-` symbols are not best practice, but I was working with a legacy database.