### PR TITLE
Deprecate not specifying either of Oracle host and connectstring

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,10 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Deprecated not specifying either of the `host` and `connectstring` parameters for `oci8` and `pdo_oci` connections.
+
+Not specifying either of the `host` and `connectstring` parameters for `oci8` and `pdo_oci` connections has been
+deprecated. One of them must be specified.
+
 ## Deprecated `dbname` connection parameter for `oci8` and `pdo_oci` connections.
 
-Using the `dbname` connection parameter for `oci8` and `pdo_oci` connections has been deprecated. Use `servicename` or
-`sid` instead.
+Using the `dbname` connection parameter for `oci8` and `pdo_oci` connections has been deprecated. Use `servicename`,
+`sid` or `connectstring` instead.
 
 # Upgrade to 4.4
 

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -300,7 +300,8 @@ pdo_oci / oci8
    database.
 -  ``password`` (string): Password to use when connecting to the
    database.
--  ``host`` (string): Hostname of the database to connect to.
+-  ``host`` (string): Hostname of the database to connect to. The hostname needs to be specified unless
+   ``connectstring`` is specified.
 -  ``port`` (integer): Port of the database to connect to.
 -  ``dbname`` (string): Name of the database/schema to connect to. Using this parameter is deprecated.
 -  ``servicename`` (string): Optional name by which clients can
@@ -321,8 +322,7 @@ pdo_oci / oci8
 -  ``connectstring`` (string): Complete Easy Connect connection descriptor,
    see `docs.oracle.com/en/database/oracle/oracle-database/23/netag/configuring-naming-methods.html <https://docs.oracle.com/en/database/oracle/oracle-database/23/netag/configuring-naming-methods.html>`_. When using this option,
    you will still need to provide the ``user`` and ``password`` parameters, but the other
-   parameters will no longer be used. Note that when using this parameter, the ``getHost``
-   and ``getPort`` methods from ``Doctrine\DBAL\Connection`` will no longer function as expected.
+   parameters will no longer be used.
 -  ``persistent`` (boolean): Whether to establish a persistent connection.
 -  ``driverOptions`` (array):
     -  ``exclusive`` (boolean): Once specified for an ``oci8`` connection, forces the driver to always establish

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -48,6 +48,12 @@ final class EasyConnectString
         }
 
         if (! isset($params['host'])) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7244',
+                'Not specifying either of the "host" and "connectstring" parameters is deprecated.',
+            );
+
             return new self($params['dbname'] ?? '');
         }
 
@@ -66,7 +72,8 @@ final class EasyConnectString
             Deprecation::trigger(
                 'doctrine/dbal',
                 'https://github.com/doctrine/dbal/pull/7239',
-                'Using the "dbname" parameter is deprecated. Use "servicename" or "sid" instead.',
+                'Using the "dbname" parameter is deprecated. Use "servicename", "sid" or "connectstring"'
+                    . ' instead.',
             );
         }
 

--- a/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -26,7 +26,6 @@ class EasyConnectStringTest extends TestCase
     public static function connectionParametersProvider(): iterable
     {
         return [
-            'empty-params' => [[],''],
             'common-params' => [
                 [
                     'host' => 'oracle.example.com',
@@ -147,5 +146,14 @@ class EasyConnectStringTest extends TestCase
             'https://github.com/doctrine/dbal/pull/7042',
             false,
         ];
+    }
+
+    public function testNoHostOrConnectStringSpecified(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7244');
+
+        $string = EasyConnectString::fromConnectionParameters([]);
+
+        self::assertSame('', (string) $string);
     }
 }


### PR DESCRIPTION
It is not documented and not covered by tests, but currently it is possible to put an Oracle connect string into the `dbname` parameter, and it will work:

https://github.com/doctrine/dbal/blob/c997965e04996a3e0382dd95ede69506e9a425b8/src/Driver/AbstractOracleDriver/EasyConnectString.php#L44-L52

The above code also allows to not specify any connection parameters, and the configuration will be considered valid (which makes no sense).

In order to completely remove the support of the `dbname` parameter for Oracle, which was deprecated in https://github.com/doctrine/dbal/pull/7239, we also need to deprecate the behavior of specifying the connect string via `dbname`. Therefore, it means that either `host` or `connectstring` needs to be specified. Otherwise, the resulting connect string will be empty.