### PR TITLE
Make AbstractPlatform::getCommentOnTableSQL() private

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -990,7 +990,7 @@ abstract class AbstractPlatform
         return $sql;
     }
 
-    protected function getCommentOnTableSQL(string $tableName, string $comment): string
+    private function getCommentOnTableSQL(string $tableName, string $comment): string
     {
         $parsedName = $this->parseOptionallyQualifiedName($tableName);
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1130,7 +1130,7 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     /** @link https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-addextendedproperty-transact-sql */
-    protected function getCommentOnTableSQL(string $tableName, string $comment): string
+    private function getCommentOnTableSQL(string $tableName, string $comment): string
     {
         $parsedName = $this->parseOptionallyQualifiedName($tableName);
 


### PR DESCRIPTION
Each of the `AbstractPlatform` and `SQLServerPlatform` classes invokes its own implementation of `getCommentOnTableSQL()`. Semantically, they are different: the former builds a part of `CREATE TABLE` statement. the latter builds a call to a stored procedure.

There is no point in keeping the base method protected.