### PR TITLE
Derive enum values from enumType

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -689,7 +689,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 throw ColumnValuesRequired::new($this, 'ENUM');
             }
 
-            $column['values'] = $values = array_map(fn ($case) => $case->value, $column['enumType']::cases());
+            $column['values'] = $values = array_map(static fn ($case) => $case->value, $column['enumType']::cases());
         }
 
         return sprintf('ENUM(%s)', implode(', ', array_map(

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -685,7 +685,11 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     public function getEnumDeclarationSQL(array $column): string
     {
         if (! isset($column['values']) || ! is_array($column['values']) || $column['values'] === []) {
-            throw ColumnValuesRequired::new($this, 'ENUM');
+            if (! isset($column['enumType'])) {
+                throw ColumnValuesRequired::new($this, 'ENUM');
+            }
+
+            $column['values'] = $values = array_map(fn ($case) => $case->value, $column['enumType']::cases());
         }
 
         return sprintf('ENUM(%s)', implode(', ', array_map(


### PR DESCRIPTION
Note: this is just a PoC.
Would it be useful going forward building this?

Currently enum values have to be specified like this:
```
#[ORM\Column(
        type: Types::ENUM,
        enumType: FooType::class,
        options: [
            'values' => ['foo', 'bar', 'baz'],
        ],
    )]
```

This change derives the values from the declared enumType.

non-backed enums will fail:
```
  Warning: Undefined property: FooType::$value  
```

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
