### PR TITLE
Bump PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "jetbrains/phpstorm-stubs": "2023.1",
         "phpstan/phpstan": "2.1.30",
         "phpstan/phpstan-strict-rules": "^2",
-        "phpunit/phpunit": "9.6.29",
+        "phpunit/phpunit": "9.6.34",
         "slevomat/coding-standard": "8.27.1",
         "squizlabs/php_codesniffer": "4.0.1",
         "symfony/cache": "^5.4|^6.0|^7.0|^8.0",


### PR DESCRIPTION
Composer refuses to install it because of
https://packagist.org/security-advisories/PKSA-z3gr-8qht-p93v

Fixes #7297 for 3.x