### PR TITLE
support mysql8+ default values for text data types

### DIFF
--- a/src/Platforms/MySQL80Platform.php
+++ b/src/Platforms/MySQL80Platform.php
@@ -3,6 +3,9 @@
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
+use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\JsonType;
+use Doctrine\DBAL\Types\TextType;
 use Doctrine\Deprecations\Deprecation;
 
 /**
@@ -30,5 +33,18 @@ class MySQL80Platform extends MySQL57Platform
     public function createSelectSQLBuilder(): SelectSQLBuilder
     {
         return AbstractPlatform::createSelectSQLBuilder();
+    }
+
+    public function getDefaultValueDeclarationSQL(array $column): string
+    {
+        if (isset($column['default']) && ($column['type'] instanceof TextType || $column['type'] instanceof BlobType || $column['type'] instanceof JsonType)) {
+            // mysql requires text type column defaults to be written as expressions
+            // https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html
+            // https://dev.mysql.com/doc/refman/8.4/en/data-type-defaults.html
+            // "The BLOB, TEXT, GEOMETRY, and JSON data types can be assigned a default value only if the value is written as an expression, even if the expression value is a literal"
+            return ' DEFAULT (' . $this->quoteStringLiteral($column['default']) . ')';
+        }
+
+        return parent::getDefaultValueDeclarationSQL($column);
     }
 }


### PR DESCRIPTION
mysql requires text type column defaults to be written as expressions
https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html

=> correct mysql8+ syntax is:
DEFAULT ('text literal')

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| Fixed issues | NA

#### Summary

mysql8+ does support default values for text typed columns (text, blob, json, geometry)
doctrine disallows this and silently drops the default value
