### PR TITLE
Fix enumType handling in Column

### DIFF
--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -35,6 +35,7 @@ use function method_exists;
  *     charset?: ?non-empty-string,
  *     collation?: ?non-empty-string,
  *     default_constraint_name?: non-empty-string,
+ *     enumType?: class-string,
  *     jsonb?: bool,
  *     version?: bool,
  * }
@@ -278,6 +279,16 @@ class Column extends AbstractNamedObject
     }
 
     /**
+     * Returns the enum type used by the column.
+     *
+     * @return ?class-string
+     */
+    public function getEnumType(): ?string
+    {
+        return $this->_platformOptions['enumType'] ?? null;
+    }
+
+    /**
      * @internal Should be used only from within the {@see AbstractSchemaManager} class hierarchy.
      *
      * Returns the name of the DEFAULT constraint that implements the default value for the column on SQL Server.
@@ -290,8 +301,8 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()} or {@see getMaximumValue()}
-     *             instead.
+     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()}
+     *             or {@see getEnumType()} instead.
      *
      * @return PlatformOptions
      */
@@ -301,8 +312,8 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()} or {@see getMaximumValue()}
-     *             instead.
+     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()}
+     *             or {@see getEnumType()} instead.
      *
      * @param key-of<PlatformOptions> $name
      */
@@ -312,8 +323,8 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()} or {@see getMaximumValue()}
-     *             instead.
+     * @deprecated Use {@see getCharset()}, {@see getCollation()}, {@see getMinimumValue()}, {@see getMaximumValue()}
+     *             or {@see getEnumType()} instead.
      *
      * @param key-of<PlatformOptions> $name
      */
@@ -415,6 +426,7 @@ class Column extends AbstractNamedObject
             ->setCollation($this->getCollation())
             ->setMinimumValue($this->getMinimumValue())
             ->setMaximumValue($this->getMaximumValue())
+            ->setEnumType($this->getEnumType())
             ->setDefaultConstraintName($this->getDefaultConstraintName());
     }
 }

--- a/src/Schema/ColumnEditor.php
+++ b/src/Schema/ColumnEditor.php
@@ -34,6 +34,9 @@ final class ColumnEditor
 
     private mixed $maximumValue = null;
 
+    /** @var ?class-string  */
+    private ?string $enumType = null;
+
     private bool $autoincrement = false;
 
     private string $comment = '';
@@ -159,6 +162,14 @@ final class ColumnEditor
         return $this;
     }
 
+    /** @param ?class-string $enumType */
+    public function setEnumType(?string $enumType): self
+    {
+        $this->enumType = $enumType;
+
+        return $this;
+    }
+
     public function setAutoincrement(bool $flag): self
     {
         $this->autoincrement = $flag;
@@ -243,6 +254,10 @@ final class ColumnEditor
 
         if ($this->maximumValue !== null) {
             $platformOptions['max'] = $this->maximumValue;
+        }
+
+        if ($this->enumType !== null) {
+            $platformOptions['enumType'] = $this->enumType;
         }
 
         if ($this->defaultConstraintName !== null) {

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -37,10 +37,12 @@ class ColumnTest extends TestCase
         self::assertTrue($column->getFixed());
         self::assertEquals('baz', $column->getDefault());
 
-        self::assertEquals(['charset' => 'utf8'], $column->getPlatformOptions());
+        self::assertEquals(['charset' => 'utf8', 'enumType' => self::class], $column->getPlatformOptions());
         self::assertTrue($column->hasPlatformOption('charset'));
         self::assertEquals('utf8', $column->getPlatformOption('charset'));
         self::assertFalse($column->hasPlatformOption('collation'));
+        self::assertTrue($column->hasPlatformOption('enumType'));
+        self::assertEquals(self::class, $column->getPlatformOption('enumType'));
     }
 
     public function testToArray(): void
@@ -60,6 +62,7 @@ class ColumnTest extends TestCase
             'comment' => '',
             'values' => [],
             'charset' => 'utf8',
+            'enumType' => self::class,
         ];
 
         self::assertSame($expected, $this->createColumn()->toArray());
@@ -98,6 +101,7 @@ class ColumnTest extends TestCase
             ->setFixed(true)
             ->setDefaultValue('baz')
             ->setCharset('utf8')
+            ->setEnumType(self::class)
             ->create();
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | 

#### Summary

cc @morozov since you made https://github.com/doctrine/dbal/pull/6975 and https://github.com/doctrine/dbal/pull/6945

With the deprecation/remove of hasPlatformOption/getPlatformOption in favor of specific getter. I feel like some getter (and editor method) are missing. (But maybe I'm misunderstand something ?)

Which means
- a call like `$column->getPlatformOption('enumType')` has currently no replacement
- editing a column is loosing extra platform options like `enumType`

The enumType platformOption is set when using something like
```
#[ORM\Column(name: 'foo', type: Types::STRING, enumType: Foo::class)]
```
and there is maybe more similar options...

I'm personally implementing a custom lib which requires to access `enumType` option from a Column and this won't be possible in 5.x without any changes.