### PR TITLE
Deprecate TableDiff::getDroppedForeignKeys()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated `TableDiff::getDroppedForeignKeys()`
+
+The `TableDiff::getDroppedForeignKeys()` method has been deprecated. Use
+`TableDiff::getDroppedForeignKeyConstraintNames()` instead.
+
 ## Deprecated `AbstractSchemaManager` methods
 
 The following `AbstractSchemaManager` methods have been deprecated:

--- a/src/Schema/Exception/InvalidState.php
+++ b/src/Schema/Exception/InvalidState.php
@@ -89,4 +89,9 @@ final class InvalidState extends LogicException implements SchemaException
     {
         return new self(sprintf('Table "%s" has invalid primary key constraint.', $tableName));
     }
+
+    public static function tableDiffContainsUnnamedDroppedForeignKeyConstraints(): self
+    {
+        return new self('Table diff contains unnamed dropped foreign key constraints');
+    }
 }

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Schema\Exception\InvalidState;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\Deprecations\Deprecation;
 
 use function array_filter;
@@ -235,10 +237,31 @@ class TableDiff
         return $this->modifiedForeignKeys;
     }
 
-    /** @return array<ForeignKeyConstraint> */
+    /**
+     * @deprecated Use {@see getDroppedForeignKeyConstraintNames()}.
+     *
+     * @return array<ForeignKeyConstraint>
+     */
     public function getDroppedForeignKeys(): array
     {
         return $this->droppedForeignKeys;
+    }
+
+    /** @return array<UnqualifiedName> */
+    public function getDroppedForeignKeyConstraintNames(): array
+    {
+        $names = [];
+        foreach ($this->droppedForeignKeys as $constraint) {
+            $name = $constraint->getObjectName();
+
+            if ($name === null) {
+                throw InvalidState::tableDiffContainsUnnamedDroppedForeignKeyConstraints();
+            }
+
+            $names[] = $name;
+        }
+
+        return $names;
     }
 
     /**

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -366,16 +366,6 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testTableRemoveForeignKey(): void
     {
-        $tableForeign = Table::editor()
-            ->setUnquotedName('bar')
-            ->setColumns(
-                Column::editor()
-                    ->setUnquotedName('id')
-                    ->setTypeName(Types::INTEGER)
-                    ->create(),
-            )
-            ->create();
-
         $table1 = Table::editor()
             ->setUnquotedName('foo')
             ->setColumns(
@@ -396,6 +386,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_bar')
                     ->setUnquotedReferencingColumnNames('fk')
                     ->setUnquotedReferencedTableName('bar')
                     ->setUnquotedReferencedColumnNames('id')
@@ -405,7 +396,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($table2, $table1);
 
-        self::assertCount(1, $tableDiff->getDroppedForeignKeys());
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
     }
 
     public function testTableUpdateForeignKey(): void
@@ -420,6 +411,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_bar')
                     ->setUnquotedReferencingColumnNames('fk')
                     ->setUnquotedReferencedTableName('bar')
                     ->setUnquotedReferencedColumnNames('id')
@@ -447,7 +439,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($table1, $table2);
 
-        self::assertCount(1, $tableDiff->getDroppedForeignKeys());
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
         self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 
@@ -463,6 +455,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_bar')
                     ->setUnquotedReferencingColumnNames('fk')
                     ->setUnquotedReferencedTableName('bar')
                     ->setUnquotedReferencedColumnNames('id')
@@ -489,7 +482,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $tableDiff = $this->comparator->compareTables($table1, $table2);
 
-        self::assertCount(1, $tableDiff->getDroppedForeignKeys());
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
         self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 

--- a/tests/Schema/TableDiffTest.php
+++ b/tests/Schema/TableDiffTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -35,6 +36,9 @@ class TableDiffTest extends TestCase
             ->create();
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7143');
-        new TableDiff($table, droppedForeignKeys: [$droppedForeignKeys]);
+        $diff = new TableDiff($table, droppedForeignKeys: [$droppedForeignKeys]);
+
+        $this->expectException(InvalidState::class);
+        $diff->getDroppedForeignKeyConstraintNames();
     }
 }


### PR DESCRIPTION
## The problem

Currently, `TableDiff` contains a list of dropped foreign key constraints. This is wrong for two reasons:
1. Dropping a constraint doesn't require knowing its full definition. The name is sufficient.
2. The name is also necessary, but constraint names are optional, so the definition isn't guaranteed to contain a name.

This way, we get what we don't need and we don't get what we need.

### Manifestations in the code

1. In some cases, unnamed dropped foreign key constraints will lead to invalid SQL: https://github.com/doctrine/dbal/blob/e2e36dd925ee31d271e9988b5f9f6349f1a51b41/src/Platforms/AbstractPlatform.php#L1372-L1374
2. In some cases, they will be silently ignored: https://github.com/doctrine/dbal/blob/6aa4070d73fa5a8f82f97e0f16fc13e91f6977de/src/Platforms/SQLitePlatform.php#L933-L938
3. In another case, this design requires a weird back-and-forth translation in order to satisfy the API: https://github.com/doctrine/dbal/blob/6aa4070d73fa5a8f82f97e0f16fc13e91f6977de/src/Schema/SQLiteSchemaManager.php#L52-L59 The foreign key constraint definition is extracted from the table definition and is then passed alongside the table definition itself only to satisfy the API. Subsequently, the definition will be discarded, and only the name will be used.

## Proposed solution

Instead of containing a list of dropped foreign key constraints, the diff should contain a list of their names.

### Scope of the change

We cannot modify production code, because:
1. The constraints being dropped aren't guaranteed to have a name (see https://github.com/doctrine/dbal/pull/7143).
2. The names themselves aren't guaranteed to be valid `UnqualifiedName`s until 5.0.

The test is modified to demonstrate the proper use of the API.

## Future scope

Likely, the same logic applies to all other dropped objects in the diff. I'd prefer to rework this logic object by object in order to minimize the diffs.