### PR TITLE
Update AbstractPlatform.php, allow to skip setting a default if nothi…

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1560,7 +1560,11 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $default;
         }
 
-        return ' DEFAULT ' . $this->quoteStringLiteral($default);
+        if ($default) {
+            return ' DEFAULT ' . $this->quoteStringLiteral($default);
+        } else {
+            return '';
+        }
     }
 
     /**

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1560,7 +1560,7 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $default;
         }
 
-        if ($default) {
+        if ($default !== false) {
             return ' DEFAULT ' . $this->quoteStringLiteral($default);
         } else {
             return '';


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| Fixed issues | 1

#### Summary

Allow to skip setting a default if nothing of use was detected.
Solves 

In AbstractMySQLPlatform.php line 850:
                                                                                                                                                                                                                                         
  Doctrine\DBAL\Platforms\AbstractMySQLPlatform::quoteStringLiteral(): Argument #1 ($str) must be of type string, false given, called in C:\xhtml\mhh4-backend\api\vendor\doctrine\dbal\src\Platforms\AbstractPlatform.php on line 1563  

with use of ApiPlatform latest