### PR TITLE
Deprecate unnamed foreign key constraints in `$droppedForeignKeys` of `TableDiff`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated dropping unnamed constraints in SQLite
+
+Passing unnamed foreign key constraints as part of the `$droppedForeignKeys` argument of the `TableDiff` constructor
+has been deprecated.
+
 ## Deprecated overwriting foreign key constraints
 
 Adding a foreign key constraint with a name that matches an existing one, whether explicitly specified or

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -56,6 +56,17 @@ class TableDiff
             );
         }
 
+        foreach ($droppedForeignKeys as $droppedForeignKey) {
+            if ($droppedForeignKey->getName() === '') {
+                Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/7143',
+                    'Dropping a foreign key constraints without specifying its name is deprecated.',
+                );
+                break;
+            }
+        }
+
         if (count($modifiedForeignKeys) === 0) {
             return;
         }

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+class TableDiffTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testCreateWithInvalidDroppedForeignKeyName(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('t1')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('c1')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $droppedForeignKeys = ForeignKeyConstraint::editor()
+            ->setUnquotedReferencingColumnNames('c1')
+            ->setUnquotedReferencedTableName('t2')
+            ->setUnquotedReferencedColumnNames('c1')
+            ->create();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7143');
+        new TableDiff($table, droppedForeignKeys: [$droppedForeignKeys]);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7124 

#### Summary

This PR introduces a deprecation notice when a unnamed foreign key constraints in `$droppedForeignKeys` is passed in the constructor of  `TableDiff`.
