### PR TITLE
Apply asset filtering to schema name retrieval

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -939,7 +939,7 @@ abstract class AbstractSchemaManager
         $schemaNames = [];
 
         if ($this->platform->supportsSchemas()) {
-            $schemaNames = $this->listSchemaNames();
+            $schemaNames = $this->filterAssetNames($this->listSchemaNames());
         }
 
         $sequences = [];

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -570,6 +570,42 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertTrue($schema->hasTable('table_to_create'));
     }
 
+    #[DataProvider('schemaFilterProvider')]
+    public function testIntrospectSchemaWithFilter(string $prefix, int $expectedCount): void
+    {
+        if (! $this->connection->getDatabasePlatform()->supportsSchemas()) {
+            self::markTestSkipped('Platform does not support schemas.');
+        }
+
+        // Create test schemas
+        $this->createTestSchema('filter_schema_1');
+        $this->createTestSchema('filter_schema_2');
+
+        $this->markConnectionNotReusable();
+
+        $this->connection->getConfiguration()->setSchemaAssetsFilter(
+            static function (string|AbstractAsset $assetName) use ($prefix): bool {
+                if ($assetName instanceof AbstractAsset) {
+                    $assetName = $assetName->getName();
+                }
+
+                return str_starts_with(strtolower($assetName), $prefix);
+            },
+        );
+
+        $schema = $this->schemaManager->introspectSchema();
+
+        // Test that only filtered schemas are included in the introspection
+        self::assertCount($expectedCount, $schema->getNamespaces());
+    }
+
+    /** @return iterable<string, array{string, int}> */
+    public static function schemaFilterProvider(): iterable
+    {
+        yield 'One schema' => ['filter_schema_1', 1];
+        yield 'Two schemas' => ['filter_schema_', 2];
+    }
+
     /** @throws Exception */
     public function testAlterTableScenario(): void
     {
@@ -1018,6 +1054,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         return $table;
+    }
+
+    /** @param non-empty-string $name */
+    protected function createTestSchema(string $name): void
+    {
+        $this->dropAndCreateSchema(UnqualifiedName::unquoted($name));
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

Filters are currently only applied to table and sequence names, but not to schema names.

I discovered the issue when using the `schema_filter` parameter in the Doctrine config of a Symfony project:

```yaml
doctrine:
    dbal:
        url: "%env(resolve:DATABASE_URL)%"
        schema_filter: "/^(?!schema_name_that_i_want_to_ignore)/"
```

The schema named `schema_name_that_i_want_to_ignore` does exist in my PostgreSQL database, but I want it to be ignored.

However, when I generate Doctrine migrations with the `doctrine:migrations:diff` command, I realized the schema gets ignored in the automatically generated `up` method, but not in the automatically generated `down` method where I constantly get the following call:

```php
$this->addSql('CREATE SCHEMA schema_name_that_i_want_to_ignore');
```

And it actually comes down to the missing filter call for schema names.

This PR adds the call to filter + adds a test very similar to the existing `testListTablesWithFilter` test.

Let me know if you have any questions or suggestion!