### PR TITLE
Deprecate creation of empty namespaces

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated `Schema::createNamespace()` and the `$namespaces` constructor parameter
+
+The `Schema::createNamespace()` method and the `$namespaces` constructor parameter have been deprecated. The schema
+automatically derives namespace names from the names of its tables and sequences. Creating empty namespaces is
+deprecated.
+
 ## Deprecated `TableDiff::getDroppedForeignKeys()`
 
 The `TableDiff::getDroppedForeignKeys()` method has been deprecated. Use

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -89,6 +89,14 @@ class Schema extends AbstractAsset
         ?SchemaConfig $schemaConfig = null,
         array $namespaces = [],
     ) {
+        if (count($namespaces) > 0) {
+            Deprecation::triggerIfCalledFromOutside(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7186',
+                'Passing the $namespaces argument to the Schema constructor is deprecated.',
+            );
+        }
+
         $schemaConfig ??= new SchemaConfig();
 
         $this->_schemaConfig = $schemaConfig;
@@ -352,10 +360,21 @@ class Schema extends AbstractAsset
     /**
      * Creates a new namespace.
      *
+     * @deprecated The schema automatically derives namespaces from the names of its tables and sequences.
+     *             Creating empty namespaces is deprecated.
+     *
      * @return $this
      */
     public function createNamespace(string $name): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7186',
+            '%s is deprecated. The schema automatically derives namespaces from the names of its tables and'
+                . ' sequences. Creating empty namespaces is deprecated.',
+            __METHOD__,
+        );
+
         $unquotedName = strtolower($this->getUnquotedAssetName($name));
 
         if (isset($this->namespaces[$unquotedName])) {


### PR DESCRIPTION
This is a prerequisite for fixing https://github.com/doctrine/dbal/issues/7184.

Currently, there are two ways of creating a namespace in the `Schema`:
1. Add a table or sequence with a qualified name. The namespace will be derived from the qualifier.
2. Create a namespace manually.

At the same time, there is no way to drop a namespace from the `Schema`:
1. Dropping the last object within a namespace doesn't automatically drop the namespace.
2. There is no method that would allow dropping a namespace manually.

In `5.0.x`, I will rework the internals of the `Schema` class such that tables and sequences will be indexed by their schema name (i.e. the namespace) and unqualified name. This way, listing the names of all namespaces in the schema will be as trivial as listing the top-level keys of this two-dimensional array.

Retaining the possibility of adding namespaces manually would require additional maintenance of the namespaces within the schema, while the deprecation of this behavior will allow fixing the issue mentioned above.

### Rejected alternatives
Adding the possibility of manually dropping the namespace from the schema doesn't look like a good options because:
1. It is not clear what the behavior should be when the namespace being dropped contains objects.
5. `Schema::toDropSql()` doesn't drop the namespaces and `AbstractPlatform::getAlterSchemaSQL()` doesn't respect `SchemaDiff::getDroppedNamespaces()`, so even if the namespace exists, it will remain there even if it's dropped from the application-managed schema.