### PR TITLE
Reorganize SQLitePlatform comment methods

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -295,7 +295,7 @@ class SQLitePlatform extends AbstractPlatform
 
         $tableComment = '';
         if (isset($options['comment'])) {
-            $tableComment = $this->getInlineTableCommentSQL($options['comment']);
+            $tableComment = $this->getInlineCommentSQL($options['comment']);
         }
 
         $query = ['CREATE TABLE ' . $name . ' ' . $tableComment . '(' . $queryFields . ')'];
@@ -429,16 +429,16 @@ class SQLitePlatform extends AbstractPlatform
     /** @internal The method should be only used from within the {@see AbstractPlatform} class hierarchy. */
     public function getInlineColumnCommentSQL(string $comment): string
     {
+        return $this->getInlineCommentSQL($comment);
+    }
+
+    private function getInlineCommentSQL(string $comment): string
+    {
         if ($comment === '') {
             return '';
         }
 
         return '--' . str_replace("\n", "\n--", $comment) . "\n";
-    }
-
-    private function getInlineTableCommentSQL(string $comment): string
-    {
-        return $this->getInlineColumnCommentSQL($comment);
     }
 
     protected function initializeDoctrineTypeMappings(): void


### PR DESCRIPTION
The affected SQLite platform methods are a bit convoluted:
1. The private method `getInlineTableCommentSQL()` delegates to `getInlineColumnCommentSQL()` just because their implementations are identical. However, tables and columns are different database objects.
2. `getInlineTableCommentSQL()` is a one-liner invoked from a single place, so there is no point in declaring it as a separate method to begin with.

Instead, now the implementation method is private and is name `getInlineCommentSQL()` (agnostic of the object type). It is is invoked from the table- and column-related methods.
