### PR TITLE
Introduce "sid" for Oracle connections

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,13 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 4.5
+
+## Deprecated `dbname` connection parameter for `oci8` and `pdo_oci` connections.
+
+Using the `dbname` connection parameter for `oci8` and `pdo_oci` connections has been deprecated. Use `servicename` or
+`sid` instead.
+
 # Upgrade to 4.4
 
 ## Deprecated using current date, time and timestamp SQL expressions as default values

--- a/ci/github/phpunit/oci8-21.xml
+++ b/ci/github/phpunit/oci8-21.xml
@@ -17,14 +17,12 @@
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="XE"/>
         <var name="db_charset" value="AL32UTF8" />
 
         <var name="tmpdb_driver" value="oci8"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="XE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/oci8.xml
+++ b/ci/github/phpunit/oci8.xml
@@ -17,14 +17,12 @@
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="FREE"/>
         <var name="db_charset" value="AL32UTF8" />
 
         <var name="tmpdb_driver" value="oci8"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="FREE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/pdo_oci-21.xml
+++ b/ci/github/phpunit/pdo_oci-21.xml
@@ -17,14 +17,12 @@
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="XE"/>
         <var name="db_charset" value="AL32UTF8" />
 
         <var name="tmpdb_driver" value="pdo_oci"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="XE"/>
     </php>
 
     <testsuites>

--- a/ci/github/phpunit/pdo_oci.xml
+++ b/ci/github/phpunit/pdo_oci.xml
@@ -17,14 +17,12 @@
         <var name="db_host" value="localhost"/>
         <var name="db_user" value="doctrine"/>
         <var name="db_password" value="oracle"/>
-        <var name="db_dbname" value="FREE"/>
         <var name="db_charset" value="AL32UTF8" />
 
         <var name="tmpdb_driver" value="pdo_oci"/>
         <var name="tmpdb_host" value="localhost"/>
         <var name="tmpdb_user" value="system"/>
         <var name="tmpdb_password" value="oracle"/>
-        <var name="tmpdb_dbname" value="FREE"/>
     </php>
 
     <testsuites>

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -302,10 +302,11 @@ pdo_oci / oci8
    database.
 -  ``host`` (string): Hostname of the database to connect to.
 -  ``port`` (integer): Port of the database to connect to.
--  ``dbname`` (string): Name of the database/schema to connect to.
+-  ``dbname`` (string): Name of the database/schema to connect to. Using this parameter is deprecated.
 -  ``servicename`` (string): Optional name by which clients can
    connect to the database instance. Will be used as Oracle's
    ``SERVICE_NAME`` connection parameter if given.
+-  ``sid`` (string): Optional identifier of the database instance to connect to.
 -  ``service`` (boolean): Whether to use Oracle's ``SERVICE_NAME``
    connection parameter in favour of ``SID`` when connecting. The
    value for this will be read from Doctrine's ``servicename`` if

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -62,6 +62,14 @@ final class EasyConnectString
             );
         }
 
+        if (isset($params['dbname'])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7239',
+                'Using the "dbname" parameter is deprecated. Use "servicename" or "sid" instead.',
+            );
+        }
+
         if (isset($params['servicename']) || isset($params['dbname'])) {
             $serviceKey = 'SID';
 
@@ -72,6 +80,10 @@ final class EasyConnectString
             $serviceName = $params['servicename'] ?? $params['dbname'];
 
             $connectData[$serviceKey] = $serviceName;
+        }
+
+        if (isset($params['sid'])) {
+            $connectData['SID'] = $params['sid'];
         }
 
         if (isset($params['instancename'])) {

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -62,6 +62,7 @@ use function is_a;
  *     replica?: array<OverrideParams>,
  *     serverVersion?: string,
  *     sessionMode?: int,
+ *     sid?: string,
  *     user?: string,
  *     wrapperClass?: class-string<Connection>,
  *     unix_socket?: string,

--- a/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -80,12 +80,13 @@ class EasyConnectStringTest extends TestCase
     public function testParameterDeprecation(
         array $parameters,
         string $expectedConnectString,
+        string $deprecation,
         bool $expectDeprecation,
     ): void {
         if ($expectDeprecation) {
-            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7042');
+            $this->expectDeprecationWithIdentifier($deprecation);
         } else {
-            $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7042');
+            $this->expectNoDeprecationWithIdentifier($deprecation);
         }
 
         $string = EasyConnectString::fromConnectionParameters($parameters);
@@ -93,13 +94,16 @@ class EasyConnectStringTest extends TestCase
         self::assertSame($expectedConnectString, (string) $string);
     }
 
-    /** @return iterable<string, array{array<string, mixed>, string, bool}> */
+    /** @return iterable<string, array{array<string, mixed>, string, string, bool}> */
     public static function getConnectionParameters(): iterable
     {
         $serviceNameString = '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))'
             . '(CONNECT_DATA=(SERVICE_NAME=BILLING)))';
 
-        yield 'dbname-and-service' => [
+        $sidString = '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))'
+            . '(CONNECT_DATA=(SID=BILLING)))';
+
+        yield 'service' => [
             [
                 'host' => 'localhost',
                 'port' => 1521,
@@ -107,6 +111,18 @@ class EasyConnectStringTest extends TestCase
                 'service' => true,
             ],
             $serviceNameString,
+            'https://github.com/doctrine/dbal/pull/7239',
+            true,
+        ];
+
+        yield 'dbname' => [
+            [
+                'host' => 'localhost',
+                'port' => 1521,
+                'dbname' => 'BILLING',
+            ],
+            $sidString,
+            'https://github.com/doctrine/dbal/pull/7239',
             true,
         ];
 
@@ -117,6 +133,18 @@ class EasyConnectStringTest extends TestCase
                 'servicename' => 'BILLING',
             ],
             $serviceNameString,
+            'https://github.com/doctrine/dbal/pull/7042',
+            false,
+        ];
+
+        yield 'sid' => [
+            [
+                'host' => 'localhost',
+                'port' => 1521,
+                'sid' => 'BILLING',
+            ],
+            $sidString,
+            'https://github.com/doctrine/dbal/pull/7042',
             false,
         ];
     }


### PR DESCRIPTION
#### Background

Currently, the "SID" or "SERVICE_NAME" parameter used in the resulting connection string for Oracle is represented by the "dbname" parameter and the presence or absence of the "service" flag. This is absolutely counterintuitive, and the usage of "service" was deprecated in https://github.com/doctrine/dbal/pull/7042.

The term "database" as it's used in the DBAL (and, by extension, the "dbname" parameter) doesn't apply to Oracle as it does to other supported platforms. For example, if `AbstractSchemaManager::createDatabase($databaseName)` is invoked against Oracle, and the "database" is successfully created, this `$databaseName` cannot be used as the "dbname" value in a new connection (`createDatabase()` creates a _user_ on Oracle).

#### Change Summary

This pull request introduces the "sid" parameter and deprecates using "dbname" for Oracle connections. This way, if the user wants to use "SERVICE_NAME" in the connection string, they will specify "servicename" (the existing DBAL parameter), and if they want to use "SID", they will specify "sid".

#### Changes in Test Configuration
Currently, the tests use the "dbname" parameter without "service", which translates to SID. SID is a low-level/legacy configuration parameter that works but should be used only if needed. SID compared to SERVICE_NAME is somewhat similar to IP addresses compared to DNS names.

The Oracle instances we test with have both the XE/FREE service names and SIDs available out of the box, so either could be used. Furthermore, they register the default service with the same name (XE/FREE) that points to the container database root.

A dedicated commit in this PR removes the `dbname` parameter from the connection configuration switching from using `SID=XE/FREE` to implicitly using the default service.