### PR TITLE
Leverage PHP 8.4 PDO classes, fix PHP 8.5 deprecation

### DIFF
--- a/src/Driver/PDO/MySQL/Driver.php
+++ b/src/Driver/PDO/MySQL/Driver.php
@@ -5,12 +5,15 @@ namespace Doctrine\DBAL\Driver\PDO\MySQL;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use PDO;
 use PDOException;
 use SensitiveParameter;
 
 final class Driver extends AbstractMySQLDriver
 {
+    use PDOConnect;
+
     /**
      * {@inheritDoc}
      *
@@ -30,7 +33,7 @@ final class Driver extends AbstractMySQLDriver
         unset($safeParams['password'], $safeParams['url']);
 
         try {
-            $pdo = new PDO(
+            $pdo = $this->doConnect(
                 $this->constructPdoDsn($safeParams),
                 $params['user'] ?? '',
                 $params['password'] ?? '',

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -5,12 +5,15 @@ namespace Doctrine\DBAL\Driver\PDO\OCI;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use PDO;
 use PDOException;
 use SensitiveParameter;
 
 final class Driver extends AbstractOracleDriver
 {
+    use PDOConnect;
+
     /**
      * {@inheritDoc}
      *
@@ -30,7 +33,7 @@ final class Driver extends AbstractOracleDriver
         unset($safeParams['password'], $safeParams['url']);
 
         try {
-            $pdo = new PDO(
+            $pdo = $this->doConnect(
                 $this->constructPdoDsn($params),
                 $params['user'] ?? '',
                 $params['password'] ?? '',

--- a/src/Driver/PDO/PDOConnect.php
+++ b/src/Driver/PDO/PDOConnect.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\PDO;
+
+use PDO;
+
+use const PHP_VERSION_ID;
+
+/** @internal */
+trait PDOConnect
+{
+    /** @param array<int, mixed> $options */
+    private function doConnect(
+        string $dsn,
+        string $username,
+        string $password,
+        array $options
+    ): PDO {
+        if (PHP_VERSION_ID < 80400) {
+            return new PDO($dsn, $username, $password, $options);
+        }
+
+        return PDO::connect($dsn, $username, $password, $options);
+    }
+}

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -5,13 +5,19 @@ namespace Doctrine\DBAL\Driver\PDO\PgSQL;
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use Doctrine\Deprecations\Deprecation;
 use PDO;
+use Pdo\Pgsql;
 use PDOException;
 use SensitiveParameter;
 
+use const PHP_VERSION_ID;
+
 final class Driver extends AbstractPostgreSQLDriver
 {
+    use PDOConnect;
+
     /**
      * {@inheritDoc}
      *
@@ -31,7 +37,7 @@ final class Driver extends AbstractPostgreSQLDriver
         unset($safeParams['password'], $safeParams['url']);
 
         try {
-            $pdo = new PDO(
+            $pdo = $this->doConnect(
                 $this->constructPdoDsn($safeParams),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
@@ -41,11 +47,11 @@ final class Driver extends AbstractPostgreSQLDriver
             throw Exception::new($exception);
         }
 
-        if (
-            ! isset($driverOptions[PDO::PGSQL_ATTR_DISABLE_PREPARES])
-            || $driverOptions[PDO::PGSQL_ATTR_DISABLE_PREPARES] === true
-        ) {
-            $pdo->setAttribute(PDO::PGSQL_ATTR_DISABLE_PREPARES, true);
+        $disablePreparesAttr = PHP_VERSION_ID >= 80400
+            ? Pgsql::ATTR_DISABLE_PREPARES
+            : PDO::PGSQL_ATTR_DISABLE_PREPARES;
+        if ($driverOptions[$disablePreparesAttr] ?? true) {
+            $pdo->setAttribute($disablePreparesAttr, true);
         }
 
         $connection = new Connection($pdo);

--- a/src/Driver/PDO/SQLSrv/Driver.php
+++ b/src/Driver/PDO/SQLSrv/Driver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use Doctrine\DBAL\Driver\PDO\Exception as PDOException;
+use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use PDO;
 use SensitiveParameter;
 
@@ -15,6 +16,8 @@ use function sprintf;
 
 final class Driver extends AbstractSQLServerDriver
 {
+    use PDOConnect;
+
     /**
      * {@inheritDoc}
      *
@@ -44,7 +47,7 @@ final class Driver extends AbstractSQLServerDriver
         unset($safeParams['password'], $safeParams['url']);
 
         try {
-            $pdo = new PDO(
+            $pdo = $this->doConnect(
                 $this->constructDsn($safeParams, $dsnOptions),
                 $params['user'] ?? '',
                 $params['password'] ?? '',

--- a/src/Driver/PDO/SQLite/Driver.php
+++ b/src/Driver/PDO/SQLite/Driver.php
@@ -6,8 +6,9 @@ use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use Doctrine\DBAL\Driver\PDO\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use Doctrine\Deprecations\Deprecation;
-use PDO;
+use Pdo\Sqlite;
 use PDOException;
 use SensitiveParameter;
 
@@ -15,6 +16,8 @@ use function array_intersect_key;
 
 final class Driver extends AbstractSQLiteDriver
 {
+    use PDOConnect;
+
     /**
      * {@inheritDoc}
      *
@@ -40,7 +43,7 @@ final class Driver extends AbstractSQLiteDriver
         }
 
         try {
-            $pdo = new PDO(
+            $pdo = $this->doConnect(
                 $this->constructPdoDsn(array_intersect_key($params, ['path' => true, 'memory' => true])),
                 $params['user'] ?? '',
                 $params['password'] ?? '',
@@ -51,7 +54,7 @@ final class Driver extends AbstractSQLiteDriver
         }
 
         UserDefinedFunctions::register(
-            [$pdo, 'sqliteCreateFunction'],
+            $pdo instanceof Sqlite ? [$pdo, 'createFunction'] : [$pdo, 'sqliteCreateFunction'],
             $userDefinedFunctions,
         );
 

--- a/tests/Functional/Driver/PDO/PDOSubclassTest.php
+++ b/tests/Functional/Driver/PDO/PDOSubclassTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Driver\PDO;
+
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
+use Pdo\Mysql;
+use Pdo\Pgsql;
+use Pdo\Sqlite;
+
+/** @requires PHP 8.4 */
+final class PDOSubclassTest extends FunctionalTestCase
+{
+    public function testMySQLSubclass(): void
+    {
+        if (! TestUtil::isDriverOneOf('pdo_mysql')) {
+            self::markTestSkipped('This test requires the pdo_mysql driver.');
+        }
+
+        self::assertInstanceOf(Mysql::class, $this->connection->getNativeConnection());
+    }
+
+    public function testPgSQLSubclass(): void
+    {
+        if (! TestUtil::isDriverOneOf('pdo_pgsql')) {
+            self::markTestSkipped('This test requires the pdo_pgsql driver.');
+        }
+
+        self::assertInstanceOf(Pgsql::class, $this->connection->getNativeConnection());
+    }
+
+    public function testSQLiteSubclass(): void
+    {
+        if (! TestUtil::isDriverOneOf('pdo_sqlite')) {
+            self::markTestSkipped('This test requires the pdo_sqlite driver.');
+        }
+
+        self::assertInstanceOf(Sqlite::class, $this->connection->getNativeConnection());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | -

https://wiki.php.net/rfc/pdo_driver_specific_subclasses

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_driver_specific_pdo_constants_and_methods