### PR TITLE
Don't test against Symfony Cache 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -245,7 +245,7 @@ jobs:
       - name: "Lower minimum stability"
         run: | 
           composer config minimum-stability dev
-          composer require --no-update --dev symfony/console:^8 symfony/cache:^8
+          composer require --no-update --dev symfony/console:^8
 
       - name: "Install development dependencies with Composer"
         uses: "ramsey/composer-install@v3"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

Symfony Cache 8 conflicts with DBAL 3. This change makes sure, our CI is green when run against the 3.10.x branch. I'm going to revert the change when merging up to 4.x.
