### PR TITLE
Fix nullability in QueryBuilder's PHPDoc types

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -880,10 +880,10 @@ class QueryBuilder
      *         ->join('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias The alias that points to a from clause.
-     * @param string $join      The table name to join.
-     * @param string $alias     The alias of the join table.
-     * @param string $condition The condition for the join.
+     * @param string      $fromAlias The alias that points to a from clause.
+     * @param string      $join      The table name to join.
+     * @param string      $alias     The alias of the join table.
+     * @param string|null $condition The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -902,10 +902,10 @@ class QueryBuilder
      *         ->innerJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias The alias that points to a from clause.
-     * @param string $join      The table name to join.
-     * @param string $alias     The alias of the join table.
-     * @param string $condition The condition for the join.
+     * @param string      $fromAlias The alias that points to a from clause.
+     * @param string      $join      The table name to join.
+     * @param string      $alias     The alias of the join table.
+     * @param string|null $condition The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -931,10 +931,10 @@ class QueryBuilder
      *         ->leftJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias The alias that points to a from clause.
-     * @param string $join      The table name to join.
-     * @param string $alias     The alias of the join table.
-     * @param string $condition The condition for the join.
+     * @param string      $fromAlias The alias that points to a from clause.
+     * @param string      $join      The table name to join.
+     * @param string      $alias     The alias of the join table.
+     * @param string|null $condition The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -960,10 +960,10 @@ class QueryBuilder
      *         ->rightJoin('u', 'phonenumbers', 'p', 'p.is_primary = 1');
      * </code>
      *
-     * @param string $fromAlias The alias that points to a from clause.
-     * @param string $join      The table name to join.
-     * @param string $alias     The alias of the join table.
-     * @param string $condition The condition for the join.
+     * @param string      $fromAlias The alias that points to a from clause.
+     * @param string      $join      The table name to join.
+     * @param string      $alias     The alias of the join table.
+     * @param string|null $condition The condition for the join.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -1293,8 +1293,8 @@ class QueryBuilder
      * Specifies an ordering for the query results.
      * Replaces any previously specified orderings, if any.
      *
-     * @param string $sort  The ordering expression.
-     * @param string $order The ordering direction.
+     * @param string      $sort  The ordering expression.
+     * @param string|null $order The ordering direction.
      *
      * @return $this This QueryBuilder instance.
      */
@@ -1306,8 +1306,8 @@ class QueryBuilder
     /**
      * Adds an ordering to the query results.
      *
-     * @param string $sort  The ordering expression.
-     * @param string $order The ordering direction.
+     * @param string      $sort  The ordering expression.
+     * @param string|null $order The ordering direction.
      *
      * @return $this This QueryBuilder instance.
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | N/A

#### Summary

This PR fixes an inconsistency in our PHPDoc types on the `QueryBuilder` class. Properties that obviously accept `null` (because it's the default value) are documented as `string` instead of `string|null`.
