### PR TITLE
Treat Psr\Cache\InvalidArgumentException as unchecked

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,7 @@ parameters:
             - LogicException
             - RuntimeException
             - ValueError
+            - Psr\Cache\InvalidArgumentException
     ignoreErrors:
         - identifier: missingType.generics
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -832,7 +832,6 @@ class Connection implements ServerVersionProvider
 
         [$cacheKey, $realKey] = $qcp->generateCacheKeys($sql, $params, $types, $connectionParams);
 
-        // @phpstan-ignore missingType.checkedException
         $item = $resultCache->getItem($cacheKey);
 
         if ($item->isHit()) {


### PR DESCRIPTION
The cache key is computed programmatically. If it is not valid, it is a program error which does not need to be handled at runtime. Therefore, this is an unchecked exception.

PhpStorm infers the checked/unchecked distinction from the SPL hierarchy (`\LogicException` and its subclasses are treated as unchecked), and our PHPStan configuration replicates this logic. Under that convention, `Psr\Cache\InvalidArgumentException` would arguably be a better fit extending SPL's `\InvalidArgumentException`, so its unchecked nature could be inferred from the type hierarchy rather than left to the caller's interpretation.