### PR TITLE
Add QueryBuilder::addComment() to attach SQL comments to generated queries

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -436,6 +436,59 @@ api needs to be used instead of using `select()`:
         ->setParameter('id1', 2)
         ->setParameter('id2', 1);
 
+Comments
+~~~~~~~~
+
+To add comments to the query, use the ``addComment()`` method which
+will add the comment above the query:
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->addComment('This is a comment');
+    // -- This is a comment
+    //
+    // SELECT id, name FROM users
+
+Multiple comments can be added by calling the method multiple times.
+They are rendered on their own line, in the order they were added:
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->addComment('Comment 1')
+        ->addComment('Comment 2');
+    // -- Comment 1
+    // -- Comment 2
+    //
+    // SELECT id, name FROM users
+
+Comments are rendered using the double-hyphen syntax, which terminates at the
+end of the line. A comment may still span multiple lines: the delimiter is
+repeated on each of them, so nothing the comment contains can end up in the
+query as SQL.
+
+.. code-block:: php
+
+    <?php
+
+    $queryBuilder
+        ->select('id', 'name')
+        ->from('users')
+        ->addComment("This comment\nspans two lines");
+    // -- This comment
+    // -- spans two lines
+    //
+    // SELECT id, name FROM users
+
 Building Expressions
 --------------------
 

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -25,9 +25,11 @@ use function array_keys;
 use function array_merge;
 use function array_unshift;
 use function count;
+use function explode;
 use function implode;
 use function is_object;
 use function sprintf;
+use function str_replace;
 use function substr;
 
 /**
@@ -174,6 +176,13 @@ class QueryBuilder
      * The query cache profile used for caching results.
      */
     private ?QueryCacheProfile $resultCacheProfile = null;
+
+    /**
+     * The comments to be added to the SQL query.
+     *
+     * @var string[]
+     */
+    private array $comments = [];
 
     /**
      * Initializes a new <tt>QueryBuilder</tt>.
@@ -358,13 +367,13 @@ class QueryBuilder
      */
     public function getSQL(): string
     {
-        return $this->sql ??= match ($this->type) {
+        return $this->sql ??= $this->addCommentsToSQL(match ($this->type) {
             QueryType::INSERT => $this->getSQLForInsert(),
             QueryType::DELETE => $this->getSQLForDelete(),
             QueryType::UPDATE => $this->getSQLForUpdate(),
             QueryType::SELECT => $this->getSQLForSelect(),
             QueryType::UNION  => $this->getSQLForUnion(),
-        };
+        });
     }
 
     /**
@@ -1658,5 +1667,74 @@ class QueryBuilder
         $this->resultCacheProfile = null;
 
         return $this;
+    }
+
+    /**
+     * Adds a comment to the SQL query.
+     *
+     * This method adds a SQL comment that will be prepended to the generated SQL query.
+     * Multiple comments can be added and will appear in the order they were added.
+     *
+     * <code>
+     *     $qb = $conn->createQueryBuilder()
+     *         ->select('u.id', 'u.name')
+     *         ->from('users', 'u')
+     *         ->addComment('This is a custom comment')
+     *         ->addComment('Another comment');
+     * </code>
+     *
+     * Comments are rendered above the query, using the double-hyphen syntax. A comment may span
+     * multiple lines: the delimiter is repeated on each of them, which is also what keeps the
+     * comment from escaping into the query as SQL.
+     *
+     * @param string $comment The comment to add to the query.
+     *
+     * @return $this This QueryBuilder instance.
+     */
+    public function addComment(string $comment): self
+    {
+        $this->comments[] = $comment;
+
+        $this->sql = null;
+
+        return $this;
+    }
+
+    /**
+     * Adds comments to the SQL query.
+     *
+     * @param string $sql The SQL query to add comments to.
+     *
+     * @return string The SQL query with comments prepended.
+     */
+    private function addCommentsToSQL(string $sql): string
+    {
+        if (count($this->comments) === 0) {
+            return $sql;
+        }
+
+        $commentLines = [];
+        foreach ($this->comments as $comment) {
+            foreach ($this->splitCommentIntoLines($comment) as $line) {
+                $commentLines[] = '-- ' . $line;
+            }
+        }
+
+        return implode("\n", $commentLines) . "\n\n" . $sql;
+    }
+
+    /**
+     * Splits a comment into the lines it is rendered on.
+     *
+     * A double-hyphen comment terminates at the end of the line, so every line terminator has to
+     * start a new comment line. Line terminators are normalized to "\n" first, otherwise a lone
+     * carriage return would end the comment on the platforms that treat it as one while leaving
+     * the rest of the line uncommented.
+     *
+     * @return non-empty-list<string>
+     */
+    private function splitCommentIntoLines(string $comment): array
+    {
+        return explode("\n", str_replace(["\r\n", "\r"], "\n", $comment));
     }
 }

--- a/tests/Functional/Query/QueryBuilderTest.php
+++ b/tests/Functional/Query/QueryBuilderTest.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_change_key_case;
 
@@ -578,6 +579,74 @@ final class QueryBuilderTest extends FunctionalTestCase
 
         self::expectException(NotSupported::class);
         $qb->executeQuery();
+    }
+
+    public function testCommentedQueryIsUnderstoodByThePlatform(): void
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('id')
+            ->from('for_update')
+            ->where('id = 1')
+            ->addComment('a comment');
+
+        self::assertEquals([1], $qb->fetchFirstColumn());
+    }
+
+    public function testCommentedStatementIsUnderstoodByThePlatform(): void
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->delete('for_update')
+            ->where('id = 2')
+            ->addComment('a comment');
+
+        self::assertSame(1, $qb->executeStatement());
+    }
+
+    #[DataProvider('lineTerminatorProvider')]
+    public function testCommentSpanningMultipleLinesIsUnderstoodByThePlatform(string $lineTerminator): void
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('id')
+            ->from('for_update')
+            ->where('id = 1')
+            ->addComment('a comment' . $lineTerminator . 'spanning multiple lines');
+
+        self::assertEquals([1], $qb->fetchFirstColumn());
+    }
+
+    /**
+     * A line terminator inside a comment must not let its remainder escape into the query, otherwise
+     * the comment would be a way to inject arbitrary SQL.
+     */
+    #[DataProvider('lineTerminatorProvider')]
+    public function testCommentCannotEscapeIntoTheQuery(string $lineTerminator): void
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('id')
+            ->from('for_update')
+            ->addComment('a comment' . $lineTerminator . 'AND id = 2');
+
+        self::assertEquals([1, 2], $qb->fetchFirstColumn());
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function lineTerminatorProvider(): iterable
+    {
+        yield 'line feed' => ["\n"];
+        yield 'carriage return' => ["\r"];
+        yield 'carriage return and line feed' => ["\r\n"];
+    }
+
+    public function testCommentDoesNotContributeQueryParameters(): void
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('id')
+            ->from('for_update')
+            ->where('id = ?')
+            ->setParameter(0, 1, ParameterType::INTEGER)
+            ->addComment('is this a placeholder? no, it is not');
+
+        self::assertEquals([1], $qb->fetchFirstColumn());
     }
 
     /**

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -1546,4 +1546,199 @@ class QueryBuilderTest extends TestCase
             $qb->getSQL(),
         );
     }
+
+    public function testAddCommentSingleComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id', 'u.name')
+            ->from('users', 'u')
+            ->addComment('This is a test query');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- This is a test query
+
+            SELECT u.id, u.name FROM users u
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentMultipleComments(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id', 'u.name')
+            ->from('users', 'u')
+            ->addComment('First comment')
+            ->addComment('Second comment')
+            ->addComment('Third comment');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- First comment
+            -- Second comment
+            -- Third comment
+
+            SELECT u.id, u.name FROM users u
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentMultilineComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id')
+            ->from('users', 'u')
+            ->addComment(
+                <<<'COMMENT'
+                This is a multiline comment.
+                It can span multiple lines.
+                COMMENT,
+            );
+
+        self::assertEquals(
+            <<<'SQL'
+            -- This is a multiline comment.
+            -- It can span multiple lines.
+
+            SELECT u.id FROM users u
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentInsertQuery(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->insert('users')
+            ->values(['name' => '?', 'email' => '?'])
+            ->addComment('Insert operation');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- Insert operation
+
+            INSERT INTO users (name, email) VALUES(?, ?)
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentUpdateQuery(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->update('users')
+            ->set('name', '?')
+            ->where('id = ?')
+            ->addComment('Update operation');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- Update operation
+
+            UPDATE users SET name = ? WHERE id = ?
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentDeleteQuery(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->delete('users')
+            ->where('id = ?')
+            ->addComment('Delete operation');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- Delete operation
+
+            DELETE FROM users WHERE id = ?
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentMethodChaining(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id')
+            ->from('users', 'u')
+            ->addComment('Comment 1')
+            ->where('u.id = ?')
+            ->addComment('Comment 2')
+            ->orderBy('u.name');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- Comment 1
+            -- Comment 2
+
+            SELECT u.id FROM users u WHERE u.id = ? ORDER BY u.name
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentEmptyComment(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id')
+            ->from('users', 'u')
+            ->addComment('');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- 
+
+            SELECT u.id FROM users u
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    public function testAddCommentSpecialCharacters(): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id')
+            ->from('users', 'u')
+            ->addComment("Comment with 'quotes' and \"double quotes\"");
+
+        self::assertEquals(
+            <<<'SQL'
+            -- Comment with 'quotes' and "double quotes"
+
+            SELECT u.id FROM users u
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    #[DataProvider('lineTerminatorProvider')]
+    public function testAddCommentCommentsOutEveryLine(string $lineTerminator): void
+    {
+        $qb = new QueryBuilder($this->conn);
+        $qb->select('u.id')
+            ->from('users', 'u')
+            ->addComment('Comment' . $lineTerminator . 'DROP TABLE users; --');
+
+        self::assertEquals(
+            <<<'SQL'
+            -- Comment
+            -- DROP TABLE users; --
+
+            SELECT u.id FROM users u
+            SQL,
+            $qb->getSQL(),
+        );
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function lineTerminatorProvider(): iterable
+    {
+        yield 'line feed' => ["\n"];
+        yield 'carriage return' => ["\r"];
+        yield 'carriage return and line feed' => ["\r\n"];
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This implementation adds an `addComment()` method to the `QueryBuilder` class, which allows attaching SQL comments to generated queries for debugging, logging, and analysis purposes.

Comments are emitted as standard SQL comments preceding the statement, so they show up in slow query logs and query analysis tools alongside the statement they belong to.

It's a similar concept to [EF Core Query Tags](https://learn.microsoft.com/en-us/ef/core/querying/tags)