### PR TITLE
Fix #7271 - SQLite - composite keys wrongly introspected as autoincrement

### DIFF
--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -467,7 +467,7 @@ SQL,
 
             $sqlByTable[$tableName] ??= $this->getCreateTableSQL($tableName);
 
-            if ($row['pk'] === 0 || $row['pk'] === '0' || $row['type'] !== 'INTEGER') {
+            if ($row['pk'] === 0 || $row['pk'] === '0') {
                 continue;
             }
 
@@ -481,7 +481,7 @@ SQL,
 
             $result[] = array_merge($row, [
                 'autoincrement' => isset($pkColumnNamesByTable[$tableName])
-                    && $pkColumnNamesByTable[$tableName] === [$columnName],
+                    && $pkColumnNamesByTable[$tableName] === [$columnName] && $row['type'] === 'INTEGER',
                 'collation' => $this->parseColumnCollationFromSQL($columnName, $tableSQL),
                 'comment' => $this->parseColumnCommentFromSQL($columnName, $tableSQL),
             ]);

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -521,6 +521,58 @@ SQL;
         );
     }
 
+    public function testIntrospectPrimaryKeyAutoincrement(): void
+    {
+        $this->dropTableIfExists('dbal_7271_1');
+        $this->dropTableIfExists('dbal_7271_2');
+        $this->dropTableIfExists('dbal_7271_3');
+
+        $ddl = <<<'DDL'
+        CREATE TABLE dbal_7271_1 (
+            user_id   INTEGER,
+            user_name VARCHAR,
+            PRIMARY KEY (user_id)
+        );
+        CREATE TABLE dbal_7271_2 (
+            user_id       INTEGER,
+            setting_name  VARCHAR,
+            setting_value TEXT,
+            PRIMARY KEY (user_id, setting_name)
+        );
+        CREATE TABLE dbal_7271_3 (
+            setting_name  VARCHAR,
+            setting_value VARCHAR,
+            PRIMARY KEY (setting_name)
+        );
+        DDL;
+
+        $this->connection->executeStatement($ddl);
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $autoincrement1 = $schemaManager
+            ->introspectSchema()
+            ->getTable('dbal_7271_1')
+            ->getColumn('user_id')
+            ->getAutoincrement();
+
+        $autoincrement2 = $schemaManager
+            ->introspectSchema()
+            ->getTable('dbal_7271_2')
+            ->getColumn('user_id')
+            ->getAutoincrement();
+
+        $autoincrement3 = $schemaManager
+            ->introspectSchema()
+            ->getTable('dbal_7271_3')
+            ->getColumn('setting_name')
+            ->getAutoincrement();
+
+        self::assertTrue($autoincrement1, 'Integer PKs are implicitly autoincrement');
+        self::assertFalse($autoincrement2, 'Composite PKs cannot autoincrement');
+        self::assertFalse($autoincrement3, 'Non-integer PKs cannot autoincrement');
+    }
+
     public function testListTableNoSchemaEmulation(): void
     {
         $databasePlatform = $this->connection->getDatabasePlatform();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7271

#### Summary

In SQLite, integer primary keys are implicitly autoincrement columns, and dbal contains logic for this.

However, this logic fails when a composite primary key contains an integer **and also other non-integer** columns.  The integer column part of the composite PK becomes wrongly flagged as autoincrement.

(A consequence of this is that when calling `getAlterSchemaSQL()`, the non-integer columns are removed from the primary key.  For example, a PK consisting of `INTEGER, VARCHAR` gets changed to just `INTEGER`.  This causes loss of data as the rows saved to the temporary table cannot be re-inserted.)

This happens because the code filters the existing PK columns by "is integer" instead of filtering the column under consideration by "is integer".

Moving this "is integer" check fixes the issue.

A new test case was added containing three assertions.  Two of these assert that the existing functionality isn't broken.  The third would fail under the old code, but passes under the new code.

-----

NOTE: I have submitted this PR against the 4.5.x branch (as requested by @morozov).
However, the code is the same in the 4.4.x branch, and could be backported if desired.