### PR TITLE
Fix PostgreSQL column collation diff

### DIFF
--- a/src/Platforms/PostgreSQL/Comparator.php
+++ b/src/Platforms/PostgreSQL/Comparator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\PostgreSQL;
+
+use Doctrine\DBAL\Schema\Comparator as BaseComparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Compares schemas in the context of PostgreSQL platform.
+ *
+ * PostgreSQL treats "default" collation as implicit, so an explicit "default" value should be ignored when comparing
+ * schemas.
+ */
+class Comparator extends BaseComparator
+{
+    public function compareTables(Table $oldTable, Table $newTable): TableDiff
+    {
+        return parent::compareTables(
+            $this->normalizeColumns($oldTable),
+            $this->normalizeColumns($newTable),
+        );
+    }
+
+    private function normalizeColumns(Table $table): Table
+    {
+        $table = clone $table;
+
+        foreach ($table->getColumns() as $column) {
+            $options = $column->getPlatformOptions();
+
+            if (! isset($options['collation']) || $options['collation'] !== 'default') {
+                continue;
+            }
+
+            unset($options['collation']);
+            $column->setPlatformOptions($options);
+        }
+
+        return $table;
+    }
+}

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -44,6 +44,9 @@ use function trim;
  */
 class PostgreSQLPlatform extends AbstractPlatform
 {
+    /** @see https://www.postgresql.org/docs/current/collation.html */
+    private const DEFAULT_COLLATION = 'default';
+
     private bool $useBooleanTrueFalseStrings = true;
 
     /** @var string[][] PostgreSQL booleans literals */
@@ -253,8 +256,18 @@ class PostgreSQLPlatform extends AbstractPlatform
 
             $newTypeSQLDeclaration = $this->getTypeSQLDeclaration($newColumn);
             $oldTypeSQLDeclaration = $this->getTypeSQLDeclaration($oldColumn);
-            if ($oldTypeSQLDeclaration !== $newTypeSQLDeclaration) {
+
+            $newCollation = $newColumn->getCollation() ?? self::DEFAULT_COLLATION;
+            $oldCollation = $oldColumn->getCollation() ?? self::DEFAULT_COLLATION;
+
+            $typeChanged      = $oldTypeSQLDeclaration !== $newTypeSQLDeclaration;
+            $collationChanged = $oldCollation !== $newCollation;
+            if ($typeChanged || $collationChanged) {
                 $query = 'ALTER ' . $newColumnName . ' TYPE ' . $newTypeSQLDeclaration;
+                if (! $typeChanged || $newCollation !== self::DEFAULT_COLLATION) {
+                    $query .= ' ' . $this->getColumnCollationDeclarationSQL($newCollation);
+                }
+
                 $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
             }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQL;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\JsonType;
@@ -15,6 +16,8 @@ use function array_map;
 use function assert;
 use function count;
 use function explode;
+use function func_get_arg;
+use function func_num_args;
 use function implode;
 use function is_string;
 use function preg_match;
@@ -33,6 +36,14 @@ use const CASE_LOWER;
  */
 class PostgreSQLSchemaManager extends AbstractSchemaManager
 {
+    public function createComparator(/* ComparatorConfig $config = new ComparatorConfig() */): Comparator
+    {
+        return new PostgreSQL\Comparator(
+            $this->platform,
+            func_num_args() > 0 ? func_get_arg(0) : new ComparatorConfig(),
+        );
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/tests/Functional/Schema/AlterColumnCollationTestCase.php
+++ b/tests/Functional/Schema/AlterColumnCollationTestCase.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+abstract class AlterColumnCollationTestCase extends FunctionalTestCase
+{
+    /**
+     * @param ?non-empty-string            $oldCollation
+     * @param callable(ColumnEditor): void $modifyColumn
+     * @param ?non-empty-string            $expectedCollation
+     */
+    #[DataProvider('provideAlterColumnCollationCases')]
+    public function testAlterColumnCollation(
+        ?string $oldCollation,
+        callable $modifyColumn,
+        bool $expectEmptyDiff,
+        ?string $expectedCollation,
+    ): void {
+        $table = Table::editor()
+            ->setUnquotedName('test_column_collation')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('value')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(50)
+                    ->setCollation($oldCollation)
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropAndCreateTable($table);
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $tableFrom     = $schemaManager->introspectTableByUnquotedName('test_column_collation');
+        $column        = $tableFrom->getColumn('value');
+
+        self::assertSame($oldCollation, $column->getCollation());
+
+        $tableTo = $tableFrom->edit()
+            ->modifyColumnByUnquotedName('value', $modifyColumn)
+            ->create();
+
+        $diff = $schemaManager->createComparator()->compareTables($tableFrom, $tableTo);
+        self::assertSame($expectEmptyDiff, $diff->isEmpty());
+
+        $schemaManager->alterTable($diff);
+
+        $column = $schemaManager
+            ->introspectTableByUnquotedName('test_column_collation')
+            ->getColumn('value');
+
+        self::assertSame($expectedCollation, $column->getCollation());
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     ?string,
+     *     callable(ColumnEditor): void,
+     *     bool,
+     *     ?string
+     * }>
+     */
+    abstract public static function provideAlterColumnCollationCases(): iterable;
+}

--- a/tests/Functional/Schema/PostgreSQL/AlterColumnCollationTest.php
+++ b/tests/Functional/Schema/PostgreSQL/AlterColumnCollationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Schema\PostgreSQL;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Tests\Functional\Schema\AlterColumnCollationTestCase;
+
+final class AlterColumnCollationTest extends AlterColumnCollationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            return;
+        }
+
+        self::markTestSkipped('Test is for PostgreSQL.');
+    }
+
+    /** {@inheritDoc} */
+    public static function provideAlterColumnCollationCases(): iterable
+    {
+        yield 'implicit default to implicit default' => [
+            null,
+            static function (ColumnEditor $editor): void {
+            },
+            true,
+            null,
+        ];
+
+        yield 'implicit default to explicit default' => [
+            null,
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('default');
+            },
+            true,
+            null,
+        ];
+
+        yield 'implicit default to C' => [
+            null,
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('C');
+            },
+            false,
+            'C',
+        ];
+
+        yield 'C to implicit default' => [
+            'C',
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation(null);
+            },
+            false,
+            null,
+        ];
+
+        yield 'C to explicit default' => [
+            'C',
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('default');
+            },
+            false,
+            null,
+        ];
+
+        yield 'C to C' => [
+            'C',
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('C');
+            },
+            true,
+            'C',
+        ];
+
+        yield 'length change preserves non-default collation' => [
+            'C',
+            static function (ColumnEditor $editor): void {
+                $editor->setLength(100);
+            },
+            false,
+            'C',
+        ];
+    }
+}

--- a/tests/Platforms/PostgreSQL/ComparatorTest.php
+++ b/tests/Platforms/PostgreSQL/ComparatorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms\PostgreSQL;
+
+use Doctrine\DBAL\Platforms\PostgreSQL\Comparator;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Tests\Schema\AbstractComparatorTestCase;
+
+class ComparatorTest extends AbstractComparatorTestCase
+{
+    protected function createComparator(ComparatorConfig $config): Comparator
+    {
+        return new Comparator(new PostgreSQLPlatform(), $config);
+    }
+}

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -24,7 +24,10 @@ use UnexpectedValueException;
 
 use function sprintf;
 
-/** @extends AbstractPlatformTestCase<PostgreSQLPlatform> */
+/**
+ * @extends AbstractPlatformTestCase<PostgreSQLPlatform>
+ * @phpstan-import-type PlatformOptions from Column
+ */
 class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 {
     public function createPlatform(): AbstractPlatform
@@ -489,6 +492,107 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         $schemaName = 'schema';
         $sql        = $this->platform->getCreateSchemaSQL($schemaName);
         self::assertEquals('CREATE SCHEMA ' . $schemaName, $sql);
+    }
+
+    /**
+     * @param array{platformOptions?: PlatformOptions} $oldOptions
+     * @param array{platformOptions?: PlatformOptions} $newOptions
+     * @param ?non-empty-string                        $newType
+     * @param list<string>                             $expectedSql
+     */
+    #[DataProvider('provideAlterColumnCollation')]
+    public function testAlterColumnCollation(
+        array $oldOptions,
+        array $newOptions,
+        ?string $newType,
+        array $expectedSql,
+    ): void {
+        $table = new Table('mytable');
+
+        $oldColumn = $table->addColumn('foo', Types::STRING, $oldOptions);
+        $newColumn = new Column('foo', Type::getType($newType ?? Types::STRING), $newOptions);
+
+        $tableDiff = new TableDiff($table, changedColumns: [
+            'foo' => new ColumnDiff(
+                $oldColumn,
+                $newColumn,
+            ),
+        ]);
+
+        $sql = $this->platform->getAlterTableSQL($tableDiff);
+
+        self::assertSame($expectedSql, $sql);
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     array{platformOptions?: PlatformOptions},
+     *     array{platformOptions?: PlatformOptions},
+     *     ?string,
+     *     list<string>
+     * }>
+     */
+    public static function provideAlterColumnCollation(): iterable
+    {
+        $default  = ['platformOptions' => ['collation' => 'default']];
+        $unicode  = ['platformOptions' => ['collation' => 'unicode']];
+        $ucsBasic = ['platformOptions' => ['collation' => 'ucs_basic']];
+
+        yield 'implicit default to implicit default' => [
+            [],
+            [],
+            null,
+            [],
+        ];
+
+        yield 'implicit default to explicit default' => [
+            [],
+            $default,
+            null,
+            [],
+        ];
+
+        yield 'implicit default to unicode' => [
+            [],
+            $unicode,
+            null,
+            ['ALTER TABLE mytable ALTER foo TYPE VARCHAR COLLATE "unicode"'],
+        ];
+
+        yield 'unicode to implicit default' => [
+            $unicode,
+            [],
+            null,
+            ['ALTER TABLE mytable ALTER foo TYPE VARCHAR COLLATE "default"'],
+        ];
+
+        yield 'unicode to explicit default' => [
+            $unicode,
+            $default,
+            null,
+            ['ALTER TABLE mytable ALTER foo TYPE VARCHAR COLLATE "default"'],
+        ];
+
+        yield 'unicode to ucs_basic' => [
+            $unicode,
+            $ucsBasic,
+            null,
+            ['ALTER TABLE mytable ALTER foo TYPE VARCHAR COLLATE "ucs_basic"'],
+        ];
+
+        yield 'collated string to non-collatable type' => [
+            [],
+            [],
+            Types::INTEGER,
+            ['ALTER TABLE mytable ALTER foo TYPE INT'],
+        ];
+
+        yield 'length change preserves non-default collation' => [
+            ['length' => 50, 'platformOptions' => ['collation' => 'C']],
+            ['length' => 100, 'platformOptions' => ['collation' => 'C']],
+            null,
+            ['ALTER TABLE mytable ALTER foo TYPE VARCHAR(100) COLLATE "C"'],
+        ];
     }
 
     public function testDroppingConstraintsBeforeColumns(): void


### PR DESCRIPTION
#### Summary

Currently, column collation changes are ignored by the schema comparator when using `PostgreSQLPlatform`.

This PR fixes the issue.

~The `selectTableColumns` query was updated to use `collname`, as it is the value used in SQL, whereas `collcollate` represents the underlying operating system `LC_COLLATE` value.~