### PR TITLE
Do not use deprecated getQuotedName() in AbstractPlatform

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -893,10 +893,10 @@ abstract class AbstractPlatform
     private function buildCreateTableSQL(Table $table, bool $createForeignKeys): array
     {
         if (count($table->getColumns()) === 0) {
-            throw NoColumnsSpecifiedForTable::new($table->getName());
+            throw NoColumnsSpecifiedForTable::new($table->getObjectName()->toString());
         }
 
-        $tableName                    = $table->getQuotedName($this);
+        $tableName                    = $table->getObjectName()->toSQL($this);
         $options                      = $table->getOptions();
         $options['primary']           = [];
         $options['indexes']           = [];
@@ -944,7 +944,7 @@ abstract class AbstractPlatform
                     continue;
                 }
 
-                $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getQuotedName($this), $comment);
+                $sql[] = $this->getCommentOnColumnSQL($tableName, $column->getObjectName()->toSQL($this), $comment);
             }
         }
 
@@ -968,7 +968,7 @@ abstract class AbstractPlatform
             foreach ($table->getForeignKeys() as $foreignKey) {
                 $sql[] = $this->getCreateForeignKeySQL(
                     $foreignKey,
-                    $table->getQuotedName($this),
+                    $table->getObjectName()->toSQL($this),
                 );
             }
         }
@@ -988,14 +988,14 @@ abstract class AbstractPlatform
         foreach ($tables as $table) {
             foreach ($table->getForeignKeys() as $foreignKey) {
                 $sql[] = $this->getDropForeignKeySQL(
-                    $foreignKey->getQuotedName($this),
-                    $table->getQuotedName($this),
+                    $foreignKey->getObjectName()->toSQL($this),
+                    $table->getObjectName()->toSQL($this),
                 );
             }
         }
 
         foreach ($tables as $table) {
-            $sql[] = $this->getDropTableSQL($table->getQuotedName($this));
+            $sql[] = $this->getDropTableSQL($table->getObjectName()->toSQL($this));
         }
 
         return $sql;
@@ -1007,7 +1007,7 @@ abstract class AbstractPlatform
 
         return sprintf(
             'COMMENT ON TABLE %s IS %s',
-            $tableName->getQuotedName($this),
+            $tableName->getObjectName()->toSQL($this),
             $this->quoteStringLiteral($comment),
         );
     }
@@ -1020,8 +1020,8 @@ abstract class AbstractPlatform
 
         return sprintf(
             'COMMENT ON COLUMN %s.%s IS %s',
-            $tableName->getQuotedName($this),
-            $columnName->getQuotedName($this),
+            $tableName->getObjectName()->toSQL($this),
+            $columnName->getObjectName()->toSQL($this),
             $this->quoteStringLiteral($comment),
         );
     }
@@ -1143,7 +1143,7 @@ abstract class AbstractPlatform
             }
 
             foreach ($diff->getDroppedSequences() as $sequence) {
-                $sql[] = $this->getDropSequenceSQL($sequence->getQuotedName($this));
+                $sql[] = $this->getDropSequenceSQL($sequence->getObjectName()->toSQL($this));
             }
 
             foreach ($diff->getCreatedSequences() as $sequence) {
@@ -1201,7 +1201,7 @@ abstract class AbstractPlatform
      */
     public function getCreateIndexSQL(Index $index, string $table): string
     {
-        $name    = $index->getQuotedName($this);
+        $name    = $index->getObjectName()->toSQL($this);
         $columns = $index->getColumns();
 
         if (count($columns) === 0) {
@@ -1367,24 +1367,24 @@ abstract class AbstractPlatform
     /** @return list<string> */
     protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
     {
-        $tableNameSQL = $diff->getOldTable()->getQuotedName($this);
+        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
 
         $sql = [];
 
         foreach ($diff->getDroppedForeignKeys() as $foreignKey) {
-            $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableNameSQL);
+            $sql[] = $this->getDropForeignKeySQL($foreignKey->getObjectName()->toSQL($this), $tableNameSQL);
         }
 
         foreach ($diff->getModifiedForeignKeys() as $foreignKey) {
-            $sql[] = $this->getDropForeignKeySQL($foreignKey->getQuotedName($this), $tableNameSQL);
+            $sql[] = $this->getDropForeignKeySQL($foreignKey->getObjectName()->toSQL($this), $tableNameSQL);
         }
 
         foreach ($diff->getDroppedIndexes() as $index) {
-            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableNameSQL);
+            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
         }
 
         foreach ($diff->getModifiedIndexes() as $index) {
-            $sql[] = $this->getDropIndexSQL($index->getQuotedName($this), $tableNameSQL);
+            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
         }
 
         return $sql;
@@ -1395,7 +1395,7 @@ abstract class AbstractPlatform
     {
         $sql = [];
 
-        $tableNameSQL = $diff->getOldTable()->getQuotedName($this);
+        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
 
         foreach ($diff->getAddedForeignKeys() as $foreignKey) {
             $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
@@ -1417,7 +1417,7 @@ abstract class AbstractPlatform
             $oldIndexName = new Identifier($oldIndexName);
             $sql          = array_merge(
                 $sql,
-                $this->getRenameIndexSQL($oldIndexName->getQuotedName($this), $index, $tableNameSQL),
+                $this->getRenameIndexSQL($oldIndexName->getObjectName()->toSQL($this), $index, $tableNameSQL),
             );
         }
 
@@ -1664,7 +1664,7 @@ abstract class AbstractPlatform
 
         if ($constraint->getName() !== '') {
             $chunks[] = 'CONSTRAINT';
-            $chunks[] = $constraint->getQuotedName($this);
+            $chunks[] = $constraint->getObjectName()->toSQL($this);
         }
 
         $chunks[] = 'UNIQUE';
@@ -1696,7 +1696,7 @@ abstract class AbstractPlatform
             throw new InvalidArgumentException('Incomplete definition. "columns" required.');
         }
 
-        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getQuotedName($this)
+        return $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $index->getObjectName()->toSQL($this)
             . ' (' . implode(', ', $index->getQuotedColumns($this)) . ')' . $this->getPartialIndexSQL($index);
     }
 
@@ -1804,7 +1804,7 @@ abstract class AbstractPlatform
     {
         $sql = '';
         if ($foreignKey->getName() !== '') {
-            $sql .= 'CONSTRAINT ' . $foreignKey->getQuotedName($this) . ' ';
+            $sql .= 'CONSTRAINT ' . $foreignKey->getObjectName()->toSQL($this) . ' ';
         }
 
         $sql .= 'FOREIGN KEY (';
@@ -2282,7 +2282,7 @@ abstract class AbstractPlatform
     {
         $tableIdentifier = new Identifier($tableName);
 
-        return 'TRUNCATE ' . $tableIdentifier->getQuotedName($this);
+        return 'TRUNCATE ' . $tableIdentifier->getObjectName()->toSQL($this);
     }
 
     /**
@@ -2385,7 +2385,7 @@ abstract class AbstractPlatform
     private function columnToArray(Column $column): array
     {
         return array_merge($column->toArray(), [
-            'name' => $column->getQuotedName($this),
+            'name' => $column->getObjectName()->toSQL($this),
             'version' => $column->hasPlatformOption('version') ? $column->getPlatformOption('version') : false,
             'comment' => $column->getComment(),
         ]);


### PR DESCRIPTION
Really not sure about this at all. 

Background: I have a table with a column named `external`. In the latest MySQL version 9.6, released yesterday, this has [become a reserved keyword](https://dev.mysql.com/doc/refman/9.6/en/keywords.html).

Using `doctrine/dbal` `4.4.1` and `doctrine/orm` `3.6.1` when working with the ORM's `SchemaTool`, it will call the `AbstractPlatform` and this one still seems to call deprecated methods all over the place. The old `$column->getQuotedName()` still uses the keywords list instead of quoting everything. Because `EXTERNAL` is not on any keywords list for the MySQL platform, this fails 💥 

We could also add it to the keyword list but the goal is to quote everything no matter what anyway, so why not use the new methods that do that? 😊 
