### PR TITLE
Document array shape for `ArrayResult::__unserialize()`

### DIFF
--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -107,7 +107,7 @@ final class ArrayResult implements Result
         return [$this->columnNames, $this->rows];
     }
 
-    /** @param mixed[] $data */
+    /** @param array{0: list<string>, 1: list<list<mixed>>} $data */
     public function __unserialize(array $data): void
     {
         // Handle objects serialized with DBAL 4.1 and earlier.

--- a/src/Cache/ArrayResult.php
+++ b/src/Cache/ArrayResult.php
@@ -107,7 +107,7 @@ final class ArrayResult implements Result
         return [$this->columnNames, $this->rows];
     }
 
-    /** @param array{0: list<string>, 1: list<list<mixed>>} $data */
+    /** @param array{list<string>, list<list<mixed>>} $data */
     public function __unserialize(array $data): void
     {
         // Handle objects serialized with DBAL 4.1 and earlier.


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Related #7248 

This small PR fixes only this 2 warnings in this file:

```
vendor/bin/phpstan analyse --level=9 src/Cache/ArrayResult.php
Note: Using configuration file /home/shakaran/Documentos/ProjectsSSD/dbal/phpstan.neon.dist.
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------------------------------- 
  Line   ArrayResult.php                                                                               
 ------ ---------------------------------------------------------------------------------------------- 
  124    Property Doctrine\DBAL\Cache\ArrayResult::$columnNames (list<string>) does not accept mixed.  
         🪪  assign.propertyType                                                                       
         💡  mixed is not a list.                                                                      
  124    Property Doctrine\DBAL\Cache\ArrayResult::$rows (list<list<mixed>>) does not accept mixed.    
         🪪  assign.propertyType                                                                       
         💡  mixed is not a list.                                                                      
 ------ ---------------------------------------------------------------------------------------------- 

```

This pull request makes a minor improvement to the type annotation in the docblock for the `$data` parameter of the `__unserialize` method in `src/Cache/ArrayResult.php`, providing a more precise description of the expected array structure.