### PR TITLE
Deterministic index order in MySQL

### DIFF
--- a/src/Platforms/MySQL/MySQLMetadataProvider.php
+++ b/src/Platforms/MySQL/MySQLMetadataProvider.php
@@ -394,6 +394,7 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             WHERE %s
               AND INDEX_NAME != 'PRIMARY'
             ORDER BY TABLE_NAME,
+                INDEX_NAME,
                 SEQ_IN_INDEX
             SQL,
             implode(' AND ', $conditions),

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -428,6 +428,7 @@ SELECT
 FROM information_schema.STATISTICS
 WHERE %s
 ORDER BY TABLE_NAME,
+         INDEX_NAME,
          SEQ_IN_INDEX
 SQL,
             implode(' AND ', $conditions),


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

Currently if you do a schema comparison that results in index changes the order of the `DROP INDEX` statements is random. This causes issues in our migrations system as it expects the SQL code of a dry run to be the same as for the actual execution.

We already sort tables by `TABLE_NAME` and columns by `ORDINAL_POSITION`, so also sorting indexes deterministically would be consistent and improve the stability.