### PR TITLE
Handle null column name in InvalidColumnDeclaration::fromInvalidColumnType()

### DIFF
--- a/src/Exception/InvalidColumnDeclaration.php
+++ b/src/Exception/InvalidColumnDeclaration.php
@@ -11,8 +11,12 @@ use function sprintf;
 
 final class InvalidColumnDeclaration extends LogicException implements Exception
 {
-    public static function fromInvalidColumnType(string $columnName, InvalidColumnType $e): self
+    public static function fromInvalidColumnType(string|null $columnName, InvalidColumnType $e): self
     {
+        if ($columnName === null) {
+            return new self('Column has invalid type', 0, $e);
+        }
+
         return new self(sprintf('Column "%s" has invalid type', $columnName), 0, $e);
     }
 }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -203,7 +203,7 @@ abstract class AbstractPlatform
             try {
                 return $this->getVarcharTypeDeclarationSQLSnippet($length);
             } catch (InvalidColumnType $e) {
-                throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'], $e);
+                throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'] ?? null, $e);
             }
         }
 
@@ -226,7 +226,7 @@ abstract class AbstractPlatform
 
             return $this->getBinaryTypeDeclarationSQLSnippet($length);
         } catch (InvalidColumnType $e) {
-            throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'], $e);
+            throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'] ?? null, $e);
         }
     }
 
@@ -1516,11 +1516,11 @@ abstract class AbstractPlatform
     public function getDecimalTypeDeclarationSQL(array $column): string
     {
         if (! isset($column['precision'])) {
-            throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'], ColumnPrecisionRequired::new());
+            throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'] ?? null, ColumnPrecisionRequired::new());
         }
 
         if (! isset($column['scale'])) {
-            throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'], ColumnScaleRequired::new());
+            throw InvalidColumnDeclaration::fromInvalidColumnType($column['name'] ?? null, ColumnScaleRequired::new());
         }
 
         return 'NUMERIC(' . $column['precision'] . ', ' . $column['scale'] . ')';

--- a/tests/Exception/InvalidColumnDeclarationTest.php
+++ b/tests/Exception/InvalidColumnDeclarationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Exception;
+
+use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
+use Doctrine\DBAL\Exception\InvalidColumnType;
+use PHPUnit\Framework\TestCase;
+
+final class InvalidColumnDeclarationTest extends TestCase
+{
+    public function testFromInvalidColumnTypeWithName(): void
+    {
+        $previous = $this->createMock(InvalidColumnType::class);
+        $exception = InvalidColumnDeclaration::fromInvalidColumnType('my_column', $previous);
+
+        self::assertSame('Column "my_column" has invalid type', $exception->getMessage());
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testFromInvalidColumnTypeWithNullName(): void
+    {
+        $previous = $this->createMock(InvalidColumnType::class);
+        $exception = InvalidColumnDeclaration::fromInvalidColumnType(null, $previous);
+
+        self::assertSame('Column has invalid type', $exception->getMessage());
+        self::assertSame($previous, $exception->getPrevious());
+    }
+}


### PR DESCRIPTION
## Summary

When `$column['name']` is not set in the column definition array, `AbstractPlatform` methods pass `null` to `InvalidColumnDeclaration::fromInvalidColumnType()`, which expects `string`, causing a `TypeError`.

This happens when using type declarations directly without a column name, e.g.:

```php
Type::getType('string')->getSQLDeclaration([], $platform);
```

## Changes

- Made `$columnName` parameter nullable (`string|null`) in `InvalidColumnDeclaration::fromInvalidColumnType()`
- Added fallback message `"Column has invalid type"` when column name is null
- Updated all call sites in `AbstractPlatform` to use `$column['name'] ?? null`
- Added unit tests for both named and unnamed column scenarios

## Fixes

Fixes #7256