### PR TITLE
Group Doctrine workflow updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     labels:
       - "CI"
     target-branch: "3.10.x"
+    groups:
+      doctrine:
+        patterns:
+          - "doctrine/*"


### PR DESCRIPTION
We do very small releases, often touching only one workflow, which means it is unlikely to have several issues when attempting to bump several references to this repository.