### PR TITLE
Test Oracle drivers on PHP 8.5

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,9 +70,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          # TODO: Switch to PHP 8.5
-          # see https://github.com/shivammathur/setup-php/issues/1028
-          - "8.4"
+          - "8.5"
         oracle-version:
           - "21"
           - "23"
@@ -86,9 +84,6 @@ jobs:
           - php-version: "7.4"
             oracle-version: "23"
             extension: pdo_oci
-          - php-version: "8.5"
-            oracle-version: "23"
-            extension: oci8
 
   phpunit-postgres:
     name: "PHPUnit with PostgreSQL"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | Follows #7219

#### Summary

Since shivammathur/setup-php#1028 is fixed now, let's see if we can run our tests with PHP 8.5 and Oracle.
