### PR TITLE
Avoid mocks without expectations

### DIFF
--- a/tests/Connection/CachedQueryTest.php
+++ b/tests/Connection/CachedQueryTest.php
@@ -88,7 +88,7 @@ class CachedQueryTest extends TestCase
             ->method('query')
             ->willReturnCallback(static fn (): ArrayResult => new ArrayResult($columnNames, $rows));
 
-        $driver = $this->createMock(Driver::class);
+        $driver = self::createStub(Driver::class);
         $driver->method('connect')
             ->willReturn($connection);
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -183,12 +183,12 @@ class ConnectionTest extends TestCase
 
     public function testTransactionIsActiveAfterTransactionalInNoAutoCommitMode(): void
     {
-        $platformMock = $this->createMock(AbstractPlatform::class);
+        $platformMock = self::createStub(AbstractPlatform::class);
         $platformMock
             ->method('supportsSavepoints')
             ->willReturn(true);
 
-        $driverMock = $this->createMock(Driver::class);
+        $driverMock = self::createStub(Driver::class);
         $driverMock
             ->method('connect')
             ->willReturn(
@@ -470,7 +470,7 @@ class ConnectionTest extends TestCase
             ->willReturn($expected);
 
         $driver = $this->createConfiguredMock(Driver::class, [
-            'connect' => $this->createMock(DriverConnection::class),
+            'connect' => self::createStub(DriverConnection::class),
         ]);
 
         $conn = $this->getMockBuilder(Connection::class)
@@ -565,7 +565,7 @@ class ConnectionTest extends TestCase
             ->method('getServerVersion')
             ->willReturn('6.6.6');
 
-        $platform = $this->createMock(AbstractPlatform::class);
+        $platform = self::createStub(AbstractPlatform::class);
 
         $driver = $this->createMock(Driver::class);
         $driver->expects(self::once())
@@ -590,7 +590,7 @@ class ConnectionTest extends TestCase
         $driverConnection->expects(self::never())
             ->method('getServerVersion');
 
-        $platform = $this->createMock(AbstractPlatform::class);
+        $platform = self::createStub(AbstractPlatform::class);
 
         $driver = $this->createMock(Driver::class);
         $driver->expects(self::never())
@@ -608,9 +608,9 @@ class ConnectionTest extends TestCase
     {
         $driverMock = $this->createMock(Driver::class);
 
-        $driverConnectionMock = $this->createMock(Driver\Connection::class);
+        $driverConnectionMock = self::createStub(Driver\Connection::class);
 
-        $platformMock = $this->createMock(AbstractPlatform::class);
+        $platformMock = self::createStub(AbstractPlatform::class);
 
         $connection = new Connection(['serverVersion' => '8.0'], $driverMock);
 
@@ -630,9 +630,9 @@ class ConnectionTest extends TestCase
     {
         $driverMock = $this->createMock(Driver::class);
 
-        $driverConnectionMock = $this->createMock(Driver\Connection::class);
+        $driverConnectionMock = self::createStub(Driver\Connection::class);
 
-        $platformMock = $this->createMock(AbstractPlatform::class);
+        $platformMock = self::createStub(AbstractPlatform::class);
 
         $connection = new Connection(['primary' => ['serverVersion' => '8.0']], $driverMock);
 
@@ -650,7 +650,7 @@ class ConnectionTest extends TestCase
 
     public function testConnectionParamsArePassedToTheQueryCacheProfileInExecuteCacheQuery(): void
     {
-        $cacheItemMock = $this->createMock(CacheItemInterface::class);
+        $cacheItemMock = self::createStub(CacheItemInterface::class);
         $cacheItemMock->method('isHit')->willReturn(true);
         $cacheItemMock->method('get')->willReturn(['realKey' => [[], []]]);
 
@@ -682,7 +682,7 @@ class ConnectionTest extends TestCase
             ->with($query, $params, $types, $expectedConnectionParams)
             ->willReturn(['cacheKey', 'realKey']);
 
-        $driver = $this->createMock(Driver::class);
+        $driver = self::createStub(Driver::class);
 
         (new Connection(self::CONNECTION_PARAMS, $driver))
             ->executeCacheQuery($query, $params, $types, $queryCacheProfileMock);

--- a/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
@@ -14,7 +14,7 @@ final class AbstractConnectionMiddlewareTest extends TestCase
 {
     public function testPrepare(): void
     {
-        $statement  = $this->createMock(Statement::class);
+        $statement  = self::createStub(Statement::class);
         $connection = $this->createMock(Connection::class);
         $connection->expects(self::once())
             ->method('prepare')
@@ -26,7 +26,7 @@ final class AbstractConnectionMiddlewareTest extends TestCase
 
     public function testQuery(): void
     {
-        $result     = $this->createMock(Result::class);
+        $result     = self::createStub(Result::class);
         $connection = $this->createMock(Connection::class);
         $connection->expects(self::once())
             ->method('query')

--- a/tests/Driver/Middleware/AbstractDriverMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractDriverMiddlewareTest.php
@@ -13,7 +13,7 @@ final class AbstractDriverMiddlewareTest extends TestCase
 {
     public function testConnect(): void
     {
-        $connection = $this->createMock(Connection::class);
+        $connection = self::createStub(Connection::class);
         $driver     = $this->createMock(Driver::class);
         $driver->expects(self::once())
             ->method('connect')

--- a/tests/Driver/Middleware/AbstractStatementMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractStatementMiddlewareTest.php
@@ -13,7 +13,7 @@ final class AbstractStatementMiddlewareTest extends TestCase
 {
     public function testExecute(): void
     {
-        $result    = $this->createMock(Result::class);
+        $result    = self::createStub(Result::class);
         $statement = $this->createMock(Statement::class);
         $statement->expects(self::once())
             ->method('execute')

--- a/tests/DriverManagerTest.php
+++ b/tests/DriverManagerTest.php
@@ -41,7 +41,7 @@ class DriverManagerTest extends TestCase
     #[RequiresPhpExtension('sqlite3')]
     public function testCustomWrapper(): void
     {
-        $wrapper      = $this->createMock(Connection::class);
+        $wrapper      = self::createStub(Connection::class);
         $wrapperClass = $wrapper::class;
 
         $options = [

--- a/tests/Logging/MiddlewareTest.php
+++ b/tests/Logging/MiddlewareTest.php
@@ -18,9 +18,9 @@ class MiddlewareTest extends TestCase
 
     public function setUp(): void
     {
-        $connection = $this->createMock(Connection::class);
+        $connection = self::createStub(Connection::class);
 
-        $driver = $this->createMock(Driver::class);
+        $driver = self::createStub(Driver::class);
         $driver->method('connect')
             ->willReturn($connection);
 

--- a/tests/Portability/ConnectionTest.php
+++ b/tests/Portability/ConnectionTest.php
@@ -28,7 +28,7 @@ class ConnectionTest extends TestCase
         $nativeConnection = new class () {
         };
 
-        $driverConnection = $this->createMock(ConnectionInterface::class);
+        $driverConnection = self::createStub(ConnectionInterface::class);
         $driverConnection->method('getNativeConnection')
             ->willReturn($nativeConnection);
 

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -38,7 +38,7 @@ class QueryBuilderTest extends TestCase
         $this->conn->method('createExpressionBuilder')
            ->willReturnCallback(fn () => new ExpressionBuilder($this->conn));
 
-        $platform = $this->createMock(AbstractPlatform::class);
+        $platform = self::createStub(AbstractPlatform::class);
         $platform->method('getUnionSelectPartSQL')
             ->willReturnArgument(0);
         $platform->method('getUnionAllSQL')

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -73,7 +73,7 @@ class ColumnTest extends TestCase
         $this->expectException(UnknownColumnOption::class);
         $this->expectExceptionMessage('The "unknown_option" column option is not supported.');
 
-        new Column('foo', $this->createMock(Type::class), ['unknown_option' => 'bar']);
+        new Column('foo', self::createStub(Type::class), ['unknown_option' => 'bar']);
     }
 
     public function testOptionsShouldNotBeIgnored(): void

--- a/tests/Schema/MySQLInheritCharsetTest.php
+++ b/tests/Schema/MySQLInheritCharsetTest.php
@@ -81,7 +81,7 @@ class MySQLInheritCharsetTest extends TestCase
      */
     private function getTableOptionsForOverride(array $params = []): array
     {
-        $driverMock = $this->createMock(Driver::class);
+        $driverMock = self::createStub(Driver::class);
 
         $platform = new MySQLPlatform();
         $conn     = new Connection($params, $driverMock, new Configuration());

--- a/tests/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Schema/SQLiteSchemaManagerTest.php
@@ -18,7 +18,7 @@ class SQLiteSchemaManagerTest extends TestCase
      */
     public function testListTableForeignKeysDefaultDatabasePassing(): void
     {
-        $conn = $this->createMock(Connection::class);
+        $conn = self::createStub(Connection::class);
         $conn->method('getDatabase')
             ->willReturn('main');
 

--- a/tests/Tools/DsnParserTest.php
+++ b/tests/Tools/DsnParserTest.php
@@ -185,7 +185,7 @@ final class DsnParserTest extends TestCase
 
     public function testDriverClassScheme(): void
     {
-        $driverClass = get_class($this->createMock(Driver::class));
+        $driverClass = get_class(self::createStub(Driver::class));
         $parser      = new DsnParser(['custom' => $driverClass]);
         $actual      = $parser->parse('custom://foo:bar@localhost/baz');
 

--- a/tests/Types/BaseDateTypeTestCase.php
+++ b/tests/Types/BaseDateTypeTestCase.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -18,7 +18,7 @@ use function date_default_timezone_set;
 
 abstract class BaseDateTypeTestCase extends TestCase
 {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform&Stub $platform;
     protected Type $type;
 
     /** @var non-empty-string */
@@ -26,7 +26,7 @@ abstract class BaseDateTypeTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform        = $this->createMock(AbstractPlatform::class);
+        $this->platform        = self::createStub(AbstractPlatform::class);
         $this->currentTimezone = date_default_timezone_get();
     }
 

--- a/tests/Types/BinaryTest.php
+++ b/tests/Types/BinaryTest.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\ConversionException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 use function array_map;
@@ -20,12 +20,12 @@ use function range;
 
 class BinaryTest extends TestCase
 {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform&Stub $platform;
     protected BinaryType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new BinaryType();
     }
 

--- a/tests/Types/BlobTest.php
+++ b/tests/Types/BlobTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BlobType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class BlobTest extends TestCase
 {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform&Stub $platform;
     protected BlobType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new BlobType();
     }
 

--- a/tests/Types/ConversionExceptionTest.php
+++ b/tests/Types/ConversionExceptionTest.php
@@ -20,7 +20,7 @@ class ConversionExceptionTest extends TestCase
 {
     public function testConversionFailedPreviousException(): void
     {
-        $previous = $this->createMock(Throwable::class);
+        $previous = self::createStub(Throwable::class);
 
         $exception = ValueNotConvertible::new('foo', 'foo', null, $previous);
 
@@ -55,7 +55,7 @@ class ConversionExceptionTest extends TestCase
 
     public function testConversionFailedInvalidTypePreviousException(): void
     {
-        $previous = $this->createMock(Throwable::class);
+        $previous = self::createStub(Throwable::class);
 
         $exception = InvalidType::new('foo', 'foo', ['bar', 'baz'], $previous);
 
@@ -64,7 +64,7 @@ class ConversionExceptionTest extends TestCase
 
     public function testConversionFailedFormatPreservesPreviousException(): void
     {
-        $previous = $this->createMock(Throwable::class);
+        $previous = self::createStub(Throwable::class);
 
         $exception = InvalidFormat::new('foo', 'bar', 'baz', $previous);
 

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
@@ -36,15 +37,11 @@ class DateImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue(): void
     {
-        $date = $this->createMock(DateTimeImmutable::class);
+        $date = new DateTimeImmutable('2016-01-01 12:34:56', new DateTimeZone('UTC'));
 
         $this->platform->expects(self::once())
             ->method('getDateFormatString')
             ->willReturn('Y-m-d');
-        $date->expects(self::once())
-            ->method('format')
-            ->with('Y-m-d')
-            ->willReturn('2016-01-01');
 
         self::assertSame(
             '2016-01-01',

--- a/tests/Types/DateIntervalTest.php
+++ b/tests/Types/DateIntervalTest.php
@@ -10,18 +10,18 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateIntervalType;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 final class DateIntervalTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private DateIntervalType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new DateIntervalType();
     }
 

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
@@ -36,15 +37,11 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue(): void
     {
-        $date = $this->createMock(DateTimeImmutable::class);
+        $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
         $this->platform->expects(self::once())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
-        $date->expects(self::once())
-            ->method('format')
-            ->with('Y-m-d H:i:s')
-            ->willReturn('2016-01-01 15:58:59');
 
         self::assertSame(
             '2016-01-01 15:58:59',

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
@@ -36,15 +37,11 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue(): void
     {
-        $date = $this->createMock(DateTimeImmutable::class);
+        $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
         $this->platform->expects(self::once())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
-        $date->expects(self::once())
-            ->method('format')
-            ->with('Y-m-d H:i:s T')
-            ->willReturn('2016-01-01 15:58:59 UTC');
 
         self::assertSame(
             '2016-01-01 15:58:59 UTC',

--- a/tests/Types/DecimalTest.php
+++ b/tests/Types/DecimalTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DecimalType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DecimalTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private DecimalType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new DecimalType();
     }
 

--- a/tests/Types/FloatTest.php
+++ b/tests/Types/FloatTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\FloatType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class FloatTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private FloatType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new FloatType();
     }
 

--- a/tests/Types/GuidTypeTest.php
+++ b/tests/Types/GuidTypeTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\GuidType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class GuidTypeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private GuidType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new GuidType();
     }
 

--- a/tests/Types/IntegerTest.php
+++ b/tests/Types/IntegerTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\IntegerType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class IntegerTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private IntegerType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new IntegerType();
     }
 

--- a/tests/Types/NumberTest.php
+++ b/tests/Types/NumberTest.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Types\NumberType;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -20,12 +20,12 @@ use stdClass;
 #[RequiresPhpExtension('bcmath')]
 final class NumberTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private NumberType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new NumberType();
     }
 

--- a/tests/Types/SmallFloatTest.php
+++ b/tests/Types/SmallFloatTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\SmallFloatType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class SmallFloatTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private SmallFloatType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new SmallFloatType();
     }
 

--- a/tests/Types/SmallIntTest.php
+++ b/tests/Types/SmallIntTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\SmallIntType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class SmallIntTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private SmallIntType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new SmallIntType();
     }
 

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
@@ -36,15 +37,11 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue(): void
     {
-        $date = $this->createMock(DateTimeImmutable::class);
+        $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
         $this->platform->expects(self::once())
             ->method('getTimeFormatString')
             ->willReturn('H:i:s');
-        $date->expects(self::once())
-            ->method('format')
-            ->with('H:i:s')
-            ->willReturn('15:58:59');
 
         self::assertSame(
             '15:58:59',

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
@@ -35,12 +36,7 @@ class VarDateTimeImmutableTypeTest extends TestCase
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 
-        $date = $this->createMock(DateTimeImmutable::class);
-
-        $date->expects(self::once())
-            ->method('format')
-            ->with('Y-m-d H:i:s')
-            ->willReturn('2016-01-01 15:58:59');
+        $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
         self::assertSame(
             '2016-01-01 15:58:59',

--- a/tests/Types/VarDateTimeTest.php
+++ b/tests/Types/VarDateTimeTest.php
@@ -8,17 +8,17 @@ use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\VarDateTimeType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class VarDateTimeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private VarDateTimeType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new VarDateTimeType();
 
         $this->platform->method('getDateTimeFormatString')


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

PHPUnit 12.5 triggers a notice if we create a mock object and don't configure any expectations on that object. A stub would suffice in that case. This PR is a first step towards separating mocks and stubs. It fixes all easy picks that I could find.

Some of our tests created mocks of the `DateTimeImmutable` class. I don't find that very reasonable, so I converted those mocks to actual `DateTimeImmutable` instances.
