### PR TITLE
Fix LIKE underscore escaping in PostgreSQL schema filtering

### DIFF
--- a/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
+++ b/src/Platforms/PostgreSQL/PostgreSQLMetadataProvider.php
@@ -711,7 +711,7 @@ final readonly class PostgreSQLMetadataProvider implements MetadataProvider
 
     private function buildNamespaceNamePredicate(string $columnName): string
     {
-        return sprintf("%1\$s NOT LIKE 'pg\_%%' AND %1\$s != 'information_schema'", $columnName);
+        return sprintf("%1\$s NOT LIKE 'pg\$_%%' ESCAPE '\$' AND %1\$s != 'information_schema'", $columnName);
     }
 
     /**

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -165,7 +165,7 @@ class PostgreSQLPlatform extends AbstractPlatform
                        increment AS increment_by
                 FROM   information_schema.sequences
                 WHERE  sequence_catalog = ' . $this->quoteStringLiteral($database) . "
-                AND    sequence_schema NOT LIKE 'pg\_%'
+                AND    sequence_schema NOT LIKE 'pg\$_%' ESCAPE '\$'
                 AND    sequence_schema != 'information_schema'";
     }
 

--- a/src/Schema/PostgreSQLSchemaManager.php
+++ b/src/Schema/PostgreSQLSchemaManager.php
@@ -42,7 +42,7 @@ class PostgreSQLSchemaManager extends AbstractSchemaManager
             <<<'SQL'
 SELECT schema_name
 FROM   information_schema.schemata
-WHERE  schema_name NOT LIKE 'pg\_%'
+WHERE  schema_name NOT LIKE 'pg$_%' ESCAPE '$'
 AND    schema_name != 'information_schema'
 SQL,
         );
@@ -338,7 +338,7 @@ SELECT quote_ident(table_name) AS table_name,
        table_schema AS schema_name
 FROM information_schema.tables
 WHERE table_catalog = ?
-  AND table_schema NOT LIKE 'pg\_%'
+  AND table_schema NOT LIKE 'pg$_%' ESCAPE '$'
   AND table_schema != 'information_schema'
   AND table_name != 'geometry_columns'
   AND table_name != 'spatial_ref_sys'

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -1006,7 +1006,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
                        increment AS increment_by
                 FROM   information_schema.sequences
                 WHERE  sequence_catalog = 'test_db'
-                AND    sequence_schema NOT LIKE 'pg\_%'
+                AND    sequence_schema NOT LIKE 'pg\$_%' ESCAPE '\$'
                 AND    sequence_schema != 'information_schema'",
             $this->platform->getListSequencesSQL('test_db'),
         );


### PR DESCRIPTION
Use an explicit ESCAPE '$' clause in all LIKE patterns that filter out PostgreSQL system schemas (pg_*).

The previous patterns relied on the backslash as the default LIKE escape character. This works correctly when standard_conforming_strings is ON (the default since PostgreSQL 9.1), but fails when the setting is OFF: the backslash in the string literal 'pg\_%' is consumed by the string parser before reaching the LIKE operator, turning the underscore into a wildcard instead of a literal match.

Using a non-backslash ESCAPE character makes the behavior explicit and correct regardless of the standard_conforming_strings setting.