### PR TITLE
PHP 8.5: Warning "unexpected NAN value was coerced to string" when binding NAN to a parameter

### DIFF
--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -367,4 +367,13 @@ EOF
 
         self::assertEquals(1, $result);
     }
+
+    public function testBindValueWithNAN(): void
+    {
+        $stmt = $this->connection->prepare('SELECT id FROM stmt_test WHERE id = ?');
+
+        $stmt->bindValue(1, NAN);
+        $result = $stmt->executeQuery();
+        self::assertEquals(0, $result->fetchOne());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature? |


When binding a `NAN` value to a prepared statement parameter, PHP 8.5 emits a warning: `"unexpected NAN value was coerced to string"`. This warning is not present in PHP 8.4, where the value was silently converted to the string `"NAN"` and handled correctly by PostgreSQL.

The Pull Request contains only a test demonstrating the issue in order to confirm it in the CI

