### PR TITLE
Use stubs for mock objects without expectations

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -469,7 +469,7 @@ class ConnectionTest extends TestCase
             ->method($method)
             ->willReturn($expected);
 
-        $driver = $this->createConfiguredMock(Driver::class, [
+        $driver = self::createConfiguredStub(Driver::class, [
             'connect' => self::createStub(DriverConnection::class),
         ]);
 

--- a/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
+++ b/tests/Driver/Middleware/AbstractConnectionMiddlewareTest.php
@@ -65,7 +65,7 @@ final class AbstractConnectionMiddlewareTest extends TestCase
         $nativeConnection = new class () {
         };
 
-        $connection = $this->createMock(Connection::class);
+        $connection = self::createStub(Connection::class);
         $connection->method('getNativeConnection')
             ->willReturn($nativeConnection);
 

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -1373,7 +1373,7 @@ class QueryBuilderTest extends TestCase
         string $expectedSql,
     ): void {
         $qb           = new QueryBuilder($this->conn);
-        $mockedResult = $this->createMock(Result::class);
+        $mockedResult = self::createStub(Result::class);
 
         $this->conn->expects(self::once())
             ->method('executeQuery')
@@ -1407,7 +1407,7 @@ class QueryBuilderTest extends TestCase
     ): void {
         $qb           = new QueryBuilder($this->conn);
         $qcp          = new QueryCacheProfile(300);
-        $mockedResult = $this->createMock(Result::class);
+        $mockedResult = self::createStub(Result::class);
 
         $this->conn->expects(self::once())
             ->method('executeQuery')

--- a/tests/Types/BooleanTest.php
+++ b/tests/Types/BooleanTest.php
@@ -6,42 +6,41 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\BooleanType;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class BooleanTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
     private BooleanType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = new BooleanType();
+        $this->type = new BooleanType();
     }
 
     public function testBooleanConvertsToDatabaseValue(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('convertBooleansToDatabaseValue')
             ->with(true)
             ->willReturn(1);
 
-        self::assertSame(1, $this->type->convertToDatabaseValue(true, $this->platform));
+        self::assertSame(1, $this->type->convertToDatabaseValue(true, $platform));
     }
 
     public function testBooleanConvertsToPHPValue(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('convertFromBoolean')
             ->with(0)
             ->willReturn(false);
 
-        self::assertFalse($this->type->convertToPHPValue(0, $this->platform));
+        self::assertFalse($this->type->convertToPHPValue(0, $platform));
     }
 
     public function testBooleanNullConvertsToPHPValue(): void
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+        self::assertNull($this->type->convertToPHPValue(null, self::createStub(AbstractPlatform::class)));
     }
 }

--- a/tests/Types/DateImmutableTypeTest.php
+++ b/tests/Types/DateImmutableTypeTest.php
@@ -11,17 +11,17 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateImmutableType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DateImmutableTypeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private DateImmutableType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new DateImmutableType();
     }
 
@@ -39,13 +39,14 @@ class DateImmutableTypeTest extends TestCase
     {
         $date = new DateTimeImmutable('2016-01-01 12:34:56', new DateTimeZone('UTC'));
 
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getDateFormatString')
             ->willReturn('Y-m-d');
 
         self::assertSame(
             '2016-01-01',
-            $this->type->convertToDatabaseValue($date, $this->platform),
+            $this->type->convertToDatabaseValue($date, $platform),
         );
     }
 
@@ -75,11 +76,12 @@ class DateImmutableTypeTest extends TestCase
 
     public function testConvertsDateStringToPHPValue(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getDateFormatString')
             ->willReturn('Y-m-d');
 
-        $date = $this->type->convertToPHPValue('2016-01-01', $this->platform);
+        $date = $this->type->convertToPHPValue('2016-01-01', $platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01', $date->format('Y-m-d'));

--- a/tests/Types/DateTimeImmutableTypeTest.php
+++ b/tests/Types/DateTimeImmutableTypeTest.php
@@ -11,17 +11,17 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DateTimeImmutableTypeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private DateTimeImmutableType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new DateTimeImmutableType();
     }
 
@@ -39,13 +39,14 @@ class DateTimeImmutableTypeTest extends TestCase
     {
         $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 
         self::assertSame(
             '2016-01-01 15:58:59',
-            $this->type->convertToDatabaseValue($date, $this->platform),
+            $this->type->convertToDatabaseValue($date, $platform),
         );
     }
 
@@ -75,11 +76,12 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeStringToPHPValue(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 
-        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59', $this->platform);
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59', $platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01 15:58:59', $date->format('Y-m-d H:i:s'));
@@ -99,12 +101,13 @@ class DateTimeImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeString(): void
     {
-        $this->platform->expects(self::atLeastOnce())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::atLeastOnce())
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid datetime string', $this->platform);
+        $this->type->convertToPHPValue('invalid datetime string', $platform);
     }
 }

--- a/tests/Types/DateTimeTzImmutableTypeTest.php
+++ b/tests/Types/DateTimeTzImmutableTypeTest.php
@@ -11,18 +11,15 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeTzImmutableType;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DateTimeTzImmutableTypeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
     private DateTimeTzImmutableType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
-        $this->type     = new DateTimeTzImmutableType();
+        $this->type = new DateTimeTzImmutableType();
     }
 
     public function testFactoryCreatesCorrectType(): void
@@ -39,47 +36,49 @@ class DateTimeTzImmutableTypeTest extends TestCase
     {
         $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
 
         self::assertSame(
             '2016-01-01 15:58:59 UTC',
-            $this->type->convertToDatabaseValue($date, $this->platform),
+            $this->type->convertToDatabaseValue($date, $platform),
         );
     }
 
     public function testConvertsNullToDatabaseValue(): void
     {
-        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, self::createStub(AbstractPlatform::class)));
     }
 
     public function testDoesNotSupportMutableDateTimeToDatabaseValueConversion(): void
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(new DateTime(), $this->platform);
+        $this->type->convertToDatabaseValue(new DateTime(), self::createStub(AbstractPlatform::class));
     }
 
     public function testConvertsDateTimeImmutableInstanceToPHPValue(): void
     {
         $date = new DateTimeImmutable();
 
-        self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
+        self::assertSame($date, $this->type->convertToPHPValue($date, self::createStub(AbstractPlatform::class)));
     }
 
     public function testConvertsNullToPHPValue(): void
     {
-        self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+        self::assertNull($this->type->convertToPHPValue(null, self::createStub(AbstractPlatform::class)));
     }
 
     public function testConvertsDateTimeWithTimezoneStringToPHPValue(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
 
-        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59 UTC', $this->platform);
+        $date = $this->type->convertToPHPValue('2016-01-01 15:58:59 UTC', $platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('2016-01-01 15:58:59 UTC', $date->format('Y-m-d H:i:s T'));
@@ -87,12 +86,13 @@ class DateTimeTzImmutableTypeTest extends TestCase
 
     public function testThrowsExceptionDuringConversionToPHPValueWithInvalidDateTimeWithTimezoneString(): void
     {
-        $this->platform->expects(self::atLeastOnce())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::atLeastOnce())
             ->method('getDateTimeTzFormatString')
             ->willReturn('Y-m-d H:i:s T');
 
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToPHPValue('invalid datetime with timezone string', $this->platform);
+        $this->type->convertToPHPValue('invalid datetime with timezone string', $platform);
     }
 }

--- a/tests/Types/JsonObjectTest.php
+++ b/tests/Types/JsonObjectTest.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\JsonObjectType;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -18,12 +18,12 @@ use function fopen;
 
 class JsonObjectTest extends TestCase
 {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform&Stub $platform;
     protected JsonObjectType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new JsonObjectType();
     }
 
@@ -34,11 +34,12 @@ class JsonObjectTest extends TestCase
 
     public function testReturnsSQLDeclaration(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getJsonTypeDeclarationSQL')
             ->willReturn('TEST_JSON');
 
-        self::assertSame('TEST_JSON', $this->type->getSQLDeclaration([], $this->platform));
+        self::assertSame('TEST_JSON', $this->type->getSQLDeclaration([], $platform));
     }
 
     public function testJsonNullConvertsToPHPValue(): void

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\JsonType;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 use function base64_encode;
@@ -17,12 +17,12 @@ use function fopen;
 
 class JsonTest extends TestCase
 {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform&Stub $platform;
     protected JsonType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new JsonType();
     }
 
@@ -33,11 +33,12 @@ class JsonTest extends TestCase
 
     public function testReturnsSQLDeclaration(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getJsonTypeDeclarationSQL')
             ->willReturn('TEST_JSON');
 
-        self::assertSame('TEST_JSON', $this->type->getSQLDeclaration([], $this->platform));
+        self::assertSame('TEST_JSON', $this->type->getSQLDeclaration([], $platform));
     }
 
     public function testJsonNullConvertsToPHPValue(): void

--- a/tests/Types/StringTest.php
+++ b/tests/Types/StringTest.php
@@ -6,27 +6,28 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class StringTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private StringType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new StringType();
     }
 
     public function testReturnsSQLDeclaration(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getStringTypeDeclarationSQL')
             ->willReturn('TEST_STRING');
 
-        self::assertEquals('TEST_STRING', $this->type->getSQLDeclaration([], $this->platform));
+        self::assertEquals('TEST_STRING', $this->type->getSQLDeclaration([], $platform));
     }
 
     public function testConvertToPHPValue(): void

--- a/tests/Types/TimeImmutableTypeTest.php
+++ b/tests/Types/TimeImmutableTypeTest.php
@@ -11,17 +11,17 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\TimeImmutableType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class TimeImmutableTypeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private TimeImmutableType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new TimeImmutableType();
     }
 
@@ -39,13 +39,14 @@ class TimeImmutableTypeTest extends TestCase
     {
         $date = new DateTimeImmutable('2016-01-01 15:58:59', new DateTimeZone('UTC'));
 
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getTimeFormatString')
             ->willReturn('H:i:s');
 
         self::assertSame(
             '15:58:59',
-            $this->type->convertToDatabaseValue($date, $this->platform),
+            $this->type->convertToDatabaseValue($date, $platform),
         );
     }
 
@@ -75,11 +76,12 @@ class TimeImmutableTypeTest extends TestCase
 
     public function testConvertsTimeStringToPHPValue(): void
     {
-        $this->platform->expects(self::once())
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform->expects(self::once())
             ->method('getTimeFormatString')
             ->willReturn('H:i:s');
 
-        $date = $this->type->convertToPHPValue('15:58:59', $this->platform);
+        $date = $this->type->convertToPHPValue('15:58:59', $platform);
 
         self::assertInstanceOf(DateTimeImmutable::class, $date);
         self::assertSame('15:58:59', $date->format('H:i:s'));

--- a/tests/Types/VarDateTimeImmutableTypeTest.php
+++ b/tests/Types/VarDateTimeImmutableTypeTest.php
@@ -11,17 +11,17 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\VarDateTimeImmutableType;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class VarDateTimeImmutableTypeTest extends TestCase
 {
-    private AbstractPlatform&MockObject $platform;
+    private AbstractPlatform&Stub $platform;
     private VarDateTimeImmutableType $type;
 
     protected function setUp(): void
     {
-        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type     = new VarDateTimeImmutableType();
     }
 
@@ -32,7 +32,7 @@ class VarDateTimeImmutableTypeTest extends TestCase
 
     public function testConvertsDateTimeImmutableInstanceToDatabaseValue(): void
     {
-        $this->platform->expects(self::any())
+        $this->platform
             ->method('getDateTimeFormatString')
             ->willReturn('Y-m-d H:i:s');
 


### PR DESCRIPTION
PHPUnit 12 emits a notice when a mock is created via `createMock()` but no expectations are set on it, suggesting a stub would be more appropriate.

I plan to merge these changes up and enable `failOnPhpunitNotice` in 5.0.x (see https://github.com/doctrine/dbal/pull/7367). PHPUnit 12.1.0 (https://github.com/sebastianbergmann/phpunit/commit/7f49f1719) is the first version that supports this configuration parameter.