### PR TITLE
Rework ALTER TABLE logic for MySQL

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -325,6 +325,13 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
      */
     public function getAlterTableSQL(TableDiff $diff): array
     {
+        $sql          = [];
+        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
+
+        foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
+            $sql[] = $this->getDropForeignKeySQL($constraintName->toSQL($this), $tableNameSQL);
+        }
+
         $queryParts = [];
 
         foreach ($diff->getAddedColumns() as $column) {
@@ -358,69 +365,29 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             $queryParts[] = 'ADD ' . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
-        $tableSql = [];
+        foreach ($diff->getDroppedIndexes() as $index) {
+            $queryParts[] = 'DROP INDEX ' . $index->getObjectName()->toSQL($this);
+        }
+
+        foreach ($diff->getAddedIndexes() as $index) {
+            $queryParts[] = 'ADD ' . $this->getIndexDeclarationSQL($index);
+        }
+
+        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+            $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
+            $queryParts[]       = 'RENAME INDEX ' . $parsedOldIndexName->toSQL($this) . ' TO '
+                . $index->getObjectName()->toSQL($this);
+        }
 
         if (count($queryParts) > 0) {
-            $tableSql[] = 'ALTER TABLE ' . $diff->getOldTable()->getObjectName()->toSQL($this) . ' '
-                . implode(', ', $queryParts);
+            $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . implode(', ', $queryParts);
         }
 
-        return array_merge(
-            $this->getPreAlterTableIndexForeignKeySQL($diff),
-            $tableSql,
-            $this->getPostAlterTableIndexForeignKeySQL($diff),
-        );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
-    {
-        $sql = [];
-
-        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
-
-        foreach ($diff->getDroppedIndexes() as $droppedIndex) {
-            foreach ($diff->getAddedIndexes() as $addedIndex) {
-                if (! $this->indexedColumnNamesEqual($droppedIndex, $addedIndex)) {
-                    continue;
-                }
-
-                $sql[] = sprintf(
-                    'ALTER TABLE %s DROP INDEX %s, ADD %s',
-                    $tableNameSQL,
-                    $droppedIndex->getObjectName()->toSQL($this),
-                    $this->getIndexDeclarationSQL($addedIndex),
-                );
-
-                $diff->unsetAddedIndex($addedIndex);
-                $diff->unsetDroppedIndex($droppedIndex);
-
-                break;
-            }
+        foreach ($diff->getAddedForeignKeys() as $addedForeignKeyConstraint) {
+            $sql[] = $this->getCreateForeignKeySQL($addedForeignKeyConstraint, $tableNameSQL);
         }
 
-        return array_merge($sql, parent::getPreAlterTableIndexForeignKeySQL($diff));
-    }
-
-    private function indexedColumnNamesEqual(Index $index1, Index $index2): bool
-    {
-        $columns1 = $index1->getIndexedColumns();
-        $columns2 = $index2->getIndexedColumns();
-
-        if (count($columns1) !== count($columns2)) {
-            return false;
-        }
-
-        $folding = $this->getUnquotedIdentifierFolding();
-        foreach ($columns1 as $i => $column1) {
-            if (! $column1->getColumnName()->equals($columns2[$i]->getColumnName(), $folding)) {
-                return false;
-            }
-        }
-
-        return true;
+        return $sql;
     }
 
     /**

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -14,7 +14,7 @@ use function count;
 /**
  * Table Diff.
  */
-final class TableDiff
+final readonly class TableDiff
 {
     /**
      * Constructs a TableDiff object.
@@ -31,17 +31,17 @@ final class TableDiff
      * @param array<UnqualifiedName>         $droppedForeignKeyConstraintNames
      */
     public function __construct(
-        private readonly Table $oldTable,
-        private readonly array $addedColumns = [],
-        private readonly array $changedColumns = [],
-        private readonly array $droppedColumns = [],
+        private Table $oldTable,
+        private array $addedColumns = [],
+        private array $changedColumns = [],
+        private array $droppedColumns = [],
         private array $addedIndexes = [],
         private array $droppedIndexes = [],
-        private readonly array $renamedIndexes = [],
-        private readonly array $addedForeignKeys = [],
-        private readonly array $droppedForeignKeyConstraintNames = [],
-        private readonly ?PrimaryKeyConstraint $addedPrimaryKeyConstraint = null,
-        private readonly ?PrimaryKeyConstraint $droppedPrimaryKeyConstraint = null,
+        private array $renamedIndexes = [],
+        private array $addedForeignKeys = [],
+        private array $droppedForeignKeyConstraintNames = [],
+        private ?PrimaryKeyConstraint $addedPrimaryKeyConstraint = null,
+        private ?PrimaryKeyConstraint $droppedPrimaryKeyConstraint = null,
     ) {
     }
 
@@ -124,38 +124,10 @@ final class TableDiff
         return $this->addedIndexes;
     }
 
-    /**
-     * @internal This method exists only for compatibility with the current implementation of schema managers
-     *           that modify the diff while processing it.
-     */
-    public function unsetAddedIndex(Index $index): void
-    {
-        $this->addedIndexes = array_filter(
-            $this->addedIndexes,
-            static function (Index $addedIndex) use ($index): bool {
-                return $addedIndex !== $index;
-            },
-        );
-    }
-
     /** @return array<Index> */
     public function getDroppedIndexes(): array
     {
         return $this->droppedIndexes;
-    }
-
-    /**
-     * @internal This method exists only for compatibility with the current implementation of schema managers
-     *           that modify the diff while processing it.
-     */
-    public function unsetDroppedIndex(Index $index): void
-    {
-        $this->droppedIndexes = array_filter(
-            $this->droppedIndexes,
-            static function (Index $droppedIndex) use ($index): bool {
-                return $droppedIndex !== $index;
-            },
-        );
     }
 
     /** @return array<non-empty-string,Index> */

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -179,10 +179,10 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
 
         $sql = $this->platform->getAlterTableSQL($diff);
 
-        self::assertEquals([
-            'ALTER TABLE `foo` ADD PRIMARY KEY (`bar`)',
-            'CREATE UNIQUE INDEX `UNIQ_8C73652178240498` ON `foo` (`baz`)',
-        ], $sql);
+        self::assertEquals(
+            ['ALTER TABLE `foo` ADD PRIMARY KEY (`bar`), ADD UNIQUE INDEX `UNIQ_8C73652178240498` (`baz`)'],
+            $sql,
+        );
     }
 
     public function testModifyLimitQuery(): void
@@ -364,12 +364,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     /** @return string[] */
     protected function getQuotedAlterTableRenameIndexSQL(): array
     {
-        return [
-            'DROP INDEX `create` ON `table`',
-            'CREATE INDEX `select` ON `table` (id)',
-            'DROP INDEX `foo` ON `table`',
-            'CREATE INDEX `bar` ON `table` (id)',
-        ];
+        return ['ALTER TABLE `table` RENAME INDEX `create` TO `select`, RENAME INDEX `foo` TO `bar`'];
     }
 
     /** @return string[] */
@@ -384,12 +379,7 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
     /** @return string[] */
     protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
     {
-        return [
-            'DROP INDEX `create` ON `schema`.`table`',
-            'CREATE INDEX `select` ON `schema`.`table` (id)',
-            'DROP INDEX `foo` ON `schema`.`table`',
-            'CREATE INDEX `bar` ON `schema`.`table` (id)',
-        ];
+        return ['ALTER TABLE `schema`.`table` RENAME INDEX `create` TO `select`, RENAME INDEX `foo` TO `bar`'];
     }
 
     protected function getQuotedCommentOnColumnSQLWithoutQuoteCharacter(): string

--- a/tests/Platforms/MariaDBPlatformTest.php
+++ b/tests/Platforms/MariaDBPlatformTest.php
@@ -24,10 +24,7 @@ class MariaDBPlatformTest extends AbstractMySQLPlatformTestCase
     /** @return string[] */
     protected function getQuotedAlterTableRenameIndexSQL(): array
     {
-        return [
-            'ALTER TABLE `table` RENAME INDEX `create` TO `select`',
-            'ALTER TABLE `table` RENAME INDEX `foo` TO `bar`',
-        ];
+        return ['ALTER TABLE `table` RENAME INDEX `create` TO `select`, RENAME INDEX `foo` TO `bar`'];
     }
 
     /** @return string[] */
@@ -39,10 +36,7 @@ class MariaDBPlatformTest extends AbstractMySQLPlatformTestCase
     /** @return string[] */
     protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
     {
-        return [
-            'ALTER TABLE `schema`.`table` RENAME INDEX `create` TO `select`',
-            'ALTER TABLE `schema`.`table` RENAME INDEX `foo` TO `bar`',
-        ];
+        return ['ALTER TABLE `schema`.`table` RENAME INDEX `create` TO `select`, RENAME INDEX `foo` TO `bar`'];
     }
 
     /**

--- a/tests/Platforms/MySQLPlatformTest.php
+++ b/tests/Platforms/MySQLPlatformTest.php
@@ -38,10 +38,7 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
     /** @return string[] */
     protected function getQuotedAlterTableRenameIndexSQL(): array
     {
-        return [
-            'ALTER TABLE `table` RENAME INDEX `create` TO `select`',
-            'ALTER TABLE `table` RENAME INDEX `foo` TO `bar`',
-        ];
+        return ['ALTER TABLE `table` RENAME INDEX `create` TO `select`, RENAME INDEX `foo` TO `bar`'];
     }
 
     /** @return string[] */
@@ -53,10 +50,7 @@ class MySQLPlatformTest extends AbstractMySQLPlatformTestCase
     /** @return string[] */
     protected function getQuotedAlterTableRenameIndexInSchemaSQL(): array
     {
-        return [
-            'ALTER TABLE `schema`.`table` RENAME INDEX `create` TO `select`',
-            'ALTER TABLE `schema`.`table` RENAME INDEX `foo` TO `bar`',
-        ];
+        return ['ALTER TABLE `schema`.`table` RENAME INDEX `create` TO `select`, RENAME INDEX `foo` TO `bar`'];
     }
 
     public function testHasCorrectDefaultTransactionIsolationLevel(): void


### PR DESCRIPTION
> duplication is far cheaper than the wrong abstraction

— [Sandi Metz](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction)

### The Problem

The `get(Pre|Post)AlterTableIndexForeignKeySQL()` methods in `AbstractPlatform` are a horrible API. They probably exist for some code reuse, but they lack a clear purpose. Besides that, the idea of breaking `ALTER TABLE` down into a set of statements is not portable leading to the need for workarounds.

More specifically, these methods build an array of SQL statements that will be prepended and appended to the rest of the statements generated by the `getAlterTable()` method. The fact that they are _distinct_ SQL statements makes it impossible to use with MySQL.

MySQL requires that the referencing columns of a foreign key constraint are covered by an index ([documentation](https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html)). If the table diff drops and recreates the corresponding index, it must be done in a _single_ SQL statement (otherwise, this requirement is not met between the statements). This leads to the workaround that the MySQL platform builds bespoke `ALTER TABLE` statements where this is absolutely needed and mutates the diff: https://github.com/doctrine/dbal/blob/95b1840c5924dc860006f153d5afea8d13052956/src/Platforms/AbstractMySQLPlatform.php#L390-L398

### Proposed solution

Do not reuse the non-reusable code. Generate the correct and optimal SQL and eliminate the need to mutate the diff.

### Technical notes

1. The first commit should be portable to 4.5.x, but the implementation of the pre/post methods there is slightly different, and I'm not sure what extra effort reconciling this difference will take.
2. We still perform the `ALTER TABLE ... DROP CONSTRAINT` and `ALTER TABLE ... ADD CONSTRAINT` as separate statements. If those were performed in a single statement, by the time of `ADD`, MySQL would think that the `DROP`ped constraint still exists and report a duplicate constraint name error:
   ```sql
   CREATE TABLE parent
   (
       id INT PRIMARY KEY
   );

   CREATE TABLE child
   (
       id        INT PRIMARY KEY,
       parent_id INT NOT NULL,
       INDEX idx_parent (parent_id),
       CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent (id)
   );

   ALTER TABLE child
       DROP FOREIGN KEY fk_parent,
       ADD CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent (id);
   -- [HY000][1826] Duplicate foreign key constraint name 'fk_parent'
   ```