### PR TITLE
Workaround for MySQL 8.4 and unknown users

### DIFF
--- a/src/Driver/API/MySQL/ExceptionConverter.php
+++ b/src/Driver/API/MySQL/ExceptionConverter.php
@@ -22,6 +22,8 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query;
 
+use function strpos;
+
 /** @internal */
 final class ExceptionConverter implements ExceptionConverterInterface
 {
@@ -84,6 +86,15 @@ final class ExceptionConverter implements ExceptionConverterInterface
             case 1554:
             case 1626:
                 return new SyntaxErrorException($exception, $query);
+
+            case 1524:
+                if (strpos($exception->getMessage(), 'Plugin \'mysql_native_password\' is not loaded') === false) {
+                    break;
+                }
+
+                // Workaround for MySQL 8.4 if we request an unknown user.
+                // https://bugs.mysql.com/bug.php?id=114876
+                return new ConnectionException($exception, $query);
 
             case 1044:
             case 1045:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

See https://bugs.mysql.com/bug.php?id=114876 for details.
Failing test: https://github.com/doctrine/dbal/actions/runs/17474044585/job/49629574307?pr=7134#step:7:98

The MySQL 8.4 branch has a known bug which causes it to complain about the legacy password hashing plugin not being loaded if we try to login with an unknown user. This _sometimes_ causes our tests to fail. With this PR, I'm upcasting this error to the same exception which we would get for invalid credentials.
