### PR TITLE
Hide sensitive parameters in `PDOConnect::doConnect()`

### DIFF
--- a/src/Driver/PDO/PDOConnect.php
+++ b/src/Driver/PDO/PDOConnect.php
@@ -14,6 +14,7 @@ trait PDOConnect
 {
     /** @param array<int, mixed> $options */
     private function doConnect(
+        #[SensitiveParameter]
         string $dsn,
         string $username,
         #[SensitiveParameter]

--- a/src/Driver/PDO/PDOConnect.php
+++ b/src/Driver/PDO/PDOConnect.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDO;
 
 use PDO;
+use SensitiveParameter;
 
 use const PHP_VERSION_ID;
 
@@ -15,6 +16,7 @@ trait PDOConnect
     private function doConnect(
         string $dsn,
         string $username,
+        #[SensitiveParameter]
         string $password,
         array $options
     ): PDO {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

If error is triggered while reconnect it will log a message with opened dsn and password.
The PR mark these fields as Sensitive

<img width="1103" height="126" alt="image" src="https://github.com/user-attachments/assets/86c95b1f-55c4-438a-9004-a07adbc7f6f4" />
