### PR TITLE
Make options check strict again

### DIFF
--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -50,7 +50,10 @@ final class Driver extends AbstractPostgreSQLDriver
         $disablePreparesAttr = PHP_VERSION_ID >= 80400
             ? Pgsql::ATTR_DISABLE_PREPARES
             : PDO::PGSQL_ATTR_DISABLE_PREPARES;
-        if ($driverOptions[$disablePreparesAttr] ?? true) {
+        if (
+            ! isset($driverOptions[$disablePreparesAttr])
+            || $driverOptions[$disablePreparesAttr] === true
+        ) {
             $pdo->setAttribute($disablePreparesAttr, true);
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

While merging up the changes from #7132, I noticed that the new code is in fact a little less strict than the old one. Previously, we required the `PDO::PGSQL_ATTR_DISABLE_PREPARES` option to be set to `true` while after the change we would accept any truthy value. I don't think that it's a big deal, but I also believe that this change was not intended. Thus, I'm restoring the old behavior.
