### PR TITLE
Compatibility with PHP 8.5+ "float-string is not representable as an int" warning

### DIFF
--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -54,7 +54,7 @@ class BigIntType extends Type implements PhpIntegerMappingType
 
         if (
             ($value > PHP_INT_MIN && $value < PHP_INT_MAX)
-            || $value === (string) (int) $value
+            || $value === (string) @(int) $value
         ) {
             return (int) $value;
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n.a.

#### Summary

Since https://wiki.php.net/rfc/warnings-php-8-5#casting_out_of_range_floats_to_int has been added to PHP 8.5 some tests fail with a warning when run on pdo_mysql:

```
1) /home/runner/work/php-latest-builds/php-latest-builds/src/Types/BigIntType.php:57
The float-string "18446744073709551615" is not representable as an int, cast occurred

Triggered by:

* Doctrine\DBAL\Tests\Functional\Types\BigIntTypeTest::testUnsignedBigIntOnMySQL
  /home/runner/work/php-latest-builds/php-latest-builds/tests/Functional/Types/BigIntTypeTest.php:74
```

I'm not very proud of silencing errors, but the check is per-se a representability check and I couldn't quickly figure out a viable alternative.