### PR TITLE
Introspect default expressions as DefaultExpression

### DIFF
--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
@@ -148,7 +149,7 @@ SQL,
         return $column;
     }
 
-    private function parseDefaultExpression(string $value): ?string
+    private function parseDefaultExpression(string $value): string|DefaultExpression|null
     {
         while (preg_match('/^\((.*)\)$/s', $value, $matches) === 1) {
             $value = $matches[1];
@@ -163,7 +164,7 @@ SQL,
         }
 
         if ($value === 'getdate()') {
-            return $this->platform->getCurrentTimestampSQL();
+            return new CurrentTimestamp();
         }
 
         return $value;


### PR DESCRIPTION
Fixes #7274.

This is a backport of the corresponding logic from https://github.com/doctrine/dbal/pull/7197.

The idea is that `AbstractSchemaManager` implementations should not invoke `AbstractPlatform::getCurrent*SQL()`, the return value of which would match the expression string and trigger a deprecation. Instead, they should instantiate the corresponding `DefaultExpression` instance.

I haven't found an existing test where I could put a "no deprecation triggered" assertion, and I don't feel like writing a throwaway one. This is how the the changes can be formally verified:
```
➜ git grep -- '->getCurrent.*SQL' 4.4.x src/Schema/**/*SchemaManager.php
4.4.x:src/Schema/MySQLSchemaManager.php:            'current_timestamp()' => $platform->getCurrentTimestampSQL(),
4.4.x:src/Schema/MySQLSchemaManager.php:            'curdate()' => $platform->getCurrentDateSQL(),
4.4.x:src/Schema/MySQLSchemaManager.php:            'curtime()' => $platform->getCurrentTimeSQL(),
4.4.x:src/Schema/SQLServerSchemaManager.php:            return $this->platform->getCurrentTimestampSQL();

➜ git grep -- '->getCurrent.*SQL' HEAD src/Schema/**/*SchemaManager.php || echo Not found
Not found
```
