### PR TITLE
Stop testing against Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
         "phpunit/phpunit": "12.3.0",
         "slevomat/coding-standard": "8.24.0",
         "squizlabs/php_codesniffer": "4.0.0",
-        "symfony/cache": "^6.4|^7.3|^8.0",
-        "symfony/console": "^6.4|^7.3|^8.0"
+        "symfony/cache": "^7.4|^8.0",
+        "symfony/console": "^7.4|^8.0"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/tests/Tools/Console/RunSqlCommandTest.php
+++ b/tests/Tools/Console/RunSqlCommandTest.php
@@ -13,7 +13,6 @@ use RuntimeException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-use function method_exists;
 use function str_replace;
 
 class RunSqlCommandTest extends TestCase
@@ -27,13 +26,7 @@ class RunSqlCommandTest extends TestCase
         $this->connectionMock = $this->createMock(Connection::class);
         $this->command        = new RunSqlCommand(new SingleConnectionProvider($this->connectionMock));
 
-        // @phpstan-ignore function.alreadyNarrowedType (This method does not exist before Symfony 7.4)
-        if (method_exists(Application::class, 'addCommand')) {
-            (new Application())->addCommand($this->command);
-        } else {
-            // @phpstan-ignore method.notFound
-            (new Application())->add($this->command);
-        }
+        (new Application())->addCommand($this->command);
 
         $this->commandTester = new CommandTester($this->command);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

Bumping to Symfony 7 allows up to get rid of a feature check in our tests.
