### PR TITLE
Fix the unsigned BIGINT check for PHP 8.5

### DIFF
--- a/src/Types/BigIntType.php
+++ b/src/Types/BigIntType.php
@@ -9,10 +9,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 use function assert;
 use function is_int;
+use function is_numeric;
 use function is_string;
-
-use const PHP_INT_MAX;
-use const PHP_INT_MIN;
 
 /**
  * Type that attempts to map a database BIGINT to a PHP int.
@@ -48,15 +46,13 @@ class BigIntType extends Type implements PhpIntegerMappingType
         }
 
         assert(
-            is_string($value),
+            is_string($value) && is_numeric($value),
             'DBAL assumes values outside of the integer range to be returned as string by the database driver.',
         );
 
-        if (
-            ($value > PHP_INT_MIN && $value < PHP_INT_MAX)
-            || $value === (string) (int) $value
-        ) {
-            return (int) $value;
+        $intValue = 0 + $value;
+        if (is_int($intValue)) {
+            return $intValue;
         }
 
         return $value;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | Replaces #7179

#### Summary

This PR simplifies our check for `UNSIGNED BIGINT` in a way that we avoid the new warning triggered by PHP 8.5 if we cause an integer overflow by casting a string to int.
