### PR TITLE
Catch mysqli_sql_exception from mysqli::begin_transaction()

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -80,8 +80,12 @@ final class Connection implements ConnectionInterface
 
     public function beginTransaction(): void
     {
-        if (! $this->connection->begin_transaction()) {
-            throw ConnectionError::new($this->connection);
+        try {
+            if (! $this->connection->begin_transaction()) {
+                throw ConnectionError::new($this->connection);
+            }
+        } catch (mysqli_sql_exception $e) {
+            throw ConnectionError::upcast($e);
         }
     }
 


### PR DESCRIPTION
The existing test started failing with the releases of PHP 8.5.2, PHP 8.4.17 and PHP 8.3.30 (https://github.com/php/php-src/commit/dbf56e0eba68c61385e9a2d15a3e3f5066f80ec4) ([example](https://github.com/doctrine/dbal/actions/runs/21100534059/job/60695481169)):
```
1) Doctrine\DBAL\Tests\Functional\TransactionTest::testBeginTransactionFailure
Failed asserting that exception of type "mysqli_sql_exception" matches expected exception "Doctrine\DBAL\Exception\ConnectionLost". Message was: "MySQL server has gone away" at
/home/runner/work/dbal/dbal/src/Driver/Mysqli/Connection.php:83
/home/runner/work/dbal/dbal/src/Connection.php:1058
/home/runner/work/dbal/dbal/tests/Functional/TransactionTest.php:29
/home/runner/work/dbal/dbal/tests/Functional/TransactionTest.php:88
/home/runner/work/dbal/dbal/tests/Functional/TransactionTest.php:28
```

The proposed logic is consistent with `commit()` and `rollBack()`~~, however I don't know if handling the return value is still needed~~.

UPD: starting PHP 8.1.0, the default mysqli error reporting mode is `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` ([documentation](https://www.php.net/manual/en/mysqli-driver.report-mode.php)), which means throwing a `mysqli_sql_exception` for errors from mysqli function calls ([documentation](https://www.php.net/manual/en/mysqli.constants.php)).

Since we require PHP ~8.2, it means that we no longer need to check the return value. The code could be cleaned up in the next minor release.