### PR TITLE
Introduce TableDiff::getIndexRenames()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Deprecated `TableDiff::getRenamedIndexes()`
+
+The `TableDiff::getRenamedIndexes()` method has been deprecated. Use `TableDiff::getIndexRenames()` instead, which
+returns a list of `IndexRename` instances exposing the old name as an `UnqualifiedName` and the new `Index` directly,
+instead of an `array<string, Index>` keyed by the raw old name.
+
 ## Deprecated `Doctrine\DBAL\SQL\Parser\Exception`
 
 The SQL parser does not raise checked exceptions: the only thing it ever throws is

--- a/src/Schema/IndexRename.php
+++ b/src/Schema/IndexRename.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+/**
+ * Represents the rename of an index.
+ */
+final readonly class IndexRename
+{
+    /** @internal The rename can be only instantiated by a {@see Comparator}. */
+    public function __construct(private UnqualifiedName $oldName, private Index $newIndex)
+    {
+    }
+
+    public function getOldName(): UnqualifiedName
+    {
+        return $this->oldName;
+    }
+
+    public function getNewIndex(): Index
+    {
+        return $this->newIndex;
+    }
+}

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -208,10 +208,34 @@ class TableDiff
         );
     }
 
-    /** @return array<string,Index> */
+    /**
+     * @deprecated Use {@see getIndexRenames()} instead.
+     *
+     * @return array<string,Index>
+     */
     public function getRenamedIndexes(): array
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7368',
+            '%s() is deprecated, use getIndexRenames() instead.',
+            __METHOD__,
+        );
+
         return $this->renamedIndexes;
+    }
+
+    /** @return list<IndexRename> */
+    public function getIndexRenames(): array
+    {
+        $renames = [];
+
+        foreach ($this->renamedIndexes as $oldName => $newIndex) {
+            /** @phpstan-ignore argument.type */
+            $renames[] = new IndexRename(UnqualifiedName::unquoted((string) $oldName), $newIndex);
+        }
+
+        return $renames;
     }
 
     /** @return array<ForeignKeyConstraint> */

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\IndexRename;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
@@ -781,6 +782,16 @@ abstract class AbstractComparatorTestCase extends TestCase
         $renamedIndexes = $tableDiff->getRenamedIndexes();
         self::assertArrayHasKey('idx_foo', $renamedIndexes);
         self::assertEquals('idx_bar', $renamedIndexes['idx_foo']->getObjectName()->toString());
+
+        self::assertEquals([
+            new IndexRename(
+                UnqualifiedName::unquoted('idx_foo'),
+                Index::editor()
+                    ->setUnquotedName('idx_bar')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            ),
+        ], $tableDiff->getIndexRenames());
     }
 
     public function testDetectRenameIndexDisabled(): void


### PR DESCRIPTION
`TableDiff::getRenamedIndexes()` returns `array<string, Index>` keyed by the old index name. The meaning of that string is disputed: `Comparator` writes the literal value of the identifier, while `AbstractPlatform` reads it back as SQL syntax via `new Identifier()`.
https://github.com/doctrine/dbal/blob/234c37cd2632c7449f3dc864c18b8b6842ebcf61/src/Schema/Comparator.php#L382 https://github.com/doctrine/dbal/blob/42e278e3f5365b75e6f8296479aaf8e75057e3e5/src/Platforms/AbstractPlatform.php#L1416-L1417

The two readings agree only for names limited to letters, digits, and underscores; names containing a dot, backtick, or quote break.

Add `getIndexRenames()` returning `IndexRename` objects. The old name is an `UnqualifiedName`, which carries the identifier value and the quoted flag separately — value and SQL serialization are distinct operations on a typed object, not two readings of the same string.

Deprecate `getRenamedIndexes()`. The ORM and Migrations do not call this method, so the deprecation does not affect them.

See also: https://github.com/doctrine/dbal/issues/4357.
