### PR TITLE
Avoid coverage upload for merge up pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -257,6 +257,7 @@ jobs:
   upload_coverage:
     name: "Upload coverage to Codecov"
     runs-on: "ubuntu-24.04"
+    if: "github.event.pull_request.head.repo.full_name != github.repository || !contains(github.event.pull_request.head.ref, '.x')"
     needs:
       - "phpunit-smoke-check"
       - "phpunit-oracle"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -242,7 +242,7 @@ jobs:
           fail-fast: true
 
       - name: "Lower minimum stability"
-        run: | 
+        run: |
           composer config minimum-stability dev
           composer require --no-update --dev symfony/console:^8
 


### PR DESCRIPTION
When there are no conflicts between branches, we create pull requests
where the head branch is a branch on the origin repository. That branch
points to a commit that should already have coverage information
provided by the build that happens after merging a regular pull request.

The thing is, coverage information provided by builds that happen before
merging a pull request are associated with the commit of the head
repository. This means that when merging up 1.2 into 1.3, the build
produces coverage information that is the result of a merge between 1.2
and 1.3, and associates it with 1.2, although it is run on a codebase
that is much closer to 1.3 (and is in fact supposed to become 1.3 after
the merge).

This means that when we create a merge up PR from 1.2 to anything else,
the coverage information is going to be wrong until a PR targeting 1.2
gets merged.

Note that I'm not sure that it would address the coverage drop in #7160 ,
because on that PR, the issue seems to be that 5.0.x is associated with 2
uploads, whereas this PR addresses an issue that is supposed to affect the
coverage of lower branches (branches that are merged up into another branch).
It might be that the removed code was just very well covered.
Anyway, when you browse the Codecov report for #7160, there is a warning that
5.0.x has 2 uploads while the head branch has only one, and this PR should fix it.