### PR TITLE
Deprecate Parser\Exception interface

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Deprecated `Doctrine\DBAL\SQL\Parser\Exception`
+
+The SQL parser does not raise checked exceptions: the only thing it ever throws is
+`Doctrine\DBAL\SQL\Parser\Exception\RegularExpressionError`, an unchecked `RuntimeException`
+subclass that signals an exhausted PCRE engine limit. The `Parser\Exception` interface has
+been deprecated and will be removed in 5.0.
+
 ## Deprecated not specifying either of the `host` and `connectstring` parameters for `oci8` and `pdo_oci` connections.
 
 Not specifying either of the `host` and `connectstring` parameters for `oci8` and `pdo_oci` connections has been

--- a/src/Driver/OCI8/Connection.php
+++ b/src/Driver/OCI8/Connection.php
@@ -47,10 +47,7 @@ final class Connection implements ConnectionInterface
         return $matches[1];
     }
 
-    /**
-     * @throws Parser\Exception
-     * @throws Error
-     */
+    /** @throws Error */
     public function prepare(string $sql): Statement
     {
         $visitor = new ConvertPositionalToNamedPlaceholders();
@@ -66,10 +63,7 @@ final class Connection implements ConnectionInterface
         return new Statement($this->connection, $statement, $visitor->getParameterMap(), $this->executionMode);
     }
 
-    /**
-     * @throws Exception
-     * @throws Parser\Exception
-     */
+    /** @throws Exception */
     public function query(string $sql): Result
     {
         return $this->prepare($sql)->execute();
@@ -80,10 +74,7 @@ final class Connection implements ConnectionInterface
         return "'" . addcslashes(str_replace("'", "''", $value), "\000\n\r\\\032") . "'";
     }
 
-    /**
-     * @throws Exception
-     * @throws Parser\Exception
-     */
+    /** @throws Exception */
     public function exec(string $sql): int|string
     {
         return $this->prepare($sql)->execute()->rowCount();

--- a/src/Driver/PgSQL/Connection.php
+++ b/src/Driver/PgSQL/Connection.php
@@ -43,7 +43,6 @@ final class Connection implements ConnectionInterface
     {
         $visitor = new ConvertParameters();
 
-        /** @phpstan-ignore missingType.checkedException */
         $this->parser->parse($sql, $visitor);
 
         $statementName = uniqid('dbal', true);

--- a/src/SQL/Parser.php
+++ b/src/SQL/Parser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\SQL;
 
-use Doctrine\DBAL\SQL\Parser\Exception;
 use Doctrine\DBAL\SQL\Parser\Exception\RegularExpressionError;
 use Doctrine\DBAL\SQL\Parser\Visitor;
 
@@ -77,8 +76,6 @@ final class Parser
 
     /**
      * Parses the given SQL statement
-     *
-     * @throws Exception
      */
     public function parse(string $sql, Visitor $visitor): void
     {

--- a/src/SQL/Parser/Exception.php
+++ b/src/SQL/Parser/Exception.php
@@ -6,6 +6,11 @@ namespace Doctrine\DBAL\SQL\Parser;
 
 use Throwable;
 
+/**
+ * @deprecated The SQL parser does not raise checked exceptions. The only concrete
+ *             implementation, {@see Exception\RegularExpressionError}, is an unchecked
+ *             {@see \RuntimeException} subclass. This interface will be removed in 5.0.
+ */
 interface Exception extends Throwable
 {
 }


### PR DESCRIPTION
## Background

`Doctrine\DBAL\SQL\Parser::parse()` declares `@throws Parser\Exception`, and the parser's callers treat that as a checked-exception contract. The PgSQL driver carries a `/** @phpstan-ignore missingType.checkedException */` because it doesn't handle it, and `Connection::prepare()` does not declare the throw.

The `@phpstan-ignore` above is the smell that revealed the problem.

The `Parser\Exception` interface, `RegularExpressionError`, and the `@throws` annotation were introduced in [#4927](https://github.com/doctrine/dbal/pull/4927) to surface PCRE engine errors. In hindsight, modeling them as a checked exception was not the right call: PCRE limit exhaustion is an environmental anomaly callers can't meaningfully recover from.

The parser has no syntax-error path — malformed SQL falls back to per-character tokens — so the `Parser\Exception` interface and `ParseError` wrapper exist solely to support a checked contract never exercised in normal use.

### Changes

1. Remove `@throws Exception` from `Parser::parse()` and the `Parser\Exception` import.
2. Remove `@throws Parser\Exception` annotations from `OCI8\Connection`.
3. Remove the `/** @phpstan-ignore missingType.checkedException */` from `PgSQL\Connection::prepare()` — no longer needed.
4. Mark the `Parser\Exception` interface as `@deprecated`.

### Runtime contract

Unchanged. `RegularExpressionError` is still thrown on PCRE engine errors and still implements `Parser\Exception`. Callers that catch `Parser\Exception` continue to work.
