### PR TITLE
feat: use phpdoc @throws for TypeError

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
+use TypeError;
 
 use function array_combine;
 use function array_fill_keys;
@@ -618,6 +619,8 @@ class SQLitePlatform extends AbstractPlatform
 
     /**
      * {@inheritDoc}
+     *
+     * @throws TypeError
      */
     public function getAlterTableSQL(TableDiff $diff): array
     {
@@ -893,7 +896,10 @@ class SQLitePlatform extends AbstractPlatform
         return $indexes;
     }
 
-    /** @return array<ForeignKeyConstraint> */
+    /** @return array<ForeignKeyConstraint>
+     *
+     * @throws TypeError
+     */
     private function getForeignKeysInAlteredTable(TableDiff $diff): array
     {
         $oldTable    = $diff->getOldTable();

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
+use TypeError;
 
 use function array_filter;
 use function array_intersect;
@@ -235,6 +236,7 @@ abstract class AbstractSchemaManager
      * @return list<Table>
      *
      * @throws Exception
+     * @throws TypeError
      */
     public function listTables(): array
     {

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use TypeError;
 
 use function array_change_key_case;
 use function implode;
@@ -128,6 +129,8 @@ class DB2SchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     * 
+     * @throws TypeError
      */
     protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
     {

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
+use TypeError;
 use ValueError;
 
 use function array_keys;
@@ -129,6 +130,8 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      * @param non-empty-list<string> $foreignColumnNames Names of the referenced table columns.
      * @param string                 $name               Name of the foreign key constraint.
      * @param array<string, mixed>   $options            Options associated with the foreign key constraint.
+     * 
+     * @throws TypeError
      */
     public function __construct(
         array $localColumnNames,
@@ -643,7 +646,11 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
         }
     }
 
-    /** @param array<string, mixed> $options */
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @throws TypeError
+     */
     private function parseMatchType(array $options): ?MatchType
     {
         if (isset($options['match'])) {
@@ -669,7 +676,11 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
         return MatchType::SIMPLE;
     }
 
-    /** @param array<string, mixed> $options */
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @throws TypeError
+     */
     private function parseReferentialAction(array $options, string $option): ?ReferentialAction
     {
         if (isset($options[$option])) {

--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use TypeError;
 
 use function array_map;
 use function array_merge;
@@ -226,6 +227,7 @@ final class ForeignKeyConstraintEditor
         return $this;
     }
 
+    /** @throws TypeError */
     public function create(): ForeignKeyConstraint
     {
         if (count($this->referencingColumnNames) < 1) {

--- a/src/Schema/Introspection/IntrospectingSchemaProvider.php
+++ b/src/Schema/Introspection/IntrospectingSchemaProvider.php
@@ -23,6 +23,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\SchemaProvider;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableConfiguration;
+use TypeError;
 
 use function array_map;
 use function array_values;

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -113,6 +113,8 @@ class MySQLSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     * 
+     * @throws TypeError
      */
     protected function _getPortableTableColumnDefinition(array $tableColumn): Column
     {

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -85,6 +85,8 @@ SQL,
 
     /**
      * {@inheritDoc}
+     * 
+     * @throws TypeError
      */
     protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
     {

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -222,6 +222,8 @@ SQL,
 
     /**
      * {@inheritDoc}
+     * 
+     * @throws TypeError
      */
     protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
     {

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -212,6 +212,8 @@ class SQLiteSchemaManager extends AbstractSchemaManager
 
     /**
      * {@inheritDoc}
+     * 
+     * @throws TypeError
      */
     protected function _getPortableTableForeignKeyDefinition(array $tableForeignKey): ForeignKeyConstraint
     {

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
+use TypeError;
 
 use function array_diff_key;
 use function array_map;
@@ -404,6 +405,7 @@ class Table extends AbstractNamedObject
      * @param non-empty-string $newName
      *
      * @throws LogicException
+     * @throws TypeError
      */
     final public function renameColumn(string $oldName, string $newName): Column
     {
@@ -495,6 +497,8 @@ class Table extends AbstractNamedObject
      * @param non-empty-list<string> $localColumnNames
      * @param non-empty-list<string> $foreignColumnNames
      * @param array<string, mixed>   $options
+     *
+     * @throws TypeError
      */
     public function addForeignKeyConstraint(
         string $foreignTableName,

--- a/src/Types/NumberType.php
+++ b/src/Types/NumberType.php
@@ -15,12 +15,18 @@ use function is_float;
 
 final class NumberType extends Type
 {
-    /** {@inheritDoc} */
+    /** {@inheritDoc}
+     *
+     * @throws TypeError
+     */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getDecimalTypeDeclarationSQL($column);
     }
 
+    /**
+     * @throws TypeError
+     */
     public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
@@ -34,6 +40,9 @@ final class NumberType extends Type
         return (string) $value;
     }
 
+    /**
+     * @throws TypeError
+     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?Number
     {
         if ($value === null) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Related https://github.com/doctrine/dbal/pull/7248

This is a splitted pull request which  adds explicit `@throws TypeError` annotations to various methods and constructors across the codebase, particularly in schema and platform classes. These annotations clarify where a `TypeError` may be thrown, improving the documentation and making error handling expectations clearer for developers and users of the library.

These changes do not alter runtime behavior but helps to infer types for phpstan level 9