### PR TITLE
Add `phpstan-baseline.neon`, `CONTRIBUTING.md`, `README.md` to export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.gitignore export-ignore
 /phpcs.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
+/phpstan-baseline.neon export-ignore
 /phpunit.xml.dist export-ignore
 /run-all.sh export-ignore
 /SECURITY.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,5 @@
 /static-analysis export-ignore
 /tests export-ignore
 /UPGRADE.md export-ignore
+/README.md export-ignore
+/CONTRIBUTING.md export-ignore


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
* Add `phpstan-baseline.neon`, `CONTRIBUTING.md`, `README.md`  to export-ignore list

Currently,  The archive targets other than src/ are as follow

~~gh api repos/doctrine/dbal/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/~~

```
gh api repos/doctrine/dbal/tarball/3.10.x | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
CONTRIBUTING.md
LICENSE
README.md
bin/
bin/doctrine-dbal
bin/doctrine-dbal.php
composer.json
phpstan-baseline.neon
```

With this PR, The archive targets other than src/ will be as follows:

```
 gh api repos/sasezaki/dbal/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
bin/
bin/doctrine-dbal
bin/doctrine-dbal.php
composer.json
```
