### PR TITLE
Use MySQL syntax for parsing SQL in AbstractMySQLPlatform

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
@@ -919,5 +920,10 @@ SQL;
         $conditions[] = "t.TABLE_TYPE = 'BASE TABLE'";
 
         return $sql . ' WHERE ' . implode(' AND ', $conditions);
+    }
+
+    public function createSQLParser(): Parser
+    {
+        return new Parser(true);
     }
 }

--- a/tests/Functional/SQL/ParserTest.php
+++ b/tests/Functional/SQL/ParserTest.php
@@ -9,6 +9,17 @@ use Doctrine\DBAL\Tests\TestUtil;
 
 class ParserTest extends FunctionalTestCase
 {
+    public function testMySQLEscaping(): void
+    {
+        if (! TestUtil::isDriverOneOf('mysqli', 'pdo_mysql')) {
+            self::markTestSkipped('This test requires the mysqli or pdo_mysql driver');
+        }
+
+        $result = $this->connection->fetchNumeric("SELECT '\'?', :parameter", ['parameter' => 'value']);
+
+        self::assertEquals(["'?", 'value'], $result);
+    }
+
     public function testPostgreSQLJSONBQuestionOperator(): void
     {
         if (! TestUtil::isDriverOneOf('pdo_pgsql')) {


### PR DESCRIPTION
Fixes #7199.

This is a regression caused by #5089 which removed the `MySQL57Platform` together with the overridden method. I don't remember why in #4397 I overrode the method only in `MySQL57Platform` but not in `AbstractMySQLPlatform` (it seems it would have been the right thing to do).

The regression was possible since at that time we didn't have platform-specific integration tests for the SQL parser. Now we have a couple of them.