### PR TITLE
feat: resolve phpstan level 9 errors over tests/Functional folder

### DIFF
--- a/tests/Functional/BlobTest.php
+++ b/tests/Functional/BlobTest.php
@@ -234,7 +234,8 @@ class BlobTest extends FunctionalTestCase
 
         $actual = [];
         foreach ($blobs as $blob) {
-            $blob     = Type::getType('blob')->convertToPHPValue($blob, $this->connection->getDatabasePlatform());
+            $blob = Type::getType('blob')->convertToPHPValue($blob, $this->connection->getDatabasePlatform());
+            /** @var resource $blob */
             $actual[] = stream_get_contents($blob);
         }
 

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -143,7 +143,9 @@ class DataAccessTest extends FunctionalTestCase
 
         $row = array_change_key_case($row, CASE_LOWER);
         self::assertEquals(1, $row['test_int']);
-        self::assertStringStartsWith($datetimeString, $row['test_datetime']);
+        $testDatetime = $row['test_datetime'];
+        /** @var string $testDatetime */
+        self::assertStringStartsWith($datetimeString, $testDatetime);
     }
 
     public function testFetchAssociative(): void
@@ -176,7 +178,9 @@ class DataAccessTest extends FunctionalTestCase
         $row = array_change_key_case($row, CASE_LOWER);
 
         self::assertEquals(1, $row['test_int']);
-        self::assertStringStartsWith($datetimeString, $row['test_datetime']);
+        $testDatetime = $row['test_datetime'];
+        /** @var string $testDatetime */
+        self::assertStringStartsWith($datetimeString, $testDatetime);
     }
 
     public function testFetchArray(): void
@@ -206,7 +210,9 @@ class DataAccessTest extends FunctionalTestCase
         $row = array_change_key_case($row, CASE_LOWER);
 
         self::assertEquals(1, $row[0]);
-        self::assertStringStartsWith($datetimeString, $row[1]);
+        $testDatetime = $row[1];
+        /** @var string $testDatetime */
+        self::assertStringStartsWith($datetimeString, $testDatetime);
     }
 
     public function testFetchColumn(): void
@@ -620,7 +626,10 @@ class DataAccessTest extends FunctionalTestCase
         $date = $stmt->executeQuery()->fetchOne();
         self::assertNotFalse($date);
 
-        self::assertEquals($expected, date('Y-m-d H:i:s', strtotime($date)));
+        /** @var string $date */
+        $timestamp = strtotime($date);
+        /** @var int $timestamp */
+        self::assertEquals($expected, date('Y-m-d H:i:s', $timestamp));
     }
 
     /** @return mixed[][] */

--- a/tests/Functional/Driver/Mysqli/StatementTest.php
+++ b/tests/Functional/Driver/Mysqli/StatementTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Statement as WrapperStatement;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Error;
+use mysqli_stmt;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use ReflectionProperty;
 
@@ -29,11 +30,14 @@ class StatementTest extends FunctionalTestCase
     public function testStatementsAreDeallocatedProperly(): void
     {
         $statement = $this->connection->prepare('SELECT 1');
+        /** @var \Doctrine\DBAL\Statement $statement */
 
         $property        = new ReflectionProperty(WrapperStatement::class, 'stmt');
         $driverStatement = $property->getValue($statement);
+        /** @var object $driverStatement */
 
-        $mysqliProperty  = new ReflectionProperty(Statement::class, 'stmt');
+        $mysqliProperty = new ReflectionProperty(Statement::class, 'stmt');
+        /** @var mysqli_stmt $mysqliStatement */
         $mysqliStatement = $mysqliProperty->getValue($driverStatement);
 
         unset($statement, $driverStatement);

--- a/tests/Functional/Driver/OCI8/ConnectionTest.php
+++ b/tests/Functional/Driver/OCI8/ConnectionTest.php
@@ -50,6 +50,8 @@ SQL,
 
         self::assertNotNull($sid, 'SID is missing.');
         self::assertNotNull($serialNumber, 'Serial number is missing.');
+        /** @var string $sid */
+        /** @var string $serialNumber */
 
         $params                               = TestUtil::getConnectionParams();
         $params['driverOptions']['exclusive'] = true;

--- a/tests/Functional/Driver/OCI8/ResultTest.php
+++ b/tests/Functional/Driver/OCI8/ResultTest.php
@@ -73,9 +73,11 @@ class ResultTest extends FunctionalTestCase
         $separateConnection = TestUtil::getPrivilegedConnection();
 
         // Query the pipelined function to get initial dataset
+        $user = $this->connectionParams['user'];
+        /** @var string $user */
         $statement = $separateConnection->prepare(sprintf(
             'SELECT * FROM TABLE(%s.test_oracle_fetch_failure())',
-            $this->connectionParams['user'],
+            $user,
         ));
         $result    = $statement->executeQuery();
 

--- a/tests/Functional/Driver/PgSQL/StatementTest.php
+++ b/tests/Functional/Driver/PgSQL/StatementTest.php
@@ -29,14 +29,17 @@ class StatementTest extends FunctionalTestCase
     public function testStatementsAreDeallocatedProperly(): void
     {
         $statement = $this->connection->prepare('SELECT 1');
+        /** @var \Doctrine\DBAL\Statement $statement */
 
         $property = new ReflectionProperty(WrapperStatement::class, 'stmt');
 
         $driverStatement = $property->getValue($statement);
+        /** @var object $driverStatement */
 
         $property = new ReflectionProperty(Statement::class, 'name');
 
         $name = $property->getValue($driverStatement);
+        /** @var string $name */
 
         unset($statement, $driverStatement);
 

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -107,7 +107,9 @@ class PortabilityTest extends FunctionalTestCase
         ));
 
         self::assertArrayHasKey('test_string', $row, 'Case should be lowered.');
-        self::assertEquals(3, strlen($row['test_string']));
+        $testString = $row['test_string'];
+        /** @var string $testString */
+        self::assertEquals(3, strlen($testString));
         self::assertNull($row['test_null']);
         self::assertArrayNotHasKey(0, $row, 'The row should not contain numerical keys.');
     }

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -26,6 +26,7 @@ class DefaultValueTest extends FunctionalTestCase
             );
 
         foreach (self::columnProvider() as [$name, $default]) {
+            /** @var non-empty-string $name */
             $editor->addColumn(
                 Column::editor()
                     ->setUnquotedName($name)

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -761,12 +761,14 @@ SQL;
         self::assertTrue($tableFinal->hasColumn('id'));
         self::assertTrue($tableFinal->hasColumn('foo'));
 
-        $partitionedTableCount = (int) ($this->connection->fetchOne(
+        $partitionedTableCountValue = $this->connection->fetchOne(
             "select count(*) as count from pg_class where relname = 'partitioned_table' and relkind = 'p'",
-        ));
+        );
+        /** @var int $partitionedTableCountValue */
+        $partitionedTableCount = (int) $partitionedTableCountValue;
         self::assertSame(1, $partitionedTableCount);
 
-        $partitionsCount = (int) ($this->connection->fetchOne(
+        $partitionsCountValue = $this->connection->fetchOne(
             <<<'SQL'
             select count(*) as count
             from pg_class parent
@@ -776,7 +778,9 @@ SQL;
                 and child.relname = 'partition'
             where parent.relname = 'partitioned_table' and parent.relkind = 'p';
             SQL,
-        ));
+        );
+        /** @var int $partitionsCountValue */
+        $partitionsCount = (int) $partitionsCountValue;
         self::assertSame(1, $partitionsCount);
     }
 

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -238,9 +238,11 @@ SQL;
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '2']);
 
-        $lastUsedIdAfterDelete = (int) $this->connection->fetchOne(
+        $lastUsedIdAfterDeleteValue = $this->connection->fetchOne(
             'SELECT id FROM test_pk_auto_increment WHERE text = "2"',
         );
+        /** @var int $lastUsedIdAfterDeleteValue */
+        $lastUsedIdAfterDelete = (int) $lastUsedIdAfterDeleteValue;
 
         // with an empty table, non autoincrement rowid is always 1
         self::assertEquals(1, $lastUsedIdAfterDelete);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -50,6 +50,7 @@ use function array_keys;
 use function array_map;
 use function array_values;
 use function get_debug_type;
+use function intval;
 use function sprintf;
 use function str_starts_with;
 use function strtolower;
@@ -1090,8 +1091,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     }
 
     /**
-     * @param non-empty-string $name
-     * @param mixed[]          $data
+     * @param non-empty-string              $name
+     * @param array{options?: array<mixed>} $data
      */
     protected function createTestTable(string $name, array $data = []): Table
     {
@@ -1559,17 +1560,21 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '1']);
 
-        $lastUsedIdBeforeDelete = (int) $this->connection->fetchOne(
+        $lastUsedIdBeforeDeleteValue = $this->connection->fetchOne(
             "SELECT id FROM test_pk_auto_increment WHERE text = '1'",
         );
+        /** @var int $lastUsedIdBeforeDeleteValue */
+        $lastUsedIdBeforeDelete = intval($lastUsedIdBeforeDeleteValue);
 
         $this->connection->executeStatement('DELETE FROM test_pk_auto_increment');
 
         $this->connection->insert('test_pk_auto_increment', ['text' => '2']);
 
-        $lastUsedIdAfterDelete = (int) $this->connection->fetchOne(
+        $lastUsedIdAfterDeleteValue = $this->connection->fetchOne(
             "SELECT id FROM test_pk_auto_increment WHERE text = '2'",
         );
+        /** @var int $lastUsedIdAfterDeleteValue */
+        $lastUsedIdAfterDelete = intval($lastUsedIdAfterDeleteValue);
 
         self::assertGreaterThan($lastUsedIdBeforeDelete, $lastUsedIdAfterDelete);
     }

--- a/tests/Functional/StatementTest.php
+++ b/tests/Functional/StatementTest.php
@@ -177,6 +177,7 @@ EOF
                 $result->fetchOne(),
                 $this->connection->getDatabasePlatform(),
             );
+        /** @var resource $stream */
 
         self::assertSame($contents, stream_get_contents($stream));
     }

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -141,7 +141,9 @@ class TransactionTest extends FunctionalTestCase
 
         $query = 'SELECT count(test_int) FROM storage';
 
-        self::assertSame('0', (string) $this->connection->fetchOne($query));
+        /** @var string $initialCount */
+        $initialCount = $this->connection->fetchOne($query);
+        self::assertSame('0', (string) $initialCount);
 
         $result = $this->connection->transactional(
             static fn (Connection $connection) => $connection->transactional(
@@ -153,7 +155,10 @@ class TransactionTest extends FunctionalTestCase
             ),
         );
 
+        /** @var string $result */
         self::assertSame('1', (string) $result);
-        self::assertSame('1', (string) $this->connection->fetchOne($query));
+        /** @var string $finalCount */
+        $finalCount = $this->connection->fetchOne($query);
+        self::assertSame('1', (string) $finalCount);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Related https://github.com/doctrine/dbal/pull/7248

This pull request introduces explicit type annotations for variables in various functional test files to improve code clarity and type safety. The changes mainly add PHPDoc comments and variable assignments to clarify expected types, especially after fetching values from database operations. This helps future maintainers understand the expected types and can assist with static analysis tools like phpstan.

It avoids to use assert or instanceOf

**Type annotation improvements in functional tests:**

* Added explicit type annotations (e.g., `/** @var string $testDatetime */`, `/** @var int $partitionedTableCountValue */`) after fetching values from the database in multiple test methods across files like `DataAccessTest.php`, `PostgreSQLSchemaManagerTest.php`, `SQLiteSchemaManagerTest.php`, and `TransactionTest.php`.

* Improved resource and object type clarity in tests related to statement handling and blob operations, with annotations such as `/** @var resource $blob */`, `/** @var object $driverStatement */`, and `/** @var mysqli_stmt $mysqliStatement */`. 

**Test structure and codebase consistency:**

* Updated parameter and return types in test helpers and table creation functions for more accurate type hints, such as changing array parameter types and using `intval` for conversion.

**Improved date and string handling:**

* Added type annotations for date and string values after fetching from the database, ensuring proper type usage before further operations (e.g., `strtotime`, `strlen`). 

**Driver-specific test improvements:**

* Added type annotations for driver-specific variables in OCI8 and schema tests, clarifying the expected types for session IDs, usernames, and column names.

Resolve 24 phstan errors:

```
./vendor/bin/phpstan analyze --level=9 ./tests/Functional/
Note: Using configuration file /home/shakaran/Documentos/ProjectsSSD/dbal/phpstan.neon.dist.
 117/117 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------------------------- 
  Line   BlobTest.php                                                                         
 ------ ------------------------------------------------------------------------------------- 
  :238   Parameter #1 $stream of function stream_get_contents expects resource, mixed given.  
         🪪  argument.type                                                                    
 ------ ------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------- 
  Line   DataAccessTest.php                                                                                                     
 ------ ----------------------------------------------------------------------------------------------------------------------- 
  :146   Parameter #2 $string of static method PHPUnit\Framework\Assert::assertStringStartsWith() expects string, mixed given.  
         🪪  argument.type                                                                                                      
  :179   Parameter #2 $string of static method PHPUnit\Framework\Assert::assertStringStartsWith() expects string, mixed given.  
         🪪  argument.type                                                                                                      
  :209   Parameter #2 $string of static method PHPUnit\Framework\Assert::assertStringStartsWith() expects string, mixed given.  
         🪪  argument.type                                                                                                      
  :623   Parameter #1 $datetime of function strtotime expects string, mixed given.                                              
         🪪  argument.type                                                                                                      
 ------ ----------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------- 
  Line   Driver/Mysqli/StatementTest.php                                                                  
 ------ ------------------------------------------------------------------------------------------------- 
  :37    Parameter #1 $object of method ReflectionProperty::getValue() expects object|null, mixed given.  
         🪪  argument.type                                                                                
  :44    Cannot call method execute() on mixed.                                                           
         🪪  method.nonObject                                                                             
 ------ ------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------ 
  Line   Driver/OCI8/ConnectionTest.php                                                
 ------ ------------------------------------------------------------------------------ 
  :58    Binary operation "." between mixed and ', ' results in an error.              
         🪪  binaryOp.invalid                                                          
  :58    Binary operation "." between non-falsy-string and mixed results in an error.  
         🪪  binaryOp.invalid                                                          
 ------ ------------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   Driver/OCI8/ResultTest.php                                                                    
 ------ ---------------------------------------------------------------------------------------------- 
  :78    Parameter #2 ...$values of function sprintf expects bool|float|int|string|null, mixed given.  
         🪪  argument.type                                                                             
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------- 
  Line   Driver/PgSQL/StatementTest.php                                                                   
 ------ ------------------------------------------------------------------------------------------------- 
  :39    Parameter #1 $object of method ReflectionProperty::getValue() expects object|null, mixed given.  
         🪪  argument.type                                                                                
  :46    Parameter #2 ...$values of function sprintf expects bool|float|int|string|null, mixed given.     
         🪪  argument.type                                                                                
 ------ ------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   PortabilityTest.php                                                   
 ------ ---------------------------------------------------------------------- 
  :110   Parameter #1 $string of function strlen expects string, mixed given.  
         🪪  argument.type                                                     
 ------ ---------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Schema/DefaultValueTest.php                                                                                               
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  :31    Parameter #1 $name of method Doctrine\DBAL\Schema\ColumnEditor::setUnquotedName() expects non-empty-string, mixed given.  
         🪪  argument.type                                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------- 
  Line   Schema/PostgreSQLSchemaManagerTest.php  
 ------ ---------------------------------------- 
  :764   Cannot cast mixed to int.               
         🪪  cast.int                            
  :769   Cannot cast mixed to int.               
         🪪  cast.int                            
 ------ ---------------------------------------- 

 ------ ------------------------------------ 
  Line   Schema/SQLiteSchemaManagerTest.php  
 ------ ------------------------------------ 
  :241   Cannot cast mixed to int.           
         🪪  cast.int                        
 ------ ------------------------------------ 

 ------- ------------------------------------------------------------------------------------------------------------------------------- 
  Line    Schema/SchemaManagerFunctionalTestCase.php                                                                                     
 ------- ------------------------------------------------------------------------------------------------------------------------------- 
  :1100   Parameter #2 $options of method Doctrine\DBAL\Tests\Functional\Schema\SchemaManagerFunctionalTestCase::getTestTable() expects  
          array<mixed>, mixed given.                                                                                                     
          🪪  argument.type                                                                                                              
  :1562   Cannot cast mixed to int.                                                                                                      
          🪪  cast.int                                                                                                                   
  :1570   Cannot cast mixed to int.                                                                                                      
          🪪  cast.int                                                                                                                   
 ------- ------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------- 
  Line   StatementTest.php                                                                    
 ------ ------------------------------------------------------------------------------------- 
  :181   Parameter #1 $stream of function stream_get_contents expects resource, mixed given.  
         🪪  argument.type                                                                    
 ------ ------------------------------------------------------------------------------------- 

 ------ ------------------------------ 
  Line   TransactionTest.php           
 ------ ------------------------------ 
  :144   Cannot cast mixed to string.  
         🪪  cast.string               
  :156   Cannot cast mixed to string.  
         🪪  cast.string               
  :157   Cannot cast mixed to string.  
         🪪  cast.string               
 ------ ------------------------------        
```         