### PR TITLE
Remove get(Pre|Post)AlterTableIndexForeignKeySQL()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Removed `AbstractPlatform::getPreAlterTableIndexForeignKeySQL()` and `AbstractPlatform::getPostAlterTableIndexForeignKeySQL()`
+
+The `getPreAlterTableIndexForeignKeySQL()` and `getPostAlterTableIndexForeignKeySQL()` methods of the `AbstractPlatform`
+class have been removed.
+
 ## BC BREAK: `AbstractDriverMiddleware` and `AbstractConnectionMiddleware` marked as readonly
 
 The `AbstractDriverMiddleware` and `AbstractConnectionMiddleware` classes have been marked as read-only. As a

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1270,49 +1270,6 @@ abstract class AbstractPlatform
         );
     }
 
-    /** @return list<string> */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
-    {
-        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
-
-        $sql = [];
-
-        foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
-            $sql[] = $this->getDropForeignKeySQL($constraintName->toSQL($this), $tableNameSQL);
-        }
-
-        foreach ($diff->getDroppedIndexes() as $index) {
-            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
-        }
-
-        return $sql;
-    }
-
-    /** @return list<string> */
-    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff): array
-    {
-        $sql = [];
-
-        $tableNameSQL = $diff->getOldTable()->getObjectName()->toSQL($this);
-
-        foreach ($diff->getAddedForeignKeys() as $foreignKey) {
-            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
-        }
-
-        foreach ($diff->getAddedIndexes() as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
-        }
-
-        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
-            $sql = array_merge(
-                $sql,
-                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
-            );
-        }
-
-        return $sql;
-    }
-
     /**
      * Returns the SQL for renaming an index on a table.
      *

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -264,6 +264,14 @@ class DB2Platform extends AbstractPlatform
         $tableName    = $diff->getOldTable()->getObjectName();
         $tableNameSQL = $tableName->toSQL($this);
 
+        foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
+            $sql[] = $this->getDropForeignKeySQL($constraintName->toSQL($this), $tableNameSQL);
+        }
+
+        foreach ($diff->getDroppedIndexes() as $index) {
+            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
+        }
+
         $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
 
         if ($droppedPrimaryKeyConstraint !== null) {
@@ -341,17 +349,27 @@ class DB2Platform extends AbstractPlatform
                 . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
+        foreach ($diff->getAddedForeignKeys() as $foreignKey) {
+            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
+        }
+
+        foreach ($diff->getAddedIndexes() as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
+        }
+
+        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+            $sql = array_merge(
+                $sql,
+                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+            );
+        }
+
         // Some table alteration operations require a table reorganization.
         if ($needsReorg) {
             $sql[] = sprintf("CALL SYSPROC.ADMIN_CMD ('REORG TABLE %s')", $tableNameSQL);
         }
 
-        return array_merge(
-            $this->getPreAlterTableIndexForeignKeySQL($diff),
-            $sql,
-            $commentsSQL,
-            $this->getPostAlterTableIndexForeignKeySQL($diff),
-        );
+        return array_merge($sql, $commentsSQL);
     }
 
     public function getRenameTableSQL(string $oldName, string $newName): string

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -513,6 +513,14 @@ SQL,
         $tableName    = $diff->getOldTable()->getObjectName();
         $tableNameSQL = $tableName->toSQL($this);
 
+        foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
+            $sql[] = $this->getDropForeignKeySQL($constraintName->toSQL($this), $tableNameSQL);
+        }
+
+        foreach ($diff->getDroppedIndexes() as $index) {
+            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
+        }
+
         $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
 
         if ($droppedPrimaryKeyConstraint !== null) {
@@ -625,12 +633,22 @@ SQL,
                 . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
-        return array_merge(
-            $this->getPreAlterTableIndexForeignKeySQL($diff),
-            $sql,
-            $commentsSQL,
-            $this->getPostAlterTableIndexForeignKeySQL($diff),
-        );
+        foreach ($diff->getAddedForeignKeys() as $foreignKey) {
+            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
+        }
+
+        foreach ($diff->getAddedIndexes() as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
+        }
+
+        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+            $sql = array_merge(
+                $sql,
+                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+            );
+        }
+
+        return array_merge($sql, $commentsSQL);
     }
 
     /**

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -176,6 +176,14 @@ class PostgreSQLPlatform extends AbstractPlatform
         $tableName    = $table->getObjectName();
         $tableNameSQL = $tableName->toSQL($this);
 
+        foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
+            $sql[] = $this->getDropForeignKeySQL($constraintName->toSQL($this), $tableNameSQL);
+        }
+
+        foreach ($diff->getDroppedIndexes() as $index) {
+            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
+        }
+
         $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
 
         if ($droppedPrimaryKeyConstraint !== null) {
@@ -274,12 +282,22 @@ class PostgreSQLPlatform extends AbstractPlatform
                 . $this->getPrimaryKeyConstraintDeclarationSQL($addedPrimaryKeyConstraint);
         }
 
-        return array_merge(
-            $this->getPreAlterTableIndexForeignKeySQL($diff),
-            $sql,
-            $commentsSQL,
-            $this->getPostAlterTableIndexForeignKeySQL($diff),
-        );
+        foreach ($diff->getAddedForeignKeys() as $foreignKey) {
+            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
+        }
+
+        foreach ($diff->getAddedIndexes() as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
+        }
+
+        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+            $sql = array_merge(
+                $sql,
+                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+            );
+        }
+
+        return array_merge($sql, $commentsSQL);
     }
 
     private function getTypeSQLDeclaration(Column $column): string

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -317,6 +317,14 @@ class SQLServerPlatform extends AbstractPlatform
 
         $tableNameSQL = $tableName->toSQL($this);
 
+        foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
+            $sql[] = $this->getDropForeignKeySQL($constraintName->toSQL($this), $tableNameSQL);
+        }
+
+        foreach ($diff->getDroppedIndexes() as $index) {
+            $sql[] = $this->getDropIndexSQL($index->getObjectName()->toSQL($this), $tableNameSQL);
+        }
+
         $droppedPrimaryKeyConstraint = $diff->getDroppedPrimaryKeyConstraint();
 
         if ($droppedPrimaryKeyConstraint !== null) {
@@ -446,12 +454,22 @@ class SQLServerPlatform extends AbstractPlatform
             $sql[] = sprintf('ALTER TABLE %s %s', $tableName->toSQL($this), $query);
         }
 
-        return array_merge(
-            $this->getPreAlterTableIndexForeignKeySQL($diff),
-            $sql,
-            $commentsSql,
-            $this->getPostAlterTableIndexForeignKeySQL($diff),
-        );
+        foreach ($diff->getAddedForeignKeys() as $foreignKey) {
+            $sql[] = $this->getCreateForeignKeySQL($foreignKey, $tableNameSQL);
+        }
+
+        foreach ($diff->getAddedIndexes() as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
+        }
+
+        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+            $sql = array_merge(
+                $sql,
+                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+            );
+        }
+
+        return array_merge($sql, $commentsSql);
     }
 
     public function getRenameTableSQL(string $oldName, string $newName): string

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -476,32 +476,6 @@ class SQLitePlatform extends AbstractPlatform
         ];
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function getPreAlterTableIndexForeignKeySQL(TableDiff $diff): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getPostAlterTableIndexForeignKeySQL(TableDiff $diff): array
-    {
-        $table = $diff->getOldTable();
-
-        $tableNameSQL = $table->getObjectName()->toSQL($this);
-
-        $sql = [];
-
-        foreach ($this->getIndexesInAlteredTable($diff) as $index) {
-            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
-        }
-
-        return $sql;
-    }
-
     protected function doModifyLimitQuery(string $query, ?int $limit, int $offset): string
     {
         if ($limit === null && $offset > 0) {
@@ -676,10 +650,12 @@ class SQLitePlatform extends AbstractPlatform
             ->getUnqualifiedName()
             ->getValue();
 
+        $tableNameSQL = $table->getObjectName()->toSQL($this);
+
         $dataTable = new Table('__temp__' . $tableName);
 
         $newTable = new Table(
-            $table->getObjectName()->toSQL($this),
+            $tableNameSQL,
             $columns,
             [],
             [],
@@ -691,15 +667,15 @@ class SQLitePlatform extends AbstractPlatform
 
         $newTable->addOption('alter', true);
 
-        $sql = $this->getPreAlterTableIndexForeignKeySQL($diff);
-
-        $sql[] = sprintf(
-            'CREATE TEMPORARY TABLE %s AS SELECT %s FROM %s',
-            $dataTable->getObjectName()->toSQL($this),
-            implode(', ', $oldColumnNames),
-            $table->getObjectName()->toSQL($this),
-        );
-        $sql[] = $this->getDropTableSQL($table->getObjectName()->toSQL($this));
+        $sql = [
+            sprintf(
+                'CREATE TEMPORARY TABLE %s AS SELECT %s FROM %s',
+                $dataTable->getObjectName()->toSQL($this),
+                implode(', ', $oldColumnNames),
+                $table->getObjectName()->toSQL($this),
+            ),
+            $this->getDropTableSQL($table->getObjectName()->toSQL($this)),
+        ];
 
         $sql   = array_merge($sql, $this->getCreateTableSQL($newTable));
         $sql[] = sprintf(
@@ -711,7 +687,11 @@ class SQLitePlatform extends AbstractPlatform
         );
         $sql[] = $this->getDropTableSQL($dataTable->getObjectName()->toSQL($this));
 
-        return array_merge($sql, $this->getPostAlterTableIndexForeignKeySQL($diff));
+        foreach ($this->getIndexesInAlteredTable($diff) as $index) {
+            $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
+        }
+
+        return $sql;
     }
 
     /** @return list<string>|false */


### PR DESCRIPTION
This is a follow up to https://github.com/doctrine/dbal/pull/7289.

The resulting slight increase in code duplication of the `AbstractPlatform::getAlterTableSQL()` implementations is justified. They are already huge and repetitive. The code being inlined naturally belongs there.

This opens up a potential for further optimization of the resulting statements. For each individual platform, we could build a smallest possible list of statements that groups multiple actions in to one and takes platform limitations into account (see `ALTER TABLE ... DROP CONSTRAINT; ALTER TABLE ... DROP INDEX ..., CREATE INDEX ...` for MySQL in https://github.com/doctrine/dbal/pull/7289).

The code duplication could be offset by proper modularization. The DDL could be represented as composable objects (e.g. `AlterTableStatement`, `abstract AlterTableAction`, `AlterTableDropConstraintAction`, etc.) that the platform classes would reuse.