### PR TITLE
Make BaseDateTypeTestCase generic

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -94,7 +94,7 @@ parameters:
         - '~^Parameter #1 \$row of method Doctrine\\DBAL\\Driver\\PgSQL\\Result\:\:mapNumericRow\(\) expects list<string\|null>, .* given\.$~'
 
         # Required for Psalm compatibility
-        - '~^Property Doctrine\\DBAL\\Tests\\Types\\BaseDateTypeTestCase\:\:\$currentTimezone \(non-empty-string\) does not accept string\.$~'
+        - '~^Property Doctrine\\DBAL\\Tests\\Types\\BaseDateTypeTestCase<TType of Doctrine\\DBAL\\Types\\Type>\:\:\$currentTimezone \(non-empty-string\) does not accept string\.$~'
 
         # The @throws annotations are part of a contract. Even if the default implementation doen't throw those
         # exceptions, the child implementations might do so.

--- a/tests/Types/BaseDateTypeTestCase.php
+++ b/tests/Types/BaseDateTypeTestCase.php
@@ -9,16 +9,19 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function date_default_timezone_get;
 use function date_default_timezone_set;
 
+/** @template TType of Type */
 abstract class BaseDateTypeTestCase extends TestCase
 {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform&Stub $platform;
+
+    /** @var TType */
     protected Type $type;
 
     /** @var non-empty-string */
@@ -26,7 +29,7 @@ abstract class BaseDateTypeTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform        = $this->createMock(AbstractPlatform::class);
+        $this->platform        = self::createStub(AbstractPlatform::class);
         $this->currentTimezone = date_default_timezone_get();
     }
 

--- a/tests/Types/DateTest.php
+++ b/tests/Types/DateTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Types\DateType;
 
 use function date_default_timezone_set;
 
+/** @extends BaseDateTypeTestCase<DateType> */
 class DateTest extends BaseDateTypeTestCase
 {
     protected function setUp(): void

--- a/tests/Types/DateTimeTest.php
+++ b/tests/Types/DateTimeTest.php
@@ -8,6 +8,7 @@ use DateTime;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 
+/** @extends BaseDateTypeTestCase<DateTimeType> */
 class DateTimeTest extends BaseDateTypeTestCase
 {
     protected function setUp(): void

--- a/tests/Types/DateTimeTzTest.php
+++ b/tests/Types/DateTimeTzTest.php
@@ -8,6 +8,7 @@ use DateTime;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzType;
 
+/** @extends BaseDateTypeTestCase<DateTimeTzType> */
 class DateTimeTzTest extends BaseDateTypeTestCase
 {
     protected function setUp(): void

--- a/tests/Types/TimeTest.php
+++ b/tests/Types/TimeTest.php
@@ -8,6 +8,7 @@ use DateTime;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\TimeType;
 
+/** @extends BaseDateTypeTestCase<TimeType> */
 class TimeTest extends BaseDateTypeTestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | https://github.com/doctrine/dbal/pull/7253#discussion_r2606733136

#### Summary

This PR improves the static analysis of the `BaseDateTypeTestCase` class by making the analyzer aware of the actual `Type` subclass that we test against.