### PR TITLE
Run tests on MySQL 8.4 LTS and 9.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -163,20 +163,21 @@ jobs:
         mysql-version:
           - "5.7"
           - "8.0" # We have code specific to ^8.0
-          - "9.3"
+          - "8.4" # LTS
+          - "9.4"
         extension:
           - "mysqli"
           - "pdo_mysql"
         include:
           - config-file-suffix: "-tls"
             php-version: "7.4"
-            mysql-version: "9.1"
+            mysql-version: "9.4"
             extension: "mysqli"
           - php-version: "7.4"
-            mysql-version: "9.1"
+            mysql-version: "9.4"
             extension: "mysqli"
           - php-version: "7.4"
-            mysql-version: "9.1"
+            mysql-version: "9.4"
             extension: "pdo_mysql"
 
   phpunit-mssql:


### PR DESCRIPTION
I'd like to update our CI:

* MySQL 8.4 is the current LTS, so we should probably cover it.
* MySQL 9.4 is the latest release.
* MySQL 9.1 and 9.3 are EOL.