### PR TITLE
Document the PDO subclasses backport

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ awareness about deprecated code.
 
 # Upgrade to 3.10
 
+## Support for new PDO subclasses on PHP 8.4
+
+In 3.10.2, we've backported support for new PDO subclasses introduced in PHP 8.4 because not using them
+could trigger deprecation warnings under certain circumstances in PHP 8.5.
+
+On PHP 8.4, if you call `getNativeConnection()` on a connection established through one of the PDO drivers,
+you will get an instance of the new PDO subclasses, e.g. `Pdo\Mysql` or `Pdo\Pgsql` instead of just `PDO`.
+
+## Optional `doctrine/cache` dependency
+
 The `doctrine/cache` package is now an optional dependency. If you are using the
 `Doctrine\DBAL\Cache` classes, you need to require the `doctrine/cache` package
 explicitly.


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| Fixed issues | N/A

#### Summary

Deprecations introduced with PHP 8.5 forced us to backport #6532 as #7132. In this PR, I'm also backporting the entry from our UPGRADE.md documentation.
