### PR TITLE
feat: resolve phpstan errors method.nonObject in tests for Types

### DIFF
--- a/src/Types/AsciiStringType.php
+++ b/src/Types/AsciiStringType.php
@@ -22,9 +22,6 @@ final class AsciiStringType extends StringType
         return ParameterType::ASCII;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;

--- a/src/Types/AsciiStringType.php
+++ b/src/Types/AsciiStringType.php
@@ -21,4 +21,12 @@ final class AsciiStringType extends StringType
     {
         return ParameterType::ASCII;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
+    }
 }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -15,4 +15,12 @@ final class EnumType extends Type
     {
         return $platform->getEnumDeclarationSQL($column);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
+    }
 }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -16,9 +16,6 @@ final class EnumType extends Type
         return $platform->getEnumDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -19,9 +19,6 @@ class GuidType extends StringType
         return $platform->getGuidTypeDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -18,4 +18,12 @@ class GuidType extends StringType
     {
         return $platform->getGuidTypeDeclarationSQL($column);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
+    }
 }

--- a/src/Types/StringType.php
+++ b/src/Types/StringType.php
@@ -19,9 +19,6 @@ class StringType extends Type
         return $platform->getStringTypeDeclarationSQL($column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;

--- a/src/Types/StringType.php
+++ b/src/Types/StringType.php
@@ -18,4 +18,12 @@ class StringType extends Type
     {
         return $platform->getStringTypeDeclarationSQL($column);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
+    }
 }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -85,10 +85,7 @@ abstract class Type
      *
      * @throws ConversionException
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
-    {
-        return $value;
-    }
+    abstract public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed;
 
     /**
      * Gets the SQL declaration snippet for a column of this type.

--- a/tests/Functional/Schema/MySQL/PointType.php
+++ b/tests/Functional/Schema/MySQL/PointType.php
@@ -24,4 +24,12 @@ class PointType extends Type
     {
         return ['point'];
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
+    }
 }

--- a/tests/Functional/Schema/MySQL/PointType.php
+++ b/tests/Functional/Schema/MySQL/PointType.php
@@ -25,9 +25,6 @@ class PointType extends Type
         return ['point'];
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -761,11 +761,11 @@ SQL;
         self::assertTrue($tableFinal->hasColumn('id'));
         self::assertTrue($tableFinal->hasColumn('foo'));
 
-        self::assertSame('1', $this->connection->fetchOne(
+        self::assertSame(1, $this->connection->fetchOne(
             "select count(*) as count from pg_class where relname = 'partitioned_table' and relkind = 'p'",
         ));
 
-        self::assertSame('1', $this->connection->fetchOne(
+        self::assertSame(1, $this->connection->fetchOne(
             <<<'SQL'
             select count(*) as count
             from pg_class parent

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -761,12 +761,11 @@ SQL;
         self::assertTrue($tableFinal->hasColumn('id'));
         self::assertTrue($tableFinal->hasColumn('foo'));
 
-        $partitionedTableCount = (int) ($this->connection->fetchOne(
+        self::assertSame('1', $this->connection->fetchOne(
             "select count(*) as count from pg_class where relname = 'partitioned_table' and relkind = 'p'",
         ));
-        self::assertSame(1, $partitionedTableCount);
 
-        $partitionsCount = (int) ($this->connection->fetchOne(
+        self::assertSame('1', $this->connection->fetchOne(
             <<<'SQL'
             select count(*) as count
             from pg_class parent
@@ -777,7 +776,6 @@ SQL;
             where parent.relname = 'partitioned_table' and parent.relkind = 'p';
             SQL,
         ));
-        self::assertSame(1, $partitionsCount);
     }
 
     /** @link https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC */
@@ -795,5 +793,13 @@ class MoneyType extends Type
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return 'MyMoney';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
     }
 }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -795,9 +795,6 @@ class MoneyType extends Type
         return 'MyMoney';
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -119,6 +119,14 @@ abstract class AbstractPlatformTestCase extends TestCase
             {
                 return $platform->getDecimalTypeDeclarationSQL($column);
             }
+
+            /**
+             * {@inheritDoc}
+             */
+            public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+            {
+                return $value;
+            }
         };
 
         if (Type::hasType($type->getName())) {

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -120,9 +120,6 @@ abstract class AbstractPlatformTestCase extends TestCase
                 return $platform->getDecimalTypeDeclarationSQL($column);
             }
 
-            /**
-             * {@inheritDoc}
-             */
             public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
             {
                 return $value;

--- a/tests/Types/DateTest.php
+++ b/tests/Types/DateTest.php
@@ -33,6 +33,7 @@ class DateTest extends BaseDateTypeTestCase
 
     public function testDateResetsNonDatePartsToZeroUnixTimeValues(): void
     {
+        /** @var DateTime $date */
         $date = $this->type->convertToPHPValue('1985-09-01', $this->platform);
 
         self::assertEquals('00:00:00', $date->format('H:i:s'));
@@ -42,10 +43,12 @@ class DateTest extends BaseDateTypeTestCase
     {
         date_default_timezone_set('Europe/Berlin');
 
+        /** @var DateTime $date */
         $date = $this->type->convertToPHPValue('2009-08-01', $this->platform);
         self::assertEquals('00:00:00', $date->format('H:i:s'));
         self::assertEquals('2009-08-01', $date->format('Y-m-d'));
 
+        /** @var DateTime $date */
         $date = $this->type->convertToPHPValue('2009-11-01', $this->platform);
         self::assertEquals('00:00:00', $date->format('H:i:s'));
         self::assertEquals('2009-11-01', $date->format('Y-m-d'));

--- a/tests/Types/DateTimeTest.php
+++ b/tests/Types/DateTimeTest.php
@@ -48,6 +48,7 @@ class DateTimeTest extends BaseDateTypeTestCase
     {
         $date = '1985/09/01 10:10:10.12345';
 
+        /** @var DateTime $actual */
         $actual = $this->type->convertToPHPValue($date, $this->platform);
 
         self::assertEquals('1985-09-01 10:10:10', $actual->format('Y-m-d H:i:s'));

--- a/tests/Types/TimeTest.php
+++ b/tests/Types/TimeTest.php
@@ -27,6 +27,7 @@ class TimeTest extends BaseDateTypeTestCase
 
     public function testDateFieldResetInPHPValue(): void
     {
+        /** @var DateTime $time */
         $time = $this->type->convertToPHPValue('01:23:34', $this->platform);
 
         self::assertEquals('01:23:34', $time->format('H:i:s'));

--- a/tests/Types/TypeWithConstructor.php
+++ b/tests/Types/TypeWithConstructor.php
@@ -20,4 +20,12 @@ class TypeWithConstructor extends Type
     {
         return '';
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        return $value;
+    }
 }

--- a/tests/Types/TypeWithConstructor.php
+++ b/tests/Types/TypeWithConstructor.php
@@ -21,9 +21,6 @@ class TypeWithConstructor extends Type
         return '';
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
         return $value;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Related #7248 

This splitted pull request makes minor improvements to the type safety and clarity of several unit tests by adding explicit type annotations for variables that hold `DateTime` objects. These changes help clarify the expected types and can improve static analysis and IDE support.

it avoids use of assert or assertInstanceOf

*Test improvements (type annotations):*

* Added `/** @var DateTime $date */` annotation before assignments to `$date` in `testDateResetsNonDatePartsToZeroUnixTimeValues` and `testDateRestsSummerTimeAffection` in `tests/Types/DateTest.php`. 
* Added `/** @var DateTime $actual */` annotation in `testConvertsNonMatchingFormatToPhpValueWithParser` in `tests/Types/DateTimeTest.php`.
* Added `/** @var DateTime $time */` annotation in `testDateFieldResetInPHPValue` in `tests/Types/TimeTest.php`.

Resolves the phpstan errors:

```
./vendor/bin/phpstan analyze --level=9 tests/Types/
Note: Using configuration file phpstan.neon.dist.                                              
 33/33 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%                                                                                                
                                                                                                                                          
 ------ ---------------------------------------                                                                                           
  Line   DateTest.php                                                                                                                     
 ------ ---------------------------------------                                                                                           
  :38    Cannot call method format() on mixed.                                                                                            
         🪪  method.nonObject                                                                                                              
  :46    Cannot call method format() on mixed.                                                                                            
         🪪  method.nonObject                                                                                                              
  :47    Cannot call method format() on mixed.                                                                                            
         🪪  method.nonObject                                                                                                              
  :50    Cannot call method format() on mixed.                                                                                            
         🪪  method.nonObject                                                                                                              
  :51    Cannot call method format() on mixed.                                                                                            
         🪪  method.nonObject                                                                                                              
 ------ ---------------------------------------                                                                                           
                                                                                                                                          
 ------ ---------------------------------------                                                                                           
  Line   DateTimeTest.php                                                                                                                 
 ------ ---------------------------------------                                                                                           
  :53    Cannot call method format() on mixed.                                                                                            
         🪪  method.nonObject                                                                                                              
 ------ ------------------------
 
 ------ --------------------------------------- 
  Line   tests/Types/TimeTest.php               
 ------ --------------------------------------- 
  :33    Cannot call method format() on mixed.  
         🪪  method.nonObject                   
  :34    Cannot call method format() on mixed.  
         🪪  method.nonObject                   
 ------ --------------------------------------- 
```