### PR TITLE
do not call setAccessible() on PHP >= 8.1

### DIFF
--- a/src/Driver/Mysqli/Exception/ConnectionError.php
+++ b/src/Driver/Mysqli/Exception/ConnectionError.php
@@ -9,6 +9,8 @@ use mysqli;
 use mysqli_sql_exception;
 use ReflectionProperty;
 
+use const PHP_VERSION_ID;
+
 /** @internal */
 final class ConnectionError extends AbstractException
 {
@@ -20,7 +22,9 @@ final class ConnectionError extends AbstractException
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
 
         return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }

--- a/src/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/src/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -11,6 +11,8 @@ use ReflectionProperty;
 
 use function assert;
 
+use const PHP_VERSION_ID;
+
 /** @internal */
 final class ConnectionFailed extends AbstractException
 {
@@ -25,7 +27,9 @@ final class ConnectionFailed extends AbstractException
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
 
         return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }

--- a/src/Driver/Mysqli/Exception/InvalidCharset.php
+++ b/src/Driver/Mysqli/Exception/InvalidCharset.php
@@ -11,6 +11,8 @@ use ReflectionProperty;
 
 use function sprintf;
 
+use const PHP_VERSION_ID;
+
 /** @internal */
 final class InvalidCharset extends AbstractException
 {
@@ -26,7 +28,9 @@ final class InvalidCharset extends AbstractException
     public static function upcast(mysqli_sql_exception $exception, string $charset): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
 
         return new self(
             sprintf('Failed to set charset "%s": %s', $charset, $exception->getMessage()),

--- a/src/Driver/Mysqli/Exception/StatementError.php
+++ b/src/Driver/Mysqli/Exception/StatementError.php
@@ -9,6 +9,8 @@ use mysqli_sql_exception;
 use mysqli_stmt;
 use ReflectionProperty;
 
+use const PHP_VERSION_ID;
+
 /** @internal */
 final class StatementError extends AbstractException
 {
@@ -20,7 +22,9 @@ final class StatementError extends AbstractException
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
 
         return new self($exception->getMessage(), $p->getValue($exception), (int) $exception->getCode(), $exception);
     }

--- a/tests/Driver/AbstractDriverTestCase.php
+++ b/tests/Driver/AbstractDriverTestCase.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+use const PHP_VERSION_ID;
+
 /** @template P of AbstractPlatform */
 abstract class AbstractDriverTestCase extends TestCase
 {
@@ -55,7 +57,9 @@ abstract class AbstractDriverTestCase extends TestCase
         self::assertEquals($this->createSchemaManager($connection), $schemaManager);
 
         $re = new ReflectionProperty($schemaManager, '_conn');
-        $re->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $re->setAccessible(true);
+        }
 
         self::assertSame($connection, $re->getValue($schemaManager));
     }

--- a/tests/Functional/Driver/Mysqli/StatementTest.php
+++ b/tests/Functional/Driver/Mysqli/StatementTest.php
@@ -36,12 +36,16 @@ class StatementTest extends FunctionalTestCase
         $statement = $this->connection->prepare('SELECT 1');
 
         $property = new ReflectionProperty(WrapperStatement::class, 'stmt');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $driverStatement = $property->getValue($statement);
 
         $mysqliProperty = new ReflectionProperty(Statement::class, 'stmt');
-        $mysqliProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $mysqliProperty->setAccessible(true);
+        }
 
         $mysqliStatement = $mysqliProperty->getValue($driverStatement);
 

--- a/tests/Functional/Driver/PgSQL/StatementTest.php
+++ b/tests/Functional/Driver/PgSQL/StatementTest.php
@@ -13,6 +13,8 @@ use ReflectionProperty;
 
 use function sprintf;
 
+use const PHP_VERSION_ID;
+
 class StatementTest extends FunctionalTestCase
 {
     protected function setUp(): void
@@ -31,12 +33,16 @@ class StatementTest extends FunctionalTestCase
         $statement = $this->connection->prepare('SELECT 1');
 
         $property = new ReflectionProperty(WrapperStatement::class, 'stmt');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $driverStatement = $property->getValue($statement);
 
         $property = new ReflectionProperty(Statement::class, 'name');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $name = $property->getValue($driverStatement);
 

--- a/tests/Functional/Ticket/DBAL461Test.php
+++ b/tests/Functional/Ticket/DBAL461Test.php
@@ -11,6 +11,8 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
+use const PHP_VERSION_ID;
+
 class DBAL461Test extends TestCase
 {
     public function testIssue(): void
@@ -27,7 +29,10 @@ class DBAL461Test extends TestCase
         $schemaManager = new SQLServerSchemaManager($conn, $platform);
 
         $reflectionMethod = new ReflectionMethod($schemaManager, '_getPortableTableColumnDefinition');
-        $reflectionMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionMethod->setAccessible(true);
+        }
+
         $column = $reflectionMethod->invoke($schemaManager, [
             'type' => 'numeric(18,0)',
             'length' => null,

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -16,6 +16,8 @@ use ReflectionProperty;
 use function current;
 use function strlen;
 
+use const PHP_VERSION_ID;
+
 class SchemaTest extends TestCase
 {
     public function testAddTable(): void
@@ -216,7 +218,9 @@ class SchemaTest extends TestCase
         $fk = current($fk);
 
         $re = new ReflectionProperty($fk, '_localTable');
-        $re->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $re->setAccessible(true);
+        }
 
         self::assertSame($schemaNew->getTable('bar'), $re->getValue($fk));
     }

--- a/tests/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Schema/SqliteSchemaManagerTest.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
+use const PHP_VERSION_ID;
+
 class SqliteSchemaManagerTest extends TestCase
 {
     /** @dataProvider getDataColumnCollation */
@@ -18,7 +20,9 @@ class SqliteSchemaManagerTest extends TestCase
 
         $manager = new SqliteSchemaManager($conn, new SqlitePlatform());
         $ref     = new ReflectionMethod($manager, 'parseColumnCollationFromSQL');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         self::assertSame($collation, $ref->invoke($manager, $column, $sql));
     }
@@ -130,7 +134,9 @@ class SqliteSchemaManagerTest extends TestCase
 
         $manager = new SqliteSchemaManager($conn, new SqlitePlatform());
         $ref     = new ReflectionMethod($manager, 'parseColumnCommentFromSQL');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         self::assertSame($comment, $ref->invoke($manager, $column, $sql));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 

#### Summary

see php/php-src#19273 and https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations
