### PR TITLE
Downgrade PHP for the DB2 workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -218,7 +218,9 @@ jobs:
       matrix:
         php-version:
           - "7.4"
-          - "8.4"
+          - "8.3"
+          # The DB2 workflow currently segfaults with PHP 8.4
+          # - "8.4"
 
   development-deps:
     name: "PHPUnit with PDO_SQLite and development dependencies"


### PR DESCRIPTION
I have no idea why the DB2 workflow started to segfault. My best guess is that there's an incompatibility with the latest patch release of PHP. Let's see if pinning to an older release works.

Update: I've downgraded from PHP 8.4 to 8.3. That seems to "fix" it for now and give us a green CI again. Let's monitor the issue and revert the patch when the issues is solved.