### PR TITLE
Remove support for "dbname" in oci8 and pdo_oci configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Either of the `host` and `connectstring` parameters must be specified for `oci8` and `pdo_oci` connections.
+
+Not specifying either of the `host` and `connectstring` parameters for `oci8` and `pdo_oci` connections is no longer
+supported.
+
 ## BC BREAK: Removed support for the current date, time and timestamp SQL expressions as default values
 
 Using SQL expressions for the current date, time, or timestamp as column default values is no longer supported. The
@@ -72,9 +77,9 @@ The `AbstractAsset` class has been removed.
 
 The `AbstractAsset::isQuoted()` and `AbstractAsset::getName()` method has been removed.
 
-## BC BREAK: Removed support for the `service` connection parameter.
+## BC BREAK: Removed support for the `dbname` and `service` connection parameters in `oci8` and `pdo_oci` configuration.
 
-The `service` parameter of the `oci8` and `pdo_oci` connections is no longer supported.
+The `dbname` and `service` connection parameters are no longer supported in `oci8` and `pdo_oci` configuration.
 
 ## BC BREAK: Removed `Column` methods
 

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -303,7 +303,6 @@ pdo_oci / oci8
 -  ``host`` (string): Hostname of the database to connect to. The hostname needs to be specified unless
    ``connectstring`` is specified.
 -  ``port`` (integer): Port of the database to connect to.
--  ``dbname`` (string): Name of the database/schema to connect to. Using this parameter is deprecated.
 -  ``servicename`` (string): Optional name by which clients can
    connect to the database instance. Will be used as Oracle's
    ``SERVICE_NAME`` connection parameter if given.

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -30,6 +30,8 @@ abstract class AbstractOracleDriver implements Driver
      * Returns an appropriate Easy Connect String for the given parameters.
      *
      * @param array<string, mixed> $params The connection parameters to return the Easy Connect String for.
+     *
+     * @throws Exception
      */
     protected function getEasyConnectString(array $params): string
     {

--- a/src/Driver/AbstractOracleDriver/EasyConnectString.php
+++ b/src/Driver/AbstractOracleDriver/EasyConnectString.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\AbstractOracleDriver;
 
-use Doctrine\Deprecations\Deprecation;
+use Doctrine\DBAL\Driver\AbstractOracleDriver\Exception\InvalidConfiguration;
+use Doctrine\DBAL\Driver\Exception;
 
 use function implode;
 use function is_array;
@@ -40,6 +41,8 @@ final readonly class EasyConnectString
      * Creates the object from the given DBAL connection parameters.
      *
      * @param mixed[] $params
+     *
+     * @throws Exception
      */
     public static function fromConnectionParameters(array $params): self
     {
@@ -48,27 +51,10 @@ final readonly class EasyConnectString
         }
 
         if (! isset($params['host'])) {
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/7244',
-                'Not specifying either of the "host" and "connectstring" parameters is deprecated.',
-            );
-
-            return new self($params['dbname'] ?? '');
+            throw InvalidConfiguration::fromMissingHostAndConnectString();
         }
 
         $connectData = [];
-
-        if (isset($params['dbname'])) {
-            $connectData['SID'] = $params['dbname'];
-
-            Deprecation::trigger(
-                'doctrine/dbal',
-                'https://github.com/doctrine/dbal/pull/7239',
-                'Using the "dbname" parameter is deprecated. Use "servicename", "sid" or "connectstring"'
-                    . ' instead.',
-            );
-        }
 
         if (isset($params['servicename'])) {
             $connectData['SERVICE_NAME'] = $params['servicename'];

--- a/src/Driver/AbstractOracleDriver/Exception/InvalidConfiguration.php
+++ b/src/Driver/AbstractOracleDriver/Exception/InvalidConfiguration.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Driver\AbstractOracleDriver\Exception;
+
+use Doctrine\DBAL\Driver\AbstractException;
+
+/** @internal */
+final class InvalidConfiguration extends AbstractException
+{
+    public static function fromMissingHostAndConnectString(): self
+    {
+        return new self('Neither of the "host" and "connectstring" parameters is specified.');
+    }
+}

--- a/src/Driver/PDO/OCI/Driver.php
+++ b/src/Driver/PDO/OCI/Driver.php
@@ -56,6 +56,8 @@ final class Driver extends AbstractOracleDriver
      * Constructs the Oracle PDO DSN.
      *
      * @param mixed[] $params
+     *
+     * @throws \Doctrine\DBAL\Driver\Exception
      */
     private function constructPdoDsn(array $params): string
     {

--- a/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Driver\AbstractOracleDriver;
 
 use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\DBAL\Driver\AbstractOracleDriver\Exception\InvalidConfiguration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class EasyConnectStringTest extends TestCase
 {
-    use VerifyDeprecations;
-
     /** @param mixed[] $params */
     #[DataProvider('connectionParametersProvider')]
     public function testFromConnectionParameters(array $params, string $expected): void
@@ -26,15 +24,15 @@ class EasyConnectStringTest extends TestCase
     public static function connectionParametersProvider(): iterable
     {
         return [
-            'common-params' => [
+            'sid' => [
                 [
                     'host' => 'oracle.example.com',
                     'port' => 1521,
-                    'dbname' => 'XE',
+                    'sid' => 'XE',
                 ],
                 '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=oracle.example.com)(PORT=1521))(CONNECT_DATA=(SID=XE)))',
             ],
-            'no-db-name' => [
+            'no-service-name-or-sid' => [
                 ['host' => 'localhost'],
                 '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521)))',
             ],
@@ -51,7 +49,7 @@ class EasyConnectStringTest extends TestCase
                 [
                     'host' => 'localhost',
                     'port' => 41521,
-                    'dbname' => 'XE',
+                    'sid' => 'XE',
                     'instancename' => 'SALES',
                     'pooled' => true,
                 ],
@@ -62,7 +60,7 @@ class EasyConnectStringTest extends TestCase
                 [
                     'host' => 'localhost',
                     'port' => 41521,
-                    'dbname' => 'XE',
+                    'sid' => 'XE',
                     'instancename' => 'SALES',
                     'pooled' => true,
                     'driverOptions' => ['protocol' => 'TCPS'],
@@ -73,57 +71,10 @@ class EasyConnectStringTest extends TestCase
         ];
     }
 
-    /** @param array<string, mixed> $parameters */
-    #[DataProvider('getConnectionParameters')]
-    public function testParameterDeprecation(
-        array $parameters,
-        string $expectedConnectString,
-        bool $expectDeprecation,
-    ): void {
-        if ($expectDeprecation) {
-            $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7239');
-        } else {
-            $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7239');
-        }
-
-        $string = EasyConnectString::fromConnectionParameters($parameters);
-
-        self::assertSame($expectedConnectString, (string) $string);
-    }
-
-    /** @return iterable<string, array{array<string, mixed>, string, bool}> */
-    public static function getConnectionParameters(): iterable
-    {
-        $sidString = '(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))'
-            . '(CONNECT_DATA=(SID=BILLING)))';
-
-        yield 'dbname' => [
-            [
-                'host' => 'localhost',
-                'port' => 1521,
-                'dbname' => 'BILLING',
-            ],
-            $sidString,
-            true,
-        ];
-
-        yield 'sid' => [
-            [
-                'host' => 'localhost',
-                'port' => 1521,
-                'sid' => 'BILLING',
-            ],
-            $sidString,
-            false,
-        ];
-    }
-
     public function testNoHostOrConnectStringSpecified(): void
     {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7244');
+        $this->expectException(InvalidConfiguration::class);
 
-        $string = EasyConnectString::fromConnectionParameters([]);
-
-        self::assertSame('', (string) $string);
+        EasyConnectString::fromConnectionParameters([]);
     }
 }

--- a/tests/Driver/OCI8/DriverTest.php
+++ b/tests/Driver/OCI8/DriverTest.php
@@ -18,6 +18,7 @@ class DriverTest extends AbstractOracleDriverTestCase
         $this->expectException(InvalidConfiguration::class);
 
         (new Driver())->connect([
+            'host' => 'localhost',
             'persistent' => true,
             'driverOptions' => ['exclusive' => true],
         ]);


### PR DESCRIPTION
The "dbname" parameter and support for configuration without either of the "host" and "connectstring" parameters were deprecated in https://github.com/doctrine/dbal/pull/7239 and https://github.com/doctrine/dbal/pull/7244.