### PR TITLE
Consistently reference IBM Db2 as Db2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -208,8 +208,8 @@ jobs:
             php-version: "7.4"
             extension: "pdo_sqlsrv"
 
-  phpunit-ibm-db2:
-    name: "PHPUnit with IBM DB2"
+  phpunit-db2:
+    name: "PHPUnit with Db2"
     needs: "phpunit-smoke-check"
     uses: ./.github/workflows/phpunit-db2.yml
     with:
@@ -265,7 +265,7 @@ jobs:
       - "phpunit-mariadb"
       - "phpunit-mysql"
       - "phpunit-mssql"
-      - "phpunit-ibm-db2"
+      - "phpunit-db2"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/phpunit-db2.yml
+++ b/.github/workflows/phpunit-db2.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install IBM DB2 CLI driver
+      - name: Install Db2 CLI driver
         working-directory: /tmp
         run: |
           wget https://github.com/ibmdb/db2drivers/raw/refs/heads/main/clidriver/v11.5.9/linuxx64_odbc_cli.tar.gz

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -779,9 +779,9 @@ following methods are deprecated:
 The protected property `AbstractPlatform::$doctrineTypeComments` is deprecated
 as well.
 
-## Deprecated support for IBM DB2 10.5 and older
+## Deprecated support for Db2 10.5 and older
 
-IBM DB2 10.5 and older won't be supported in DBAL 4. Consider upgrading to IBM DB2 11.1 or later.
+Db2 10.5 and older won't be supported in DBAL 4. Consider upgrading to Db2 11.1 or later.
 
 ## Deprecated support for Oracle 12c (12.2.0.1) and older
 
@@ -1447,9 +1447,9 @@ All implementations of the `VersionAwarePlatformDriver` interface have to implem
 The `Doctrine\DBAL\Platforms\MsSQLKeywords` class has been removed.
 Please use `Doctrine\DBAL\Platforms\SQLServerPlatform` instead.
 
-## BC BREAK: Removed PDO DB2 driver
+## BC BREAK: Removed PDO Db2 driver
 
-This PDO-based IBM DB2 driver (built on top of `pdo_ibm` extension) has already been unsupported as of 2.5, it has been now removed.
+This PDO-based Db2 driver (built on top of `pdo_ibm` extension) has already been unsupported as of 2.5, it has been now removed.
 
 The following class has been removed:
 

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -172,7 +172,7 @@ interfaces to use. It can be configured in one of two ways:
    -  ``pdo_sqlsrv``: A Microsoft SQL Server driver that uses pdo_sqlsrv PDO
    -  ``sqlsrv``: A Microsoft SQL Server driver that uses the sqlsrv PHP extension.
    -  ``oci8``: An Oracle driver that uses the oci8 PHP extension.
-   -  ``ibm_db2``: An IBM DB2 driver that uses the ibm_db2 PHP extension.
+   -  ``ibm_db2``: A Db2 driver that uses the ibm_db2 PHP extension.
 
 -  ``driverClass``: Specifies a custom driver implementation if no
    'driver' is specified. This allows the use of custom drivers that

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -13,7 +13,7 @@ the oci8 extension under the hood.
 
 The following database vendors are currently supported:
 
-- DB2 (IBM)
+- Db2 (IBM)
 - MariaDB
 - MySQL (Oracle)
 - Oracle

--- a/docs/en/reference/known-vendor-issues.rst
+++ b/docs/en/reference/known-vendor-issues.rst
@@ -127,13 +127,13 @@ columns in the table is not the same as the order in the primary key. Tables
 created with Doctrine use the order of the columns as defined in the primary
 key.
 
-IBM DB2
--------
+Db2
+---
 
 DateTimeTz
 ~~~~~~~~~~
 
-DB2 does not support saving timezone offsets. The DateTimeTz type therefore behaves like the DateTime
+Db2 does not support saving timezone offsets. The DateTimeTz type therefore behaves like the DateTime
 type.
 
 Oracle

--- a/docs/en/reference/platforms.rst
+++ b/docs/en/reference/platforms.rst
@@ -64,8 +64,8 @@ PostgreSQL
 -  ``PostgreSQL100Platform`` for version 10.0 and above.
 -  ``PostgreSQL120Platform`` for version 12.0 and above.
 
-IBM DB2
-^^^^^^^
+Db2
+^^^
 
 -  ``Db2Platform`` for version 9.7 and above.
 -  ``Db2111Platform`` for version 11.1 (11.1 GA) and above.

--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -18,7 +18,7 @@ use function preg_match;
 use function version_compare;
 
 /**
- * Abstract base implementation of the {@see Driver} interface for IBM DB2 based drivers.
+ * Abstract base implementation of the {@see Driver} interface for Db2 based drivers.
  */
 abstract class AbstractDB2Driver implements VersionAwarePlatformDriver
 {
@@ -66,17 +66,17 @@ abstract class AbstractDB2Driver implements VersionAwarePlatformDriver
         Deprecation::trigger(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/5156',
-            'IBM DB2 < 11.1 support is deprecated and will be removed in DBAL 4.'
-                . ' Consider upgrading to IBM DB2 11.1 or later.',
+            'Db2 < 11.1 support is deprecated and will be removed in DBAL 4.'
+                . ' Consider upgrading to Db2 11.1 or later.',
         );
 
         return $this->getDatabasePlatform();
     }
 
     /**
-     * Detects IBM DB2 server version
+     * Detects Db2 server version
      *
-     * @param string $versionString Version string as returned by IBM DB2 server, i.e. 'DB2/LINUXX8664 11.5.8.0'
+     * @param string $versionString Version string as returned by Db2 server, i.e. 'DB2/LINUXX8664 11.5.8.0'
      *
      * @throws DBALException
      */

--- a/src/Driver/IBMDB2/DataSourceName.php
+++ b/src/Driver/IBMDB2/DataSourceName.php
@@ -11,7 +11,7 @@ use function sprintf;
 use function strpos;
 
 /**
- * IBM DB2 DSN
+ * Db2 DSN
  */
 final class DataSourceName
 {

--- a/src/Platforms/DB2111Platform.php
+++ b/src/Platforms/DB2111Platform.php
@@ -7,9 +7,9 @@ use Doctrine\DBAL\Exception;
 use function sprintf;
 
 /**
- * Provides the behavior, features and SQL dialect of the IBM DB2 11.1 (11.1 GA) database platform.
+ * Provides the behavior, features and SQL dialect of the Db2 11.1 (11.1 GA) database platform.
  *
- * @deprecated This class will be merged with {@see DB2Platform} in 4.0 because support for IBM DB2
+ * @deprecated This class will be merged with {@see DB2Platform} in 4.0 because support for Db2
  *             releases prior to 11.1 will be dropped.
  *
  * @see https://www.ibm.com/docs/en/db2/11.1?topic=database-whats-new-db2-version-111-ga

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -26,7 +26,7 @@ use function sprintf;
 use function strpos;
 
 /**
- * Provides the behavior, features and SQL dialect of the IBM DB2 database platform of the oldest supported version.
+ * Provides the behavior, features and SQL dialect of the Db2 database platform of the oldest supported version.
  */
 class DB2Platform extends AbstractPlatform
 {
@@ -104,7 +104,7 @@ class DB2Platform extends AbstractPlatform
      */
     public function getVarcharTypeDeclarationSQL(array $column)
     {
-        // for IBM DB2, the CHAR max length is less than VARCHAR default length
+        // for Db2, the CHAR max length is less than VARCHAR default length
         if (! isset($column['length']) && ! empty($column['fixed'])) {
             $column['length'] = $this->getCharMaxLength();
         }
@@ -175,7 +175,7 @@ class DB2Platform extends AbstractPlatform
             Deprecation::trigger(
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/issues/3263',
-                'Relying on the default string column length on IBM DB2 is deprecated'
+                'Relying on the default string column length on Db2 is deprecated'
                     . ', specify the length explicitly.',
             );
         }
@@ -193,8 +193,8 @@ class DB2Platform extends AbstractPlatform
             Deprecation::trigger(
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/issues/3263',
-                'Relying on the default binary column length on IBM DB2 is deprecated'
-                . ', specify the length explicitly.',
+                'Relying on the default binary column length on Db2 is deprecated'
+                    . ', specify the length explicitly.',
             );
         }
 
@@ -1004,9 +1004,9 @@ class DB2Platform extends AbstractPlatform
     /**
      * {@inheritDoc}
      *
-     * DB2 supports savepoints, but they work semantically different than on other vendor platforms.
+     * Db2 supports savepoints, but they work semantically different than on other vendor platforms.
      *
-     * TODO: We have to investigate how to get DB2 up and running with savepoints.
+     * TODO: We have to investigate how to get Db2 up and running with savepoints.
      */
     public function supportsSavepoints()
     {

--- a/src/Platforms/Keywords/DB2Keywords.php
+++ b/src/Platforms/Keywords/DB2Keywords.php
@@ -5,7 +5,7 @@ namespace Doctrine\DBAL\Platforms\Keywords;
 use Doctrine\Deprecations\Deprecation;
 
 /**
- * DB2 Keywords.
+ * Db2 Keywords.
  */
 class DB2Keywords extends KeywordList
 {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -21,7 +21,7 @@ use function substr;
 use const CASE_LOWER;
 
 /**
- * IBM Db2 Schema Manager.
+ * Db2 Schema Manager.
  *
  * @extends AbstractSchemaManager<DB2Platform>
  */

--- a/tests/Functional/Driver/IBMDB2/DriverTest.php
+++ b/tests/Functional/Driver/IBMDB2/DriverTest.php
@@ -23,12 +23,12 @@ class DriverTest extends AbstractDriverTestCase
 
     public function testConnectsWithoutDatabaseNameParameter(): void
     {
-        self::markTestSkipped('IBM DB2 does not support connecting without database name.');
+        self::markTestSkipped('Db2 does not support connecting without database name.');
     }
 
     public function testReturnsDatabaseNameWithoutDatabaseNameParameter(): void
     {
-        self::markTestSkipped('IBM DB2 does not support connecting without database name.');
+        self::markTestSkipped('Db2 does not support connecting without database name.');
     }
 
     protected function createDriver(): DriverInterface

--- a/tests/Functional/ModifyLimitQueryTest.php
+++ b/tests/Functional/ModifyLimitQueryTest.php
@@ -190,7 +190,7 @@ SQL;
     {
         $platform = $this->connection->getDatabasePlatform();
         if ($platform instanceof DB2Platform) {
-            self::markTestSkipped('DB2 cannot handle ORDER BY in subquery');
+            self::markTestSkipped('Db2 cannot handle ORDER BY in subquery');
         }
 
         if ($platform instanceof OraclePlatform) {

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1725,7 +1725,7 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         if ($platform instanceof DB2Platform) {
             self::markTestIncomplete(
-                'Introspection of lower-case identifiers as quoted is currently not implemented on IBM DB2.',
+                'Introspection of lower-case identifiers as quoted is currently not implemented on Db2.',
             );
         }
 


### PR DESCRIPTION
Db2 is a database by IBM. IBM itself references it as Db2 ([source](https://www.ibm.com/products/db2)), Wikipedia references it as IBM Db2 ([source](https://en.wikipedia.org/wiki/IBM_Db2)). Note the lower-case _b_ in both cases.

Both Db2 and IBM Db2 are technically correct, but let's use Db2 similar to how we use SQL Server when referencing Microsoft SQL Server.

Once this is merged, I'll rename the label on GitHub accordingly.