### PR TITLE
Trigger invalid name deprecation only for outside calls

### DIFF
--- a/src/Schema/AbstractAsset.php
+++ b/src/Schema/AbstractAsset.php
@@ -137,8 +137,17 @@ abstract class AbstractAsset
         if ($input !== '') {
             try {
                 $parsedName = $this->getNameParser()->parse($input);
-            } catch (Throwable $e) {
+            } catch (NotImplemented $e) {
                 Deprecation::trigger(
+                    'doctrine/dbal',
+                    'https://github.com/doctrine/dbal/pull/6592',
+                    'Unable to parse object name: %s.',
+                    $e->getMessage(),
+                );
+
+                return;
+            } catch (Throwable $e) {
+                Deprecation::triggerIfCalledFromOutside(
                     'doctrine/dbal',
                     'https://github.com/doctrine/dbal/pull/6592',
                     'Unable to parse object name: %s.',

--- a/tests/Schema/AbstractAssetTest.php
+++ b/tests/Schema/AbstractAssetTest.php
@@ -40,12 +40,6 @@ class AbstractAssetTest extends TestCase
             ['"_".id', new OraclePlatform()],
             ['"_".ID', new PostgreSQLPlatform()],
 
-            // parse error
-            ['table.', new MySQLPlatform()],
-            ['"table', new MySQLPlatform()],
-            ['table"', new MySQLPlatform()],
-            [' ', new MySQLPlatform()],
-
             // incompatible parser behavior
             ['"example.com"', new MySQLPlatform()],
         ];

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -170,17 +170,6 @@ class ColumnTest extends TestCase
     }
 
     /** @throws Exception */
-    public function testQualifiedName(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        Column::editor()
-            ->setUnquotedName('t.id')
-            ->setType(Type::getType(Types::INTEGER))
-            ->create();
-    }
-
-    /** @throws Exception */
     public function testGetObjectName(): void
     {
         $column = Column::editor()

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -89,13 +89,6 @@ class ForeignKeyConstraintTest extends TestCase
         self::assertSame($fk1->onDelete(), $fk2->onDelete());
     }
 
-    public function testQualifiedName(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        new ForeignKeyConstraint(['user_id'], 'users', ['id'], 'auth.fk_user_id');
-    }
-
     /** @throws Exception */
     public function testGetNonNullObjectName(): void
     {

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -190,13 +190,6 @@ class IndexTest extends TestCase
         new Index(null, ['user_id']);
     }
 
-    public function testQualifiedName(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        new Index('auth.idx_user_id', ['user_id']);
-    }
-
     public function testGetObjectName(): void
     {
         $index = new Index('idx_user_id', ['user_id']);

--- a/tests/Schema/SequenceTest.php
+++ b/tests/Schema/SequenceTest.php
@@ -83,13 +83,6 @@ class SequenceTest extends TestCase
         new Sequence('');
     }
 
-    public function testOverqualifiedName(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        new Sequence('identity.auth.user_id_seq');
-    }
-
     /** @throws Exception */
     public function testGetUnqualifiedObjectName(): void
     {

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -1598,13 +1598,6 @@ class TableTest extends TestCase
         $table->dropColumn('id');
     }
 
-    public function testOverqualifiedName(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        new Table('warehouse.inventory.products');
-    }
-
     /** @throws Exception */
     public function testGetUnqualifiedObjectName(): void
     {

--- a/tests/Schema/ViewTest.php
+++ b/tests/Schema/ViewTest.php
@@ -21,13 +21,6 @@ class ViewTest extends TestCase
         new View('', '');
     }
 
-    public function testOverqualifiedName(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6592');
-
-        new View('warehouse.inventory.available_products', '');
-    }
-
     /** @throws Exception */
     public function testGetUnqualifiedObjectName(): void
     {


### PR DESCRIPTION
Fixes #7030.

The unexpected deprecation can be reproduced as follows on MySQL:
```php
$connection->executeStatement(
    <<<'SQL'
    CREATE TABLE `user` (
        `id` INTEGER NOT NULL,
        PRIMARY KEY (`id`)
    )
    SQL,
);

$connection->executeStatement(
    <<<'SQL'
    CREATE TABLE `example` (
        `id`      INTEGER NOT NULL,
        `user_id` INTEGER NOT NULL,
        PRIMARY KEY (`id`),
        CONSTRAINT `fk.example.user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (id)
    );
    SQL,
);

$schemaManager->introspectTable('example');
// E_USER_DEPRECATED: Unable to parse object name: An unqualified name must consist of one identifier, 3 given.
```

This is because the DBAL introspects raw identifier names, but then the `Schema` objects (e.g. foreign key constraints) parse them as if they were SQL. This way, regardless of the deprecation, if a name contains more than one dot, the part of the name after the second dot would be discarded:
```php
$table = $this->schemaManager->introspectTable('example');
foreach ($table->getForeignKeys() as $constraint) {
    echo $constraint->getName(), PHP_EOL;
}
// fk.example
```

I'm not adding a test for this, since a table with such a constraint name cannot be created programmatically on 4.x.

### Additional tests

The tests covering this deprecation had to be removed. The test executing the code being tested, based on its path in the filesystem, is considered part of the library, so the call is not considered external, and the deprecations no longer trigger.