### PR TITLE
Bump dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
-    target-branch: "3.9.x"
+    target-branch: "3.10.x"


### PR DESCRIPTION
I noticed we did not receive updates on this repository for a long time. 3.9.x no longer exists, which probably explains it.