### PR TITLE
Skip OCI8 ResultTest tearDown on non-oci8 drivers

### DIFF
--- a/tests/Functional/Driver/OCI8/ResultTest.php
+++ b/tests/Functional/Driver/OCI8/ResultTest.php
@@ -41,6 +41,10 @@ class ResultTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        if (! TestUtil::isDriverOneOf('oci8')) {
+            return;
+        }
+
         $this->connection->executeQuery('DROP FUNCTION test_oracle_fetch_failure');
         $this->connection->executeQuery('DROP TYPE return_numbers');
     }


### PR DESCRIPTION
PHPUnit unconditionally executes `tearDown()`, so the Oracle-specific cleanup queries ran against whichever local driver was configured (e.g. SQLite) and failed with a syntax error. Mirrors the fix applied in #7299.

The issue is not reproducible with the non-oci8 drivers on CI because each run has only the target driver loaded, and the test execution is gated by: https://github.com/doctrine/dbal/blob/b69736d45fe6dc6e2204cf73ae56b3c2f746b75c/tests/Functional/Driver/OCI8/ResultTest.php#L21