### PR TITLE
Introduce DefaultExpression

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.4
 
+## Deprecated using current date, time and timestamp SQL expressions as default values
+
+Using SQL expressions for the current date, time, or timestamp as column default values is deprecated. Instead, use an
+instance of the `CurrentDate`, `CurrentTime`, or `CurrentTimestamp` class, respectively.
+
 ## Deprecated `Schema::createNamespace()` and the `$namespaces` constructor parameter
 
 The `Schema::createNamespace()` method and the `$namespaces` constructor parameter have been deprecated. The schema

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\DefaultExpression;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index;
@@ -1542,6 +1543,10 @@ abstract class AbstractPlatform
         }
 
         $default = $column['default'];
+
+        if ($default instanceof DefaultExpression) {
+            return ' DEFAULT ' . $default->toSQL($this);
+        }
 
         if (! isset($column['type'])) {
             return " DEFAULT '" . $default . "'";

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1559,14 +1559,35 @@ abstract class AbstractPlatform
         }
 
         if ($type instanceof Types\PhpDateTimeMappingType && $default === $this->getCurrentTimestampSQL()) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7195',
+                'Using "%s" as a column default value is deprecated. Use a CurrentTimestamp instance instead.',
+                $default,
+            );
+
             return ' DEFAULT ' . $this->getCurrentTimestampSQL();
         }
 
         if ($type instanceof Types\PhpTimeMappingType && $default === $this->getCurrentTimeSQL()) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7195',
+                'Using "%s" as a column default value is deprecated. Use a CurrentTime instance instead.',
+                $default,
+            );
+
             return ' DEFAULT ' . $this->getCurrentTimeSQL();
         }
 
         if ($type instanceof Types\PhpDateMappingType && $default === $this->getCurrentDateSQL()) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7195',
+                'Using "%s" as a column default value is deprecated. Use a CurrentDate instance instead.',
+                $default,
+            );
+
             return ' DEFAULT ' . $this->getCurrentDateSQL();
         }
 

--- a/src/Schema/DefaultExpression.php
+++ b/src/Schema/DefaultExpression.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * Represents the default expression of a column.
+ */
+interface DefaultExpression
+{
+    /**
+     * Returns the SQL representation of the default expression for the given platform.
+     */
+    public function toSQL(AbstractPlatform $platform): string;
+}

--- a/src/Schema/DefaultExpression/CurrentDate.php
+++ b/src/Schema/DefaultExpression/CurrentDate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\DefaultExpression;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\DefaultExpression;
+
+/**
+ * Represents the "current date" default expression.
+ */
+final readonly class CurrentDate implements DefaultExpression
+{
+    public function toSQL(AbstractPlatform $platform): string
+    {
+        return $platform->getCurrentDateSQL();
+    }
+}

--- a/src/Schema/DefaultExpression/CurrentTime.php
+++ b/src/Schema/DefaultExpression/CurrentTime.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\DefaultExpression;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\DefaultExpression;
+
+/**
+ * Represents the "current time" default expression.
+ */
+final readonly class CurrentTime implements DefaultExpression
+{
+    public function toSQL(AbstractPlatform $platform): string
+    {
+        return $platform->getCurrentTimeSQL();
+    }
+}

--- a/src/Schema/DefaultExpression/CurrentTimestamp.php
+++ b/src/Schema/DefaultExpression/CurrentTimestamp.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\DefaultExpression;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\DefaultExpression;
+
+/**
+ * Represents the "current timestamp" default expression.
+ */
+final readonly class CurrentTimestamp implements DefaultExpression
+{
+    public function toSQL(AbstractPlatform $platform): string
+    {
+        return $platform->getCurrentTimestampSQL();
+    }
+}

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
@@ -594,7 +595,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        $currentTimeStampSql = $platform->getCurrentTimestampSQL();
+        $currentTimeStamp    = new CurrentTimestamp();
+        $currentTimeStampSQL = $currentTimeStamp->toSQL($platform);
 
         $table = Table::editor()
             ->setUnquotedName('test_column_defaults_current_timestamp')
@@ -602,12 +604,12 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
                 Column::editor()
                     ->setUnquotedName('col_datetime')
                     ->setTypeName(Types::DATETIME_MUTABLE)
-                    ->setDefaultValue($currentTimeStampSql)
+                    ->setDefaultValue($currentTimeStamp)
                     ->create(),
                 Column::editor()
                     ->setUnquotedName('col_datetime_nullable')
                     ->setTypeName(Types::DATETIME_MUTABLE)
-                    ->setDefaultValue($currentTimeStampSql)
+                    ->setDefaultValue($currentTimeStamp)
                     ->create(),
             )
             ->create();
@@ -615,8 +617,8 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         $this->dropAndCreateTable($table);
 
         $onlineTable = $this->schemaManager->introspectTableByUnquotedName('test_column_defaults_current_timestamp');
-        self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime')->getDefault());
-        self::assertSame($currentTimeStampSql, $onlineTable->getColumn('col_datetime_nullable')->getDefault());
+        self::assertSame($currentTimeStampSQL, $onlineTable->getColumn('col_datetime')->getDefault());
+        self::assertSame($currentTimeStampSQL, $onlineTable->getColumn('col_datetime_nullable')->getDefault());
 
         self::assertTrue(
             $this->schemaManager

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
-use DateTime;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\DatabaseRequired;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
@@ -629,16 +628,9 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
     public function testColumnDefaultsAreValid(): void
     {
-        $currentTimeStampSql = $this->connection->getDatabasePlatform()->getCurrentTimestampSQL();
-
         $table = Table::editor()
             ->setUnquotedName('test_column_defaults_are_valid')
             ->setColumns(
-                Column::editor()
-                    ->setUnquotedName('col_datetime')
-                    ->setTypeName(Types::DATETIME_MUTABLE)
-                    ->setDefaultValue($currentTimeStampSql)
-                    ->create(),
                 Column::editor()
                     ->setUnquotedName('col_datetime_null')
                     ->setTypeName(Types::DATETIME_MUTABLE)
@@ -681,19 +673,15 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             'INSERT INTO test_column_defaults_are_valid () VALUES()',
         );
 
-        $row = $this->connection->fetchAssociative(
-            'SELECT *, DATEDIFF(CURRENT_TIMESTAMP(), col_datetime) as diff_seconds FROM test_column_defaults_are_valid',
-        );
+        $row = $this->connection->fetchAssociative('SELECT * FROM test_column_defaults_are_valid');
         self::assertNotFalse($row);
 
-        self::assertInstanceOf(DateTime::class, DateTime::createFromFormat('Y-m-d H:i:s', $row['col_datetime']));
         self::assertNull($row['col_datetime_null']);
         self::assertSame('2012-12-12', $row['col_date']);
         self::assertSame('A', $row['col_string']);
         self::assertEquals(1, $row['col_int']);
         self::assertEquals(-1, $row['col_neg_int']);
         self::assertEquals('-2.300', $row['col_decimal']);
-        self::assertLessThan(5, $row['diff_seconds']);
     }
 
     /**

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Name\Identifier;
@@ -338,7 +340,7 @@ abstract class AbstractPlatformTestCase extends TestCase
                 ' DEFAULT ' . $this->platform->getCurrentTimestampSQL(),
                 $this->platform->getDefaultValueDeclarationSQL([
                     'type'    => Type::getType($type),
-                    'default' => $this->platform->getCurrentTimestampSQL(),
+                    'default' => new CurrentTimestamp(),
                 ]),
             );
         }
@@ -365,7 +367,7 @@ abstract class AbstractPlatformTestCase extends TestCase
                 ' DEFAULT ' . $currentDateSql,
                 $this->platform->getDefaultValueDeclarationSQL([
                     'type'    => Type::getType($type),
-                    'default' => $currentDateSql,
+                    'default' => new CurrentDate(),
                 ]),
             );
         }

--- a/tests/Platforms/SQLServerPlatformTest.php
+++ b/tests/Platforms/SQLServerPlatformTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
@@ -1087,7 +1088,7 @@ class SQLServerPlatformTest extends AbstractPlatformTestCase
                 ' DEFAULT CONVERT(date, GETDATE())',
                 $this->platform->getDefaultValueDeclarationSQL([
                     'type' => Type::getType($type),
-                    'default' => $currentDateSql,
+                    'default' => new CurrentDate(),
                 ]),
             );
         }


### PR DESCRIPTION
This is a prerequisite for fixing https://github.com/doctrine/dbal/issues/7194. `DefaultExpression` can be used to represent column default expressions in a portable way. Subsequently, we can use the same interface to represent literal expressions (strings, numbers, etc.).

## Backward compatibility

In theory, using objects instead of strings may impact schema comparison: the column definition obtained via schema introspection will still contain a string representing the default expression, not the `DefaultExpression` object. In practice, it shouldn’t be a problem because column definitions are compared as their DDL: https://github.com/doctrine/dbal/blob/42e278e3f5365b75e6f8296479aaf8e75057e3e5/src/Platforms/AbstractPlatform.php#L2417-L2422