### PR TITLE
Remove handling of boolean return values from mysqli

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError;
 use mysqli;
 use mysqli_sql_exception;
 
+use function assert;
+
 final class Connection implements ConnectionInterface
 {
     /**
@@ -35,9 +37,7 @@ final class Connection implements ConnectionInterface
             throw ConnectionError::upcast($e);
         }
 
-        if ($stmt === false) {
-            throw ConnectionError::new($this->connection);
-        }
+        assert($stmt !== false);
 
         return new Statement($stmt);
     }
@@ -55,13 +55,9 @@ final class Connection implements ConnectionInterface
     public function exec(string $sql): int|string
     {
         try {
-            $result = $this->connection->query($sql);
+            $this->connection->query($sql);
         } catch (mysqli_sql_exception $e) {
             throw ConnectionError::upcast($e);
-        }
-
-        if ($result === false) {
-            throw ConnectionError::new($this->connection);
         }
 
         return $this->connection->affected_rows;
@@ -81,6 +77,9 @@ final class Connection implements ConnectionInterface
     public function beginTransaction(): void
     {
         try {
+            // Prior to PHP 8.5.2, PHP 8.4.17 and PHP 8.3.30, mysqli::begin_transaction() didn't respect error reporting
+            // configuration and reported failure as false return value
+            // See: https://github.com/php/php-src/commit/dbf56e0eba68c61385e9a2d15a3e3f5066f80ec4
             if (! $this->connection->begin_transaction()) {
                 throw ConnectionError::new($this->connection);
             }
@@ -92,9 +91,7 @@ final class Connection implements ConnectionInterface
     public function commit(): void
     {
         try {
-            if (! $this->connection->commit()) {
-                throw ConnectionError::new($this->connection);
-            }
+            $this->connection->commit();
         } catch (mysqli_sql_exception $e) {
             throw ConnectionError::upcast($e);
         }
@@ -103,9 +100,7 @@ final class Connection implements ConnectionInterface
     public function rollBack(): void
     {
         try {
-            if (! $this->connection->rollback()) {
-                throw ConnectionError::new($this->connection);
-            }
+            $this->connection->rollback();
         } catch (mysqli_sql_exception $e) {
             throw ConnectionError::upcast($e);
         }

--- a/src/Driver/Mysqli/Driver.php
+++ b/src/Driver/Mysqli/Driver.php
@@ -41,7 +41,7 @@ final class Driver extends AbstractMySQLDriver
         }
 
         try {
-            $success = @$connection->real_connect(
+            @$connection->real_connect(
                 $host,
                 $params['user'] ?? '',
                 $params['password'] ?? '',
@@ -52,10 +52,6 @@ final class Driver extends AbstractMySQLDriver
             );
         } catch (mysqli_sql_exception $e) {
             throw ConnectionFailed::upcast($e);
-        }
-
-        if (! $success) {
-            throw ConnectionFailed::new($connection);
         }
 
         foreach ($this->compilePostInitializers($params) as $initializer) {

--- a/src/Driver/Mysqli/Exception/ConnectionFailed.php
+++ b/src/Driver/Mysqli/Exception/ConnectionFailed.php
@@ -5,23 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
-use mysqli;
 use mysqli_sql_exception;
 use ReflectionProperty;
-
-use function assert;
 
 /** @internal */
 final class ConnectionFailed extends AbstractException
 {
-    public static function new(mysqli $connection): self
-    {
-        $error = $connection->connect_error;
-        assert($error !== null);
-
-        return new self($error, 'HY000', $connection->connect_errno);
-    }
-
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');

--- a/src/Driver/Mysqli/Exception/InvalidCharset.php
+++ b/src/Driver/Mysqli/Exception/InvalidCharset.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
-use mysqli;
 use mysqli_sql_exception;
 use ReflectionProperty;
 
@@ -14,15 +13,6 @@ use function sprintf;
 /** @internal */
 final class InvalidCharset extends AbstractException
 {
-    public static function fromCharset(mysqli $connection, string $charset): self
-    {
-        return new self(
-            sprintf('Failed to set charset "%s": %s', $charset, $connection->error),
-            $connection->sqlstate,
-            $connection->errno,
-        );
-    }
-
     public static function upcast(mysqli_sql_exception $exception, string $charset): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');

--- a/src/Driver/Mysqli/Exception/StatementError.php
+++ b/src/Driver/Mysqli/Exception/StatementError.php
@@ -6,17 +6,11 @@ namespace Doctrine\DBAL\Driver\Mysqli\Exception;
 
 use Doctrine\DBAL\Driver\AbstractException;
 use mysqli_sql_exception;
-use mysqli_stmt;
 use ReflectionProperty;
 
 /** @internal */
 final class StatementError extends AbstractException
 {
-    public static function new(mysqli_stmt $statement): self
-    {
-        return new self($statement->error, $statement->sqlstate, $statement->errno);
-    }
-
     public static function upcast(mysqli_sql_exception $exception): self
     {
         $p = new ReflectionProperty(mysqli_sql_exception::class, 'sqlstate');

--- a/src/Driver/Mysqli/Initializer/Charset.php
+++ b/src/Driver/Mysqli/Initializer/Charset.php
@@ -18,15 +18,9 @@ final class Charset implements Initializer
     public function initialize(mysqli $connection): void
     {
         try {
-            $success = $connection->set_charset($this->charset);
+            $connection->set_charset($this->charset);
         } catch (mysqli_sql_exception $e) {
             throw InvalidCharset::upcast($e, $this->charset);
         }
-
-        if ($success) {
-            return;
-        }
-
-        throw InvalidCharset::fromCharset($connection, $this->charset);
     }
 }

--- a/src/Driver/Mysqli/Initializer/Options.php
+++ b/src/Driver/Mysqli/Initializer/Options.php
@@ -20,6 +20,8 @@ final class Options implements Initializer
     public function initialize(mysqli $connection): void
     {
         foreach ($this->options as $option => $value) {
+            // mysqli::options() doesn't respect error reporting configuration and reports failure as false return value
+            // See: https://github.com/php/php-src/issues/20968
             if (! mysqli_options($connection, $option, $value)) {
                 throw InvalidOption::fromOption($option, $value);
             }

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -81,8 +81,10 @@ final class Result implements ResultInterface
         // The following is necessary as PHP cannot handle references to properties properly
         $refs = &$this->boundValues;
 
-        if (! $this->statement->bind_result(...$refs)) {
-            throw StatementError::new($this->statement);
+        try {
+            $this->statement->bind_result(...$refs);
+        } catch (mysqli_sql_exception $e) {
+            throw StatementError::upcast($e);
         }
     }
 
@@ -92,10 +94,6 @@ final class Result implements ResultInterface
             $ret = $this->statement->fetch();
         } catch (mysqli_sql_exception $e) {
             throw StatementError::upcast($e);
-        }
-
-        if ($ret === false) {
-            throw StatementError::new($this->statement);
         }
 
         if ($ret === null) {

--- a/src/Driver/Mysqli/Statement.php
+++ b/src/Driver/Mysqli/Statement.php
@@ -70,9 +70,7 @@ final class Statement implements StatementInterface
         }
 
         try {
-            if (! $this->stmt->execute()) {
-                throw StatementError::new($this->stmt);
-            }
+            $this->stmt->execute();
         } catch (mysqli_sql_exception $e) {
             throw StatementError::upcast($e);
         }
@@ -113,8 +111,10 @@ final class Statement implements StatementInterface
             $values[$parameter] = $value;
         }
 
-        if (! $this->stmt->bind_param($types, ...$values)) {
-            throw StatementError::new($this->stmt);
+        try {
+            $this->stmt->bind_param($types, ...$values);
+        } catch (mysqli_sql_exception $e) {
+            throw StatementError::upcast($e);
         }
 
         $this->sendLongData($streams);
@@ -137,8 +137,10 @@ final class Statement implements StatementInterface
                     throw FailedReadingStreamOffset::new($paramNr);
                 }
 
-                if (! $this->stmt->send_long_data($paramNr - 1, $chunk)) {
-                    throw StatementError::new($this->stmt);
+                try {
+                    $this->stmt->send_long_data($paramNr - 1, $chunk);
+                } catch (mysqli_sql_exception $e) {
+                    throw StatementError::upcast($e);
                 }
             }
         }


### PR DESCRIPTION
Starting PHP 8.1.0, the default `mysqli` error reporting mode is `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` ([documentation](https://www.php.net/manual/en/mysqli-driver.report-mode.php)), which means throwing a `mysqli_sql_exception` for errors from mysqli function calls ([documentation](https://www.php.net/manual/en/mysqli.constants.php)). As a result, the DBAL code that interacts with `mysqli` and throws an exception if a `mysqli` method returns `false` is in fact dead code.

The exceptions are:
1. `mysqli::options()` which still returns false on error (see https://github.com/php/php-src/issues/20968)
2. `mysqli::begin_transaction()` which returns false on error on versions prior PHP 8.5.2, PHP 8.4.17 and PHP 8.3.30 (see https://github.com/php/php-src/commit/dbf56e0eba68c61385e9a2d15a3e3f5066f80ec4)

### Test Coverage

Per [Codecov](https://app.codecov.io/gh/doctrine/dbal/tree/morozov%2Fdbal%3Amysqli-error-handling/src%2FDriver%2FMysqli), all modified code is covered with tests except for the call to `mysqli_stmt::bind_param()` in `Statement::bindParameters()`: https://github.com/doctrine/dbal/blob/e3ae1f90cee73f09009cf89b9bb6c7535c8b1227/src/Driver/Mysqli/Statement.php#L114-L118

### Research

I tried to make `mysqli_stmt::bind_param()` throw a `mysqli_sql_exception` but only managed to make it throw an `ArgumentCountError` (which the DBAL currently doesn't handle, and it's not clear if it should).

```php
$stmt = $mysqli->prepare('SELECT ?');
$value1 = 1;
$value2 = 2;

try {
    $stmt->bind_param('i', $value1, $value2);
} catch (Error $e) {
    echo 'Caught error: ',  $e->getMessage(), PHP_EOL;
}
// Caught error: The number of elements in the type definition string must match the number of bind variables
```

`ArgumentCountError` is also thrown if the number of bound variables doesn't match the number of statement parameters.