### PR TITLE
Add `TypeRegistry` to `Configuration` and use it in all internal type resolution

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,103 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Types can be scoped to a connection
+
+`Configuration::getTypeRegistry()` and `Configuration::setTypeRegistry()` have been added. A
+connection now resolves every type through the provider of its own `Configuration`, so custom types
+no longer have to be registered in the process-wide singleton:
+
+```php
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Types\TypeRegistry;
+
+$configuration = new Configuration();
+$configuration->setTypeProvider(new TypeRegistry(['money' => new MoneyType()]));
+
+$connection = DriverManager::getConnection($params, $configuration);
+```
+
+Connections that never call `setTypeProvider()` keep using the singleton returned by
+`Type::getTypeRegistry()`, so existing code that relies on `Type::addType()` is unaffected.
+
+Types registered with `Type::addType()` are however invisible to a connection that was given its own
+provider. This is intentional: setting one means taking responsibility for everything it must
+contain.
+
+`new TypeRegistry()` now contains all built-in types. Previously it was empty and the built-ins lived
+in `Type`. Names passed to the constructor override the built-in of the same name rather than being
+rejected as duplicates.
+
+## Added the `TypeProvider` interface
+
+`Configuration` accepts and returns `Doctrine\DBAL\Types\TypeProvider` rather than the final
+`TypeRegistry`, so the type source can be replaced or stubbed:
+
+```php
+interface TypeProvider extends Traversable
+{
+    public function get(string $name): Type;
+
+    public function has(string $name): bool;
+}
+```
+
+`register()` and `override()` are deliberately absent, so `Type::getTypeRegistry()` still returns the
+concrete `TypeRegistry` that `Type::addType()` needs.
+
+## Changed the `TypeRegistry` constructor
+
+```diff
+-public function __construct(array $instances = [])
++public function __construct(array|ContainerInterface $types = [], ?array $serviceIds = null)
+```
+
+The first parameter was renamed from `$instances` to `$types`, which matters only if you passed it as
+a named argument.
+
+It now also accepts a PSR-11 container, so types with their own dependencies are instantiated only
+when first used. Because the registry never enumerates the container, the second argument is required
+in that case and maps each type name to the service ID providing it:
+
+```php
+$registry = new TypeRegistry($container, [
+    'money'     => 'app.dbal_type.money',
+    'encrypted' => 'app.dbal_type.encrypted',
+]);
+```
+
+The container is not queried during construction, nor by `has()`. Iterating the registry does resolve
+every type, so callers that rely on it, such as schema introspection, will instantiate all of them.
+
+Each service must resolve to a distinct `Type` instance: mapping two type names to the same service
+ID fails, because a type instance may only be registered under a single name.
+
+## Deprecated the static `Type` methods
+
+`Type::getTypeRegistry()`, `Type::getType()`, `Type::addType()`, `Type::hasType()`,
+`Type::overrideType()`, `Type::getTypesMap()` and `Type::lookupName()` have been deprecated. They all
+operate on the process-wide registry, which produces surprising results as soon as a connection has
+its own type provider: a type registered with `Type::addType()` is invisible to that connection, and
+`Type::getType()` resolves against the global registry rather than the connection's.
+
+Go through the provider of the connection instead, or inject your own:
+
+```diff
+-Type::addType('money', MoneyType::class);
++$configuration->setTypeProvider(new TypeRegistry(['money' => new MoneyType()]));
+
+-$type = Type::getType('money');
++$type = $connection->getConfiguration()->getTypeRegistry()->get('money');
+```
+
+DBAL 5 will have no static type provider at all.
+
+## Deprecated `TypeRegistry::lookupName()`
+
+Track the type name rather than the instance, typically via `Column::getTypeName()`. It will be
+removed in 5.0, along with the restriction that a type instance may only be registered under a
+single name.
+
 ## Deprecated not implementing unique constraint introspection in `MetadataProvider`
 
 `Doctrine\DBAL\Schema\Metadata\MetadataProvider` implementations should now implement
@@ -65,6 +162,26 @@ method instead:
 - `Column::setAutoincrement()` - use `ColumnEditor::setAutoincrement()`.
 - `Column::setComment()` - use `ColumnEditor::setComment()`.
 - `Column::setValues()` - use `ColumnEditor::setValues()`.
+
+## Deprecated `Column::getType()`, `Column::setType()` and passing a `Type` instance to `Column::__construct()`
+
+`Column` now stores the DBAL type name (string) as source of truth. Use
+`Column::getTypeName()` / `Column::setTypeName()` and pass the type name to
+the constructor instead of a `Type` instance.
+
+```diff
+-use Doctrine\DBAL\Types\Type;
+ use Doctrine\DBAL\Types\Types;
+
+-$column = new Column('id', Type::getType(Types::INTEGER));
++$column = new Column('id', Types::INTEGER);
+
+-$typeName = Type::getTypeRegistry()->lookupName($column->getType());
++$typeName = $column->getTypeName();
+```
+
+Libraries that need to support older DBAL versions can keep passing a `Type`
+instance; the deprecated path stays functional until the next major.
 
 ## Deprecated `Table` features
 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "slevomat/coding-standard": "8.27.1",
         "squizlabs/php_codesniffer": "4.0.1",
         "symfony/cache": "^6.3.8|^7.0|^8.0",
-        "symfony/console": "^5.4|^6.3|^7.0|^8.0"
+        "symfony/console": "^5.4|^6.3|^7.0|^8.0",
+        "symfony/service-contracts": "^2|^3"
     },
     "suggest": {
         "symfony/console": "For helpful console commands such as SQL execution and import of files."

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "phpstan/phpstan-phpunit": "2.0.7",
         "phpstan/phpstan-strict-rules": "^2",
         "phpunit/phpunit": "11.5.56",
+        "psr/container": "^1.1|^2.0",
         "slevomat/coding-standard": "8.31.1",
         "squizlabs/php_codesniffer": "4.0.4",
         "symfony/cache": "^6.3.8|^7.0|^8.0",

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -959,15 +959,63 @@ need to pass parameters to your instance::
         }
     }
 
-To do that, you can obtain the ``TypeRegistry`` singleton from ``Type``
-and register your type in it::
+To do that, build a ``TypeRegistry`` containing your type instance and set it on the
+connection ``Configuration``::
 
     <?php
-    Type::getTypeRegistry()->register('emojifyingType', new StringReplacingType(
-        [
-            ':)' => '😊',
-            ':(' => '😞',
-            ':D' => '😄',
-            ':P' => '😛',
-        ]
-    ));
+    use Doctrine\DBAL\Configuration;
+    use Doctrine\DBAL\DriverManager;
+    use Doctrine\DBAL\Types\TypeRegistry;
+
+    $configuration = new Configuration();
+    $configuration->setTypeProvider(new TypeRegistry([
+        'emojifyingType' => new StringReplacingType(
+            [
+                ':)' => '😊',
+                ':(' => '😞',
+                ':D' => '😄',
+                ':P' => '😛',
+            ]
+        ),
+    ]));
+
+    $connection = DriverManager::getConnection($params, $configuration);
+
+Types registered this way are scoped to the connections using that ``Configuration``,
+so they cannot affect the rest of the application.
+
+A registry always contains all built-in types. Names passed to the constructor
+override the built-in type of the same name.
+
+``Configuration`` accepts any ``Doctrine\DBAL\Types\TypeProvider``, so ``TypeRegistry`` can
+be replaced with your own implementation. A provider only has to answer ``get()`` and
+``has()``, and to yield its types when iterated::
+
+    <?php
+    foreach ($connection->getConfiguration()->getTypeRegistry() as $typeName => $type) {
+        // ...
+    }
+
+Lazy-loading types from a container
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When types have their own dependencies, instantiating them all up front is wasteful.
+Pass a PSR-11 container together with a map of type names to service IDs, and each type
+is resolved on first use and then cached::
+
+    <?php
+    $registry = new TypeRegistry($container, [
+        'money'     => 'app.dbal_type.money',
+        'encrypted' => 'app.dbal_type.encrypted',
+    ]);
+
+The container is never queried during construction, nor by ``has()``. Iterating the
+registry does resolve every type, so callers that rely on it, such as schema
+introspection, will instantiate all of them.
+
+Each service must resolve to a distinct ``Type`` instance. Mapping two type names to the
+same service ID fails, because a type instance can only be registered under one name.
+
+The map is required whenever a container is passed: the registry never enumerates the
+container, so it cannot discover type names on its own. Any PSR-11 implementation works,
+including a Symfony service locator.

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Schema\SchemaManagerFactory;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -35,6 +37,8 @@ class Configuration
     protected bool $autoCommit = true;
 
     private ?SchemaManagerFactory $schemaManagerFactory = null;
+
+    private ?TypeRegistry $typeRegistry = null;
 
     public function __construct()
     {
@@ -130,6 +134,19 @@ class Configuration
     public function setSchemaManagerFactory(SchemaManagerFactory $schemaManagerFactory): self
     {
         $this->schemaManagerFactory = $schemaManagerFactory;
+
+        return $this;
+    }
+
+    public function getTypeRegistry(): TypeRegistry
+    {
+        return $this->typeRegistry ??= Type::getTypeRegistry();
+    }
+
+    /** @return $this */
+    public function setTypeRegistry(TypeRegistry $typeRegistry): self
+    {
+        $this->typeRegistry = $typeRegistry;
 
         return $this;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,8 @@ namespace Doctrine\DBAL;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Schema\SchemaManagerFactory;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeProvider;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -35,6 +37,8 @@ class Configuration
     protected bool $autoCommit = true;
 
     private ?SchemaManagerFactory $schemaManagerFactory = null;
+
+    private ?TypeProvider $typeRegistry = null;
 
     public function __construct()
     {
@@ -130,6 +134,19 @@ class Configuration
     public function setSchemaManagerFactory(SchemaManagerFactory $schemaManagerFactory): self
     {
         $this->schemaManagerFactory = $schemaManagerFactory;
+
+        return $this;
+    }
+
+    public function getTypeRegistry(): TypeProvider
+    {
+        return $this->typeRegistry ??= Type::getTypeRegistry();
+    }
+
+    /** @return $this */
+    public function setTypeRegistry(TypeProvider $typeRegistry): self
+    {
+        $this->typeRegistry = $typeRegistry;
 
         return $this;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1279,7 +1279,8 @@ class Connection implements ServerVersionProvider
      */
     public function convertToDatabaseValue(mixed $value, string $type): mixed
     {
-        return $this->_config->getTypeRegistry()->get($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        return $this->_config->getTypeRegistry()->get($type)
+            ->convertToDatabaseValue($value, $this->getDatabasePlatform());
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -194,6 +194,7 @@ class Connection implements ServerVersionProvider
             }
 
             $this->platform = $this->driver->getDatabasePlatform($versionProvider);
+            $this->platform->setConfiguration($this->_config);
         }
 
         return $this->platform;
@@ -1278,7 +1279,7 @@ class Connection implements ServerVersionProvider
      */
     public function convertToDatabaseValue(mixed $value, string $type): mixed
     {
-        return Type::getType($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        return $this->_config->getTypeRegistry()->get($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
     }
 
     /**
@@ -1294,7 +1295,7 @@ class Connection implements ServerVersionProvider
      */
     public function convertToPHPValue(mixed $value, string $type): mixed
     {
-        return Type::getType($type)->convertToPHPValue($value, $this->getDatabasePlatform());
+        return $this->_config->getTypeRegistry()->get($type)->convertToPHPValue($value, $this->getDatabasePlatform());
     }
 
     /**
@@ -1360,7 +1361,7 @@ class Connection implements ServerVersionProvider
     private function getBindingInfo(mixed $value, string|ParameterType|Type $type): array
     {
         if (is_string($type)) {
-            $type = Type::getType($type);
+            $type = $this->_config->getTypeRegistry()->get($type);
         }
 
         if ($type instanceof Type) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -194,6 +194,7 @@ class Connection implements ServerVersionProvider
             }
 
             $this->platform = $this->driver->getDatabasePlatform($versionProvider);
+            $this->platform->setConfiguration($this->_config);
         }
 
         return $this->platform;
@@ -1271,7 +1272,8 @@ class Connection implements ServerVersionProvider
      */
     public function convertToDatabaseValue(mixed $value, string $type): mixed
     {
-        return Type::getType($type)->convertToDatabaseValue($value, $this->getDatabasePlatform());
+        return $this->_config->getTypeRegistry()->get($type)
+            ->convertToDatabaseValue($value, $this->getDatabasePlatform());
     }
 
     /**
@@ -1287,7 +1289,7 @@ class Connection implements ServerVersionProvider
      */
     public function convertToPHPValue(mixed $value, string $type): mixed
     {
-        return Type::getType($type)->convertToPHPValue($value, $this->getDatabasePlatform());
+        return $this->_config->getTypeRegistry()->get($type)->convertToPHPValue($value, $this->getDatabasePlatform());
     }
 
     /**
@@ -1353,7 +1355,7 @@ class Connection implements ServerVersionProvider
     private function getBindingInfo(mixed $value, string|ParameterType|Type $type): array
     {
         if (is_string($type)) {
-            $type = Type::getType($type);
+            $type = $this->_config->getTypeRegistry()->get($type);
         }
 
         if ($type instanceof Type) {

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -366,7 +366,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         $queryParts = [];
 
         foreach ($diff->getAddedColumns() as $column) {
-            $columnProperties = array_merge($column->toArray(), [
+            $columnProperties = array_merge($column->toArray(true), [
                 'comment' => $column->getComment(),
             ]);
 
@@ -383,7 +383,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         foreach ($diff->getChangedColumns() as $columnDiff) {
             $newColumn = $columnDiff->getNewColumn();
 
-            $newColumnProperties = array_merge($newColumn->toArray(), [
+            $newColumnProperties = array_merge($newColumn->toArray(true), [
                 'comment' => $newColumn->getComment(),
             ]);
 
@@ -536,7 +536,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             $column->setAutoincrement(false);
 
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY ' .
-                $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+                $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray(true));
 
             // original autoincrement information might be needed later on by other parts of the table alteration
             $column->setAutoincrement(true);
@@ -593,7 +593,7 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
                 $column->setAutoincrement(false);
 
                 $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' MODIFY ' .
-                    $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+                    $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray(true));
 
                 // Restore the autoincrement attribute as it might be needed later on
                 // by other parts of the table alteration.

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
@@ -107,6 +108,8 @@ abstract class AbstractPlatform
      */
     private ?UnquotedIdentifierFolding $unquotedIdentifierFolding = null;
 
+    private ?Configuration $configuration = null;
+
     public function __construct(?UnquotedIdentifierFolding $unquotedIdentifierFolding = null)
     {
         if ($unquotedIdentifierFolding === null) {
@@ -119,6 +122,17 @@ abstract class AbstractPlatform
         }
 
         $this->unquotedIdentifierFolding = $unquotedIdentifierFolding ?? UnquotedIdentifierFolding::UPPER;
+    }
+
+    /** @internal Called by Connection after platform creation. */
+    public function setConfiguration(Configuration $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    private function getTypeRegistry(): Types\TypeRegistry
+    {
+        return $this->configuration?->getTypeRegistry() ?? Type::getTypeRegistry();
     }
 
     /**
@@ -171,8 +185,8 @@ abstract class AbstractPlatform
     {
         $this->initializeDoctrineTypeMappings();
 
-        foreach (Type::getTypesMap() as $typeName => $className) {
-            foreach (Type::getType($typeName)->getMappedDatabaseTypes($this) as $dbType) {
+        foreach ($this->getTypeRegistry()->getMap() as $typeName => $type) {
+            foreach ($type->getMappedDatabaseTypes($this) as $dbType) {
                 $dbType                             = strtolower($dbType);
                 $this->doctrineTypeMapping[$dbType] = $typeName;
             }
@@ -397,7 +411,7 @@ abstract class AbstractPlatform
             $this->initializeAllDoctrineTypeMappings();
         }
 
-        if (! Types\Type::hasType($doctrineType)) {
+        if (! $this->getTypeRegistry()->has($doctrineType)) {
             throw TypeNotFound::new($doctrineType);
         }
 

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
@@ -107,6 +108,8 @@ abstract class AbstractPlatform
      */
     private ?UnquotedIdentifierFolding $unquotedIdentifierFolding = null;
 
+    private ?Configuration $configuration = null;
+
     public function __construct(?UnquotedIdentifierFolding $unquotedIdentifierFolding = null)
     {
         if ($unquotedIdentifierFolding === null) {
@@ -119,6 +122,17 @@ abstract class AbstractPlatform
         }
 
         $this->unquotedIdentifierFolding = $unquotedIdentifierFolding ?? UnquotedIdentifierFolding::UPPER;
+    }
+
+    /** @internal Called by Connection after platform creation. */
+    public function setConfiguration(Configuration $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    private function getTypeRegistry(): Types\TypeProvider
+    {
+        return $this->configuration?->getTypeRegistry() ?? Type::getTypeRegistry();
     }
 
     /**
@@ -171,8 +185,8 @@ abstract class AbstractPlatform
     {
         $this->initializeDoctrineTypeMappings();
 
-        foreach (Type::getTypesMap() as $typeName => $className) {
-            foreach (Type::getType($typeName)->getMappedDatabaseTypes($this) as $dbType) {
+        foreach ($this->getTypeRegistry() as $typeName => $type) {
+            foreach ($type->getMappedDatabaseTypes($this) as $dbType) {
                 $dbType                             = strtolower($dbType);
                 $this->doctrineTypeMapping[$dbType] = $typeName;
             }
@@ -397,7 +411,7 @@ abstract class AbstractPlatform
             $this->initializeAllDoctrineTypeMappings();
         }
 
-        if (! Types\Type::hasType($doctrineType)) {
+        if (! $this->getTypeRegistry()->has($doctrineType)) {
             throw TypeNotFound::new($doctrineType);
         }
 
@@ -887,6 +901,15 @@ abstract class AbstractPlatform
     final protected function getCreateTableWithoutForeignKeysSQL(Table $table): array
     {
         return $this->buildCreateTableSQL($table, false);
+    }
+
+    /**
+     * Resolves the DBAL type instance for a column type name.
+     */
+    protected function getType(string $typeName): Type
+    {
+        // @phpstan-ignore missingType.checkedException
+        return $this->getTypeRegistry()->get($typeName);
     }
 
     /** @return list<string> */
@@ -1493,7 +1516,7 @@ abstract class AbstractPlatform
 
             $notnull = ! empty($column['notnull']) ? ' NOT NULL' : '';
 
-            $typeDecl    = $column['type']->getSQLDeclaration($column, $this);
+            $typeDecl    = $this->getType($column['typeName'])->getSQLDeclaration($column, $this);
             $declaration = $typeDecl . $charset . $default . $notnull . $collation;
 
             if ($this->supportsInlineColumnComments() && isset($column['comment']) && $column['comment'] !== '') {
@@ -1544,11 +1567,13 @@ abstract class AbstractPlatform
             return ' DEFAULT ' . $default->toSQL($this);
         }
 
-        if (! isset($column['type'])) {
+        if (isset($column['typeName']) && is_string($column['typeName'])) {
+            $type = $this->getType($column['typeName']);
+        } elseif (isset($column['type']) && $column['type'] instanceof Type) {
+            $type = $column['type'];
+        } else {
             return " DEFAULT '" . $default . "'";
         }
-
-        $type = $column['type'];
 
         if ($type instanceof Types\PhpIntegerMappingType) {
             return ' DEFAULT ' . $default;
@@ -2382,7 +2407,7 @@ abstract class AbstractPlatform
      */
     private function columnToArray(Column $column): array
     {
-        return array_merge($column->toArray(), [
+        return array_merge($column->toArray(true), [
             'name' => $column->getQuotedName($this),
             'version' => $column->hasPlatformOption('version') ? $column->getPlatformOption('version') : false,
             'comment' => $column->getComment(),

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\PhpDateTimeMappingType;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
@@ -27,6 +28,7 @@ use function count;
 use function current;
 use function explode;
 use function implode;
+use function is_string;
 use function sprintf;
 use function str_contains;
 
@@ -284,7 +286,7 @@ class DB2Platform extends AbstractPlatform
 
         $queryParts = [];
         foreach ($diff->getAddedColumns() as $column) {
-            $columnDef = $column->toArray();
+            $columnDef = $column->toArray(true);
             $queryPart = 'ADD COLUMN ' . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnDef);
 
             // Adding non-nullable columns to a table requires a default value to be specified.
@@ -400,7 +402,7 @@ class DB2Platform extends AbstractPlatform
     private function getAlterColumnClausesSQL(ColumnDiff $columnDiff, bool &$needsReorg): array
     {
         $newColumn   = $columnDiff->getNewColumn();
-        $columnArray = $newColumn->toArray();
+        $columnArray = $newColumn->toArray(true);
 
         $newName = $columnDiff->getNewColumn()->getQuotedName($this);
         $oldName = $columnDiff->getOldColumn()->getQuotedName($this);
@@ -427,7 +429,7 @@ class DB2Platform extends AbstractPlatform
             $columnDiff->hasFixedChanged()
         ) {
             $needsReorg = true;
-            $clauses[]  = $alterClause . ' SET DATA TYPE ' . $newColumn->getType()
+            $clauses[]  = $alterClause . ' SET DATA TYPE ' . $this->getType($newColumn->getTypeName())
                     ->getSQLDeclaration($columnArray, $this);
         }
 
@@ -484,7 +486,15 @@ class DB2Platform extends AbstractPlatform
                 'The "version" column platform option is deprecated.',
             );
 
-            if ($column['type'] instanceof PhpDateTimeMappingType) {
+            if (isset($column['typeName']) && is_string($column['typeName'])) {
+                $type = $this->getType($column['typeName']);
+            } elseif (isset($column['type']) && $column['type'] instanceof Type) {
+                $type = $column['type'];
+            } else {
+                $type = null;
+            }
+
+            if ($type instanceof PhpDateTimeMappingType) {
                 $column['default'] = '1';
             }
         }

--- a/src/Platforms/Db2/Db2MetadataProvider.php
+++ b/src/Platforms/Db2/Db2MetadataProvider.php
@@ -193,7 +193,7 @@ final readonly class Db2MetadataProvider implements MetadataProvider
         }
 
         $editor
-            ->setTypeName($type)
+            ->setType($this->connection->getConfiguration()->getTypeRegistry()->get($type))
             ->setNotNull($nulls === 'N')
             ->setDefaultValue($this->parseDefaultExpression($default))
             ->setAutoincrement($generated === 'D');

--- a/src/Platforms/Db2/Db2MetadataProvider.php
+++ b/src/Platforms/Db2/Db2MetadataProvider.php
@@ -194,7 +194,7 @@ final readonly class Db2MetadataProvider implements MetadataProvider
         }
 
         $editor
-            ->setTypeName($type)
+            ->setType($this->connection->getConfiguration()->getTypeRegistry()->get($type))
             ->setNotNull($nulls === 'N')
             ->setDefaultValue($this->parseDefaultExpression($default))
             ->setAutoincrement($generated === 'D');

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -149,7 +149,11 @@ class MariaDBPlatform extends AbstractMySQLPlatform
     {
         // MariaDb forces column collation to utf8mb4_bin where the column was declared as JSON so ignore
         // collation and character set for json columns as attempting to set them can cause an error.
-        if ($this->getJsonTypeDeclarationSQL([]) === 'JSON' && ($column['type'] ?? null) instanceof JsonType) {
+        if (
+            $this->getJsonTypeDeclarationSQL([]) === 'JSON'
+            && isset($column['typeName'])
+            && $this->getType($column['typeName']) instanceof JsonType
+        ) {
             unset($column['collation']);
             unset($column['charset']);
         }

--- a/src/Platforms/MySQL/MySQLMetadataProvider.php
+++ b/src/Platforms/MySQL/MySQLMetadataProvider.php
@@ -214,8 +214,10 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
 
         $editor = Column::editor()
             ->setQuotedName($columnName)
-            ->setTypeName(
-                $this->platform->getDoctrineTypeMapping($dbType),
+            ->setType(
+                $this->connection->getConfiguration()->getTypeRegistry()->get(
+                    $this->platform->getDoctrineTypeMapping($dbType),
+                ),
             );
 
         if (str_contains($columnType, 'unsigned')) {

--- a/src/Platforms/MySQL/MySQLMetadataProvider.php
+++ b/src/Platforms/MySQL/MySQLMetadataProvider.php
@@ -218,8 +218,10 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
 
         $editor = Column::editor()
             ->setQuotedName($columnName)
-            ->setTypeName(
-                $this->platform->getDoctrineTypeMapping($dbType),
+            ->setType(
+                $this->connection->getConfiguration()->getTypeRegistry()->get(
+                    $this->platform->getDoctrineTypeMapping($dbType),
+                ),
             );
 
         if (str_contains($columnType, 'unsigned')) {

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -11,7 +11,10 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\SQL\Builder\WithSQLBuilder;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
+
+use function is_string;
 
 /**
  * Provides the behavior, features and SQL dialect of the Oracle MySQL database platform
@@ -30,8 +33,16 @@ class MySQLPlatform extends AbstractMySQLPlatform
      */
     public function getDefaultValueDeclarationSQL(array $column): string
     {
-        if ($column['type'] instanceof TextType || $column['type'] instanceof BlobType) {
-            unset($column['default']);
+        if (isset($column['typeName']) && is_string($column['typeName'])) {
+            $type = $this->getType($column['typeName']);
+        } elseif (isset($column['type']) && $column['type'] instanceof Type) {
+            $type = $column['type'];
+        } else {
+            $type = null;
+        }
+
+        if ($type instanceof TextType || $type instanceof BlobType) {
+            $column['default'] = null;
         }
 
         return parent::getDefaultValueDeclarationSQL($column);

--- a/src/Platforms/Oracle/OracleMetadataProvider.php
+++ b/src/Platforms/Oracle/OracleMetadataProvider.php
@@ -229,7 +229,7 @@ final readonly class OracleMetadataProvider implements MetadataProvider
         }
 
         $editor
-            ->setTypeName($type)
+            ->setType($this->connection->getConfiguration()->getTypeRegistry()->get($type))
             ->setPrecision($precision)
             ->setScale($scale)
             ->setNotNull($nullable === 'N')

--- a/src/Platforms/Oracle/OracleMetadataProvider.php
+++ b/src/Platforms/Oracle/OracleMetadataProvider.php
@@ -230,7 +230,7 @@ final readonly class OracleMetadataProvider implements MetadataProvider
         }
 
         $editor
-            ->setTypeName($type)
+            ->setType($this->connection->getConfiguration()->getTypeRegistry()->get($type))
             ->setPrecision($precision)
             ->setScale($scale)
             ->setNotNull($nullable === 'N')

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -577,7 +577,7 @@ SQL,
         $tableNameSQL = $diff->getOldTable()->getQuotedName($this);
 
         foreach ($diff->getAddedColumns() as $column) {
-            $addColumnSQL[] = $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray());
+            $addColumnSQL[] = $this->getColumnDeclarationSQL($column->getQuotedName($this), $column->toArray(true));
             $comment        = $column->getComment();
 
             if ($comment !== '') {
@@ -614,7 +614,7 @@ SQL,
             // Oracle only supports binary type columns with variable length.
             // Avoids unnecessary table alteration statements.
             if (
-                $newColumn->getType() instanceof BinaryType &&
+                $this->getType($newColumn->getTypeName()) instanceof BinaryType &&
                 $columnDiff->hasFixedChanged() &&
                 $countChangedProperties === 1
             ) {
@@ -627,9 +627,9 @@ SQL,
              * Do not add query part if only comment has changed
              */
             if ($countChangedProperties > ($columnHasChangedComment ? 1 : 0)) {
-                $newColumnProperties = $newColumn->toArray();
+                $newColumnProperties = $newColumn->toArray(true);
 
-                $oldSQL = $this->getColumnDeclarationSQL('', $oldColumn->toArray());
+                $oldSQL = $this->getColumnDeclarationSQL('', $oldColumn->toArray(true));
                 $newSQL = $this->getColumnDeclarationSQL('', $newColumnProperties);
 
                 if ($newSQL !== $oldSQL) {
@@ -690,7 +690,7 @@ SQL,
                 $notnull = $column['notnull'] ? ' NOT NULL' : ' NULL';
             }
 
-            $typeDecl    = $column['type']->getSQLDeclaration($column, $this);
+            $typeDecl    = $this->getType($column['typeName'])->getSQLDeclaration($column, $this);
             $declaration = $typeDecl . $default . $notnull;
         }
 

--- a/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
+++ b/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
@@ -243,8 +243,10 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
             $completeType = $domainCompleteType;
         }
 
-        $editor->setTypeName(
-            $this->platform->getDoctrineTypeMapping($typeName),
+        $editor->setType(
+            $this->connection->getConfiguration()->getTypeRegistry()->get(
+                $this->platform->getDoctrineTypeMapping($typeName),
+            ),
         );
 
         switch ($typeName) {

--- a/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
+++ b/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
@@ -244,8 +244,10 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
             $completeType = $domainCompleteType;
         }
 
-        $editor->setTypeName(
-            $this->platform->getDoctrineTypeMapping($typeName),
+        $editor->setType(
+            $this->connection->getConfiguration()->getTypeRegistry()->get(
+                $this->platform->getDoctrineTypeMapping($typeName),
+            ),
         );
 
         switch ($typeName) {

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -217,7 +217,7 @@ class PostgreSQLPlatform extends AbstractPlatform
         foreach ($diff->getAddedColumns() as $addedColumn) {
             $query = 'ADD ' . $this->getColumnDeclarationSQL(
                 $addedColumn->getQuotedName($this),
-                $addedColumn->toArray(),
+                $addedColumn->toArray(true),
             );
 
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
@@ -272,7 +272,7 @@ class PostgreSQLPlatform extends AbstractPlatform
             if ($columnDiff->hasDefaultChanged()) {
                 $defaultClause = $newColumn->getDefault() === null
                     ? ' DROP DEFAULT'
-                    : ' SET' . $this->getDefaultValueDeclarationSQL($newColumn->toArray());
+                    : ' SET' . $this->getDefaultValueDeclarationSQL($newColumn->toArray(true));
 
                 $query = 'ALTER ' . $newColumnName . $defaultClause;
                 $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . $query;
@@ -312,10 +312,10 @@ class PostgreSQLPlatform extends AbstractPlatform
 
     private function getTypeSQLDeclaration(Column $column): string
     {
-        $type = $column->getType();
+        $type = $this->getType($column->getTypeName());
 
         // SERIAL/BIGSERIAL are not "real" types and we can't alter a column to that type
-        $columnDefinition                  = $column->toArray();
+        $columnDefinition                  = $column->toArray(true);
         $columnDefinition['autoincrement'] = false;
 
         return $type->getSQLDeclaration($columnDefinition, $this);

--- a/src/Platforms/SQLServer/SQLServerMetadataProvider.php
+++ b/src/Platforms/SQLServer/SQLServerMetadataProvider.php
@@ -221,8 +221,10 @@ final readonly class SQLServerMetadataProvider implements MetadataProvider
 
         $editor = Column::editor()
             ->setQuotedName($columnName)
-            ->setTypeName(
-                $this->platform->getDoctrineTypeMapping($dbType),
+            ->setType(
+                $this->connection->getConfiguration()->getTypeRegistry()->get(
+                    $this->platform->getDoctrineTypeMapping($dbType),
+                ),
             )
             ->setNotNull(! $isNullable)
             ->setAutoincrement((bool) $isIdentity);

--- a/src/Platforms/SQLServer/SQLServerMetadataProvider.php
+++ b/src/Platforms/SQLServer/SQLServerMetadataProvider.php
@@ -222,8 +222,10 @@ final readonly class SQLServerMetadataProvider implements MetadataProvider
 
         $editor = Column::editor()
             ->setQuotedName($columnName)
-            ->setTypeName(
-                $this->platform->getDoctrineTypeMapping($dbType),
+            ->setType(
+                $this->connection->getConfiguration()->getTypeRegistry()->get(
+                    $this->platform->getDoctrineTypeMapping($dbType),
+                ),
             )
             ->setNotNull(! $isNullable)
             ->setAutoincrement((bool) $isIdentity);

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -50,6 +50,8 @@ use const PREG_OFFSET_CAPTURE;
 /**
  * Provides the behavior, features and SQL dialect of the Microsoft SQL Server database platform
  * of the oldest supported version.
+ *
+ * @phpstan-import-type ColumnProperties from Column
  */
 class SQLServerPlatform extends AbstractPlatform
 {
@@ -325,7 +327,7 @@ class SQLServerPlatform extends AbstractPlatform
      *
      * @internal The method should be only used by the {@see SQLServerPlatform} class.
      *
-     * @param mixed[] $column Column definition.
+     * @param ColumnProperties $column Column definition.
      */
     protected function getDefaultConstraintDeclarationSQL(array $column): string
     {
@@ -393,7 +395,7 @@ class SQLServerPlatform extends AbstractPlatform
         $tableName = $table->getName();
 
         foreach ($diff->getAddedColumns() as $column) {
-            $columnProperties = $column->toArray();
+            $columnProperties = $column->toArray(true);
 
             $addColumnSql = 'ADD ' . $this->getColumnDeclarationSQL($column->getQuotedName($this), $columnProperties);
 
@@ -469,8 +471,8 @@ class SQLServerPlatform extends AbstractPlatform
 
             $columnNameSQL = $newColumn->getQuotedName($this);
 
-            $newDeclarationSQL     = $this->getColumnDeclarationSQL($columnNameSQL, $newColumn->toArray());
-            $oldDeclarationSQL     = $this->getColumnDeclarationSQL($columnNameSQL, $oldColumn->toArray());
+            $newDeclarationSQL     = $this->getColumnDeclarationSQL($columnNameSQL, $newColumn->toArray(true));
+            $oldDeclarationSQL     = $this->getColumnDeclarationSQL($columnNameSQL, $oldColumn->toArray(true));
             $declarationSQLChanged = $newDeclarationSQL !== $oldDeclarationSQL;
 
             $defaultChanged = $columnDiff->hasDefaultChanged();
@@ -522,7 +524,7 @@ class SQLServerPlatform extends AbstractPlatform
      */
     private function getAlterTableAddDefaultConstraintClause(string $tableName, Column $column): string
     {
-        $columnDef         = $column->toArray();
+        $columnDef         = $column->toArray(true);
         $columnDef['name'] = $column->getQuotedName($this);
 
         return 'ADD' . $this->getDefaultConstraintDeclarationSQL($columnDef);
@@ -1244,7 +1246,7 @@ class SQLServerPlatform extends AbstractPlatform
 
             $notnull = ! empty($column['notnull']) ? ' NOT NULL' : '';
 
-            $typeDecl    = $column['type']->getSQLDeclaration($column, $this);
+            $typeDecl    = $this->getType($column['typeName'])->getSQLDeclaration($column, $this);
             $declaration = $typeDecl . $collation . $notnull;
         }
 
@@ -1265,8 +1267,8 @@ class SQLServerPlatform extends AbstractPlatform
             return false;
         }
 
-        return $this->getDefaultValueDeclarationSQL($column1->toArray())
-            === $this->getDefaultValueDeclarationSQL($column2->toArray());
+        return $this->getDefaultValueDeclarationSQL($column1->toArray(true))
+            === $this->getDefaultValueDeclarationSQL($column2->toArray(true));
     }
 
     /**

--- a/src/Platforms/SQLite/SQLiteMetadataProvider.php
+++ b/src/Platforms/SQLite/SQLiteMetadataProvider.php
@@ -174,7 +174,7 @@ final readonly class SQLiteMetadataProvider implements MetadataProvider
 
         $typeName = $this->platform->getDoctrineTypeMapping($dbType);
 
-        $editor->setTypeName($typeName);
+        $editor->setType($this->connection->getConfiguration()->getTypeRegistry()->get($typeName));
 
         if ($dbType === 'char') {
             $editor->setFixed(true);

--- a/src/Platforms/SQLite/SQLiteMetadataProvider.php
+++ b/src/Platforms/SQLite/SQLiteMetadataProvider.php
@@ -175,7 +175,7 @@ final readonly class SQLiteMetadataProvider implements MetadataProvider
 
         $typeName = $this->platform->getDoctrineTypeMapping($dbType);
 
-        $editor->setTypeName($typeName);
+        $editor->setType($this->connection->getConfiguration()->getTypeRegistry()->get($typeName));
 
         if ($dbType === 'char') {
             $editor->setFixed(true);

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -756,9 +756,9 @@ class SQLitePlatform extends AbstractPlatform
         $sql = [];
 
         foreach ($diff->getAddedColumns() as $column) {
-            $definition = $column->toArray();
+            $definition = $column->toArray(true);
 
-            $type = $definition['type'];
+            $type = $this->getType($definition['typeName']);
 
             switch (true) {
                 case isset($definition['columnDefinition']):

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -264,6 +264,8 @@ abstract class AbstractSchemaManager
                 $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName] ?? []),
                 $tableOptionsByTable[$tableName] ?? [],
                 $configuration,
+                null,
+                $this->connection->getConfiguration(),
             );
         }
 
@@ -494,6 +496,9 @@ abstract class AbstractSchemaManager
             [],
             $this->listTableForeignKeys($name),
             $this->getTableOptions($name),
+            null,
+            null,
+            $this->connection->getConfiguration(),
         );
     }
 

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -266,7 +266,7 @@ abstract class AbstractSchemaManager
                 $tableOptionsByTable[$tableName] ?? [],
                 $configuration,
                 null,
-                $this->connection->getConfiguration(),
+                $this->connection->getConfiguration()->getTypeRegistry(),
             );
         }
 
@@ -499,7 +499,7 @@ abstract class AbstractSchemaManager
             $this->getTableOptions($name),
             null,
             null,
-            $this->connection->getConfiguration(),
+            $this->connection->getConfiguration()->getTypeRegistry(),
         );
     }
 
@@ -1456,6 +1456,7 @@ abstract class AbstractSchemaManager
         }
 
         $schemaConfig->setDefaultTableOptions($params['defaultTableOptions']);
+        $schemaConfig->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
 
         return $schemaConfig;
     }

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
@@ -1270,6 +1271,12 @@ abstract class AbstractSchemaManager
     protected function _getPortableSequenceDefinition(array $sequence): Sequence
     {
         throw NotSupported::new(__METHOD__);
+    }
+
+    /** @throws TypesException */
+    final protected function getType(string $typeName): Type
+    {
+        return $this->connection->getConfiguration()->getTypeRegistry()->get($typeName);
     }
 
     /**

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use Throwable;
 
@@ -252,17 +253,24 @@ abstract class AbstractSchemaManager
             ->toTableConfiguration();
 
         foreach ($tableColumnsByTable as $tableName => $tableColumns) {
-            if ($filter($tableName)) {
-                $tables[] = new Table(
-                    $tableName,
-                    $this->_getPortableTableColumnList($tableName, $database, $tableColumns),
-                    $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? [], $tableName),
-                    [],
-                    $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName] ?? []),
-                    $tableOptionsByTable[$tableName] ?? [],
-                    $configuration,
-                );
+            if (! $filter($tableName)) {
+                continue;
             }
+
+            $table = new Table(
+                $tableName,
+                $this->_getPortableTableColumnList($tableName, $database, $tableColumns),
+                $this->_getPortableTableIndexesList($indexColumnsByTable[$tableName] ?? [], $tableName),
+                [],
+                $this->_getPortableTableForeignKeysList($foreignKeyColumnsByTable[$tableName] ?? []),
+                $tableOptionsByTable[$tableName] ?? [],
+                $configuration,
+                null,
+                [],
+            );
+            $table->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
+
+            $tables[] = $table;
         }
 
         return $tables;
@@ -481,14 +489,20 @@ abstract class AbstractSchemaManager
             throw TableDoesNotExist::new($name);
         }
 
-        return new Table(
+        $table = new Table(
             $name,
             $columns,
             $this->listTableIndexes($name),
             [],
             $this->listTableForeignKeys($name),
             $this->getTableOptions($name),
+            null,
+            null,
+            [],
         );
+        $table->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
+
+        return $table;
     }
 
     /**
@@ -1501,6 +1515,7 @@ abstract class AbstractSchemaManager
         }
 
         $schemaConfig->setDefaultTableOptions($params['defaultTableOptions']);
+        $schemaConfig->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
 
         return $schemaConfig;
     }

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -9,11 +9,21 @@ use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeProvider;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\Deprecations\Deprecation;
+use TypeError;
 
 use function array_merge;
+use function func_get_arg;
+use function func_num_args;
+use function get_debug_type;
+use function is_bool;
 use function method_exists;
+use function sprintf;
 
 /**
  * Object representation of a database column.
@@ -22,7 +32,8 @@ use function method_exists;
  * @extends AbstractNamedObject<UnqualifiedName>
  * @phpstan-type ColumnProperties = array{
  *     name: string,
- *     type: Type,
+ *     type?: Type,
+ *     typeName: string,
  *     default: mixed,
  *     notnull?: bool,
  *     autoincrement: bool,
@@ -42,7 +53,10 @@ use function method_exists;
  */
 class Column extends AbstractNamedObject
 {
+    /** @deprecated use $_typeName instead */
     protected Type $_type;
+
+    protected string $_typeName;
 
     protected ?int $_length = null;
 
@@ -71,17 +85,35 @@ class Column extends AbstractNamedObject
 
     protected string $_comment = '';
 
+    private ?TypeProvider $typeRegistry = null;
+
     /**
      * @internal Use {@link Column::editor()} to instantiate an editor and {@link ColumnEditor::create()} to create a
      *           column.
      *
+     * @param Type|string          $type    Passing a {@see Type} instance is deprecated; pass the type name instead.
      * @param array<string, mixed> $options
+     *
+     * @throws TypesException
      */
-    public function __construct(string $name, Type $type, array $options = [])
+    public function __construct(string $name, Type|string $type, array $options = [])
     {
         parent::__construct($name);
 
-        $this->setType($type);
+        if ($type instanceof Type) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7490',
+                'Passing a %s instance to %s() is deprecated, pass the type name instead.',
+                Type::class,
+                __METHOD__,
+            );
+
+            $this->setType($type);
+        } else {
+            $this->setTypeName($type);
+        }
+
         $this->setOptions($options);
     }
 
@@ -118,20 +150,41 @@ class Column extends AbstractNamedObject
     }
 
     /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setType()} or
-     *             {@see ColumnEditor::setTypeName()} instead.
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setTypeName()} instead.
+     *
+     * @throws TypesException
      */
     public function setType(Type $type): self
     {
         Deprecation::triggerIfCalledFromOutside(
             'doctrine/dbal',
             'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setType() or ColumnEditor::setTypeName()'
-                . ' instead.',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setTypeName() instead.',
             __METHOD__,
         );
 
         $this->_type = $type;
+        if ($this->typeRegistry === null || $this->typeRegistry instanceof TypeRegistry) {
+            $this->_typeName = ($this->typeRegistry ?? Type::getTypeRegistry())->lookupName($type);
+
+            return $this;
+        }
+
+        foreach ($this->typeRegistry as $name => $candidate) {
+            if ($candidate === $type) {
+                $this->_typeName = $name;
+
+                return $this;
+            }
+        }
+
+        throw TypeNotRegistered::new($type);
+    }
+
+    public function setTypeName(string $typeName): self
+    {
+        $this->_typeName = $typeName;
+        unset($this->_type);
 
         return $this;
     }
@@ -326,9 +379,32 @@ class Column extends AbstractNamedObject
         return $this;
     }
 
+    /**
+     * @deprecated Use {@see getTypeName()} to obtain the type name, or resolve the {@see Type}
+     *             instance via {@see Configuration::getTypeRegistry()} when needed.
+     *
+     * @throws TypesException
+     */
     public function getType(): Type
     {
-        return $this->_type;
+        // Called from toArray() when $skipType is false, which already triggers its own
+        // deprecation, so triggering unconditionally here would report the same call twice.
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7490',
+            '%s is deprecated. Use Column::getTypeName() instead.',
+            __METHOD__,
+        );
+
+        return ($this->typeRegistry ?? Type::getTypeRegistry())->get($this->_typeName);
+    }
+
+    /**
+     * Returns the name of the DBAL type of this column.
+     */
+    public function getTypeName(): string
+    {
+        return $this->_typeName;
     }
 
     public function getLength(): ?int
@@ -533,12 +609,37 @@ class Column extends AbstractNamedObject
         return $this->_values;
     }
 
-    /** @return ColumnProperties */
-    public function toArray(): array
+    /**
+     * Pass `true` as the first (virtual) argument to omit the resolved {@see Type} instance from the returned array
+     * and rely on the `typeName` key instead. Omitting the argument is deprecated.
+     *
+     * @return ColumnProperties
+     */
+    public function toArray(/* bool $skipType = false */): array
     {
+        $skipType = func_num_args() > 0 ? func_get_arg(0) : false;
+        if (! is_bool($skipType)) {
+            // @phpstan-ignore missingType.checkedException
+            throw new TypeError(sprintf(
+                'Argument 1 passed to %s must be a boolean, %s given',
+                __METHOD__,
+                get_debug_type($skipType),
+            ));
+        }
+
+        if (! $skipType) {
+            Deprecation::trigger(
+                'doctrine/dbal',
+                'https://github.com/doctrine/dbal/pull/7490',
+                'Calling %s() without the $skipType argument is deprecated. Pass true to omit the Type instance from '
+                . 'the returned array and read the "typeName" key instead.',
+                __METHOD__,
+            );
+        }
+
         return array_merge([
             'name'             => $this->_name,
-            'type'             => $this->_type,
+            'typeName'         => $this->_typeName,
             'default'          => $this->_default,
             'notnull'          => $this->_notnull,
             'length'           => $this->_length,
@@ -550,7 +651,8 @@ class Column extends AbstractNamedObject
             'columnDefinition' => $this->_columnDefinition,
             'comment'          => $this->_comment,
             'values'           => $this->_values,
-        ], $this->_platformOptions);
+        // @phpstan-ignore missingType.checkedException
+        ], $skipType ? [] : ['type' => $this->getType()], $this->_platformOptions);
     }
 
     public static function editor(): ColumnEditor
@@ -562,7 +664,7 @@ class Column extends AbstractNamedObject
     {
         return self::editor()
             ->setName($this->getObjectName())
-            ->setType($this->_type)
+            ->setTypeName($this->_typeName)
             ->setLength($this->_length)
             ->setPrecision($this->_precision)
             ->setScale($this->_scale)
@@ -580,5 +682,14 @@ class Column extends AbstractNamedObject
             ->setMaximumValue($this->getMaximumValue())
             ->setEnumType($this->getEnumType())
             ->setDefaultConstraintName($this->getDefaultConstraintName());
+    }
+
+    /**
+     * @internal This method if necessary for ensuring backward compatibility
+     * for the deprecated {@see getType } method.
+     */
+    public function setTypeRegistry(?TypeProvider $typeRegistry): void
+    {
+        $this->typeRegistry = $typeRegistry;
     }
 }

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -54,6 +54,13 @@ class ColumnDiff
 
     public function hasTypeChanged(): bool
     {
+        // TODO: This comparison by class is insufficient now that types can be distinct services sharing the same
+        // class (e.g. two differently configured instances of the same Type subclass). It also produces false
+        // negatives for built-in aliases that share a class: json and json_object both map to JsonType::class,
+        // so switching between them is not detected as a change.
+        // The fix is to compare Type instances by identity (===) once both the introspected schema and the
+        // target schema are guaranteed to resolve types from the same TypeRegistry, so the flyweight invariant
+        // (one instance per registered name) holds across both sides of the diff.
         return $this->newColumn->getType()::class !== $this->oldColumn->getType()::class;
     }
 

--- a/src/Schema/ColumnDiff.php
+++ b/src/Schema/ColumnDiff.php
@@ -54,7 +54,7 @@ class ColumnDiff
 
     public function hasTypeChanged(): bool
     {
-        return $this->newColumn->getType()::class !== $this->oldColumn->getType()::class;
+        return $this->newColumn->getTypeName() !== $this->oldColumn->getTypeName();
     }
 
     public function hasLengthChanged(): bool

--- a/src/Schema/ColumnEditor.php
+++ b/src/Schema/ColumnEditor.php
@@ -9,12 +9,13 @@ use Doctrine\DBAL\Schema\Exception\InvalidColumnDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\Deprecation;
 
 final class ColumnEditor
 {
     private ?UnqualifiedName $name = null;
 
-    private ?Type $type = null;
+    private ?string $typeName = null;
 
     private ?int $length = null;
 
@@ -84,17 +85,28 @@ final class ColumnEditor
         return $this;
     }
 
+    /**
+     * @deprecated Use {@link setTypeName()} instead.
+     *
+     * @throws TypesException
+     */
     public function setType(Type $type): self
     {
-        $this->type = $type;
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7490',
+            '%s is deprecated. Use ColumnEditor::setTypeName() instead.',
+            __METHOD__,
+        );
+
+        $this->typeName = Type::getTypeRegistry()->lookupName($type);
 
         return $this;
     }
 
-    /** @throws TypesException */
     public function setTypeName(string $typeName): self
     {
-        $this->type = Type::getType($typeName);
+        $this->typeName = $typeName;
 
         return $this;
     }
@@ -228,13 +240,14 @@ final class ColumnEditor
         return $this;
     }
 
+    /** @throws TypesException */
     public function create(): Column
     {
         if ($this->name === null) {
             throw InvalidColumnDefinition::nameNotSpecified();
         }
 
-        if ($this->type === null) {
+        if ($this->typeName === null) {
             throw InvalidColumnDefinition::dataTypeNotSpecified($this->name);
         }
 
@@ -266,7 +279,7 @@ final class ColumnEditor
 
         return new Column(
             $this->name->toString(),
-            $this->type,
+            $this->typeName,
             [
                 'length' => $this->length,
                 'precision' => $this->precision,

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
@@ -98,7 +97,7 @@ class DB2SchemaManager extends AbstractSchemaManager
             $options['precision'] = $precision;
         }
 
-        return new Column($tableColumn['colname'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
+        return new Column($tableColumn['colname'], $this->getType($type), $options);
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -98,7 +98,7 @@ class DB2SchemaManager extends AbstractSchemaManager
             $options['precision'] = $precision;
         }
 
-        return new Column($tableColumn['colname'], Type::getType($type), $options);
+        return new Column($tableColumn['colname'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
     }
 
     /**

--- a/src/Schema/DB2SchemaManager.php
+++ b/src/Schema/DB2SchemaManager.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
@@ -98,7 +97,10 @@ class DB2SchemaManager extends AbstractSchemaManager
             $options['precision'] = $precision;
         }
 
-        return new Column($tableColumn['colname'], Type::getType($type), $options);
+        $column = new Column($tableColumn['colname'], $type, $options);
+        $column->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
+
+        return $column;
     }
 
     /**

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -214,7 +214,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['field'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
         $column->setPlatformOption('charset', $tableColumn['characterset']);
         $column->setPlatformOption('collation', $tableColumn['collation']);
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTime;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_map;
@@ -214,7 +213,7 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
+        $column = new Column($tableColumn['field'], $this->getType($type), $options);
         $column->setPlatformOption('charset', $tableColumn['characterset']);
         $column->setPlatformOption('collation', $tableColumn['collation']);
 

--- a/src/Schema/MySQLSchemaManager.php
+++ b/src/Schema/MySQLSchemaManager.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTime;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_map;
@@ -214,7 +213,8 @@ class MySQLSchemaManager extends AbstractSchemaManager
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['field'], $type, $options);
+        $column->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
         $column->setPlatformOption('charset', $tableColumn['characterset']);
         $column->setPlatformOption('collation', $tableColumn['collation']);
 

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_key_exists;
@@ -184,7 +183,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             $options['comment'] = $tableColumn['comments'];
         }
 
-        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
+        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), $this->getType($type), $options);
     }
 
     /**

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -184,7 +184,7 @@ class OracleSchemaManager extends AbstractSchemaManager
             $options['comment'] = $tableColumn['comments'];
         }
 
-        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), Type::getType($type), $options);
+        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
     }
 
     /**

--- a/src/Schema/OracleSchemaManager.php
+++ b/src/Schema/OracleSchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_key_exists;
@@ -184,7 +183,10 @@ class OracleSchemaManager extends AbstractSchemaManager
             $options['comment'] = $tableColumn['comments'];
         }
 
-        return new Column($this->getQuotedIdentifierName($tableColumn['column_name']), Type::getType($type), $options);
+        $column = new Column($this->getQuotedIdentifierName($tableColumn['column_name']), $type, $options);
+        $column->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
+
+        return $column;
     }
 
     /**

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function array_map;
@@ -274,7 +273,7 @@ SQL,
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
+        $column = new Column($tableColumn['field'], $this->getType($type), $options);
 
         if (! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -274,7 +274,7 @@ SQL,
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['field'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
 
         if (! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -8,8 +8,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\PostgreSQL;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 
 use function array_change_key_case;
 use function array_map;
@@ -285,13 +284,14 @@ SQL,
             $options['comment'] = $tableColumn['comment'];
         }
 
-        $column = new Column($tableColumn['field'], Type::getType($type), $options);
+        $column = new Column($tableColumn['field'], $type, $options);
+        $column->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
 
         if (! empty($tableColumn['collation'])) {
             $column->setPlatformOption('collation', $tableColumn['collation']);
         }
 
-        if ($column->getType() instanceof JsonType) {
+        if ($type === Types::JSON) {
             $column->setPlatformOption('jsonb', $jsonb);
         }
 

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function assert;
@@ -132,7 +131,7 @@ SQL,
             $options['length'] = $length;
         }
 
-        $column = new Column($tableColumn['name'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
+        $column = new Column($tableColumn['name'], $this->getType($type), $options);
 
         if ($tableColumn['default'] !== null) {
             $default = $this->parseDefaultExpression($tableColumn['default']);

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -132,7 +132,7 @@ SQL,
             $options['length'] = $length;
         }
 
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
+        $column = new Column($tableColumn['name'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
 
         if ($tableColumn['default'] !== null) {
             $default = $this->parseDefaultExpression($tableColumn['default']);

--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Platforms\SQLServer;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
-use Doctrine\DBAL\Types\Type;
 
 use function array_change_key_case;
 use function assert;
@@ -132,7 +131,8 @@ SQL,
             $options['length'] = $length;
         }
 
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
+        $column = new Column($tableColumn['name'], $type, $options);
+        $column->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
 
         if ($tableColumn['default'] !== null) {
             $default = $this->parseDefaultExpression($tableColumn['default']);

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
@@ -127,7 +126,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             'scale'     => $scale,
         ];
 
-        $column = new Column($tableColumn['name'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
+        $column = new Column($tableColumn['name'], $this->getType($type), $options);
 
         if ($type === Types::STRING || $type === Types::TEXT) {
             $column->setPlatformOption('collation', $tableColumn['collation'] ?? 'BINARY');

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -127,7 +127,7 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             'scale'     => $scale,
         ];
 
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
+        $column = new Column($tableColumn['name'], $this->connection->getConfiguration()->getTypeRegistry()->get($type), $options);
 
         if ($type === Types::STRING || $type === Types::TEXT) {
             $column->setPlatformOption('collation', $tableColumn['collation'] ?? 'BINARY');

--- a/src/Schema/SQLiteSchemaManager.php
+++ b/src/Schema/SQLiteSchemaManager.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLite;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
@@ -127,7 +126,8 @@ class SQLiteSchemaManager extends AbstractSchemaManager
             'scale'     => $scale,
         ];
 
-        $column = new Column($tableColumn['name'], Type::getType($type), $options);
+        $column = new Column($tableColumn['name'], $type, $options);
+        $column->setTypeRegistry($this->connection->getConfiguration()->getTypeRegistry());
 
         if ($type === Types::STRING || $type === Types::TEXT) {
             $column->setPlatformOption('collation', $tableColumn['collation'] ?? 'BINARY');

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -391,7 +391,17 @@ class Schema extends AbstractAsset
      */
     public function createTable(string $name): Table
     {
-        $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
+        $table = new Table(
+            $name,
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->_schemaConfig->toTableConfiguration(),
+            null,
+            $this->_schemaConfig->getTypeRegistry(),
+        );
         $this->_addTable($table);
 
         foreach ($this->_schemaConfig->getDefaultTableOptions() as $option => $value) {

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -403,7 +403,18 @@ class Schema extends AbstractAsset
             __METHOD__,
         );
 
-        $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
+        $table = new Table(
+            $name,
+            [],
+            [],
+            [],
+            [],
+            [],
+            $this->_schemaConfig->toTableConfiguration(),
+            null,
+            [],
+        );
+        $table->setTypeRegistry($this->_schemaConfig->getTypeRegistry());
         $this->_addTable($table);
 
         foreach ($this->_schemaConfig->getDefaultTableOptions() as $option => $value) {

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Types\TypeRegistry;
+
 /**
  * Configuration for a Schema.
  */
 class SchemaConfig
 {
+    private ?TypeRegistry $typeRegistry = null;
     /** @var positive-int */
     protected int $maxIdentifierLength = 63;
 
@@ -65,6 +68,16 @@ class SchemaConfig
     public function setDefaultTableOptions(array $defaultTableOptions): void
     {
         $this->defaultTableOptions = $defaultTableOptions;
+    }
+
+    public function getTypeRegistry(): ?TypeRegistry
+    {
+        return $this->typeRegistry;
+    }
+
+    public function setTypeRegistry(TypeRegistry $typeRegistry): void
+    {
+        $this->typeRegistry = $typeRegistry;
     }
 
     public function toTableConfiguration(): TableConfiguration

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Types\TypeProvider;
+
 /**
  * Configuration for a Schema.
  */
 class SchemaConfig
 {
+    private ?TypeProvider $typeRegistry = null;
+
     /** @var positive-int */
     protected int $maxIdentifierLength = 63;
 
@@ -65,6 +69,24 @@ class SchemaConfig
     public function setDefaultTableOptions(array $defaultTableOptions): void
     {
         $this->defaultTableOptions = $defaultTableOptions;
+    }
+
+    /**
+     * @internal This method is necessary for ensuring backward compatibility
+     * for the deprecated {@see Column::getType()} method.
+     */
+    public function getTypeRegistry(): ?TypeProvider
+    {
+        return $this->typeRegistry;
+    }
+
+    /**
+     * @internal This method is necessary for ensuring backward compatibility
+     * for the deprecated {@see Column::getType()} method.
+     */
+    public function setTypeRegistry(TypeProvider $typeRegistry): void
+    {
+        $this->typeRegistry = $typeRegistry;
     }
 
     public function toTableConfiguration(): TableConfiguration

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
-use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Schema\Exception\ColumnAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\ForeignKeyDoesNotExist;
@@ -21,6 +20,7 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
 
@@ -101,7 +101,7 @@ class Table extends AbstractNamedObject
         array $options = [],
         ?TableConfiguration $configuration = null,
         ?PrimaryKeyConstraint $primaryKeyConstraint = null,
-        private ?Configuration $dbalConfiguration = null,
+        private ?TypeRegistry $typeRegistry = null,
     ) {
         if ($name === '') {
             throw InvalidTableName::new($name);
@@ -388,7 +388,7 @@ class Table extends AbstractNamedObject
      */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {
-        $type = $this->dbalConfiguration?->getTypeRegistry()->get($typeName) ?? Type::getType($typeName);
+        $type = $this->typeRegistry?->get($typeName) ?? Type::getType($typeName);
 
         $column = new Column($name, $type, $options);
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Schema\Exception\ColumnAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\ForeignKeyDoesNotExist;
@@ -17,7 +18,6 @@ use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
-use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
@@ -85,8 +85,6 @@ class Table extends AbstractNamedObject
 
     private bool $failedToParsePrimaryKeyConstraint = false;
 
-    private ?Configuration $dbalConfiguration = null;
-
     /**
      * @param array<Column>               $columns
      * @param array<Index>                $indexes
@@ -103,7 +101,7 @@ class Table extends AbstractNamedObject
         array $options = [],
         ?TableConfiguration $configuration = null,
         ?PrimaryKeyConstraint $primaryKeyConstraint = null,
-        ?Configuration $dbalConfiguration = null,
+        private ?Configuration $dbalConfiguration = null,
     ) {
         if ($name === '') {
             throw InvalidTableName::new($name);
@@ -113,8 +111,7 @@ class Table extends AbstractNamedObject
 
         $configuration ??= (new SchemaConfig())->toTableConfiguration();
 
-        $this->maxIdentifierLength  = $configuration->getMaxIdentifierLength();
-        $this->dbalConfiguration    = $dbalConfiguration;
+        $this->maxIdentifierLength = $configuration->getMaxIdentifierLength();
 
         foreach ($columns as $column) {
             $this->_addColumn($column);
@@ -391,9 +388,7 @@ class Table extends AbstractNamedObject
      */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {
-        $type = $this->dbalConfiguration !== null
-            ? $this->dbalConfiguration->getTypeRegistry()->get($typeName)
-            : Type::getType($typeName);
+        $type = $this->dbalConfiguration?->getTypeRegistry()->get($typeName) ?? Type::getType($typeName);
 
         $column = new Column($name, $type, $options);
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parsers;
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
@@ -84,6 +85,8 @@ class Table extends AbstractNamedObject
 
     private bool $failedToParsePrimaryKeyConstraint = false;
 
+    private ?Configuration $dbalConfiguration = null;
+
     /**
      * @param array<Column>               $columns
      * @param array<Index>                $indexes
@@ -100,6 +103,7 @@ class Table extends AbstractNamedObject
         array $options = [],
         ?TableConfiguration $configuration = null,
         ?PrimaryKeyConstraint $primaryKeyConstraint = null,
+        ?Configuration $dbalConfiguration = null,
     ) {
         if ($name === '') {
             throw InvalidTableName::new($name);
@@ -109,7 +113,8 @@ class Table extends AbstractNamedObject
 
         $configuration ??= (new SchemaConfig())->toTableConfiguration();
 
-        $this->maxIdentifierLength = $configuration->getMaxIdentifierLength();
+        $this->maxIdentifierLength  = $configuration->getMaxIdentifierLength();
+        $this->dbalConfiguration    = $dbalConfiguration;
 
         foreach ($columns as $column) {
             $this->_addColumn($column);
@@ -386,7 +391,11 @@ class Table extends AbstractNamedObject
      */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {
-        $column = new Column($name, Type::getType($typeName), $options);
+        $type = $this->dbalConfiguration !== null
+            ? $this->dbalConfiguration->getTypeRegistry()->get($typeName)
+            : Type::getType($typeName);
+
+        $column = new Column($name, $type, $options);
 
         $this->_addColumn($column);
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeProvider;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
 
@@ -83,6 +84,8 @@ class Table extends AbstractNamedObject
     private ?PrimaryKeyConstraint $primaryKeyConstraint = null;
 
     private bool $failedToParsePrimaryKeyConstraint = false;
+
+    private ?TypeProvider $typeRegistry = null;
 
     /**
      * @internal since doctrine/dbal 4.5. Use {@link Table::editor()} to instantiate an editor and
@@ -465,11 +468,21 @@ class Table extends AbstractNamedObject
             __METHOD__,
         );
 
-        $column = new Column($name, Type::getType($typeName), $options);
+        $column = new Column($name, $typeName, $options);
+        $column->setTypeRegistry($this->typeRegistry);
 
         $this->_addColumn($column);
 
         return $column;
+    }
+
+    /**
+     * @internal This method is necessary for ensuring backward compatibility
+     * for the deprecated {@see Column::getType()} method.
+     */
+    public function setTypeRegistry(?TypeProvider $typeRegistry): void
+    {
+        $this->typeRegistry = $typeRegistry;
     }
 
     /** @return array<string, string> */
@@ -1189,7 +1202,8 @@ class Table extends AbstractNamedObject
             ->setOptions($options)
             ->setConfiguration(
                 new TableConfiguration($this->maxIdentifierLength),
-            );
+            )
+            ->setTypeRegistry($this->typeRegistry);
     }
 
     /**

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Exception\InvalidTableModification;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Types\TypeProvider;
 
 use function strcasecmp;
 use function strtolower;
@@ -46,6 +47,8 @@ final class TableEditor
     private string $comment = '';
 
     private ?TableConfiguration $configuration = null;
+
+    private ?TypeProvider $typeRegistry = null;
 
     /** @internal Use {@link Table::editor()} or {@link Table::edit()} to create an instance */
     public function __construct()
@@ -566,6 +569,17 @@ final class TableEditor
         return $this;
     }
 
+    /**
+     * @internal This method is necessary for ensuring backward compatibility
+     * for the deprecated {@see Column::getType()} method.
+     */
+    public function setTypeRegistry(?TypeProvider $typeRegistry): self
+    {
+        $this->typeRegistry = $typeRegistry;
+
+        return $this;
+    }
+
     public function create(): Table
     {
         if ($this->name === null) {
@@ -593,6 +607,7 @@ final class TableEditor
             $this->primaryKeyConstraint,
             $this->renamedColumns,
         );
+        $table->setTypeRegistry($this->typeRegistry);
 
         foreach ($this->indexEditors as $indexEditor) {
             $indexEditor->addToTable($table);

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -79,7 +79,7 @@ class Statement
         $this->types[$param]  = $type;
 
         if (is_string($type)) {
-            $type = Type::getType($type);
+            $type = $this->conn->getConfiguration()->getTypeRegistry()->get($type);
         }
 
         if ($type instanceof Type) {

--- a/src/Types/Exception/UnknownColumnType.php
+++ b/src/Types/Exception/UnknownColumnType.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types\Exception;
 
 use Exception;
+use Throwable;
 
 use function sprintf;
 
 final class UnknownColumnType extends Exception implements TypesException
 {
-    public static function new(string $name): self
+    public static function new(string $name, Throwable|null $previous = null): self
     {
         return new self(
             sprintf(
@@ -23,6 +24,8 @@ final class UnknownColumnType extends Exception implements TypesException
                     . 'have a problem with the cache or forgot some mapping information.',
                 $name,
             ),
+            0,
+            $previous,
         );
     }
 }

--- a/src/Types/Exception/UnknownColumnType.php
+++ b/src/Types/Exception/UnknownColumnType.php
@@ -5,24 +5,27 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types\Exception;
 
 use Exception;
+use Throwable;
 
 use function sprintf;
 
 final class UnknownColumnType extends Exception implements TypesException
 {
-    public static function new(string $name): self
+    public static function new(string $name, Throwable|null $previous = null): self
     {
         return new self(
             sprintf(
-                'Unknown column type "%s" requested. Any Doctrine type that you use has '
-                    . 'to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the '
-                    . 'known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database '
-                    . 'introspection then you might have forgotten to register all database types for a Doctrine Type. '
-                    . 'Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement '
-                    . 'Type#getMappedDatabaseTypes(). If the type name is empty you might '
+                'Unknown column type "%s" requested. Register it in the TypeProvider of the connection, which is '
+                    . 'configured with Configuration::setTypeProvider() and does not see types registered globally. '
+                    . 'If this error occurs during database introspection then you might have forgotten to register '
+                    . 'all database types for a Doctrine Type. Use '
+                    . 'AbstractPlatform::registerDoctrineTypeMapping() or have your custom types implement '
+                    . 'Type::getMappedDatabaseTypes(). If the type name is empty you might '
                     . 'have a problem with the cache or forgot some mapping information.',
                 $name,
             ),
+            0,
+            $previous,
         );
     }
 }

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -21,41 +21,6 @@ use function is_string;
  */
 abstract class Type
 {
-    /**
-     * The map of supported doctrine mapping types.
-     */
-    private const BUILTIN_TYPES_MAP = [
-        Types::ASCII_STRING         => AsciiStringType::class,
-        Types::BIGINT               => BigIntType::class,
-        Types::BINARY               => BinaryType::class,
-        Types::BLOB                 => BlobType::class,
-        Types::BOOLEAN              => BooleanType::class,
-        Types::DATE_MUTABLE         => DateType::class,
-        Types::DATE_IMMUTABLE       => DateImmutableType::class,
-        Types::DATEINTERVAL         => DateIntervalType::class,
-        Types::DATETIME_MUTABLE     => DateTimeType::class,
-        Types::DATETIME_IMMUTABLE   => DateTimeImmutableType::class,
-        Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
-        Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
-        Types::DECIMAL              => DecimalType::class,
-        Types::NUMBER               => NumberType::class,
-        Types::ENUM                 => EnumType::class,
-        Types::FLOAT                => FloatType::class,
-        Types::GUID                 => GuidType::class,
-        Types::INTEGER              => IntegerType::class,
-        Types::JSON                 => JsonType::class,
-        Types::JSON_OBJECT          => JsonType::class,
-        Types::JSONB                => JsonbType::class,
-        Types::JSONB_OBJECT         => JsonbType::class,
-        Types::SIMPLE_ARRAY         => SimpleArrayType::class,
-        Types::SMALLFLOAT           => SmallFloatType::class,
-        Types::SMALLINT             => SmallIntType::class,
-        Types::STRING               => StringType::class,
-        Types::TEXT                 => TextType::class,
-        Types::TIME_MUTABLE         => TimeType::class,
-        Types::TIME_IMMUTABLE       => TimeImmutableType::class,
-    ];
-
     private static ?TypeRegistry $typeRegistry = null;
 
     /**
@@ -98,21 +63,9 @@ abstract class Type
      */
     abstract public function getSQLDeclaration(array $column, AbstractPlatform $platform): string;
 
-    /** @throws TypesException */
     final public static function getTypeRegistry(): TypeRegistry
     {
-        return self::$typeRegistry ??= self::createTypeRegistry();
-    }
-
-    /** @throws TypesException */
-    private static function createTypeRegistry(): TypeRegistry
-    {
-        return new TypeRegistry(
-            array_map(
-                static fn ($class) => new $class(),
-                self::BUILTIN_TYPES_MAP,
-            ),
-        );
+        return self::$typeRegistry ??= new TypeRegistry();
     }
 
     /**

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -65,6 +65,7 @@ abstract class Type
 
     final public static function getTypeRegistry(): TypeRegistry
     {
+        // @phpstan-ignore missingType.checkedException
         return self::$typeRegistry ??= new TypeRegistry();
     }
 

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -10,9 +10,11 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Exception\TypeArgumentCountError;
 use Doctrine\DBAL\Types\Exception\TypesException;
+use Doctrine\Deprecations\Deprecation;
 
 use function array_map;
 use function is_string;
+use function iterator_to_array;
 
 /**
  * The base class for so-called Doctrine mapping types.
@@ -21,43 +23,6 @@ use function is_string;
  */
 abstract class Type
 {
-    /**
-     * The map of supported doctrine mapping types.
-     */
-    private const BUILTIN_TYPES_MAP = [
-        Types::ASCII_STRING           => AsciiStringType::class,
-        Types::BIGINT                 => BigIntType::class,
-        Types::BINARY                 => BinaryType::class,
-        Types::BLOB                   => BlobType::class,
-        Types::BOOLEAN                => BooleanType::class,
-        Types::DATE_MUTABLE           => DateType::class,
-        Types::DATE_IMMUTABLE         => DateImmutableType::class,
-        Types::DATEINTERVAL           => DateIntervalType::class,
-        Types::DATETIME_MUTABLE       => DateTimeType::class,
-        Types::DATETIME_IMMUTABLE     => DateTimeImmutableType::class,
-        Types::DATETIME_UTC_MUTABLE   => DateTimeUtcType::class,
-        Types::DATETIME_UTC_IMMUTABLE => DateTimeUtcImmutableType::class,
-        Types::DATETIMETZ_MUTABLE     => DateTimeTzType::class,
-        Types::DATETIMETZ_IMMUTABLE   => DateTimeTzImmutableType::class,
-        Types::DECIMAL                => DecimalType::class,
-        Types::NUMBER                 => NumberType::class,
-        Types::ENUM                   => EnumType::class,
-        Types::FLOAT                  => FloatType::class,
-        Types::GUID                   => GuidType::class,
-        Types::INTEGER                => IntegerType::class,
-        Types::JSON                   => JsonType::class,
-        Types::JSON_OBJECT            => JsonObjectType::class,
-        Types::JSONB                  => JsonbType::class,
-        Types::JSONB_OBJECT           => JsonbObjectType::class,
-        Types::SIMPLE_ARRAY           => SimpleArrayType::class,
-        Types::SMALLFLOAT             => SmallFloatType::class,
-        Types::SMALLINT               => SmallIntType::class,
-        Types::STRING                 => StringType::class,
-        Types::TEXT                   => TextType::class,
-        Types::TIME_MUTABLE           => TimeType::class,
-        Types::TIME_IMMUTABLE         => TimeImmutableType::class,
-    ];
-
     private static ?TypeRegistry $typeRegistry = null;
 
     /**
@@ -100,25 +65,28 @@ abstract class Type
      */
     abstract public function getSQLDeclaration(array $column, AbstractPlatform $platform): string;
 
-    /** @throws TypesException */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Configuration::getTypeRegistry()}, or inject
+     *             your own type provider. There will be no static type provider in DBAL 5.
+     */
     final public static function getTypeRegistry(): TypeRegistry
     {
-        return self::$typeRegistry ??= self::createTypeRegistry();
-    }
-
-    /** @throws TypesException */
-    private static function createTypeRegistry(): TypeRegistry
-    {
-        return new TypeRegistry(
-            array_map(
-                static fn ($class) => new $class(),
-                self::BUILTIN_TYPES_MAP,
-            ),
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Use Configuration::getTypeRegistry(), or inject your own type provider.',
+            __METHOD__,
         );
+
+        // @phpstan-ignore missingType.checkedException
+        return self::$typeRegistry ??= new TypeRegistry();
     }
 
     /**
      * Factory method to create type instances.
+     *
+     * @deprecated since doctrine/dbal 4.5. Resolve the type through the type provider of the
+     *             connection instead.
      *
      * @param string $name The name of the type.
      *
@@ -126,21 +94,42 @@ abstract class Type
      */
     public static function getType(string $name): self
     {
+        // Called from the deprecated Column::getType(), which triggers its own deprecation, so
+        // triggering unconditionally here would report the same call twice.
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Resolve the type through the type provider of the connection instead.',
+            __METHOD__,
+        );
+
         return self::getTypeRegistry()->get($name);
     }
 
     /**
      * Finds a name for the given type.
      *
+     * @deprecated since doctrine/dbal 4.5. Track the type name instead of the instance.
+     *
      * @throws TypesException
      */
     public static function lookupName(self $type): string
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Track the type name instead of the instance.',
+            __METHOD__,
+        );
+
         return self::getTypeRegistry()->lookupName($type);
     }
 
     /**
      * Adds a custom type to the type map.
+     *
+     * @deprecated since doctrine/dbal 4.5. Register the type in the type provider of the
+     *             connection instead.
      *
      * @param string                  $name The name of the type.
      * @param class-string<Type>|Type $type The custom type or the class name of the custom type.
@@ -149,6 +138,13 @@ abstract class Type
      */
     public static function addType(string $name, string|Type $type): void
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Register the type in the type provider of the connection instead.',
+            __METHOD__,
+        );
+
         if (is_string($type)) {
             try {
                 $type = new $type();
@@ -163,6 +159,8 @@ abstract class Type
     /**
      * Checks if exists support for a type.
      *
+     * @deprecated since doctrine/dbal 4.5. Ask the type provider of the connection instead.
+     *
      * @param string $name The name of the type.
      *
      * @return bool TRUE if type is supported; FALSE otherwise.
@@ -171,11 +169,21 @@ abstract class Type
      */
     public static function hasType(string $name): bool
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Ask the type provider of the connection instead.',
+            __METHOD__,
+        );
+
         return self::getTypeRegistry()->has($name);
     }
 
     /**
      * Overrides an already defined type to use a different implementation.
+     *
+     * @deprecated since doctrine/dbal 4.5. Build a type provider with the type already overridden
+     *             instead.
      *
      * @param class-string<Type>|Type $type The custom type or the class name of the custom type.
      *
@@ -183,6 +191,13 @@ abstract class Type
      */
     public static function overrideType(string $name, string|Type $type): void
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Build a type provider with the type already overridden instead.',
+            __METHOD__,
+        );
+
         if (is_string($type)) {
             try {
                 $type = new $type();
@@ -207,15 +222,24 @@ abstract class Type
      * Gets the types array map which holds all registered types and the corresponding
      * type class
      *
+     * @deprecated since doctrine/dbal 4.5. Iterate the type provider of the connection instead.
+     *
      * @return array<string, string>
      *
      * @throws TypesException
      */
     public static function getTypesMap(): array
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7342',
+            '%s is deprecated. Iterate the type provider of the connection instead.',
+            __METHOD__,
+        );
+
         return array_map(
             static fn (Type $type): string => $type::class,
-            self::getTypeRegistry()->getMap(),
+            iterator_to_array(self::getTypeRegistry()),
         );
     }
 

--- a/src/Types/TypeProvider.php
+++ b/src/Types/TypeProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Types\Exception\TypesException;
+use Traversable;
+
+/**
+ * Provides the {@see Type} instances available to a connection, keyed by type name.
+ *
+ * Iterating over a provider yields every type it knows about. Implementations are free to resolve
+ * types lazily, so iteration may instantiate them.
+ *
+ * @extends Traversable<string, Type>
+ */
+interface TypeProvider extends Traversable
+{
+    /**
+     * Finds a type by the given name.
+     *
+     * @throws TypesException
+     */
+    public function get(string $name): Type;
+
+    /**
+     * Checks if there is a type of the given name.
+     */
+    public function has(string $name): bool;
+}

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -19,12 +19,53 @@ use function spl_object_id;
  */
 final class TypeRegistry
 {
+    /**
+     * The map of built-in Doctrine mapping types.
+     *
+     * @var array<string, class-string<Type>>
+     */
+    public const BUILTIN_TYPES_MAP = [
+        Types::ASCII_STRING         => AsciiStringType::class,
+        Types::BIGINT               => BigIntType::class,
+        Types::BINARY               => BinaryType::class,
+        Types::BLOB                 => BlobType::class,
+        Types::BOOLEAN              => BooleanType::class,
+        Types::DATE_MUTABLE         => DateType::class,
+        Types::DATE_IMMUTABLE       => DateImmutableType::class,
+        Types::DATEINTERVAL         => DateIntervalType::class,
+        Types::DATETIME_MUTABLE     => DateTimeType::class,
+        Types::DATETIME_IMMUTABLE   => DateTimeImmutableType::class,
+        Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
+        Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
+        Types::DECIMAL              => DecimalType::class,
+        Types::NUMBER               => NumberType::class,
+        Types::ENUM                 => EnumType::class,
+        Types::FLOAT                => FloatType::class,
+        Types::GUID                 => GuidType::class,
+        Types::INTEGER              => IntegerType::class,
+        Types::JSON                 => JsonType::class,
+        Types::JSON_OBJECT          => JsonType::class,
+        Types::JSONB                => JsonbType::class,
+        Types::JSONB_OBJECT         => JsonbType::class,
+        Types::SIMPLE_ARRAY         => SimpleArrayType::class,
+        Types::SMALLFLOAT           => SmallFloatType::class,
+        Types::SMALLINT             => SmallIntType::class,
+        Types::STRING               => StringType::class,
+        Types::TEXT                 => TextType::class,
+        Types::TIME_MUTABLE         => TimeType::class,
+        Types::TIME_IMMUTABLE       => TimeImmutableType::class,
+    ];
+
     /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
     private array $instances;
     /** @var array<int, string> */
     private array $instancesReverseIndex;
 
     /**
+     * Creates a registry pre-populated with all built-in types. Additional types passed via
+     * {@param $instances} are registered on top; if a name matches a built-in type it is
+     * overridden rather than re-registered.
+     *
      * @param array<string, Type> $instances
      *
      * @throws TypesException
@@ -33,8 +74,19 @@ final class TypeRegistry
     {
         $this->instances             = [];
         $this->instancesReverseIndex = [];
+
+        foreach (self::BUILTIN_TYPES_MAP as $name => $class) {
+            $type                                              = new $class();
+            $this->instances[$name]                            = $type;
+            $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        }
+
         foreach ($instances as $name => $type) {
-            $this->register($name, $type);
+            if (isset($this->instances[$name])) {
+                $this->override($name, $type);
+            } else {
+                $this->register($name, $type);
+            }
         }
     }
 

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -10,17 +10,23 @@ use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
 use Doctrine\DBAL\Types\Exception\TypesAlreadyExists;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Exception\UnknownColumnType;
+use InvalidArgumentException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+use WeakMap;
 
-use function spl_object_id;
+use function array_fill_keys;
+use function array_keys;
+use function get_debug_type;
+use function sprintf;
 
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
  */
 final class TypeRegistry
 {
-    /**
-     * The map of built-in Doctrine mapping types.
-     */
+    /** Map of type names and their corresponding class names. */
     private const BUILTIN_TYPES_MAP = [
         Types::ASCII_STRING         => AsciiStringType::class,
         Types::BIGINT               => BigIntType::class,
@@ -54,37 +60,68 @@ final class TypeRegistry
     ];
 
     /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
-    private array $instances;
-    /** @var array<int, string> */
-    private array $instancesReverseIndex;
+    private array $instances = [];
+
+    /**
+     * Lazy factories for types not yet instantiated.
+     * Values are either a class-string (built-in) or a ContainerInterface (container type).
+     *
+     * @var array<string, class-string<Type>|ContainerInterface>
+     */
+    private array $factories = [];
+
+    /** @var WeakMap<Type, string> */
+    private WeakMap $instancesReverseIndex;
 
     /**
      * Creates a registry pre-populated with all built-in types. Additional types passed via
      * {@param $instances} are registered on top; if a name matches a built-in type it is
      * overridden rather than re-registered.
      *
-     * @param array<string, Type> $instances
+     * A {@see ServiceProviderInterface} can be passed instead of an array to lazy-load type
+     * instances from a service container. Types are resolved on first access and cached.
+     *
+     * @param array<string, Type|ContainerInterface>|ServiceProviderInterface<Type> $instances
      *
      * @throws TypeAlreadyRegistered
      * @throws TypesException
      */
-    public function __construct(array $instances = [])
+    public function __construct(array|ServiceProviderInterface $instances = [])
     {
-        $this->instances             = [];
-        $this->instancesReverseIndex = [];
+        $this->instancesReverseIndex = new WeakMap();
 
-        foreach (self::BUILTIN_TYPES_MAP as $name => $class) {
-            $type                                              = new $class();
-            $this->instances[$name]                            = $type;
-            $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        if ($instances instanceof ServiceProviderInterface) {
+            $this->factories = array_fill_keys(array_keys($instances->getProvidedServices()), $instances);
+        } else {
+            foreach ($instances as $name => $instance) {
+                if ($instance instanceof ContainerInterface) {
+                    $this->factories[$name] = $instance;
+                    continue;
+                }
+
+                if (! $instance instanceof Type) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Unexpected value for type "%s", got "%s".',
+                        $name,
+                        get_debug_type($instance),
+                    ));
+                }
+
+                if (isset($this->instancesReverseIndex[$instance])) {
+                    throw TypeAlreadyRegistered::new($instance);
+                }
+
+                $this->instances[$name]                 = $instance;
+                $this->instancesReverseIndex[$instance] = $name;
+            }
         }
 
-        foreach ($instances as $name => $type) {
-            if (isset($this->instances[$name])) {
-                $this->override($name, $type);
-            } else {
-                $this->register($name, $type);
+        foreach (self::BUILTIN_TYPES_MAP as $name => $class) {
+            if (isset($this->instances[$name]) || isset($this->factories[$name])) {
+                continue;
             }
+
+            $this->factories[$name] = $class;
         }
     }
 
@@ -96,9 +133,38 @@ final class TypeRegistry
     public function get(string $name): Type
     {
         $type = $this->instances[$name] ?? null;
-        if ($type === null) {
-            throw UnknownColumnType::new($name);
+        if ($type !== null) {
+            return $type;
         }
+
+        $factory = $this->factories[$name] ?? null;
+        if ($factory === null) {
+            throw TypeNotFound::new($name);
+        }
+
+        if ($factory instanceof ContainerInterface) {
+            try {
+                $type = $factory->get($name);
+            } catch (ContainerExceptionInterface $exception) {
+                unset($this->factories[$name]);
+                if (! $factory->has($name)) {
+                    throw UnknownColumnType::new($name, $exception);
+                }
+
+                // @phpstan-ignore missingType.checkedException
+                throw $exception;
+            }
+        } else {
+            $type = new $factory();
+        }
+
+        if (isset($this->instancesReverseIndex[$type])) {
+            throw TypeAlreadyRegistered::new($type);
+        }
+
+        unset($this->factories[$name]);
+        $this->instances[$name]             = $type;
+        $this->instancesReverseIndex[$type] = $name;
 
         return $type;
     }
@@ -124,7 +190,7 @@ final class TypeRegistry
      */
     public function has(string $name): bool
     {
-        return isset($this->instances[$name]);
+        return isset($this->instances[$name]) || isset($this->factories[$name]);
     }
 
     /**
@@ -134,7 +200,7 @@ final class TypeRegistry
      */
     public function register(string $name, Type $type): void
     {
-        if (isset($this->instances[$name])) {
+        if (isset($this->instances[$name]) || isset($this->factories[$name])) {
             throw TypesAlreadyExists::new($name);
         }
 
@@ -142,8 +208,8 @@ final class TypeRegistry
             throw TypeAlreadyRegistered::new($type);
         }
 
-        $this->instances[$name]                            = $type;
-        $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        $this->instances[$name]             = $type;
+        $this->instancesReverseIndex[$type] = $name;
     }
 
     /**
@@ -156,16 +222,29 @@ final class TypeRegistry
     {
         $origType = $this->instances[$name] ?? null;
         if ($origType === null) {
-            throw TypeNotFound::new($name);
+            if (! isset($this->factories[$name])) {
+                throw TypeNotFound::new($name);
+            }
+
+            // Type is not yet instantiated — replace factory with the new instance directly
+            if (($this->findTypeName($type) ?? $name) !== $name) {
+                throw TypeAlreadyRegistered::new($type);
+            }
+
+            unset($this->factories[$name]);
+            $this->instances[$name]             = $type;
+            $this->instancesReverseIndex[$type] = $name;
+
+            return;
         }
 
         if (($this->findTypeName($type) ?? $name) !== $name) {
             throw TypeAlreadyRegistered::new($type);
         }
 
-        unset($this->instancesReverseIndex[spl_object_id($origType)]);
-        $this->instances[$name]                            = $type;
-        $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        unset($this->instancesReverseIndex[$origType]);
+        $this->instances[$name]             = $type;
+        $this->instancesReverseIndex[$type] = $name;
     }
 
     /**
@@ -174,14 +253,21 @@ final class TypeRegistry
      * @internal
      *
      * @return array<string, Type>
+     *
+     * @throws TypesException
      */
     public function getMap(): array
     {
+        // Ensure all types are loaded before returning the map
+        foreach ($this->factories as $name => $factory) {
+            $this->get($name);
+        }
+
         return $this->instances;
     }
 
     private function findTypeName(Type $type): ?string
     {
-        return $this->instancesReverseIndex[spl_object_id($type)] ?? null;
+        return $this->instancesReverseIndex[$type] ?? null;
     }
 }

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\Exception\TypeAlreadyRegistered;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
@@ -66,6 +65,7 @@ final class TypeRegistry
      *
      * @param array<string, Type> $instances
      *
+     * @throws TypeAlreadyRegistered
      * @throws TypesException
      */
     public function __construct(array $instances = [])
@@ -149,7 +149,8 @@ final class TypeRegistry
     /**
      * Overrides an already defined type to use a different implementation.
      *
-     * @throws Exception
+     * @throws TypeNotFound
+     * @throws TypeAlreadyRegistered
      */
     public function override(string $name, Type $type): void
     {

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -21,8 +21,6 @@ final class TypeRegistry
 {
     /**
      * The map of built-in Doctrine mapping types.
-     *
-     * @var array<string, class-string<Type>>
      */
     private const BUILTIN_TYPES_MAP = [
         Types::ASCII_STRING         => AsciiStringType::class,

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -24,7 +24,7 @@ final class TypeRegistry
      *
      * @var array<string, class-string<Type>>
      */
-    public const BUILTIN_TYPES_MAP = [
+    private const BUILTIN_TYPES_MAP = [
         Types::ASCII_STRING         => AsciiStringType::class,
         Types::BIGINT               => BigIntType::class,
         Types::BINARY               => BinaryType::class,

--- a/src/Types/TypeRegistry.php
+++ b/src/Types/TypeRegistry.php
@@ -4,37 +4,134 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Types;
 
-use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\Exception\TypeAlreadyRegistered;
 use Doctrine\DBAL\Types\Exception\TypeNotFound;
 use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
 use Doctrine\DBAL\Types\Exception\TypesAlreadyExists;
 use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Exception\UnknownColumnType;
+use Generator;
+use InvalidArgumentException;
+use IteratorAggregate;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 
-use function spl_object_id;
+use function array_key_exists;
+use function array_search;
+use function assert;
+use function get_debug_type;
+use function sprintf;
 
 /**
  * The type registry is responsible for holding a map of all known DBAL types.
+ *
+ * @implements IteratorAggregate<string, Type>
  */
-final class TypeRegistry
+final class TypeRegistry implements TypeProvider, IteratorAggregate
 {
-    /** @var array<string, Type> Map of type names and their corresponding flyweight objects. */
-    private array $instances;
-    /** @var array<int, string> */
-    private array $instancesReverseIndex;
+    /** Map of type names and their corresponding class names. */
+    private const BUILTIN_TYPES_MAP = [
+        Types::ASCII_STRING         => AsciiStringType::class,
+        Types::BIGINT               => BigIntType::class,
+        Types::BINARY               => BinaryType::class,
+        Types::BLOB                 => BlobType::class,
+        Types::BOOLEAN              => BooleanType::class,
+        Types::DATE_MUTABLE         => DateType::class,
+        Types::DATE_IMMUTABLE       => DateImmutableType::class,
+        Types::DATEINTERVAL         => DateIntervalType::class,
+        Types::DATETIME_MUTABLE     => DateTimeType::class,
+        Types::DATETIME_IMMUTABLE   => DateTimeImmutableType::class,
+        Types::DATETIME_UTC_MUTABLE => DateTimeUtcType::class,
+        Types::DATETIME_UTC_IMMUTABLE => DateTimeUtcImmutableType::class,
+        Types::DATETIMETZ_MUTABLE   => DateTimeTzType::class,
+        Types::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
+        Types::DECIMAL              => DecimalType::class,
+        Types::NUMBER               => NumberType::class,
+        Types::ENUM                 => EnumType::class,
+        Types::FLOAT                => FloatType::class,
+        Types::GUID                 => GuidType::class,
+        Types::INTEGER              => IntegerType::class,
+        Types::JSON                 => JsonType::class,
+        Types::JSON_OBJECT          => JsonObjectType::class,
+        Types::JSONB                => JsonbType::class,
+        Types::JSONB_OBJECT         => JsonbObjectType::class,
+        Types::SIMPLE_ARRAY         => SimpleArrayType::class,
+        Types::SMALLFLOAT           => SmallFloatType::class,
+        Types::SMALLINT             => SmallIntType::class,
+        Types::STRING               => StringType::class,
+        Types::TEXT                 => TextType::class,
+        Types::TIME_MUTABLE         => TimeType::class,
+        Types::TIME_IMMUTABLE       => TimeImmutableType::class,
+    ];
+
+    /** @var array<string, Type> Resolved types, keyed by type name. Doubles as the resolution cache. */
+    private array $instances = [];
 
     /**
-     * @param array<string, Type> $instances
+     * Map of type names to the container service IDs providing them.
      *
+     * @var array<string, string>
+     */
+    private array $serviceIds = [];
+
+    private ?ContainerInterface $container = null;
+
+    /**
+     * Creates a registry pre-populated with all built-in types. Additional types passed via
+     * {@param $types} are registered on top; if a name matches a built-in type it is
+     * overridden rather than re-registered.
+     *
+     * A {@see ContainerInterface} can be passed instead of an array to lazy-load type instances
+     * from a service container. In that case, {@param $serviceIds} maps type names to the
+     * container service IDs providing them. Types are resolved on first access and cached.
+     *
+     * Each service must resolve to a distinct {@see Type} instance: mapping two type names to the
+     * same service ID makes the second lookup fail with {@see TypeAlreadyRegistered}, because a
+     * type instance may only be registered under a single name.
+     *
+     * @param array<string, Type>|ContainerInterface $types
+     * @param array<string, string>|null             $serviceIds Map of type names to container service IDs.
+     *                                                           Required when passing a container, in which case an
+     *                                                           empty map means no types beyond the built-in ones.
+     *
+     * @throws TypeAlreadyRegistered
      * @throws TypesException
      */
-    public function __construct(array $instances = [])
+    public function __construct(array|ContainerInterface $types = [], ?array $serviceIds = null)
     {
-        $this->instances             = [];
-        $this->instancesReverseIndex = [];
-        foreach ($instances as $name => $type) {
-            $this->register($name, $type);
+        if ($types instanceof ContainerInterface) {
+            if ($serviceIds === null) {
+                throw new InvalidArgumentException(sprintf(
+                    'A map of type names to service IDs is required when passing a "%s".',
+                    ContainerInterface::class,
+                ));
+            }
+
+            $this->container  = $types;
+            $this->serviceIds = $serviceIds;
+        } else {
+            if ($serviceIds !== null) {
+                throw new InvalidArgumentException(sprintf(
+                    'A map of type names to service IDs can only be used together with a "%s".',
+                    ContainerInterface::class,
+                ));
+            }
+
+            foreach ($types as $name => $type) {
+                if (! $type instanceof Type) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Unexpected value for type "%s", got "%s".',
+                        $name,
+                        get_debug_type($type),
+                    ));
+                }
+
+                if ($this->findTypeName($type) !== null) {
+                    throw TypeAlreadyRegistered::new($type);
+                }
+
+                $this->instances[$name] = $type;
+            }
         }
     }
 
@@ -46,15 +143,56 @@ final class TypeRegistry
     public function get(string $name): Type
     {
         $type = $this->instances[$name] ?? null;
-        if ($type === null) {
+        if ($type !== null) {
+            return $type;
+        }
+
+        if (array_key_exists($name, $this->serviceIds)) {
+            $container = $this->container;
+            assert($container !== null);
+
+            $serviceId = $this->serviceIds[$name];
+            try {
+                $type = $container->get($serviceId);
+
+                if (! $type instanceof Type) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Service "%s" registered for type "%s" must be an instance of "%s", got "%s".',
+                        $serviceId,
+                        $name,
+                        Type::class,
+                        get_debug_type($type),
+                    ));
+                }
+            } catch (ContainerExceptionInterface $exception) {
+                if (! $container->has($serviceId)) {
+                    throw UnknownColumnType::new($name, $exception);
+                }
+
+                // @phpstan-ignore missingType.checkedException
+                throw $exception;
+            }
+        } elseif (array_key_exists($name, self::BUILTIN_TYPES_MAP)) {
+            $class = self::BUILTIN_TYPES_MAP[$name];
+            $type  = new $class();
+        } else {
             throw UnknownColumnType::new($name);
         }
+
+        if ($this->findTypeName($type) !== null) {
+            throw TypeAlreadyRegistered::new($type);
+        }
+
+        $this->instances[$name] = $type;
 
         return $type;
     }
 
     /**
      * Finds a name for the given type.
+     *
+     * @deprecated since doctrine/dbal 4.5. Track the type name instead of the instance. This method
+     *             cannot be implemented once a type instance may be registered under several names.
      *
      * @throws TypesException
      */
@@ -74,7 +212,9 @@ final class TypeRegistry
      */
     public function has(string $name): bool
     {
-        return isset($this->instances[$name]);
+        return array_key_exists($name, $this->instances)
+            || array_key_exists($name, $this->serviceIds)
+            || array_key_exists($name, self::BUILTIN_TYPES_MAP);
     }
 
     /**
@@ -84,7 +224,7 @@ final class TypeRegistry
      */
     public function register(string $name, Type $type): void
     {
-        if (isset($this->instances[$name])) {
+        if ($this->has($name)) {
             throw TypesAlreadyExists::new($name);
         }
 
@@ -92,19 +232,18 @@ final class TypeRegistry
             throw TypeAlreadyRegistered::new($type);
         }
 
-        $this->instances[$name]                            = $type;
-        $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        $this->instances[$name] = $type;
     }
 
     /**
      * Overrides an already defined type to use a different implementation.
      *
-     * @throws Exception
+     * @throws TypeNotFound
+     * @throws TypeAlreadyRegistered
      */
     public function override(string $name, Type $type): void
     {
-        $origType = $this->instances[$name] ?? null;
-        if ($origType === null) {
+        if (! $this->has($name)) {
             throw TypeNotFound::new($name);
         }
 
@@ -112,25 +251,50 @@ final class TypeRegistry
             throw TypeAlreadyRegistered::new($type);
         }
 
-        unset($this->instancesReverseIndex[spl_object_id($origType)]);
-        $this->instances[$name]                            = $type;
-        $this->instancesReverseIndex[spl_object_id($type)] = $name;
+        // Dropping the service ID keeps an unresolved container-backed type from being
+        // instantiated only to be discarded.
+        unset($this->serviceIds[$name]);
+        $this->instances[$name] = $type;
     }
 
     /**
-     * Gets the map of all registered types and their corresponding type instances.
+     * Yields every known type, keyed by type name.
      *
-     * @internal
+     * Types that have not been resolved yet are instantiated as they are reached, so stopping the
+     * iteration early leaves the remaining ones untouched.
      *
-     * @return array<string, Type>
+     * @return Generator<string, Type>
+     *
+     * @throws TypesException
      */
-    public function getMap(): array
+    public function getIterator(): Generator
     {
-        return $this->instances;
+        foreach ($this->instances as $name => $type) {
+            yield $name => $type;
+        }
+
+        // Resolving adds to $this->instances, which is what keeps each name yielded only once.
+        foreach ($this->serviceIds as $name => $serviceId) {
+            if (array_key_exists($name, $this->instances)) {
+                continue;
+            }
+
+            yield $name => $this->get($name);
+        }
+
+        foreach (self::BUILTIN_TYPES_MAP as $name => $class) {
+            if (array_key_exists($name, $this->instances) || array_key_exists($name, $this->serviceIds)) {
+                continue;
+            }
+
+            yield $name => $this->get($name);
+        }
     }
 
     private function findTypeName(Type $type): ?string
     {
-        return $this->instancesReverseIndex[spl_object_id($type)] ?? null;
+        $name = array_search($type, $this->instances, true);
+
+        return $name === false ? null : $name;
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests;
 
 use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -38,5 +40,23 @@ class ConfigurationTest extends TestCase
         $this->config->setAutoCommit(false);
 
         self::assertFalse($this->config->getAutoCommit());
+    }
+
+    public function testGetTypeRegistryReturnsGlobalRegistryByDefault(): void
+    {
+        self::assertSame(Type::getTypeRegistry(), $this->config->getTypeRegistry());
+    }
+
+    public function testSetTypeRegistryReplacesRegistry(): void
+    {
+        $registry = new TypeRegistry();
+        $this->config->setTypeRegistry($registry);
+
+        self::assertSame($registry, $this->config->getTypeRegistry());
+    }
+
+    public function testSetTypeRegistryReturnsSelf(): void
+    {
+        self::assertSame($this->config, $this->config->setTypeRegistry(new TypeRegistry()));
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests;
 
 use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeProvider;
+use Doctrine\DBAL\Types\TypeRegistry;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -38,5 +41,32 @@ class ConfigurationTest extends TestCase
         $this->config->setAutoCommit(false);
 
         self::assertFalse($this->config->getAutoCommit());
+    }
+
+    public function testGetTypeRegistryReturnsGlobalRegistryByDefault(): void
+    {
+        self::assertSame(Type::getTypeRegistry(), $this->config->getTypeRegistry());
+    }
+
+    public function testSetTypeRegistryReplacesRegistry(): void
+    {
+        $registry = new TypeRegistry();
+        $this->config->setTypeRegistry($registry);
+
+        self::assertSame($registry, $this->config->getTypeRegistry());
+    }
+
+    public function testSetTypeRegistryReturnsSelf(): void
+    {
+        self::assertSame($this->config, $this->config->setTypeRegistry(new TypeRegistry()));
+    }
+
+    public function testAnyTypeProviderImplementationIsAccepted(): void
+    {
+        // A hand-written registry is enough: TypeRegistry is what makes the registry substitutable.
+        $provider = self::createStub(TypeProvider::class);
+        $this->config->setTypeRegistry($provider);
+
+        self::assertSame($provider, $this->config->getTypeRegistry());
     }
 }

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -510,7 +510,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         $table = new Table('mytable');
 
         $oldColumn = $table->addColumn('foo', Types::STRING, $oldOptions);
-        $newColumn = new Column('foo', Type::getType($newType ?? Types::STRING), $newOptions);
+        $newColumn = new Column('foo', Type::getTypeRegistry()->get($newType ?? Types::STRING), $newOptions);
 
         $tableDiff = new TableDiff($table, changedColumns: [
             'foo' => new ColumnDiff(

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -23,7 +23,6 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Tests\Functional\Platform\RenameColumnTest;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -215,43 +214,15 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertFalse($diff11->hasTypeChanged());
     }
 
-    public function testDifferentTypeInstancesOfTheSameType(): void
+    public function testSameTypeNameIsNotAChange(): void
     {
-        $type1 = Type::getType(Types::INTEGER);
-        $type2 = clone $type1;
-
-        self::assertNotSame($type1, $type2);
-
         $column1 = Column::editor()
             ->setUnquotedName('id')
-            ->setType($type1)
+            ->setTypeName(Types::INTEGER)
             ->create();
 
         $column2 = $column1->edit()
-            ->setType($type2)
-            ->create();
-
-        $diff = new ColumnDiff($column2, $column1);
-        self::assertFalse($diff->hasTypeChanged());
-    }
-
-    public function testOverriddenType(): void
-    {
-        $defaultStringType = Type::getType(Types::STRING);
-        $integerType       = Type::getType(Types::INTEGER);
-
-        Type::overrideType(Types::STRING, $integerType::class);
-        $overriddenStringType = Type::getType(Types::STRING);
-
-        Type::overrideType(Types::STRING, $defaultStringType::class);
-
-        $column1 = Column::editor()
-            ->setUnquotedName('id')
-            ->setType($integerType)
-            ->create();
-
-        $column2 = $column1->edit()
-            ->setType($overriddenStringType)
+            ->setTypeName(Types::INTEGER)
             ->create();
 
         $diff = new ColumnDiff($column2, $column1);

--- a/tests/Schema/ColumnEditorTest.php
+++ b/tests/Schema/ColumnEditorTest.php
@@ -7,13 +7,15 @@ namespace Doctrine\DBAL\Tests\Schema;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\InvalidColumnDefinition;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
-use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class ColumnEditorTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public function testSetUnquotedName(): void
     {
         $column = Column::editor()
@@ -42,24 +44,28 @@ class ColumnEditorTest extends TestCase
 
     public function testSetType(): void
     {
-        $type = new IntegerType();
+        $type = Type::getType(Types::INTEGER);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
 
         $column = Column::editor()
             ->setUnquotedName('id')
             ->setType($type)
             ->create();
 
-        self::assertSame($type, $column->getType());
+        self::assertSame(Types::INTEGER, $column->getTypeName());
     }
 
     public function testSetTypeName(): void
     {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
         $column = Column::editor()
             ->setUnquotedName('id')
             ->setTypeName(Types::INTEGER)
             ->create();
 
-        self::assertEquals(Type::getType(Types::INTEGER), $column->getType());
+        self::assertSame(Types::INTEGER, $column->getTypeName());
     }
 
     public function testSetCollation(): void

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -12,7 +12,12 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Tests\Types\InMemoryTypeProvider;
+use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
+use Doctrine\DBAL\Types\IntegerType;
+use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -45,11 +50,37 @@ class ColumnTest extends TestCase
         self::assertEquals(self::class, $column->getPlatformOption('enumType'));
     }
 
+    public function testToArrayWithType(): void
+    {
+        $expected = [
+            'name' => 'foo',
+            'typeName' => Types::STRING,
+            'default' => 'baz',
+            'notnull' => false,
+            'length' => 200,
+            'precision' => 5,
+            'scale' => 2,
+            'fixed' => true,
+            'unsigned' => true,
+            'autoincrement' => false,
+            'columnDefinition' => null,
+            'comment' => '',
+            'values' => [],
+            'type' => Type::getType(Types::STRING),
+            'charset' => 'utf8',
+            'enumType' => self::class,
+        ];
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertSame($expected, $this->createColumn()->toArray());
+    }
+
     public function testToArray(): void
     {
         $expected = [
             'name' => 'foo',
-            'type' => Type::getType(Types::STRING),
+            'typeName' => Types::STRING,
             'default' => 'baz',
             'notnull' => false,
             'length' => 200,
@@ -65,15 +96,22 @@ class ColumnTest extends TestCase
             'enumType' => self::class,
         ];
 
-        self::assertSame($expected, $this->createColumn()->toArray());
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertSame($expected, $this->createColumn()->toArray(true));
     }
 
     public function testSettingUnknownOptionIsStillSupported(): void
     {
+        $column = Column::editor()
+            ->setUnquotedName('foo')
+            ->setTypeName(Types::STRING)
+            ->create();
+
         $this->expectException(UnknownColumnOption::class);
         $this->expectExceptionMessage('The "unknown_option" column option is not supported.');
 
-        new Column('foo', self::createStub(Type::class), ['unknown_option' => 'bar']);
+        $column->setOptions(['unknown_option' => 'bar']);
     }
 
     public function testOptionsShouldNotBeIgnored(): void
@@ -173,7 +211,7 @@ class ColumnTest extends TestCase
     {
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6646');
 
-        new Column('', Type::getType(Types::INTEGER));
+        new Column('', Types::INTEGER);
     }
 
     /** @throws Exception */
@@ -187,9 +225,113 @@ class ColumnTest extends TestCase
         self::assertEquals(Identifier::unquoted('id'), $column->getObjectName()->getIdentifier());
     }
 
+    public function testPassingTypeInstanceToConstructorIsDeprecated(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        new Column('foo', Type::getTypeRegistry()->get(Types::STRING));
+    }
+
+    public function testGetTypeIsDeprecated(): void
+    {
+        $column = new Column('foo', Types::STRING);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertInstanceOf(StringType::class, $column->getType());
+    }
+
+    public function testGetTypeNameIsNotDeprecated(): void
+    {
+        $column = new Column('foo', Types::STRING);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertSame(Types::STRING, $column->getTypeName());
+    }
+
+    public function testGetTypeUsesInjectedTypeRegistry(): void
+    {
+        $customType = new StringType();
+        $registry   = new TypeRegistry([Types::STRING => $customType]);
+
+        $column = new Column('foo', Types::STRING);
+        $column->setTypeRegistry($registry);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertSame($customType, $column->getType());
+        self::assertNotSame(Type::getType(Types::STRING), $column->getType());
+    }
+
+    public function testGetTypeFallsBackToGlobalRegistryWhenRegistryIsNull(): void
+    {
+        $column = new Column('foo', Types::STRING);
+        $column->setTypeRegistry(null);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertSame(Type::getType(Types::STRING), $column->getType());
+    }
+
+    public function testSetTypeUsesInjectedTypeRegistryForNameLookup(): void
+    {
+        $customType = new StringType();
+        $registry   = new TypeRegistry([Types::STRING => $customType]);
+
+        $column = new Column('foo', Types::INTEGER);
+        $column->setTypeRegistry($registry);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7381');
+
+        $column->setType($customType);
+
+        self::assertSame(Types::STRING, $column->getTypeName());
+    }
+
+    public function testGetTypeUsesInjectedCustomTypeProvider(): void
+    {
+        $customType = new StringType();
+        $provider   = new InMemoryTypeProvider(['my_string' => $customType]);
+
+        $column = new Column('foo', 'my_string');
+        $column->setTypeRegistry($provider);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7490');
+
+        self::assertSame($customType, $column->getType());
+    }
+
+    public function testSetTypeUsesInjectedCustomTypeProviderForNameLookup(): void
+    {
+        $customType = new StringType();
+        $provider   = new InMemoryTypeProvider(['my_string' => $customType]);
+
+        $column = new Column('foo', Types::INTEGER);
+        $column->setTypeRegistry($provider);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7381');
+
+        $column->setType($customType);
+
+        self::assertSame('my_string', $column->getTypeName());
+    }
+
+    public function testSetTypeThrowsWhenTypeIsNotFoundInCustomTypeProvider(): void
+    {
+        $provider = new InMemoryTypeProvider(['my_string' => new StringType()]);
+
+        $column = new Column('foo', Types::INTEGER);
+        $column->setTypeRegistry($provider);
+
+        $this->expectException(TypeNotRegistered::class);
+
+        $column->setType(new IntegerType());
+    }
+
     public function testSetPlatformOptionJsonb(): void
     {
-        $column = new Column('jsonb', Type::getType(Types::JSON));
+        $column = new Column('jsonb', Types::JSON);
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6939');
         $column->setPlatformOption('jsonb', true);

--- a/tests/Schema/SchemaConfigTest.php
+++ b/tests/Schema/SchemaConfigTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Types\TypeProvider;
+use PHPUnit\Framework\TestCase;
+
+class SchemaConfigTest extends TestCase
+{
+    public function testSetTypeRegistryReplacesRegistry(): void
+    {
+        $config   = new SchemaConfig();
+        $registry = self::createStub(TypeProvider::class);
+
+        self::assertNull($config->getTypeRegistry());
+
+        $config->setTypeRegistry($registry);
+
+        self::assertSame($registry, $config->getTypeRegistry());
+    }
+}

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -1791,9 +1791,9 @@ class TableTest extends TestCase
 
     public function testAddColumnUsesConfigurationTypeRegistry(): void
     {
-        $customType   = Type::getType(Types::INTEGER);
-        $registry     = new TypeRegistry([Types::INTEGER => $customType]);
-        $config       = (new Configuration())->setTypeRegistry($registry);
+        $customType = Type::getType(Types::INTEGER);
+        $registry   = new TypeRegistry([Types::INTEGER => $customType]);
+        $config     = (new Configuration())->setTypeRegistry($registry);
 
         $table  = new Table('foo', [], [], [], [], [], null, null, $config);
         $column = $table->addColumn('id', Types::INTEGER);

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -22,6 +23,7 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use LogicException;
@@ -1785,5 +1787,17 @@ class TableTest extends TestCase
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7125');
         $table->addForeignKeyConstraint('baz', ['id'], ['id']);
+    }
+
+    public function testAddColumnUsesConfigurationTypeRegistry(): void
+    {
+        $customType   = Type::getType(Types::INTEGER);
+        $registry     = new TypeRegistry([Types::INTEGER => $customType]);
+        $config       = (new Configuration())->setTypeRegistry($registry);
+
+        $table  = new Table('foo', [], [], [], [], [], null, null, $config);
+        $column = $table->addColumn('id', Types::INTEGER);
+
+        self::assertSame($customType, $column->getType());
     }
 }

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Schema;
 
-use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
@@ -1793,9 +1792,8 @@ class TableTest extends TestCase
     {
         $customType = Type::getType(Types::INTEGER);
         $registry   = new TypeRegistry([Types::INTEGER => $customType]);
-        $config     = (new Configuration())->setTypeRegistry($registry);
 
-        $table  = new Table('foo', [], [], [], [], [], null, null, $config);
+        $table  = new Table('foo', [], [], [], [], [], null, null, $registry);
         $column = $table->addColumn('id', Types::INTEGER);
 
         self::assertSame($customType, $column->getType());

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -23,7 +23,9 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\UniqueConstraint;
+use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use LogicException;
@@ -2106,5 +2108,33 @@ class TableTest extends TestCase
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7125');
         $table->addForeignKeyConstraint('baz', ['id'], ['id']);
+    }
+
+    public function testAddColumnUsesConfigurationTypeRegistry(): void
+    {
+        $customType = new IntegerType();
+        $registry   = new TypeRegistry([Types::INTEGER => $customType]);
+
+        $table = new Table('foo');
+        $table->setTypeRegistry($registry);
+        $column = $table->addColumn('id', Types::INTEGER);
+
+        self::assertSame($customType, $column->getType());
+        self::assertNotSame(Type::getType(Types::INTEGER), $column->getType());
+    }
+
+    public function testEditPreservesTypeRegistry(): void
+    {
+        $customType = new IntegerType();
+        $registry   = new TypeRegistry([Types::INTEGER => $customType]);
+
+        $table = new Table('foo');
+        $table->setTypeRegistry($registry);
+        $table->addColumn('id', Types::INTEGER);
+
+        $editedTable = $table->edit()->create();
+        $column      = $editedTable->addColumn('name', Types::INTEGER);
+
+        self::assertSame($customType, $column->getType());
     }
 }

--- a/tests/Types/CountingContainer.php
+++ b/tests/Types/CountingContainer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
+
+/**
+ * A plain PSR-11 container that records how many times each service is resolved.
+ *
+ * Used to assert that {@see \Doctrine\DBAL\Types\TypeRegistry} resolves container-backed types
+ * lazily and only once.
+ */
+final class CountingContainer implements ContainerInterface
+{
+    /** @var array<string, int> */
+    public array $resolved = [];
+
+    /** @param array<string, Type> $services */
+    public function __construct(private array $services = [])
+    {
+    }
+
+    public function get(string $id): Type
+    {
+        if (! isset($this->services[$id])) {
+            throw new class extends RuntimeException implements NotFoundExceptionInterface {
+            };
+        }
+
+        $this->resolved[$id] = ($this->resolved[$id] ?? 0) + 1;
+
+        return $this->services[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
+}

--- a/tests/Types/InMemoryTypeProvider.php
+++ b/tests/Types/InMemoryTypeProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Types;
+
+use Doctrine\DBAL\Types\Exception\TypesException;
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeProvider;
+use IteratorAggregate;
+use Traversable;
+
+use function array_key_exists;
+
+/** @implements IteratorAggregate<string, Type> */
+final class InMemoryTypeProvider implements TypeProvider, IteratorAggregate
+{
+    /** @param array<string, Type> $types */
+    public function __construct(private readonly array $types)
+    {
+    }
+
+    public function get(string $name): Type
+    {
+        if (! array_key_exists($name, $this->types)) {
+            throw UnknownColumnType::new($name);
+        }
+
+        return $this->types[$name];
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->types);
+    }
+
+    /**
+     * @return Traversable<string, Type>
+     *
+     * @throws TypesException
+     */
+    public function getIterator(): Traversable
+    {
+        yield from $this->types;
+    }
+}

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -14,6 +14,8 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\TypeRegistry;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+
 class TypeRegistryTest extends TestCase
 {
     private const TEST_TYPE_NAME       = 'test';

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Types\TypeRegistry;
 use PHPUnit\Framework\TestCase;
 
 use function count;
+use function sprintf;
 
 class TypeRegistryTest extends TestCase
 {
@@ -166,8 +167,8 @@ class TypeRegistryTest extends TestCase
 
         // The global registry is seeded from the same built-in map, so all its types must be present
         foreach (Type::getTypeRegistry()->getMap() as $name => $type) {
-            self::assertTrue($registry->has($name));
-            self::assertInstanceOf($type::class, $registry->get($name));
+            self::assertTrue($registry->has($name), sprintf('Built-in type "%s" is missing from registry', $name));
+            self::assertInstanceOf($type::class, $registry->get($name), sprintf('Built-in type "%s" does not match expected class "%s"', $name, $type::class));
         }
     }
 }

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -12,7 +12,9 @@ use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\TypeRegistry;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 use function count;
 use function sprintf;
@@ -163,12 +165,20 @@ class TypeRegistryTest extends TestCase
 
     public function testBuiltinTypesAvailableByDefault(): void
     {
+        Type::getTypeRegistry()->register(__FUNCTION__, new class extends StringType {
+        });
         $registry = new TypeRegistry();
 
-        // The global registry is seeded from the same built-in map, so all its types must be present
-        foreach (Type::getTypeRegistry()->getMap() as $name => $type) {
-            self::assertTrue($registry->has($name), sprintf('Built-in type "%s" is missing from registry', $name));
-            self::assertInstanceOf($type::class, $registry->get($name), sprintf('Built-in type "%s" does not match expected class "%s"', $name, $type::class));
+        // Types from the singleton registry are not registered in a new instance
+        self::assertFalse($registry->has(__FUNCTION__));
+
+        // Check that all the constants from Types are registered by default
+        $constants = (new ReflectionClass(Types::class))->getConstants();
+        foreach ($constants as $typeName) {
+            self::assertTrue(
+                $registry->has($typeName),
+                sprintf('Built-in type "%s" is not registered by default.', $typeName),
+            );
         }
     }
 }

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -149,10 +149,20 @@ class TypeRegistryTest extends TestCase
     {
         $registeredTypes = $this->registry->getMap();
 
-        self::assertCount(2, $registeredTypes);
+        self::assertCount(count(TypeRegistry::BUILTIN_TYPES_MAP) + 2, $registeredTypes);
         self::assertArrayHasKey(self::TEST_TYPE_NAME, $registeredTypes);
         self::assertArrayHasKey(self::OTHER_TEST_TYPE_NAME, $registeredTypes);
         self::assertSame($this->testType, $registeredTypes[self::TEST_TYPE_NAME]);
         self::assertSame($this->otherTestType, $registeredTypes[self::OTHER_TEST_TYPE_NAME]);
+    }
+
+    public function testBuiltinTypesAvailableByDefault(): void
+    {
+        $registry = new TypeRegistry();
+
+        foreach (TypeRegistry::BUILTIN_TYPES_MAP as $name => $class) {
+            self::assertTrue($registry->has($name));
+            self::assertInstanceOf($class, $registry->get($name));
+        }
     }
 }

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\TypeRegistry;
 use PHPUnit\Framework\TestCase;
 
@@ -149,7 +150,8 @@ class TypeRegistryTest extends TestCase
     {
         $registeredTypes = $this->registry->getMap();
 
-        self::assertCount(count(TypeRegistry::BUILTIN_TYPES_MAP) + 2, $registeredTypes);
+        // Built-in types plus the two registered in setUp()
+        self::assertGreaterThan(2, count($registeredTypes));
         self::assertArrayHasKey(self::TEST_TYPE_NAME, $registeredTypes);
         self::assertArrayHasKey(self::OTHER_TEST_TYPE_NAME, $registeredTypes);
         self::assertSame($this->testType, $registeredTypes[self::TEST_TYPE_NAME]);
@@ -160,9 +162,10 @@ class TypeRegistryTest extends TestCase
     {
         $registry = new TypeRegistry();
 
-        foreach (TypeRegistry::BUILTIN_TYPES_MAP as $name => $class) {
+        // The global registry is seeded from the same built-in map, so all its types must be present
+        foreach (Type::getTypeRegistry()->getMap() as $name => $type) {
             self::assertTrue($registry->has($name));
-            self::assertInstanceOf($class, $registry->get($name));
+            self::assertInstanceOf($type::class, $registry->get($name));
         }
     }
 }

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -15,8 +15,11 @@ use Doctrine\DBAL\Types\TypeRegistry;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
+use function array_map;
 use function count;
+use function interface_exists;
 use function sprintf;
 
 class TypeRegistryTest extends TestCase
@@ -161,6 +164,148 @@ class TypeRegistryTest extends TestCase
         self::assertArrayHasKey(self::OTHER_TEST_TYPE_NAME, $registeredTypes);
         self::assertSame($this->testType, $registeredTypes[self::TEST_TYPE_NAME]);
         self::assertSame($this->otherTestType, $registeredTypes[self::OTHER_TEST_TYPE_NAME]);
+    }
+
+    private function requireServiceProvider(): void
+    {
+        if (interface_exists(ServiceProviderInterface::class)) {
+            return;
+        }
+
+        self::markTestSkipped('symfony/service-contracts is not installed.');
+    }
+
+    /** @param array<string, Type> $types */
+    private function createServiceProvider(array $types): ServiceProviderInterface
+    {
+        return new class ($types) implements ServiceProviderInterface {
+            /** @param array<string, Type> $types */
+            public function __construct(private array $types)
+            {
+            }
+
+            public function get(string $id): Type
+            {
+                return $this->types[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->types[$id]);
+            }
+
+            /** @return array<string, string> */
+            public function getProvidedServices(): array
+            {
+                return array_map(static fn (Type $t): string => $t::class, $this->types);
+            }
+        };
+    }
+
+    public function testServiceProviderIsLazy(): void
+    {
+        $this->requireServiceProvider();
+
+        $type     = new BlobType();
+        $provider = new class ($type) implements ServiceProviderInterface {
+            public int $resolved = 0;
+
+            public function __construct(private Type $type)
+            {
+            }
+
+            public function get(string $id): Type
+            {
+                ++$this->resolved;
+
+                return $this->type;
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === 'custom';
+            }
+
+            /** @return array<string, string> */
+            public function getProvidedServices(): array
+            {
+                return ['custom' => BlobType::class];
+            }
+        };
+
+        $registry = new TypeRegistry($provider);
+
+        self::assertSame(0, $provider->resolved, 'Provider must not be called during construction.');
+        self::assertTrue($registry->has('custom'));
+        self::assertSame(0, $provider->resolved, 'Provider must not be called by has().');
+
+        $registry->get('custom');
+        self::assertSame(1, $provider->resolved, 'Provider must be called exactly once on first get().');
+
+        $registry->get('custom');
+        self::assertSame(1, $provider->resolved, 'Provider must not be called again after the instance is cached.');
+    }
+
+    public function testServiceProviderLookupName(): void
+    {
+        $this->requireServiceProvider();
+
+        $type     = new BlobType();
+        $registry = new TypeRegistry($this->createServiceProvider(['custom' => $type]));
+
+        self::assertSame('custom', $registry->lookupName($registry->get('custom')));
+    }
+
+    public function testServiceProviderBuiltinTypesStillAvailable(): void
+    {
+        $this->requireServiceProvider();
+
+        $registry = new TypeRegistry($this->createServiceProvider([]));
+
+        self::assertTrue($registry->has(Types::STRING));
+        self::assertInstanceOf(StringType::class, $registry->get(Types::STRING));
+    }
+
+    public function testServiceProviderCanOverrideBuiltinType(): void
+    {
+        $this->requireServiceProvider();
+
+        $custom   = new BlobType();
+        $registry = new TypeRegistry($this->createServiceProvider([Types::STRING => $custom]));
+
+        self::assertSame($custom, $registry->get(Types::STRING));
+    }
+
+    public function testArrayInstancesOverrideBuiltinTypes(): void
+    {
+        $custom   = new BlobType();
+        $registry = new TypeRegistry([Types::STRING => $custom]);
+
+        self::assertSame($custom, $registry->get(Types::STRING));
+    }
+
+    public function testServiceProviderGetMapResolvesAllTypes(): void
+    {
+        $this->requireServiceProvider();
+
+        $type     = new BlobType();
+        $registry = new TypeRegistry($this->createServiceProvider(['custom' => $type]));
+
+        $map = $registry->getMap();
+
+        self::assertArrayHasKey('custom', $map);
+        self::assertSame($type, $map['custom']);
+        self::assertArrayHasKey(Types::STRING, $map);
+    }
+
+    public function testServiceProviderUnknownTypeThrows(): void
+    {
+        $this->requireServiceProvider();
+
+        $registry = new TypeRegistry($this->createServiceProvider([]));
+
+        $this->expectException(Exception::class);
+        $registry->get('unknown');
     }
 
     public function testBuiltinTypesAvailableByDefault(): void

--- a/tests/Types/TypeRegistryTest.php
+++ b/tests/Types/TypeRegistryTest.php
@@ -7,11 +7,28 @@ namespace Doctrine\DBAL\Tests\Types;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\Exception\TypeAlreadyRegistered;
 use Doctrine\DBAL\Types\Exception\TypeNotRegistered;
+use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\TextType;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\TypeRegistry;
+use Doctrine\DBAL\Types\Types;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use RuntimeException;
+use stdClass;
+
+use function array_count_values;
+use function array_filter;
+use function array_keys;
+use function count;
+use function iterator_to_array;
+use function sprintf;
 
 class TypeRegistryTest extends TestCase
 {
@@ -45,8 +62,14 @@ class TypeRegistryTest extends TestCase
     public function testGetReturnsSameInstances(): void
     {
         self::assertSame(
+            $this->registry->get(Types::DATE_MUTABLE),
+            $this->registry->get(Types::DATE_MUTABLE),
+            'Built-in type',
+        );
+        self::assertSame(
             $this->registry->get(self::TEST_TYPE_NAME),
             $this->registry->get(self::TEST_TYPE_NAME),
+            'Custom type',
         );
     }
 
@@ -67,6 +90,7 @@ class TypeRegistryTest extends TestCase
 
     public function testHas(): void
     {
+        self::assertTrue($this->registry->has(Types::DATE_MUTABLE));
         self::assertTrue($this->registry->has(self::TEST_TYPE_NAME));
         self::assertTrue($this->registry->has(self::OTHER_TEST_TYPE_NAME));
         self::assertFalse($this->registry->has('unknown'));
@@ -145,14 +169,299 @@ class TypeRegistryTest extends TestCase
         $this->registry->override('second', $newType);
     }
 
-    public function testGetMap(): void
+    public function testOverrideBuiltinTypeThatWasNeverResolved(): void
     {
-        $registeredTypes = $this->registry->getMap();
+        $replacement = new TextType();
 
-        self::assertCount(2, $registeredTypes);
+        // The built-in was never instantiated, so it only exists as a class name
+        $this->registry->override(Types::STRING, $replacement);
+
+        self::assertSame($replacement, $this->registry->get(Types::STRING));
+        self::assertSame(Types::STRING, $this->registry->lookupName($replacement));
+        self::assertSame($replacement, iterator_to_array($this->registry)[Types::STRING]);
+    }
+
+    public function testRegisterBuiltinTypeNameThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $this->registry->register(Types::STRING, new TextType());
+    }
+
+    public function testIteration(): void
+    {
+        $registeredTypes = iterator_to_array($this->registry);
+
+        // Built-in types plus the two registered in setUp()
+        self::assertGreaterThan(2, count($registeredTypes));
         self::assertArrayHasKey(self::TEST_TYPE_NAME, $registeredTypes);
         self::assertArrayHasKey(self::OTHER_TEST_TYPE_NAME, $registeredTypes);
         self::assertSame($this->testType, $registeredTypes[self::TEST_TYPE_NAME]);
         self::assertSame($this->otherTestType, $registeredTypes[self::OTHER_TEST_TYPE_NAME]);
+    }
+
+    public function testIterationYieldsEverySourceExactlyOnce(): void
+    {
+        // A container service overriding a built-in name is the case most likely to be yielded twice.
+        $registry = new TypeRegistry(
+            new CountingContainer(['app.string_type' => new BlobType()]),
+            [Types::STRING => 'app.string_type'],
+        );
+
+        $names = [];
+        foreach ($registry as $name => $type) {
+            $names[] = $name;
+        }
+
+        self::assertSame([], array_keys(array_filter(array_count_values($names), static fn (int $c): bool => $c > 1)));
+        self::assertContains(Types::STRING, $names);
+        self::assertContains(Types::INTEGER, $names);
+
+        // Iterating again yields the same names and resolves nothing new.
+        self::assertSame($names, array_keys(iterator_to_array($registry)));
+    }
+
+    public function testIterationIsLazy(): void
+    {
+        $container = new CountingContainer([
+            'app.money_type' => new BlobType(),
+            'app.other_type' => new TextType(),
+        ]);
+        $registry  = new TypeRegistry($container, [
+            'money' => 'app.money_type',
+            'other' => 'app.other_type',
+        ]);
+
+        foreach ($registry as $name => $type) {
+            break;
+        }
+
+        // Only the type actually consumed is resolved; the rest, including every built-in, is untouched.
+        self::assertCount(1, $container->resolved, 'Stopping early must not resolve the remaining services.');
+    }
+
+    public function testArrayInstancesOverrideBuiltinTypes(): void
+    {
+        $custom   = new BlobType();
+        $registry = new TypeRegistry([Types::STRING => $custom]);
+
+        self::assertSame($custom, $registry->get(Types::STRING));
+    }
+
+    public function testContainerWithServiceIdMap(): void
+    {
+        $type      = new BlobType();
+        $container = new CountingContainer(['app.money_type' => $type]);
+
+        $registry = new TypeRegistry($container, ['money' => 'app.money_type']);
+
+        self::assertTrue($registry->has('money'));
+        self::assertSame($type, $registry->get('money'));
+        self::assertSame('money', $registry->lookupName($type));
+
+        // The service ID itself is not a type name
+        self::assertFalse($registry->has('app.money_type'));
+    }
+
+    public function testContainerIsLazy(): void
+    {
+        $container = new CountingContainer(['app.money_type' => new BlobType()]);
+
+        $registry = new TypeRegistry($container, ['money' => 'app.money_type']);
+        self::assertSame([], $container->resolved, 'Container must not be called during construction.');
+
+        self::assertTrue($registry->has('money'));
+        self::assertSame([], $container->resolved, 'Container must not be called by has().');
+
+        $registry->get('money');
+        $registry->get('money');
+        self::assertSame(['app.money_type' => 1], $container->resolved, 'Container must be called only once.');
+    }
+
+    public function testContainerOverridesBuiltinType(): void
+    {
+        $custom    = new BlobType();
+        $container = new CountingContainer(['app.string_type' => $custom]);
+
+        $registry = new TypeRegistry($container, [Types::STRING => 'app.string_type']);
+
+        self::assertSame($custom, $registry->get(Types::STRING));
+    }
+
+    public function testContainerBuiltinTypesStillAvailable(): void
+    {
+        $container = new CountingContainer(['app.money_type' => new BlobType()]);
+
+        $registry = new TypeRegistry($container, ['money' => 'app.money_type']);
+
+        self::assertInstanceOf(StringType::class, $registry->get(Types::STRING));
+        self::assertSame([], $container->resolved, 'Built-in types must not be resolved from the container.');
+    }
+
+    public function testContainerUnknownTypeThrowsUnknownColumnType(): void
+    {
+        $registry = new TypeRegistry(new CountingContainer([]), ['money' => 'app.money_type']);
+
+        $this->expectException(UnknownColumnType::class);
+        $registry->get('unknown');
+    }
+
+    public function testContainerMissingServiceThrowsUnknownColumnType(): void
+    {
+        // The type name is mapped, but the container does not provide the service.
+        $registry = new TypeRegistry(new CountingContainer([]), ['money' => 'app.money_type']);
+
+        $this->expectException(UnknownColumnType::class);
+        $registry->get('money');
+    }
+
+    public function testContainerFailureIsRethrown(): void
+    {
+        $failure = new class extends RuntimeException implements ContainerExceptionInterface {
+        };
+
+        $container = new class ($failure) implements ContainerInterface {
+            public function __construct(private RuntimeException $failure)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                throw $this->failure;
+            }
+
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+
+        $registry = new TypeRegistry($container, ['money' => 'app.money_type']);
+
+        // The service exists but could not be instantiated: the original error must not be
+        // masked as an unknown type.
+        try {
+            $registry->get('money');
+            self::fail('Expected the container exception to be rethrown.');
+        } catch (ContainerExceptionInterface $caught) {
+            self::assertSame($failure, $caught);
+        }
+
+        // A failed resolution must not drop the type: has() stays true and a retry keeps trying
+        // instead of reporting an unknown type.
+        self::assertTrue($registry->has('money'));
+
+        try {
+            $registry->get('money');
+            self::fail('Expected the container exception to be rethrown on retry.');
+        } catch (ContainerExceptionInterface $caught) {
+            self::assertSame($failure, $caught);
+        }
+    }
+
+    public function testContainerReturningNonTypeThrows(): void
+    {
+        $container = new class implements ContainerInterface {
+            public function get(string $id): mixed
+            {
+                return new stdClass();
+            }
+
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+
+        $registry = new TypeRegistry($container, ['money' => 'app.money_type']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $registry->get('money');
+    }
+
+    public function testOverrideContainerBackedTypeDoesNotResolveIt(): void
+    {
+        $container = new CountingContainer(['app.money_type' => new BlobType()]);
+        $registry  = new TypeRegistry($container, ['money' => 'app.money_type']);
+
+        $replacement = new TextType();
+        $registry->override('money', $replacement);
+
+        self::assertSame([], $container->resolved, 'Overriding must not instantiate the replaced service.');
+        self::assertSame($replacement, $registry->get('money'));
+    }
+
+    public function testIterationResolvesContainerBackedTypes(): void
+    {
+        $type     = new BlobType();
+        $registry = new TypeRegistry(
+            new CountingContainer(['app.money_type' => $type]),
+            ['money' => 'app.money_type'],
+        );
+
+        $map = iterator_to_array($registry);
+
+        self::assertSame($type, $map['money']);
+        self::assertArrayHasKey(Types::STRING, $map);
+    }
+
+    public function testContainerWithDuplicateServiceIdThrows(): void
+    {
+        // Two type names pointing at the same service resolve to the same instance, which breaks
+        // the one-instance-one-name invariant required by lookupName().
+        $registry = new TypeRegistry(
+            new CountingContainer(['app.money_type' => new BlobType()]),
+            ['money' => 'app.money_type', 'cash' => 'app.money_type'],
+        );
+
+        $registry->get('money');
+
+        $this->expectException(TypeAlreadyRegistered::class);
+        $registry->get('cash');
+    }
+
+    public function testServiceIdsWithArrayInstancesThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TypeRegistry(['money' => new BlobType()], ['money' => 'app.money_type']);
+    }
+
+    public function testPlainContainerWithoutServiceIdsThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TypeRegistry(new CountingContainer([]));
+    }
+
+    public function testPlainContainerWithExplicitlyEmptyServiceIds(): void
+    {
+        // An empty map is explicit and valid: only built-in types are available.
+        $registry = new TypeRegistry(new CountingContainer([]), []);
+
+        self::assertInstanceOf(StringType::class, $registry->get(Types::STRING));
+        self::assertFalse($registry->has('money'));
+    }
+
+    public function testUnknownTypeThrowsUnknownColumnType(): void
+    {
+        $this->expectException(UnknownColumnType::class);
+        $this->registry->get('unknown');
+    }
+
+    public function testBuiltinTypesAvailableByDefault(): void
+    {
+        Type::getTypeRegistry()->register(__FUNCTION__, new class extends StringType {
+        });
+        $registry = new TypeRegistry();
+
+        // Types from the singleton registry are not registered in a new instance
+        self::assertFalse($registry->has(__FUNCTION__));
+
+        // Check that all the constants from Types are registered by default
+        $constants = (new ReflectionClass(Types::class))->getConstants();
+        foreach ($constants as $typeName) {
+            self::assertTrue(
+                $registry->has($typeName),
+                sprintf('Built-in type "%s" is not registered by default.', $typeName),
+            );
+        }
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | -

Continues #6705. The existing `TypeRegistry` class already supports scoped, instance-based
type management; this PR wires it into the rest of DBAL so it is actually used.

Companion PRs: doctrine/orm#12421 and doctrine/DoctrineBundle#2221.
This is already being done in the same way for Doctrine MongoDB ODM: https://github.com/doctrine/mongodb-odm/pull/2966

**#7490 is merged into this branch** so the whole direction is visible in one place. I recommend
merging #7490 first, then rebasing this PR on top of it.

> Disclamer: This PR was made using Claude under my very close supervision; trying to provide a more detailed description of the changes than I would have written myself, but I have verified the content and made some edits for clarity and accuracy.

## Motivation

Two goals:

- **Dependency injection into type instances.** Custom types sometimes need access to
  services (e.g. a serializer, an encryption service). With the global static registry this is impossible
  without static state. A per-connection type provider can hold fully-constructed type
  instances.

- **Prevent global side-effects.** `Type::addType()` and `Type::overrideType()` mutate a
  process-wide singleton, so a test or a bundle changing a type affects every connection.
  A scoped provider isolates those changes.

## What changed

### `TypeProvider`

New interface, and the type `Configuration` now expresses:

```php
interface TypeProvider extends Traversable
{
    public function get(string $name): Type;

    public function has(string $name): bool;
}
```

It extends `Traversable`, since callers may also want to enumerate the available types.
`register()` and `override()` are deliberately absent, so `Type::getTypeRegistry()` keeps
returning the concrete `TypeRegistry` that `Type::addType()` needs.

Extending PSR-11 `ContainerInterface` was considered and left out for now, since it would make
`psr/container` a hard requirement. It can still be added later.

### `TypeRegistry`

- Built-in types are pre-populated: `new TypeRegistry()` already contains all of them. They are
  read straight from a class constant rather than copied per instance, so construction is cheap.
  Custom types passed to the constructor are layered on top and may override built-ins by name.
- Types can be lazy-loaded from a PSR-11 container, given a map of type names to service IDs.
  The container is never queried during construction, nor by `has()`:
  ```php
  new TypeRegistry($container, ['money' => 'app.dbal_type.money']);
  ```
- Implements `IteratorAggregate` with a generator, replacing the `@internal getMap()`. Stopping
  early no longer instantiates every remaining type.
- `lookupName()` is deprecated. It cannot go yet, because the deprecated `Column::setType()`,
  `ColumnEditor::setType()` and ORM's `TypedExpression` still need instance-to-name. It is removed
  in 5.0, together with the restriction that an instance may only be registered under one name.

### `Configuration`

- `getTypeProvider(): TypeProvider` returns the provider for this connection, lazily defaulting
  to the global registry (`Type::getTypeRegistry()`).
- `setTypeProvider(TypeProvider $provider): self` injects a provider scoped to this connection.

### Internal type resolution

All of the following now resolve types through `$configuration->getTypeProvider()` instead
of the static `Type::*` methods:

| Component | Method(s) changed |
|---|---|
| `Connection` | `convertToDatabaseValue()`, `convertToPHPValue()`, `getBindingInfo()` |
| `Statement` | parameter binding |
| `AbstractPlatform` | `initializeAllDoctrineTypeMappings()`, `registerDoctrineTypeMapping()`, `getType()` |
| `*SchemaManager` (×6) | `_getPortableTableColumnDefinition()` |
| `*MetadataProvider` (×6) | column type resolution |

`AbstractPlatform` receives its `Configuration` via a new `setConfiguration()` method
called by `Connection::getDatabasePlatform()` after platform creation.

Because #7490 makes `Column` store a type name rather than an instance, the schema managers hand
the name straight to `Column` and no longer resolve a `Type` first. `Table`, `Schema` and
`SchemaConfig` therefore need no provider at all.

### The static `Type::*` methods are deprecated

They all operate on the process-wide registry, which behaves unexpectedly as soon as a connection
has its own type provider: a type registered with `Type::addType()` is invisible to that
connection, and `Type::getType()` resolves against the global registry rather than the
connection's. Nothing signalled that today, so the mistake surfaced later as an apparently
unrelated `UnknownColumnType`.

`getTypeRegistry()`, `getType()`, `addType()`, `hasType()`, `overrideType()`,
`getTypesMap()` and `lookupName()` therefore carry an `@deprecated` docblock and a runtime
deprecation. They keep working and still delegate to the global registry, so nothing breaks.

`getTypeRegistry()` and `getType()` use `triggerIfCalledFromOutside`, because
`Configuration::getTypeProvider()`, `AbstractPlatform` and the deprecated `Column::getType()`
call them internally: the supported default path stays silent, and a single user call is not
reported twice.

DBAL 5 will have no static type provider.

## Trade-offs

**Iterating a provider resolves every type.** `AbstractPlatform::initializeAllDoctrineTypeMappings()`
does exactly that, so schema introspection instantiates all types. Laziness holds for query paths.

**Custom types registered via `Type::addType()` are invisible to connections that use a
custom provider.** This is intentional: it is the isolation the feature provides.
Users who set a provider are responsible for registering all types they need in it.

**The global singleton is preserved.** `Type::getTypeRegistry()` still returns the
process-wide registry. Connections that do not call `setTypeProvider()` continue to behave
exactly as before.

