### PR TITLE
Run Rector with readonly-related rules

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: `AbstractConnectionMiddleware` marked as readonly
+
+The `AbstractConnectionMiddleware` class has been marked as read-only. As a
+result, classes extending it must be declared as read-only as well.
+
 ## BC BREAK: Either of the `host` and `connectstring` parameters must be specified for `oci8` and `pdo_oci` connections.
 
 Not specifying either of the `host` and `connectstring` parameters for `oci8` and `pdo_oci` connections is no longer

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -105,7 +105,7 @@ class Connection implements ServerVersionProvider
      */
     private bool $isRollbackOnly = false;
 
-    private SchemaManagerFactory $schemaManagerFactory;
+    private readonly SchemaManagerFactory $schemaManagerFactory;
 
     /**
      * Initializes a new instance of the Connection class.

--- a/src/Driver/Middleware/AbstractConnectionMiddleware.php
+++ b/src/Driver/Middleware/AbstractConnectionMiddleware.php
@@ -8,9 +8,9 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
 
-abstract class AbstractConnectionMiddleware implements Connection
+abstract readonly class AbstractConnectionMiddleware implements Connection
 {
-    public function __construct(private readonly Connection $wrappedConnection)
+    public function __construct(private Connection $wrappedConnection)
     {
     }
 

--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -12,7 +12,7 @@ use mysqli_sql_exception;
 
 use function assert;
 
-final class Connection implements ConnectionInterface
+final readonly class Connection implements ConnectionInterface
 {
     /**
      * Name of the option to set connection flags
@@ -20,7 +20,7 @@ final class Connection implements ConnectionInterface
     public const string OPTION_FLAGS = 'flags';
 
     /** @internal The connection can be only instantiated by its driver. */
-    public function __construct(private readonly mysqli $connection)
+    public function __construct(private mysqli $connection)
     {
     }
 

--- a/src/Driver/Mysqli/Result.php
+++ b/src/Driver/Mysqli/Result.php
@@ -33,7 +33,7 @@ final class Result implements ResultInterface
      */
     public function __construct(
         private readonly mysqli_stmt $statement,
-        private ?Statement $statementReference = null, // @phpstan-ignore property.onlyWritten
+        private readonly ?Statement $statementReference = null, // @phpstan-ignore property.onlyWritten
     ) {
         try {
             $this->result = $statement->get_result();

--- a/src/Driver/PDO/SQLSrv/Connection.php
+++ b/src/Driver/PDO/SQLSrv/Connection.php
@@ -8,9 +8,9 @@ use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use PDO;
 
-final class Connection extends AbstractConnectionMiddleware
+final readonly class Connection extends AbstractConnectionMiddleware
 {
-    public function __construct(private readonly PDOConnection $connection)
+    public function __construct(private PDOConnection $connection)
     {
         parent::__construct($connection);
     }

--- a/src/Driver/SQLite3/Statement.php
+++ b/src/Driver/SQLite3/Statement.php
@@ -16,7 +16,7 @@ use const SQLITE3_INTEGER;
 use const SQLITE3_NULL;
 use const SQLITE3_TEXT;
 
-final class Statement implements StatementInterface
+final readonly class Statement implements StatementInterface
 {
     private const int TYPE_BLOB    = SQLITE3_BLOB;
     private const int TYPE_INTEGER = SQLITE3_INTEGER;
@@ -25,8 +25,8 @@ final class Statement implements StatementInterface
 
     /** @internal The statement can be only instantiated by its driver connection. */
     public function __construct(
-        private readonly SQLite3 $connection,
-        private readonly SQLite3Stmt $statement,
+        private SQLite3 $connection,
+        private SQLite3Stmt $statement,
     ) {
     }
 

--- a/src/Logging/Connection.php
+++ b/src/Logging/Connection.php
@@ -10,10 +10,10 @@ use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Psr\Log\LoggerInterface;
 
-final class Connection extends AbstractConnectionMiddleware
+final readonly class Connection extends AbstractConnectionMiddleware
 {
     /** @internal This connection can be only instantiated by its driver. */
-    public function __construct(ConnectionInterface $connection, private readonly LoggerInterface $logger)
+    public function __construct(ConnectionInterface $connection, private LoggerInterface $logger)
     {
         parent::__construct($connection);
     }

--- a/src/Portability/Connection.php
+++ b/src/Portability/Connection.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 /**
  * Portability wrapper for a Connection.
  */
-final class Connection extends AbstractConnectionMiddleware
+final readonly class Connection extends AbstractConnectionMiddleware
 {
     public const int PORTABILITY_ALL           = 255;
     public const int PORTABILITY_NONE          = 0;
@@ -18,7 +18,7 @@ final class Connection extends AbstractConnectionMiddleware
     public const int PORTABILITY_EMPTY_TO_NULL = 4;
     public const int PORTABILITY_FIX_CASE      = 8;
 
-    public function __construct(ConnectionInterface $connection, private readonly Converter $converter)
+    public function __construct(ConnectionInterface $connection, private Converter $converter)
     {
         parent::__construct($connection);
     }

--- a/src/Portability/Converter.php
+++ b/src/Portability/Converter.php
@@ -17,18 +17,18 @@ use function strtoupper;
 use const CASE_LOWER;
 use const CASE_UPPER;
 
-final class Converter
+final readonly class Converter
 {
     public const int CASE_LOWER = CASE_LOWER;
     public const int CASE_UPPER = CASE_UPPER;
 
-    private readonly Closure $convertNumeric;
-    private readonly Closure $convertAssociative;
-    private readonly Closure $convertOne;
-    private readonly Closure $convertAllNumeric;
-    private readonly Closure $convertAllAssociative;
-    private readonly Closure $convertFirstColumn;
-    private readonly Closure $convertColumnName;
+    private Closure $convertNumeric;
+    private Closure $convertAssociative;
+    private Closure $convertOne;
+    private Closure $convertAllNumeric;
+    private Closure $convertAllAssociative;
+    private Closure $convertFirstColumn;
+    private Closure $convertColumnName;
 
     /**
      * @param bool                                   $convertEmptyStringToNull Whether each empty string should

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -27,7 +27,7 @@ use const PREG_NO_ERROR;
  *
  * @see https://github.com/php/php-src/blob/php-7.4.12/ext/pdo/pdo_sql_parser.re#L49-L69
  */
-final class Parser
+final readonly class Parser
 {
     private const string SPECIAL_CHARS = ':\?\'"`\\[\\-\\/';
 
@@ -41,8 +41,8 @@ final class Parser
     private const string SPECIAL              = '[' . self::SPECIAL_CHARS . ']';
     private const string OTHER                = '[^' . self::SPECIAL_CHARS . ']+';
 
-    private readonly string $sqlPattern;
-    private readonly string $tokenPattern;
+    private string $sqlPattern;
+    private string $tokenPattern;
 
     public function __construct(bool $mySQLStringEscaping)
     {

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -71,7 +71,7 @@ final class Schema
     /** @var array<string, Sequence> */
     private array $sequences = [];
 
-    private SchemaConfig $schemaConfig;
+    private readonly SchemaConfig $schemaConfig;
 
     /**
      * The default namespace name that the schema will use as a qualifier to resolve unqualified names.
@@ -80,7 +80,7 @@ final class Schema
      *
      * @var ?non-empty-string
      */
-    private ?string $defaultNamespaceName;
+    private readonly ?string $defaultNamespaceName;
 
     /**
      * Indicates whether the schema uses unqualified names for its objects. Once this flag is set to true, it won't be

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -23,7 +23,7 @@ final class TableEditor
     private readonly UnqualifiedNamedObjectSet $columns;
 
     /** @var UnqualifiedNamedObjectSet<Index> */
-    private UnqualifiedNamedObjectSet $indexes;
+    private readonly UnqualifiedNamedObjectSet $indexes;
 
     private ?PrimaryKeyConstraint $primaryKeyConstraint = null;
 

--- a/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
@@ -74,7 +74,7 @@ final class AbstractConnectionMiddlewareTest extends TestCase
 
     private function createMiddleware(Connection $connection): AbstractConnectionMiddleware
     {
-        return new class ($connection) extends AbstractConnectionMiddleware {
+        return new readonly class ($connection) extends AbstractConnectionMiddleware {
         };
     }
 }

--- a/tests/Schema/Collections/OptionallyUnqualifiedNamedObjectSetTest.php
+++ b/tests/Schema/Collections/OptionallyUnqualifiedNamedObjectSetTest.php
@@ -167,11 +167,11 @@ class OptionallyUnqualifiedNamedObjectSetTest extends TestCase
     private function createObject(?string $name, int $value): OptionallyNamedObject
     {
         return new /** @template-implements OptionallyNamedObject<UnqualifiedName> */
-        class ($name, $value) implements OptionallyNamedObject {
-            private readonly ?UnqualifiedName $name;
+        readonly class ($name, $value) implements OptionallyNamedObject {
+            private ?UnqualifiedName $name;
 
             /** @param ?non-empty-string $name */
-            public function __construct(?string $name, private readonly int $value)
+            public function __construct(?string $name, private int $value)
             {
                 $this->name = $name !== null ? UnqualifiedName::unquoted($name) : null;
             }

--- a/tests/Schema/Collections/UnqualifiedNamedObjectSetTest.php
+++ b/tests/Schema/Collections/UnqualifiedNamedObjectSetTest.php
@@ -169,11 +169,11 @@ class UnqualifiedNamedObjectSetTest extends TestCase
     private function createObject(string $name, int $value): NamedObject
     {
         return new /** @template-implements NamedObject<UnqualifiedName> */
-        class ($name, $value) implements NamedObject {
-            private readonly UnqualifiedName $name;
+        readonly class ($name, $value) implements NamedObject {
+            private UnqualifiedName $name;
 
             /** @param non-empty-string $name */
-            public function __construct(string $name, private readonly int $value)
+            public function __construct(string $name, private int $value)
             {
                 $this->name = UnqualifiedName::unquoted($name);
             }


### PR DESCRIPTION
#### Summary

This is an automated follow-up on https://github.com/doctrine/dbal/pull/6925

Configuration:

```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
use Rector\Php83\Rector\Class_\ReadOnlyAnonymousClassRector;

return RectorConfig::configure()
	->withPaths([
	__DIR__ . '/src',
	__DIR__ . '/static-analysis',
	__DIR__ . '/tests',
	])
	->withRules([
	ReadOnlyAnonymousClassRector::class,
	ReadOnlyClassRector::class,
	ReadOnlyPropertyRector::class,
	]);
```