### PR TITLE
Declare AbstractPlatform::getRenameIndexSQL() as abstract

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1272,13 +1272,7 @@ abstract class AbstractPlatform
      *
      * @return list<string> The sequence of SQL statements for renaming the given index.
      */
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        return [
-            $this->getDropIndexSQL($oldIndexName, $tableName),
-            $this->getCreateIndexSQL($index, $tableName),
-        ];
-    }
+    abstract protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array;
 
     /**
      * Returns the SQL for renaming a column

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -571,6 +571,15 @@ class SQLitePlatform extends AbstractPlatform
         return implode(' ', $chunks);
     }
 
+    /** {@inheritDoc} */
+    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
+    {
+        return [
+            $this->getDropIndexSQL($oldIndexName, $tableName),
+            $this->getCreateIndexSQL($index, $tableName),
+        ];
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
The base implementation was overridden in all implementations except for SQLitePlatform.
