### PR TITLE
Drop deprecation in `TableDiff` and throw exception instead

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: changes in `TableDiff` constructor
+
+The `TableDiff` class constructor no longer accepts `droppedForeignKeys`
+without a name.
+
 ## BC BREAK: Changes in `Table` method return types
 
 The following `Table` methods no longer return associative arrays of objects. Instead, they return lists:

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
@@ -44,12 +45,9 @@ final class TableDiff
     ) {
         foreach ($droppedForeignKeys as $droppedForeignKey) {
             if ($droppedForeignKey->getObjectName() === null) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/7143',
-                    'Dropping a foreign key constraints without specifying its name is deprecated.',
+                throw new InvalidArgumentException(
+                    'Dropping a foreign key constraints without specifying its name is not allowed.',
                 );
-                break;
             }
         }
     }

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -859,6 +859,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_rename_name')
                     ->setUnquotedReferencingColumnNames('fk_id')
                     ->setUnquotedReferencedTableName('test_fk_base')
                     ->setUnquotedReferencedColumnNames('id')
@@ -902,6 +903,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_rename_name')
                     ->setUnquotedReferencingColumnNames('rename_fk_id')
                     ->setUnquotedReferencedTableName('test_fk_base')
                     ->setUnquotedReferencedColumnNames('id')

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -393,6 +393,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_foo')
                     ->setUnquotedReferencingColumnNames('fk')
                     ->setUnquotedReferencedTableName('bar')
                     ->setUnquotedReferencedColumnNames('id')
@@ -417,6 +418,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_foo')
                     ->setUnquotedReferencingColumnNames('fk')
                     ->setUnquotedReferencedTableName('bar')
                     ->setUnquotedReferencedColumnNames('id')
@@ -460,6 +462,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_foo')
                     ->setUnquotedReferencingColumnNames('fk')
                     ->setUnquotedReferencedTableName('bar')
                     ->setUnquotedReferencedColumnNames('id')
@@ -1116,6 +1119,7 @@ abstract class AbstractComparatorTestCase extends TestCase
                 )
                 ->setForeignKeyConstraints(
                     ForeignKeyConstraint::editor()
+                        ->setUnquotedName('fk_table2')
                         ->setUnquotedReferencingColumnNames('id_table1')
                         ->setUnquotedReferencedTableName('table1')
                         ->setUnquotedReferencedColumnNames('fk_table2_table1')

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class TableDiffTest extends TestCase
 {
-    use VerifyDeprecations;
-
     public function testCreateWithInvalidDroppedForeignKeyName(): void
     {
         $table = Table::editor()
@@ -34,7 +32,7 @@ class TableDiffTest extends TestCase
             ->setUnquotedReferencedColumnNames('c1')
             ->create();
 
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7143');
+        $this->expectException(InvalidArgumentException::class);
 
         // @phpstan-ignore new.resultUnused
         new TableDiff($table, droppedForeignKeys: [$droppedForeignKeys]);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | deprecation
| Fixed issues |no

Fixes #7124

#### Summary

The `TableDiff` constructor no longer allows dropped foreign keys without names. A deprecation warning was triggered since `4.4`. This patch removes the trigger and replaces it with an immediate Exception if an unnamed dropped foreign key is passed.


Reference:
https://github.com/doctrine/dbal/pull/7143
