### PR TITLE
Don't attempt to rollback when connections are lost

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -964,8 +964,11 @@ class Connection implements ServerVersionProvider
             $res = $func($this);
 
             $successful = true;
+        } catch (ConnectionLost $connectionLost) {
+            // Catching here only to be able to prevent a rollback attempt
+            throw $connectionLost;
         } finally {
-            if (! $successful) {
+            if (! isset($connectionLost) && ! $successful) {
                 $this->rollBack();
             }
         }
@@ -981,6 +984,7 @@ class Connection implements ServerVersionProvider
                 || $t instanceof UniqueConstraintViolationException
                 || $t instanceof ForeignKeyConstraintViolationException
                 || $t instanceof DeadlockException
+                || $t instanceof ConnectionLost
             );
 
             throw $t;

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -48,6 +48,27 @@ class TransactionTest extends FunctionalTestCase
         });
     }
 
+    public function testTransactionalFailureDuringCallback(): void
+    {
+        $this->connection->transactional(
+            function (): void {
+                $this->expectConnectionLoss(static function (Connection $connection): void {
+                    $connection->executeQuery($connection->getDatabasePlatform()->getDummySelectSQL());
+                });
+            },
+        );
+    }
+
+    public function testTransactionalFailureDuringCommit(): void
+    {
+        $this->connection->transactional(
+            function (): void {
+                $this->expectConnectionLoss(static function (Connection $connection): void {
+                });
+            },
+        );
+    }
+
     private function expectConnectionLoss(callable $scenario): void
     {
         $this->killCurrentSession();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug

#### Summary

It's useless to try to perform a rollback when there's no active connection, not to mention that the use of `NoActiveTransaction` exceptions masks the real underlying issue.

This attempts to fix the problem by detecting connection issues and bypassing rollbacks.
