### PR TITLE
Remove TableDiff::getRenamedIndexes()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -42,6 +42,10 @@ The `TableDiff::getDroppedForeignKeys()` method has been removed.
 
 An attempt to drop an unnamed foreign key constraint on SQLite will result in an exception.
 
+## BC BREAK: Removed `TableDiff::getRenamedIndexes()`
+
+The `TableDiff::getRenamedIndexes()` method has been removed.
+
 ## BC BREAK: Removed `AbstractSchemaManager` methods
 
 The following `AbstractSchemaManager` methods have been removed:

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -370,10 +370,9 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             $queryParts[] = 'ADD ' . $this->getIndexDeclarationSQL($index);
         }
 
-        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
-            $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-            $queryParts[]       = 'RENAME INDEX ' . $parsedOldIndexName->toSQL($this) . ' TO '
-                . $index->getObjectName()->toSQL($this);
+        foreach ($diff->getIndexRenames() as $rename) {
+            $queryParts[] = 'RENAME INDEX ' . $rename->getOldName()->toSQL($this) . ' TO '
+                . $rename->getNewIndex()->getObjectName()->toSQL($this);
         }
 
         if (count($queryParts) > 0) {

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -349,10 +349,14 @@ class DB2Platform extends AbstractPlatform
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
-        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+        foreach ($diff->getIndexRenames() as $rename) {
             $sql = array_merge(
                 $sql,
-                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+                $this->getRenameIndexSQL(
+                    $rename->getOldName()->toSQL($this),
+                    $rename->getNewIndex(),
+                    $tableNameSQL,
+                ),
             );
         }
 

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -639,10 +639,14 @@ SQL,
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
-        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+        foreach ($diff->getIndexRenames() as $rename) {
             $sql = array_merge(
                 $sql,
-                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+                $this->getRenameIndexSQL(
+                    $rename->getOldName()->toSQL($this),
+                    $rename->getNewIndex(),
+                    $tableNameSQL,
+                ),
             );
         }
 

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -313,10 +313,14 @@ class PostgreSQLPlatform extends AbstractPlatform
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
-        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+        foreach ($diff->getIndexRenames() as $rename) {
             $sql = array_merge(
                 $sql,
-                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+                $this->getRenameIndexSQL(
+                    $rename->getOldName()->toSQL($this),
+                    $rename->getNewIndex(),
+                    $tableNameSQL,
+                ),
             );
         }
 

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -471,10 +471,14 @@ class SQLServerPlatform extends AbstractPlatform
             $sql[] = $this->getCreateIndexSQL($index, $tableNameSQL);
         }
 
-        foreach ($diff->getRenamedIndexes() as $oldIndexName => $index) {
+        foreach ($diff->getIndexRenames() as $rename) {
             $sql = array_merge(
                 $sql,
-                $this->getRenameIndexSQL($oldIndexName, $index, $tableNameSQL),
+                $this->getRenameIndexSQL(
+                    $rename->getOldName()->toSQL($this),
+                    $rename->getNewIndex(),
+                    $tableNameSQL,
+                ),
             );
         }
 

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -699,7 +699,7 @@ class SQLitePlatform extends AbstractPlatform
             || count($diff->getDroppedColumns()) > 0
             || count($diff->getAddedIndexes()) > 0
             || count($diff->getDroppedIndexes()) > 0
-            || count($diff->getRenamedIndexes()) > 0
+            || count($diff->getIndexRenames()) > 0
             || count($diff->getAddedForeignKeys()) > 0
             || count($diff->getDroppedForeignKeyConstraintNames()) > 0
             || $diff->getDroppedPrimaryKeyConstraint() !== null
@@ -783,8 +783,11 @@ class SQLitePlatform extends AbstractPlatform
 
         foreach ($indexes as $index) {
             $indexName = $index->getObjectName();
-            foreach ($diff->getRenamedIndexes() as $oldIndexName => $renamedIndex) {
-                if (strtolower($indexName->getIdentifier()->getValue()) !== strtolower($oldIndexName)) {
+            foreach ($diff->getIndexRenames() as $rename) {
+                if (
+                    strtolower($indexName->getIdentifier()->getValue())
+                    !== strtolower($rename->getOldName()->getIdentifier()->getValue())
+                ) {
                     continue;
                 }
 
@@ -822,13 +825,12 @@ class SQLitePlatform extends AbstractPlatform
             $indexes->remove($index->getObjectName());
         }
 
-        foreach (
-            array_merge(
-                $diff->getAddedIndexes(),
-                $diff->getRenamedIndexes(),
-            ) as $index
-        ) {
+        foreach ($diff->getAddedIndexes() as $index) {
             $indexes->add($index);
+        }
+
+        foreach ($diff->getIndexRenames() as $rename) {
+            $indexes->add($rename->getNewIndex());
         }
 
         return $indexes->toList();

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -133,7 +133,7 @@ class Comparator
         $droppedColumns                   = [];
         $addedIndexes                     = [];
         $droppedIndexes                   = [];
-        $renamedIndexes                   = [];
+        $indexRenames                     = [];
         $addedForeignKeys                 = [];
         $droppedForeignKeyConstraintNames = [];
         $addedPrimaryKeyConstraint        = null;
@@ -261,7 +261,7 @@ class Comparator
         }
 
         if ($this->config->getDetectRenamedIndexes()) {
-            $renamedIndexes = $this->detectRenamedIndexes($addedIndexes, $droppedIndexes, $folding);
+            $indexRenames = $this->detectIndexRenames($addedIndexes, $droppedIndexes, $folding);
         }
 
         $oldForeignKeys = $oldTable->getForeignKeys();
@@ -309,7 +309,7 @@ class Comparator
             droppedColumns: $droppedColumns,
             addedIndexes: $addedIndexes,
             droppedIndexes: $droppedIndexes,
-            renamedIndexes: $renamedIndexes,
+            indexRenames: $indexRenames,
             addedForeignKeys: $addedForeignKeys,
             droppedForeignKeyConstraintNames: $droppedForeignKeyConstraintNames,
             addedPrimaryKeyConstraint: $addedPrimaryKeyConstraint,
@@ -389,9 +389,9 @@ class Comparator
      * @param array<Index> $addedIndexes
      * @param array<Index> $removedIndexes
      *
-     * @return array<non-empty-string, Index>
+     * @return list<IndexRename>
      */
-    private function detectRenamedIndexes(
+    private function detectIndexRenames(
         array &$addedIndexes,
         array &$removedIndexes,
         UnquotedIdentifierFolding $folding,
@@ -411,7 +411,8 @@ class Comparator
             }
         }
 
-        $renamedIndexes = [];
+        $indexRenames = [];
+        $seen         = [];
 
         foreach ($candidatesByName as $candidates) {
             // If the current rename candidate contains exactly one semantically equal index,
@@ -431,20 +432,20 @@ class Comparator
                     ->getValue(),
             );
 
-            if (isset($renamedIndexes[$removedIndexName])) {
+            if (isset($seen[$removedIndexName])) {
                 continue;
             }
 
-            $addedIndex = $addedIndexes[$addedIndexKey];
+            $seen[$removedIndexName] = true;
 
-            $renamedIndexes[$removedIndexName] = $addedIndex;
+            $indexRenames[] = new IndexRename($removedIndex->getObjectName(), $addedIndexes[$addedIndexKey]);
             unset(
                 $addedIndexes[$addedIndexKey],
                 $removedIndexes[$removedIndexKey],
             );
         }
 
-        return $renamedIndexes;
+        return $indexRenames;
     }
 
     /**

--- a/src/Schema/TableDiff.php
+++ b/src/Schema/TableDiff.php
@@ -21,14 +21,14 @@ final readonly class TableDiff
      *
      * @internal The diff can be only instantiated by a {@see Comparator}.
      *
-     * @param array<Column>                  $addedColumns
-     * @param array<string, ColumnDiff>      $changedColumns
-     * @param array<Column>                  $droppedColumns
-     * @param array<Index>                   $addedIndexes
-     * @param array<Index>                   $droppedIndexes
-     * @param array<non-empty-string, Index> $renamedIndexes
-     * @param array<ForeignKeyConstraint>    $addedForeignKeys
-     * @param array<UnqualifiedName>         $droppedForeignKeyConstraintNames
+     * @param array<Column>               $addedColumns
+     * @param array<string, ColumnDiff>   $changedColumns
+     * @param array<Column>               $droppedColumns
+     * @param array<Index>                $addedIndexes
+     * @param array<Index>                $droppedIndexes
+     * @param list<IndexRename>           $indexRenames
+     * @param array<ForeignKeyConstraint> $addedForeignKeys
+     * @param array<UnqualifiedName>      $droppedForeignKeyConstraintNames
      */
     public function __construct(
         private Table $oldTable,
@@ -37,7 +37,7 @@ final readonly class TableDiff
         private array $droppedColumns = [],
         private array $addedIndexes = [],
         private array $droppedIndexes = [],
-        private array $renamedIndexes = [],
+        private array $indexRenames = [],
         private array $addedForeignKeys = [],
         private array $droppedForeignKeyConstraintNames = [],
         private ?PrimaryKeyConstraint $addedPrimaryKeyConstraint = null,
@@ -130,34 +130,10 @@ final readonly class TableDiff
         return $this->droppedIndexes;
     }
 
-    /**
-     * @deprecated Use {@see getIndexRenames()} instead.
-     *
-     * @return array<string,Index>
-     */
-    public function getRenamedIndexes(): array
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7368',
-            '%s() is deprecated, use getIndexRenames() instead.',
-            __METHOD__,
-        );
-
-        return $this->renamedIndexes;
-    }
-
     /** @return list<IndexRename> */
     public function getIndexRenames(): array
     {
-        $renames = [];
-
-        foreach ($this->renamedIndexes as $oldName => $newIndex) {
-            /** @phpstan-ignore argument.type */
-            $renames[] = new IndexRename(UnqualifiedName::unquoted((string) $oldName), $newIndex);
-        }
-
-        return $renames;
+        return $this->indexRenames;
     }
 
     /** @return array<ForeignKeyConstraint> */
@@ -192,7 +168,7 @@ final readonly class TableDiff
             && count($this->droppedColumns) === 0
             && count($this->addedIndexes) === 0
             && count($this->droppedIndexes) === 0
-            && count($this->renamedIndexes) === 0
+            && count($this->indexRenames) === 0
             && count($this->addedForeignKeys) === 0
             && count($this->droppedForeignKeyConstraintNames) === 0
             && $this->addedPrimaryKeyConstraint === null

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\IndexRename;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -623,11 +624,14 @@ abstract class AbstractPlatformTestCase extends TestCase
             )
             ->create();
 
-        $tableDiff = new TableDiff($table, renamedIndexes: [
-            'idx_foo' => Index::editor()
-                ->setUnquotedName('idx_bar')
-                ->setUnquotedColumnNames('id')
-                ->create(),
+        $tableDiff = new TableDiff($table, indexRenames: [
+            new IndexRename(
+                UnqualifiedName::unquoted('idx_foo'),
+                Index::editor()
+                    ->setUnquotedName('idx_bar')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            ),
         ]);
 
         self::assertSame(
@@ -662,15 +666,21 @@ abstract class AbstractPlatformTestCase extends TestCase
             )
             ->create();
 
-        $tableDiff = new TableDiff($table, renamedIndexes: [
-            'create' => Index::editor()
-                ->setUnquotedName('select')
-                ->setUnquotedColumnNames('id')
-                ->create(),
-            'foo' => Index::editor()
-                ->setUnquotedName('bar')
-                ->setUnquotedColumnNames('id')
-                ->create(),
+        $tableDiff = new TableDiff($table, indexRenames: [
+            new IndexRename(
+                UnqualifiedName::unquoted('create'),
+                Index::editor()
+                    ->setUnquotedName('select')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            ),
+            new IndexRename(
+                UnqualifiedName::unquoted('foo'),
+                Index::editor()
+                    ->setUnquotedName('bar')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            ),
         ]);
 
         self::assertSame(
@@ -707,11 +717,14 @@ abstract class AbstractPlatformTestCase extends TestCase
             )
             ->create();
 
-        $tableDiff = new TableDiff($table, renamedIndexes: [
-            'idx_foo' => Index::editor()
-                ->setUnquotedName('idx_bar')
-                ->setUnquotedColumnNames('id')
-                ->create(),
+        $tableDiff = new TableDiff($table, indexRenames: [
+            new IndexRename(
+                UnqualifiedName::unquoted('idx_foo'),
+                Index::editor()
+                    ->setUnquotedName('idx_bar')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            ),
         ]);
 
         self::assertSame(
@@ -751,15 +764,21 @@ abstract class AbstractPlatformTestCase extends TestCase
             )
             ->create();
 
-        $tableDiff = new TableDiff($table, renamedIndexes: [
-            'create' => Index::editor()
-                ->setUnquotedName('select')
-                ->setUnquotedColumnNames('id')
-                ->create(),
-            'foo' => Index::editor()
-                ->setUnquotedName('bar')
-                ->setUnquotedColumnNames('id')
-                ->create(),
+        $tableDiff = new TableDiff($table, indexRenames: [
+            new IndexRename(
+                UnqualifiedName::unquoted('create'),
+                Index::editor()
+                    ->setUnquotedName('select')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            ),
+            new IndexRename(
+                UnqualifiedName::unquoted('foo'),
+                Index::editor()
+                    ->setUnquotedName('bar')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            ),
         ]);
 
         self::assertSame(
@@ -925,11 +944,14 @@ abstract class AbstractPlatformTestCase extends TestCase
             )
             ->create();
 
-        $tableDiff = new TableDiff($primaryTable, renamedIndexes: [
-            'idx_foo' => Index::editor()
-                ->setUnquotedName('idx_foo_renamed')
-                ->setUnquotedColumnNames('foo')
-                ->create(),
+        $tableDiff = new TableDiff($primaryTable, indexRenames: [
+            new IndexRename(
+                UnqualifiedName::unquoted('idx_foo'),
+                Index::editor()
+                    ->setUnquotedName('idx_foo_renamed')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            ),
         ]);
 
         self::assertSame(

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -557,11 +557,14 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->create();
 
         self::assertEquals(
-            new TableDiff($tableA, renamedIndexes: [
-                'foo_bar_idx' => Index::editor()
-                    ->setUnquotedName('bar_foo_idx')
-                    ->setUnquotedColumnNames('id')
-                    ->create(),
+            new TableDiff($tableA, indexRenames: [
+                new IndexRename(
+                    UnqualifiedName::unquoted('foo_bar_idx'),
+                    Index::editor()
+                        ->setUnquotedName('bar_foo_idx')
+                        ->setUnquotedColumnNames('id')
+                        ->create(),
+                ),
             ]),
             $this->comparator->compareTables($tableA, $tableB),
         );
@@ -746,10 +749,6 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertCount(0, $tableDiff->getAddedColumns());
         self::assertCount(0, $tableDiff->getDroppedIndexes());
 
-        $renamedIndexes = $tableDiff->getRenamedIndexes();
-        self::assertArrayHasKey('idx_foo', $renamedIndexes);
-        self::assertEquals('idx_bar', $renamedIndexes['idx_foo']->getObjectName()->toString());
-
         self::assertEquals([
             new IndexRename(
                 UnqualifiedName::unquoted('idx_foo'),
@@ -796,7 +795,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         self::assertCount(1, $tableDiff->getAddedIndexes());
         self::assertCount(1, $tableDiff->getDroppedIndexes());
-        self::assertCount(0, $tableDiff->getRenamedIndexes());
+        self::assertCount(0, $tableDiff->getIndexRenames());
     }
 
     /**
@@ -844,7 +843,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         self::assertEquals(['idx_baz'], $this->getObjectNames($tableDiff->getAddedIndexes()));
         self::assertEquals(['idx_foo', 'idx_bar'], $this->getObjectNames($tableDiff->getDroppedIndexes()));
-        self::assertCount(0, $tableDiff->getRenamedIndexes());
+        self::assertCount(0, $tableDiff->getIndexRenames());
     }
 
     public function testDetectChangeIdentifierType(): void


### PR DESCRIPTION
The method in question was deprecated in https://github.com/doctrine/dbal/pull/7368. Now index renames are represented as `list<IndexRename>` across the codebase.