### PR TITLE
Ignore CVE-2026-24765 in Composer's audit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,11 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "composer/package-versions-deprecated": true
+        },
+        "audit": {
+            "ignore": {
+                "CVE-2026-24765": "We are not affected by this vulnerability."
+            }
         }
     },
     "autoload": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | chore
| Fixed issues | #7297

#### Summary

Composer complains about the PHPUnit version in use because a vulnerability has been discovered (GHSA-vvj3-c3rp-c85p). However, upgrading is complicated for us at the moment (see #7190). Also, I'm pretty certain that this vulnerability does not affect us. Therefore, I'd like to ignore this report in order to unblock the CI for us.
