### PR TITLE
Test against stable Symfony 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -250,7 +250,6 @@ jobs:
       - name: "Lower minimum stability"
         run: |
           composer config minimum-stability dev
-          composer require --no-update --dev symfony/console:^8
 
       - name: "Install development dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
         "phpunit/phpunit": "9.6.29",
         "slevomat/coding-standard": "8.24.0",
         "squizlabs/php_codesniffer": "4.0.0",
-        "symfony/cache": "^5.4|^6.0|^7.0",
-        "symfony/console": "^4.4|^5.4|^6.0|^7.0"
+        "symfony/cache": "^5.4|^6.0|^7.0|^8.0",
+        "symfony/console": "^4.4|^5.4|^6.0|^7.0|^8.0"
     },
     "conflict": {
         "doctrine/cache": "< 1.11"

--- a/tests/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Tools/Console/RunSqlCommandTest.php
@@ -27,10 +27,11 @@ class RunSqlCommandTest extends TestCase
         $this->connectionMock = $this->createMock(Connection::class);
         $this->command        = new RunSqlCommand(new SingleConnectionProvider($this->connectionMock));
 
+        // @phpstan-ignore function.alreadyNarrowedType (This method does not exist before Symfony 7.4)
         if (method_exists(Application::class, 'addCommand')) {
-            // @phpstan-ignore method.notFound (This method will be added in Symfony 7.4)
             (new Application())->addCommand($this->command);
         } else {
+            // @phpstan-ignore method.notFound
             (new Application())->add($this->command);
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Symfony 8 is stable now. Let's run our tests and static analysis run against it.