### PR TITLE
Deprecate Schema features and introduce SchemaEditor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Deprecated `Schema` features
+
+The `Schema` constructor has been marked as internal. Use `Schema::editor()` to instantiate an editor and
+`SchemaEditor::create()` to create a schema.
+
 ## Deprecated `TableDiff::getRenamedIndexes()`
 
 The `TableDiff::getRenamedIndexes()` method has been deprecated. Use `TableDiff::getIndexRenames()` instead, which

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,14 @@ awareness about deprecated code.
 The `Schema` constructor has been marked as internal. Use `Schema::editor()` to instantiate an editor and
 `SchemaEditor::create()` to create a schema.
 
+The following `Schema` methods have been deprecated:
+
+- `Schema::createTable()` - use `Schema::edit()` and `SchemaEditor::addTable()` instead.
+- `Schema::renameTable()` - use `Schema::edit()` and `SchemaEditor::renameTable()` instead.
+- `Schema::dropTable()` - use `Schema::edit()` and `SchemaEditor::dropTable()` instead.
+- `Schema::createSequence()` - use `Schema::edit()` and `SchemaEditor::addSequence()` instead.
+- `Schema::dropSequence()` - use `Schema::edit()` and `SchemaEditor::dropSequence()` instead.
+
 ## Deprecated `TableDiff::getRenamedIndexes()`
 
 The `TableDiff::getRenamedIndexes()` method has been deprecated. Use `TableDiff::getIndexRenames()` instead, which

--- a/src/Schema/Exception/ImproperlyQualifiedName.php
+++ b/src/Schema/Exception/ImproperlyQualifiedName.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\SchemaException;
+use InvalidArgumentException;
+
+use function sprintf;
+
+/** @psalm-immutable */
+class ImproperlyQualifiedName extends InvalidArgumentException implements SchemaException
+{
+    public static function fromUnqualifiedName(OptionallyQualifiedName $name): self
+    {
+        return new self(sprintf('Schema uses qualified names, but %s is unqualified.', $name->toString()));
+    }
+
+    public static function fromQualifiedName(OptionallyQualifiedName $name): self
+    {
+        return new self(sprintf('Schema uses unqualified names, but %s is qualified.', $name->toString()));
+    }
+}

--- a/src/Schema/Exception/InvalidSchemaModification.php
+++ b/src/Schema/Exception/InvalidSchemaModification.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema\Exception;
+
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\SchemaException;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+final class InvalidSchemaModification extends LogicException implements SchemaException
+{
+    public static function schemaConfigMustBeSetBeforeAddingObjects(): self
+    {
+        return new self(
+            'The schema config must be set before any tables or sequences are added to the editor.',
+        );
+    }
+
+    public static function tableAlreadyExists(OptionallyQualifiedName $name): self
+    {
+        return new self(sprintf('Table %s already exists in the schema.', $name->toString()));
+    }
+
+    public static function tableDoesNotExist(OptionallyQualifiedName $name): self
+    {
+        return new self(sprintf('Table %s does not exist in the schema.', $name->toString()));
+    }
+
+    public static function sequenceAlreadyExists(OptionallyQualifiedName $name): self
+    {
+        return new self(sprintf('Sequence %s already exists in the schema.', $name->toString()));
+    }
+
+    public static function sequenceDoesNotExist(OptionallyQualifiedName $name): self
+    {
+        return new self(sprintf('Sequence %s does not exist in the schema.', $name->toString()));
+    }
+}

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -391,9 +391,18 @@ class Schema extends AbstractAsset
 
     /**
      * Creates a new table.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see SchemaEditor::addTable()} instead.
      */
     public function createTable(string $name): Table
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7373',
+            '%s is deprecated. Use Schema::edit() and SchemaEditor::addTable() instead.',
+            __METHOD__,
+        );
+
         $table = new Table($name, [], [], [], [], [], $this->_schemaConfig->toTableConfiguration());
         $this->_addTable($table);
 
@@ -407,10 +416,19 @@ class Schema extends AbstractAsset
     /**
      * Renames a table.
      *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see SchemaEditor::renameTable()} instead.
+     *
      * @return $this
      */
     public function renameTable(string $oldName, string $newName): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7373',
+            '%s is deprecated. Use Schema::edit() and SchemaEditor::renameTable() instead.',
+            __METHOD__,
+        );
+
         $table = $this->getTable($oldName);
 
         $identifier = new Identifier($newName);
@@ -428,10 +446,19 @@ class Schema extends AbstractAsset
     /**
      * Drops a table from the schema.
      *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see SchemaEditor::dropTable()} instead.
+     *
      * @return $this
      */
     public function dropTable(string $name): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7373',
+            '%s is deprecated. Use Schema::edit() and SchemaEditor::dropTable() instead.',
+            __METHOD__,
+        );
+
         $key = $this->getKeyFromName($name);
         if (! isset($this->_tables[$key])) {
             throw TableDoesNotExist::new($name);
@@ -444,18 +471,38 @@ class Schema extends AbstractAsset
 
     /**
      * Creates a new sequence.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see SchemaEditor::addSequence()} instead.
      */
     public function createSequence(string $name, int $allocationSize = 1, int $initialValue = 1): Sequence
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7373',
+            '%s is deprecated. Use Schema::edit() and SchemaEditor::addSequence() instead.',
+            __METHOD__,
+        );
+
         $seq = new Sequence($name, $allocationSize, $initialValue);
         $this->_addSequence($seq);
 
         return $seq;
     }
 
-    /** @return $this */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see SchemaEditor::dropSequence()} instead.
+     *
+     * @return $this
+     */
     public function dropSequence(string $name): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7373',
+            '%s is deprecated. Use Schema::edit() and SchemaEditor::dropSequence() instead.',
+            __METHOD__,
+        );
+
         $key = $this->getKeyFromName($name);
         unset($this->_sequences[$key]);
 

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -79,6 +79,9 @@ class Schema extends AbstractAsset
     private bool $usesUnqualifiedNames = false;
 
     /**
+     * @internal since doctrine/dbal 4.5. Use {@link Schema::editor()} to instantiate an editor
+     *           and {@link SchemaEditor::create()} to create a schema.
+     *
      * @param array<Table>    $tables
      * @param array<Sequence> $sequences
      * @param array<string>   $namespaces

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -486,6 +486,25 @@ class Schema extends AbstractAsset
     }
 
     /**
+     * Instantiates a new schema editor.
+     */
+    public static function editor(): SchemaEditor
+    {
+        return new SchemaEditor();
+    }
+
+    /**
+     * Instantiates a new schema editor seeded with this schema's tables, sequences, and configuration.
+     */
+    public function edit(): SchemaEditor
+    {
+        return self::editor()
+            ->setSchemaConfig($this->_schemaConfig)
+            ->setTables(...$this->getTables())
+            ->setSequences(...$this->getSequences());
+    }
+
+    /**
      * Cloning a Schema triggers a deep clone of all related assets.
      */
     public function __clone()

--- a/src/Schema/SchemaEditor.php
+++ b/src/Schema/SchemaEditor.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Schema;
+
+use Doctrine\DBAL\Schema\Exception\ImproperlyQualifiedName;
+use Doctrine\DBAL\Schema\Exception\InvalidSchemaModification;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+use function strtolower;
+
+final class SchemaEditor
+{
+    private SchemaConfig $schemaConfig;
+
+    /** @var array<string, Table> */
+    private array $tables = [];
+
+    /** @var array<string, Sequence> */
+    private array $sequences = [];
+
+    /** @internal Use {@link Schema::editor()} or {@link Schema::edit()} to create an instance */
+    public function __construct()
+    {
+        $this->schemaConfig = new SchemaConfig();
+    }
+
+    public function setSchemaConfig(SchemaConfig $schemaConfig): self
+    {
+        if ($this->tables !== [] || $this->sequences !== []) {
+            throw InvalidSchemaModification::schemaConfigMustBeSetBeforeAddingObjects();
+        }
+
+        $this->schemaConfig = $schemaConfig;
+
+        return $this;
+    }
+
+    public function setTables(Table ...$tables): self
+    {
+        $this->tables = [];
+
+        foreach ($tables as $table) {
+            $this->addTable($table);
+        }
+
+        return $this;
+    }
+
+    public function addTable(Table $table): self
+    {
+        $name = $table->getObjectName();
+        $key  = $this->getKey($name);
+
+        if (isset($this->tables[$key])) {
+            throw InvalidSchemaModification::tableAlreadyExists($name);
+        }
+
+        $this->tables[$key] = $table;
+
+        return $this;
+    }
+
+    /** @param callable(TableEditor): void $modification */
+    public function modifyTable(OptionallyQualifiedName $tableName, callable $modification): self
+    {
+        $key = $this->getKey($tableName);
+
+        if (! isset($this->tables[$key])) {
+            throw InvalidSchemaModification::tableDoesNotExist($tableName);
+        }
+
+        $editor = $this->tables[$key]->edit();
+        $modification($editor);
+        $newTable = $editor->create();
+
+        $newName = $newTable->getObjectName();
+        $newKey  = $this->getKey($newName);
+
+        if ($newKey === $key) {
+            $this->tables[$key] = $newTable;
+
+            return $this;
+        }
+
+        if (isset($this->tables[$newKey])) {
+            throw InvalidSchemaModification::tableAlreadyExists($newName);
+        }
+
+        unset($this->tables[$key]);
+        $this->tables[$newKey] = $newTable;
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string            $tableName
+     * @param callable(TableEditor): void $modification
+     * @param ?non-empty-string           $qualifier
+     */
+    public function modifyTableByUnquotedName(
+        string $tableName,
+        callable $modification,
+        ?string $qualifier = null,
+    ): self {
+        return $this->modifyTable(OptionallyQualifiedName::unquoted($tableName, $qualifier), $modification);
+    }
+
+    public function renameTable(OptionallyQualifiedName $oldTableName, UnqualifiedName $newTableName): self
+    {
+        return $this->modifyTable(
+            $oldTableName,
+            static function (TableEditor $editor) use ($oldTableName, $newTableName): void {
+                $editor->setName(
+                    new OptionallyQualifiedName($newTableName->getIdentifier(), $oldTableName->getQualifier()),
+                );
+            },
+        );
+    }
+
+    /**
+     * @param non-empty-string  $oldTableName
+     * @param non-empty-string  $newTableName
+     * @param ?non-empty-string $qualifier
+     */
+    public function renameTableByUnquotedName(
+        string $oldTableName,
+        string $newTableName,
+        ?string $qualifier = null,
+    ): self {
+        return $this->renameTable(
+            OptionallyQualifiedName::unquoted($oldTableName, $qualifier),
+            UnqualifiedName::unquoted($newTableName),
+        );
+    }
+
+    public function dropTable(OptionallyQualifiedName $tableName): self
+    {
+        $key = $this->getKey($tableName);
+
+        if (! isset($this->tables[$key])) {
+            throw InvalidSchemaModification::tableDoesNotExist($tableName);
+        }
+
+        unset($this->tables[$key]);
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string  $tableName
+     * @param ?non-empty-string $qualifier
+     */
+    public function dropTableByUnquotedName(string $tableName, ?string $qualifier = null): self
+    {
+        return $this->dropTable(OptionallyQualifiedName::unquoted($tableName, $qualifier));
+    }
+
+    public function setSequences(Sequence ...$sequences): self
+    {
+        $this->sequences = [];
+
+        foreach ($sequences as $sequence) {
+            $this->addSequence($sequence);
+        }
+
+        return $this;
+    }
+
+    public function addSequence(Sequence $sequence): self
+    {
+        $name = $sequence->getObjectName();
+        $key  = $this->getKey($name);
+
+        if (isset($this->sequences[$key])) {
+            throw InvalidSchemaModification::sequenceAlreadyExists($name);
+        }
+
+        $this->sequences[$key] = $sequence;
+
+        return $this;
+    }
+
+    public function dropSequence(OptionallyQualifiedName $sequenceName): self
+    {
+        $key = $this->getKey($sequenceName);
+
+        if (! isset($this->sequences[$key])) {
+            throw InvalidSchemaModification::sequenceDoesNotExist($sequenceName);
+        }
+
+        unset($this->sequences[$key]);
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string  $sequenceName
+     * @param ?non-empty-string $qualifier
+     */
+    public function dropSequenceByUnquotedName(string $sequenceName, ?string $qualifier = null): self
+    {
+        return $this->dropSequence(OptionallyQualifiedName::unquoted($sequenceName, $qualifier));
+    }
+
+    public function create(): Schema
+    {
+        $this->ensureUniformQualification();
+
+        return new Schema($this->tables, $this->sequences, $this->schemaConfig);
+    }
+
+    private function getKey(OptionallyQualifiedName $name): string
+    {
+        return $this->buildKey($this->resolveName($name));
+    }
+
+    private function buildKey(OptionallyQualifiedName $resolved): string
+    {
+        $qualifier       = $resolved->getQualifier();
+        $unqualifiedName = $resolved->getUnqualifiedName()->getValue();
+
+        if ($qualifier === null) {
+            return strtolower($unqualifiedName);
+        }
+
+        return strtolower($qualifier->getValue()) . "\0" . strtolower($unqualifiedName);
+    }
+
+    /**
+     * Returns the given name qualified with the default namespace if one is configured and the name is unqualified;
+     * otherwise returns the name unchanged. Mirrors {@see Schema} resolution rules so that names added unqualified
+     * can be looked up by either form.
+     */
+    private function resolveName(OptionallyQualifiedName $name): OptionallyQualifiedName
+    {
+        if ($name->getQualifier() !== null) {
+            return $name;
+        }
+
+        $defaultNamespace = $this->schemaConfig->getName();
+
+        if ($defaultNamespace === null) {
+            return $name;
+        }
+
+        return new OptionallyQualifiedName(
+            $name->getUnqualifiedName(),
+            Identifier::quoted($defaultNamespace),
+        );
+    }
+
+    /**
+     * Throws if the editor's contents mix qualified and unqualified names after resolution against the default
+     * namespace. Tables and sequences are checked together — the schema is either fully qualified or fully unqualified.
+     */
+    private function ensureUniformQualification(): void
+    {
+        $qualified   = false;
+        $unqualified = false;
+
+        foreach ($this->tables as $table) {
+            $this->checkQualification($table->getObjectName(), $qualified, $unqualified);
+        }
+
+        foreach ($this->sequences as $sequence) {
+            $this->checkQualification($sequence->getObjectName(), $qualified, $unqualified);
+        }
+    }
+
+    private function checkQualification(OptionallyQualifiedName $name, bool &$qualified, bool &$unqualified): void
+    {
+        if ($this->resolveName($name)->getQualifier() !== null) {
+            if ($unqualified) {
+                throw ImproperlyQualifiedName::fromQualifiedName($name);
+            }
+
+            $qualified = true;
+        } else {
+            if ($qualified) {
+                throw ImproperlyQualifiedName::fromUnqualifiedName($name);
+            }
+
+            $unqualified = true;
+        }
+    }
+}

--- a/tests/Functional/SQL/Builder/CreateAndDropSchemaObjectsSQLBuilderTest.php
+++ b/tests/Functional/SQL/Builder/CreateAndDropSchemaObjectsSQLBuilderTest.php
@@ -21,7 +21,9 @@ class CreateAndDropSchemaObjectsSQLBuilderTest extends FunctionalTestCase
         $table1 = $this->createTable('t1', 't2');
         $table2 = $this->createTable('t2', 't1');
 
-        $schema = new Schema([$table1, $table2]);
+        $schema = Schema::editor()
+            ->setTables($table1, $table2)
+            ->create();
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);

--- a/tests/Functional/Schema/PostgreSQL/SchemaTest.php
+++ b/tests/Functional/Schema/PostgreSQL/SchemaTest.php
@@ -39,7 +39,11 @@ final class SchemaTest extends FunctionalTestCase
             ->setUnquotedName('my_table_id_seq')
             ->create();
 
-        $schema = new Schema([$table], [$sequence]);
+        $schema = Schema::editor()
+            ->addTable($table)
+            ->addSequence($sequence)
+            ->create();
+
         foreach ($schema->toSql($platform) as $sql) {
             $this->connection->executeStatement($sql);
         }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -383,7 +383,9 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
             )
             ->create();
 
-        $schema = new Schema([$table]);
+        $schema = Schema::editor()
+            ->addTable($table)
+            ->create();
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -29,6 +29,7 @@ use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableEditor;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Schema\View;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -616,17 +617,44 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->createTestTable('table_to_alter');
         $this->createTestTable('table_to_drop');
 
-        $schema = $this->schemaManager->introspectSchema();
+        $schema       = $this->schemaManager->introspectSchema();
+        $schemaConfig = $this->schemaManager->createSchemaConfig();
 
-        $tableToAlter = $schema->getTable('table_to_alter');
-        $tableToAlter->dropColumn('foreign_key_test');
-        $tableToAlter->addColumn('number', Types::INTEGER);
+        $tableToCreate = Table::editor()
+            ->setConfiguration($schemaConfig->toTableConfiguration())
+            ->setUnquotedName('table_to_create')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->setNotNull(true)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setOptions($schemaConfig->getDefaultTableOptions())
+            ->create();
 
-        $schema->dropTable('table_to_drop');
-
-        $tableToCreate = $schema->createTable('table_to_create');
-        $tableToCreate->addColumn('id', Types::INTEGER, ['notnull' => true]);
-        $tableToCreate->setPrimaryKey(['id']);
+        $schema = $schema->edit()
+            ->modifyTableByUnquotedName(
+                'table_to_alter',
+                static function (TableEditor $editor): void {
+                    $editor
+                        ->dropColumnByUnquotedName('foreign_key_test')
+                        ->addColumn(
+                            Column::editor()
+                                ->setUnquotedName('number')
+                                ->setTypeName(Types::INTEGER)
+                                ->create(),
+                        );
+                },
+            )
+            ->dropTableByUnquotedName('table_to_drop')
+            ->addTable($tableToCreate)
+            ->create();
 
         $this->schemaManager->migrateSchema($schema);
 
@@ -1711,7 +1739,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->create();
 
-        $schema = new Schema([$user, $group]);
+        $schema = Schema::editor()
+            ->setTables($user, $group)
+            ->create();
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);
@@ -1893,7 +1923,9 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->create();
 
-        $schema = new Schema([$parent, $child]);
+        $schema = Schema::editor()
+            ->setTables($parent, $child)
+            ->create();
 
         $schemaManager = $this->connection->createSchemaManager();
         $schemaManager->createSchemaObjects($schema);

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -165,7 +165,12 @@ abstract class FunctionalTestCase extends TestCase
         }
 
         if (count($sequencesToDrop) > 0 || count($tablesToDrop) > 0) {
-            $schemaManager->dropSchemaObjects(new Schema($tablesToDrop, $sequencesToDrop));
+            $schemaManager->dropSchemaObjects(
+                Schema::editor()
+                    ->setTables(...$tablesToDrop)
+                    ->setSequences(...$sequencesToDrop)
+                    ->create(),
+            );
         }
 
         try {

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -47,28 +47,33 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testCompareSame1(): void
     {
-        $schema1 = new Schema([
-            Table::editor()
-                ->setUnquotedName('bugdb')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('integercolumn1')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->create(),
-        ]);
-        $schema2 = new Schema([
-            Table::editor()
-                ->setUnquotedName('bugdb')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('integercolumn1')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->create(),
-        ]);
+        $schema1 = Schema::editor()
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('bugdb')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('integercolumn1')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
+
+        $schema2 = Schema::editor()
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('bugdb')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('integercolumn1')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
 
         self::assertEquals(
             new SchemaDiff([], [], [], [], [], [], [], []),
@@ -78,36 +83,41 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testCompareSame2(): void
     {
-        $schema1 = new Schema([
-            Table::editor()
-                ->setUnquotedName('bugdb')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('integercolumn1')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                    Column::editor()
-                        ->setUnquotedName('integercolumn2')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->create(),
-        ]);
-        $schema2 = new Schema([
-            Table::editor()
-                ->setUnquotedName('bugdb')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('integercolumn2')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                    Column::editor()
-                        ->setUnquotedName('integercolumn1')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->create(),
-        ]);
+        $schema1 = Schema::editor()
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('bugdb')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('integercolumn1')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                        Column::editor()
+                            ->setUnquotedName('integercolumn2')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
+
+        $schema2 = Schema::editor()
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('bugdb')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('integercolumn2')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                        Column::editor()
+                            ->setUnquotedName('integercolumn1')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
 
         self::assertEquals(
             new SchemaDiff([], [], [], [], [], [], [], []),
@@ -130,8 +140,14 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->setConfiguration($schemaConfig->toTableConfiguration())
             ->create();
 
-        $schema1 = new Schema([$table], [], $schemaConfig);
-        $schema2 = new Schema([], [], $schemaConfig);
+        $schema1 = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->addTable($table)
+            ->create();
+
+        $schema2 = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->create();
 
         self::assertEquals(
             new SchemaDiff([], [], [], [], [$table], [], [], []),
@@ -154,8 +170,14 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->setConfiguration($schemaConfig->toTableConfiguration())
             ->create();
 
-        $schema1 = new Schema([], [], $schemaConfig);
-        $schema2 = new Schema([$table], [], $schemaConfig);
+        $schema1 = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->create();
+
+        $schema2 = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->addTable($table)
+            ->create();
 
         $expected = new SchemaDiff([], [], [$table], [], [], [], [], []);
 
@@ -299,10 +321,14 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testRemovedSequence(): void
     {
-        $schema1 = new Schema();
-        $seq     = $schema1->createSequence('foo');
+        $seq = $this->createSequence('foo');
 
-        $schema2 = new Schema();
+        $schema1 = Schema::editor()
+            ->addSequence($seq)
+            ->create();
+
+        $schema2 = Schema::editor()
+            ->create();
 
         $diffSchema = $this->comparator->compareSchemas($schema1, $schema2);
 
@@ -311,10 +337,14 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testAddedSequence(): void
     {
-        $schema1 = new Schema();
+        $seq = $this->createSequence('foo');
 
-        $schema2 = new Schema();
-        $seq     = $schema2->createSequence('foo');
+        $schema1 = Schema::editor()
+            ->create();
+
+        $schema2 = Schema::editor()
+            ->addSequence($seq)
+            ->create();
 
         $diffSchema = $this->comparator->compareSchemas($schema1, $schema2);
 
@@ -489,19 +519,23 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testTablesCaseInsensitive(): void
     {
-        $schemaA = new Schema([
-            $this->createTable('foo'),
-            $this->createTable('bAr'),
-            $this->createTable('BAZ'),
-            $this->createTable('new'),
-        ]);
+        $schemaA = Schema::editor()
+            ->setTables(
+                $this->createTable('foo'),
+                $this->createTable('bAr'),
+                $this->createTable('BAZ'),
+                $this->createTable('new'),
+            )
+            ->create();
 
-        $schemaB = new Schema([
-            $this->createTable('FOO'),
-            $this->createTable('bar'),
-            $this->createTable('Baz'),
-            $this->createTable('old'),
-        ]);
+        $schemaB = Schema::editor()
+            ->setTables(
+                $this->createTable('FOO'),
+                $this->createTable('bar'),
+                $this->createTable('Baz'),
+                $this->createTable('old'),
+            )
+            ->create();
 
         $diff = $this->comparator->compareSchemas($schemaA, $schemaB);
 
@@ -512,17 +546,23 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testSequencesCaseInsensitive(): void
     {
-        $schemaA = new Schema();
-        $schemaA->createSequence('foo');
-        $schemaA->createSequence('BAR');
-        $schemaA->createSequence('Baz');
-        $schemaA->createSequence('new');
+        $schemaA = Schema::editor()
+            ->setSequences(
+                $this->createSequence('foo'),
+                $this->createSequence('BAR'),
+                $this->createSequence('Baz'),
+                $this->createSequence('new'),
+            )
+            ->create();
 
-        $schemaB = new Schema();
-        $schemaB->createSequence('FOO');
-        $schemaB->createSequence('Bar');
-        $schemaB->createSequence('baz');
-        $schemaB->createSequence('old');
+        $schemaB = Schema::editor()
+            ->setSequences(
+                $this->createSequence('FOO'),
+                $this->createSequence('Bar'),
+                $this->createSequence('baz'),
+                $this->createSequence('old'),
+            )
+            ->create();
 
         $diff = $this->comparator->compareSchemas($schemaA, $schemaB);
 
@@ -1033,11 +1073,20 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testAlteredSequence(): void
     {
-        $oldSchema = new Schema();
-        $oldSchema->createSequence('baz');
+        $oldSchema = Schema::editor()
+            ->addSequence(
+                $this->createSequence('baz'),
+            )
+            ->create();
 
-        $newSchema = clone $oldSchema;
-        $newSchema->getSequence('baz')->setAllocationSize(20);
+        $newSequence = Sequence::editor()
+            ->setUnquotedName('baz')
+            ->setAllocationSize(20)
+            ->create();
+
+        $newSchema = Schema::editor()
+            ->addSequence($newSequence)
+            ->create();
 
         $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
@@ -1049,13 +1098,15 @@ abstract class AbstractComparatorTestCase extends TestCase
         $config = new SchemaConfig();
         $config->setName('foo');
 
-        $oldSchema = new Schema([
-            $this->createTable('bar'),
-        ], [], $config);
+        $oldSchema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('bar'))
+            ->create();
 
-        $newSchema = new Schema([
-            $this->createTable('foo.bar'),
-        ], [], $config);
+        $newSchema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('foo.bar'))
+            ->create();
 
         self::assertEquals(
             new SchemaDiff([], [], [], [], [], [], [], []),
@@ -1068,16 +1119,22 @@ abstract class AbstractComparatorTestCase extends TestCase
         $config = new SchemaConfig();
         $config->setName('schemaName');
 
-        $oldSchema = new Schema([
-            $this->createTable('taz'),
-            $this->createTable('war.tab'),
-        ], [], $config);
+        $oldSchema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->setTables(
+                $this->createTable('taz'),
+                $this->createTable('war.tab'),
+            )
+            ->create();
 
-        $newSchema = new Schema([
-            $this->createTable('bar.tab'),
-            $this->createTable('baz.tab'),
-            $this->createTable('war.tab'),
-        ], [], $config);
+        $newSchema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->setTables(
+                $this->createTable('bar.tab'),
+                $this->createTable('baz.tab'),
+                $this->createTable('war.tab'),
+            )
+            ->create();
 
         $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
@@ -1090,11 +1147,24 @@ abstract class AbstractComparatorTestCase extends TestCase
         $config = new SchemaConfig();
         $config->setName('foo');
 
-        $oldSchema = new Schema([], [], $config);
-        $oldSchema->createTable('foo.bar');
+        $oldSchema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('bar', 'foo')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('id')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
 
-        $newSchema = new Schema();
-        $newSchema->createTable('bar');
+        $newSchema = Schema::editor()
+            ->addTable($this->createTable('bar'))
+            ->create();
 
         self::assertEquals(
             new SchemaDiff([], [], [], [], [], [], [], []),
@@ -1106,9 +1176,15 @@ abstract class AbstractComparatorTestCase extends TestCase
     {
         $config = new SchemaConfig();
         $config->setName('foo');
-        $oldSchema = new Schema([$this->createTable('bar')], [], $config);
 
-        $newSchema = new Schema([$this->createTable('bar')]);
+        $oldSchema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('bar'))
+            ->create();
+
+        $newSchema = Schema::editor()
+            ->addTable($this->createTable('bar'))
+            ->create();
 
         self::assertEquals(
             new SchemaDiff([], [], [], [], [], [], [], []),
@@ -1134,10 +1210,14 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->create();
 
-        $oldSchema = new Schema([$table]);
-        $oldSchema->createSequence('foo_id_seq');
+        $oldSchema = Schema::editor()
+            ->addTable($table)
+            ->addSequence($this->createSequence('foo_id_seq'))
+            ->create();
 
-        $newSchema = new Schema([$table]);
+        $newSchema = Schema::editor()
+            ->addTable($table)
+            ->create();
 
         $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
@@ -1165,10 +1245,14 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->create();
 
-        $oldSchema = new Schema([$table]);
+        $oldSchema = Schema::editor()
+            ->addTable($table)
+            ->create();
 
-        $newSchema = new Schema([$table]);
-        $newSchema->createSequence('foo_id_seq');
+        $newSchema = Schema::editor()
+            ->addTable($table)
+            ->addSequence($this->createSequence('foo_id_seq'))
+            ->create();
 
         $diff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
@@ -1228,69 +1312,74 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testForeignKeyRemovalWithRenamedLocalColumn(): void
     {
-        $oldSchema = new Schema([
-            Table::editor()
-                ->setUnquotedName('table1')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('id')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->create(),
-            Table::editor()
-                ->setUnquotedName('table2')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('id')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                    Column::editor()
-                        ->setUnquotedName('id_table1')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->setForeignKeyConstraints(
-                    ForeignKeyConstraint::editor()
-                        ->setUnquotedReferencingColumnNames('id_table1')
-                        ->setUnquotedReferencedTableName('table1')
-                        ->setUnquotedReferencedColumnNames('fk_table2_table1')
-                        ->create(),
-                )
-                ->create(),
-        ]);
-        $newSchema = new Schema([
-            Table::editor()
-                ->setUnquotedName('table2')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('id')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                    Column::editor()
-                        ->setUnquotedName('id_table3')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->setForeignKeyConstraints(
-                    ForeignKeyConstraint::editor()
-                        ->setUnquotedName('fk_table2_table3')
-                        ->setUnquotedReferencingColumnNames('id_table3')
-                        ->setUnquotedReferencedTableName('table3')
-                        ->setUnquotedReferencedColumnNames('id')
-                        ->create(),
-                )
-                ->create(),
-            Table::editor()
-                ->setUnquotedName('table3')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('id')
-                        ->setTypeName(Types::INTEGER)
-                        ->create(),
-                )
-                ->create(),
-        ]);
+        $oldSchema = Schema::editor()
+            ->setTables(
+                Table::editor()
+                    ->setUnquotedName('table1')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('id')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+                Table::editor()
+                    ->setUnquotedName('table2')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('id')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                        Column::editor()
+                            ->setUnquotedName('id_table1')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->setForeignKeyConstraints(
+                        ForeignKeyConstraint::editor()
+                            ->setUnquotedReferencingColumnNames('id_table1')
+                            ->setUnquotedReferencedTableName('table1')
+                            ->setUnquotedReferencedColumnNames('fk_table2_table1')
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
+
+        $newSchema = Schema::editor()
+            ->setTables(
+                Table::editor()
+                    ->setUnquotedName('table2')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('id')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                        Column::editor()
+                            ->setUnquotedName('id_table3')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->setForeignKeyConstraints(
+                        ForeignKeyConstraint::editor()
+                            ->setUnquotedName('fk_table2_table3')
+                            ->setUnquotedReferencingColumnNames('id_table3')
+                            ->setUnquotedReferencedTableName('table3')
+                            ->setUnquotedReferencedColumnNames('id')
+                            ->create(),
+                    )
+                    ->create(),
+                Table::editor()
+                    ->setUnquotedName('table3')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('id')
+                            ->setTypeName(Types::INTEGER)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
 
         $schemaDiff = $this->comparator->compareSchemas($oldSchema, $newSchema);
 
@@ -1304,31 +1393,36 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testWillNotProduceSchemaDiffOnTableWithAddedCustomSchemaDefinition(): void
     {
-        $oldSchema = new Schema([
-            Table::editor()
-                ->setUnquotedName('a_table')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('is_default')
-                        ->setTypeName(Types::STRING)
-                        ->setLength(32)
-                        ->create(),
-                )
-                ->create(),
-        ]);
-        $newSchema = new Schema([
-            Table::editor()
-                ->setUnquotedName('a_table')
-                ->setColumns(
-                    Column::editor()
-                        ->setUnquotedName('is_default')
-                        ->setTypeName(Types::STRING)
-                        ->setLength(32)
-                        ->setColumnDefinition('ENUM(\'default\')')
-                        ->create(),
-                )
-                ->create(),
-        ]);
+        $oldSchema = Schema::editor()
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('a_table')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('is_default')
+                            ->setTypeName(Types::STRING)
+                            ->setLength(32)
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
+
+        $newSchema = Schema::editor()
+            ->addTable(
+                Table::editor()
+                    ->setUnquotedName('a_table')
+                    ->setColumns(
+                        Column::editor()
+                            ->setUnquotedName('is_default')
+                            ->setTypeName(Types::STRING)
+                            ->setLength(32)
+                            ->setColumnDefinition('ENUM(\'default\')')
+                            ->create(),
+                    )
+                    ->create(),
+            )
+            ->create();
 
         self::assertEmpty(
             $this->comparator->compareSchemas($oldSchema, $newSchema)
@@ -1364,6 +1458,14 @@ abstract class AbstractComparatorTestCase extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->create();
+    }
+
+    /** @param non-empty-string $name */
+    private function createSequence(string $name): Sequence
+    {
+        return Sequence::editor()
+            ->setUnquotedName($name)
             ->create();
     }
 }

--- a/tests/Schema/SchemaEditorTest.php
+++ b/tests/Schema/SchemaEditorTest.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Exception\ImproperlyQualifiedName;
+use Doctrine\DBAL\Schema\Exception\InvalidSchemaModification;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Schema\Sequence;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableEditor;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function array_shift;
+
+class SchemaEditorTest extends TestCase
+{
+    public function testEditorCreatesEmptySchema(): void
+    {
+        $schema = Schema::editor()->create();
+
+        self::assertSame([], $schema->getTables());
+        self::assertSame([], $schema->getSequences());
+    }
+
+    public function testEditRoundTripPreservesTablesAndSequences(): void
+    {
+        $tableA   = $this->createTable('foo');
+        $tableB   = $this->createTable('bar');
+        $sequence = Sequence::editor()->setUnquotedName('a_seq')->create();
+
+        $schema = new Schema([$tableA, $tableB], [$sequence]);
+
+        $result = $schema->edit()->create();
+
+        self::assertSame([$tableA, $tableB], $result->getTables());
+        self::assertSame([$sequence], $result->getSequences());
+    }
+
+    public function testEditRoundTripPropagatesSchemaConfig(): void
+    {
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $schema = new Schema([$this->createTable('foo')], [], $config);
+
+        $result = $schema->edit()->create();
+
+        self::assertTrue($result->hasTable('public.foo'));
+        self::assertTrue($result->hasTable('foo'));
+    }
+
+    public function testAddTableRejectsDuplicateName(): void
+    {
+        $editor = Schema::editor()->addTable($this->createTable('foo'));
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->addTable($this->createTable('foo'));
+    }
+
+    public function testSetTablesReplacesPreviousTables(): void
+    {
+        $bar = $this->createTable('bar');
+
+        $schema = Schema::editor()
+            ->setTables($this->createTable('foo'))
+            ->setTables($bar)
+            ->create();
+
+        self::assertFalse($schema->hasTable('foo'));
+        self::assertSame([$bar], $schema->getTables());
+    }
+
+    public function testSetSequencesReplacesPreviousSequences(): void
+    {
+        $bar = Sequence::editor()->setUnquotedName('bar')->create();
+
+        $schema = Schema::editor()
+            ->setSequences(Sequence::editor()->setUnquotedName('foo')->create())
+            ->setSequences($bar)
+            ->create();
+
+        self::assertFalse($schema->hasSequence('foo'));
+        self::assertSame([$bar], $schema->getSequences());
+    }
+
+    public function testAddSequenceRejectsDuplicateName(): void
+    {
+        $sequence = Sequence::editor()->setUnquotedName('a_seq')->create();
+
+        $editor = Schema::editor()->addSequence($sequence);
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->addSequence(Sequence::editor()->setUnquotedName('a_seq')->create());
+    }
+
+    public function testModifyTableReplacesInPlacePreservingOrder(): void
+    {
+        $schema = Schema::editor()
+            ->addTable($this->createTable('first'))
+            ->addTable($this->createTable('second'))
+            ->addTable($this->createTable('third'))
+            ->modifyTableByUnquotedName('second', static function (TableEditor $editor): void {
+                $editor->addIndex(
+                    Index::editor()
+                        ->setUnquotedName('second_idx')
+                        ->setUnquotedColumnNames('id')
+                        ->create(),
+                );
+            })
+            ->create();
+
+        self::assertSame(
+            ['first', 'second', 'third'],
+            array_map(static fn (Table $table): string => $table->getObjectName()->toString(), $schema->getTables()),
+        );
+
+        self::assertCount(1, $schema->getTable('second')->getIndexes());
+    }
+
+    public function testModifyTableAllowsRename(): void
+    {
+        $schema = Schema::editor()
+            ->addTable($this->createTable('foo'))
+            ->modifyTableByUnquotedName('foo', static function (TableEditor $editor): void {
+                $editor->setUnquotedName('renamed');
+            })
+            ->create();
+
+        self::assertTrue($schema->hasTable('renamed'));
+        self::assertFalse($schema->hasTable('foo'));
+    }
+
+    public function testModifyTableOnAbsentNameThrows(): void
+    {
+        $editor = Schema::editor();
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->modifyTableByUnquotedName('missing', static function (): void {
+        });
+    }
+
+    public function testModifyTableRenameCollisionThrows(): void
+    {
+        $editor = Schema::editor()
+            ->addTable($this->createTable('foo'))
+            ->addTable($this->createTable('bar'));
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->modifyTableByUnquotedName('foo', static function (TableEditor $te): void {
+            $te->setUnquotedName('bar');
+        });
+    }
+
+    public function testRenameTablePreservesQualifier(): void
+    {
+        $schema = Schema::editor()
+            ->addTable($this->createTable('foo', 'public'))
+            ->renameTable(
+                OptionallyQualifiedName::unquoted('foo', 'public'),
+                UnqualifiedName::unquoted('renamed'),
+            )
+            ->create();
+
+        self::assertTrue($schema->hasTable('public.renamed'));
+        self::assertFalse($schema->hasTable('public.foo'));
+    }
+
+    public function testRenameTableByUnquotedName(): void
+    {
+        $schema = Schema::editor()
+            ->addTable($this->createTable('foo', 'public'))
+            ->renameTableByUnquotedName('foo', 'renamed', 'public')
+            ->create();
+
+        self::assertTrue($schema->hasTable('public.renamed'));
+        self::assertFalse($schema->hasTable('public.foo'));
+    }
+
+    public function testDropTable(): void
+    {
+        $schema = Schema::editor()
+            ->addTable($this->createTable('foo'))
+            ->addTable($this->createTable('bar'))
+            ->dropTableByUnquotedName('foo')
+            ->create();
+
+        self::assertFalse($schema->hasTable('foo'));
+        self::assertTrue($schema->hasTable('bar'));
+    }
+
+    public function testDropTableOnAbsentNameThrows(): void
+    {
+        $editor = Schema::editor();
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->dropTableByUnquotedName('missing');
+    }
+
+    public function testDropSequence(): void
+    {
+        $foo = Sequence::editor()
+            ->setUnquotedName('foo')
+            ->create();
+
+        $bar = Sequence::editor()
+            ->setUnquotedName('bar')
+            ->create();
+
+        $schema = Schema::editor()
+            ->addSequence($foo)
+            ->addSequence($bar)
+            ->dropSequenceByUnquotedName('foo')
+            ->create();
+
+        self::assertFalse($schema->hasSequence('foo'));
+        self::assertTrue($schema->hasSequence('bar'));
+    }
+
+    public function testDropSequenceOnAbsentNameThrows(): void
+    {
+        $editor = Schema::editor();
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->dropSequenceByUnquotedName('missing');
+    }
+
+    public function testDefaultNamespaceLookupParity(): void
+    {
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $editor = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('users'));
+
+        // Lookup by unqualified name finds it.
+        $editor->modifyTableByUnquotedName('users', static function (TableEditor $te): void {
+            $te->setComment('via unqualified');
+        });
+
+        // Lookup by qualified name (resolved against default namespace) finds the same entry.
+        $editor->modifyTable(
+            OptionallyQualifiedName::unquoted('users', 'public'),
+            static function (TableEditor $te): void {
+                $te->setComment('via qualified');
+            },
+        );
+
+        $schema = $editor->create();
+
+        self::assertCount(1, $schema->getTables());
+    }
+
+    public function testSequenceDefaultNamespaceLookupParity(): void
+    {
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $editor = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addSequence(Sequence::editor()->setUnquotedName('s')->create());
+
+        // Drop by the qualified form (resolved against the default namespace) finds the entry added unqualified.
+        $editor->dropSequence(OptionallyQualifiedName::unquoted('s', 'public'));
+
+        self::assertSame([], $editor->create()->getSequences());
+    }
+
+    public function testQualifiedAndUnqualifiedCollideUnderDefaultNamespace(): void
+    {
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $editor = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('foo'));
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->addTable($this->createTable('foo', 'public'));
+    }
+
+    public function testMixingQualifiedAndUnqualifiedThrows(): void
+    {
+        $editor = Schema::editor()
+            ->addTable($this->createTable('a'))
+            ->addTable($this->createTable('b', 'public'));
+
+        $this->expectException(ImproperlyQualifiedName::class);
+
+        $editor->create();
+    }
+
+    public function testMixingUnqualifiedAfterQualifiedThrows(): void
+    {
+        $editor = Schema::editor()
+            ->addTable($this->createTable('a', 'public'))
+            ->addTable($this->createTable('b'));
+
+        $this->expectException(ImproperlyQualifiedName::class);
+
+        $editor->create();
+    }
+
+    public function testMixedQualificationUnderDefaultNamespaceIsAccepted(): void
+    {
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $schema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('foo'))
+            ->addTable($this->createTable('bar', 'public'))
+            ->create();
+
+        self::assertCount(2, $schema->getTables());
+        self::assertTrue($schema->hasTable('foo'));
+        self::assertTrue($schema->hasTable('public.bar'));
+    }
+
+    public function testEditRoundTripPreservesMixedQualificationUnderDefaultNamespace(): void
+    {
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $schema = new Schema(
+            [$this->createTable('foo'), $this->createTable('bar', 'public')],
+            [],
+            $config,
+        );
+
+        $result = $schema->edit()->create();
+
+        self::assertCount(2, $result->getTables());
+        self::assertTrue($result->hasTable('foo'));
+        self::assertTrue($result->hasTable('public.bar'));
+    }
+
+    public function testSetSchemaConfigAfterAddingTableThrows(): void
+    {
+        $editor = Schema::editor()
+            ->addTable($this->createTable('foo'));
+
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->setSchemaConfig($config);
+    }
+
+    public function testSetSchemaConfigAfterAddingSequenceThrows(): void
+    {
+        $editor = Schema::editor()
+            ->addSequence(Sequence::editor()->setUnquotedName('a_seq')->create());
+
+        $config = new SchemaConfig();
+        $config->setName('public');
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->setSchemaConfig($config);
+    }
+
+    public function testWorkedExampleAddingUniqueIndex(): void
+    {
+        $tableEditor = Table::editor()
+            ->setUnquotedName('users')
+            ->setColumns(
+                Column::editor()->setUnquotedName('id')->setTypeName(Types::INTEGER)->create(),
+                Column::editor()->setUnquotedName('email')->setTypeName(Types::STRING)->create(),
+            )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('uniq_users_email')
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('email')
+                    ->create(),
+            );
+
+        $schema = Schema::editor()->addTable($tableEditor->create())->create();
+
+        $indexes = $schema->getTable('users')->getIndexes();
+        self::assertCount(1, $indexes);
+
+        $index = array_shift($indexes);
+        self::assertSame(IndexType::UNIQUE, $index->getType());
+    }
+
+    /**
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
+     */
+    private function createTable(string $unqualifiedName, ?string $qualifier = null): Table
+    {
+        return Table::editor()
+            ->setUnquotedName($unqualifiedName, $qualifier)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+    }
+}

--- a/tests/Schema/SchemaEditorTest.php
+++ b/tests/Schema/SchemaEditorTest.php
@@ -38,7 +38,10 @@ class SchemaEditorTest extends TestCase
         $tableB   = $this->createTable('bar');
         $sequence = Sequence::editor()->setUnquotedName('a_seq')->create();
 
-        $schema = new Schema([$tableA, $tableB], [$sequence]);
+        $schema = Schema::editor()
+            ->setTables($tableA, $tableB)
+            ->addSequence($sequence)
+            ->create();
 
         $result = $schema->edit()->create();
 
@@ -51,7 +54,10 @@ class SchemaEditorTest extends TestCase
         $config = new SchemaConfig();
         $config->setName('public');
 
-        $schema = new Schema([$this->createTable('foo')], [], $config);
+        $schema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->addTable($this->createTable('foo'))
+            ->create();
 
         $result = $schema->edit()->create();
 
@@ -339,11 +345,13 @@ class SchemaEditorTest extends TestCase
         $config = new SchemaConfig();
         $config->setName('public');
 
-        $schema = new Schema(
-            [$this->createTable('foo'), $this->createTable('bar', 'public')],
-            [],
-            $config,
-        );
+        $schema = Schema::editor()
+            ->setSchemaConfig($config)
+            ->setTables(
+                $this->createTable('foo'),
+                $this->createTable('bar', 'public'),
+            )
+            ->create();
 
         $result = $schema->edit()->create();
 

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -36,7 +36,9 @@ class SchemaTest extends TestCase
             )
             ->create();
 
-        $schema = new Schema([$table]);
+        $schema = Schema::editor()
+            ->addTable($table)
+            ->create();
 
         self::assertTrue($schema->hasTable($tableName));
 
@@ -49,7 +51,10 @@ class SchemaTest extends TestCase
     {
         $table = $this->createTable('Foo');
 
-        $schema = new Schema([$table]);
+        $schema = Schema::editor()
+            ->addTable($table)
+            ->create();
+
         self::assertTrue($schema->hasTable('foo'));
         self::assertTrue($schema->hasTable('FOO'));
 
@@ -60,9 +65,11 @@ class SchemaTest extends TestCase
 
     public function testGetUnknownTableThrowsException(): void
     {
+        $schema = Schema::editor()
+            ->create();
+
         $this->expectException(SchemaException::class);
 
-        $schema = new Schema();
         $schema->getTable('unknown');
     }
 
@@ -88,7 +95,9 @@ class SchemaTest extends TestCase
             )
             ->create();
 
-        $schema = new Schema([$table]);
+        $schema = Schema::editor()
+            ->addTable($table)
+            ->create();
 
         self::assertTrue($schema->hasTable('foo'));
         $schema->renameTable('foo', 'bar');
@@ -99,8 +108,11 @@ class SchemaTest extends TestCase
 
     public function testDropTable(): void
     {
-        $table  = $this->createTable('foo');
-        $schema = new Schema([$table]);
+        $table = $this->createTable('foo');
+
+        $schema = Schema::editor()
+            ->addTable($table)
+            ->create();
 
         self::assertTrue($schema->hasTable('foo'));
 
@@ -111,7 +123,8 @@ class SchemaTest extends TestCase
 
     public function testCreateTable(): void
     {
-        $schema = new Schema();
+        $schema = Schema::editor()
+            ->create();
 
         self::assertFalse($schema->hasTable('foo'));
 
@@ -127,7 +140,9 @@ class SchemaTest extends TestCase
             ->setUnquotedName('a_seq')
             ->create();
 
-        $schema = new Schema([], [$sequence]);
+        $schema = Schema::editor()
+            ->addSequence($sequence)
+            ->create();
 
         self::assertTrue($schema->hasSequence('a_seq'));
         self::assertEquals(
@@ -144,7 +159,10 @@ class SchemaTest extends TestCase
             ->setUnquotedName('a_Seq')
             ->create();
 
-        $schema = new Schema([], [$sequence]);
+        $schema = Schema::editor()
+            ->addSequence($sequence)
+            ->create();
+
         self::assertTrue($schema->hasSequence('a_seq'));
         self::assertTrue($schema->hasSequence('a_Seq'));
         self::assertTrue($schema->hasSequence('A_SEQ'));
@@ -156,15 +174,19 @@ class SchemaTest extends TestCase
 
     public function testGetUnknownSequenceThrowsException(): void
     {
+        $schema = Schema::editor()
+            ->create();
+
         $this->expectException(SchemaException::class);
 
-        $schema = new Schema();
         $schema->getSequence('unknown');
     }
 
     public function testCreateSequence(): void
     {
-        $schema   = new Schema();
+        $schema = Schema::editor()
+            ->create();
+
         $sequence = $schema->createSequence('a_seq', 10, 20);
 
         self::assertEquals(
@@ -189,7 +211,9 @@ class SchemaTest extends TestCase
             ->setUnquotedName('a_seq')
             ->create();
 
-        $schema = new Schema([], [$sequence]);
+        $schema = Schema::editor()
+            ->addSequence($sequence)
+            ->create();
 
         $schema->dropSequence('a_seq');
         self::assertFalse($schema->hasSequence('a_seq'));
@@ -211,8 +235,11 @@ class SchemaTest extends TestCase
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setMaxIdentifierLength(5);
 
-        $schema = new Schema([], [], $schemaConfig);
-        $table  = $schema->createTable('smalltable');
+        $schema = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->create();
+
+        $table = $schema->createTable('smalltable');
         $table->addColumn('long_id', Types::INTEGER);
         $table->addIndex(['long_id']);
 
@@ -257,8 +284,12 @@ class SchemaTest extends TestCase
             )
             ->create();
 
-        $schema   = new Schema([$tableA, $tableB]);
-        $sequence = $schema->createSequence('baz');
+        $sequence = Sequence::editor()->setUnquotedName('baz')->create();
+
+        $schema = Schema::editor()
+            ->setTables($tableA, $tableB)
+            ->addSequence($sequence)
+            ->create();
 
         $schemaNew = clone $schema;
 
@@ -283,7 +314,9 @@ class SchemaTest extends TestCase
             )
             ->create();
 
-        $schema = new Schema([$tableA]);
+        $schema = Schema::editor()
+            ->addTable($tableA)
+            ->create();
 
         self::assertTrue($schema->hasTable('`foo`'));
     }
@@ -293,28 +326,37 @@ class SchemaTest extends TestCase
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setName('public');
 
-        $schema = new Schema([], [], $schemaConfig);
+        $schema = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
 
-        $schema->createTable('foo');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('foo'))
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
 
-        $schema->createTable('bar.baz');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('baz', 'bar'))
+            ->create();
 
         self::assertFalse($schema->hasNamespace('baz'));
         self::assertTrue($schema->hasNamespace('bar'));
         self::assertFalse($schema->hasNamespace('tab'));
 
-        $schema->createTable('tab.taz');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('taz', 'tab'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('tab'));
     }
 
     public function testCreatesNamespace(): void
     {
-        $schema = new Schema();
+        $schema = Schema::editor()
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
 
@@ -337,7 +379,8 @@ class SchemaTest extends TestCase
 
     public function testThrowsExceptionOnCreatingNamespaceTwice(): void
     {
-        $schema = new Schema();
+        $schema = Schema::editor()
+            ->create();
 
         $schema->createNamespace('foo');
 
@@ -351,26 +394,36 @@ class SchemaTest extends TestCase
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setName('public');
 
-        $schema = new Schema([], [], $schemaConfig);
+        $schema = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
 
-        $schema->createTable('baz');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('baz'))
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
         self::assertFalse($schema->hasNamespace('baz'));
 
-        $schema->createTable('foo.bar');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('bar', 'foo'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('foo'));
         self::assertFalse($schema->hasNamespace('bar'));
 
-        $schema->createTable('`baz`.bloo');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('bloo', 'baz'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('baz'));
         self::assertFalse($schema->hasNamespace('bloo'));
 
-        $schema->createTable('`baz`.moo');
+        $schema = $schema->edit()
+            ->addTable($this->createTable('moo', 'baz'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('baz'));
         self::assertFalse($schema->hasNamespace('moo'));
@@ -381,26 +434,36 @@ class SchemaTest extends TestCase
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setName('public');
 
-        $schema = new Schema([], [], $schemaConfig);
+        $schema = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
 
-        $schema->createSequence('baz');
+        $schema = $schema->edit()
+            ->addSequence($this->createSequence('baz'))
+            ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
         self::assertFalse($schema->hasNamespace('baz'));
 
-        $schema->createSequence('foo.bar');
+        $schema = $schema->edit()
+            ->addSequence($this->createSequence('bar', 'foo'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('foo'));
         self::assertFalse($schema->hasNamespace('bar'));
 
-        $schema->createSequence('`baz`.bloo');
+        $schema = $schema->edit()
+            ->addSequence($this->createSequence('bloo', 'baz'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('baz'));
         self::assertFalse($schema->hasNamespace('bloo'));
 
-        $schema->createSequence('`baz`.moo');
+        $schema = $schema->edit()
+            ->addSequence($this->createSequence('moo', 'baz'))
+            ->create();
 
         self::assertTrue($schema->hasNamespace('baz'));
         self::assertFalse($schema->hasNamespace('moo'));
@@ -426,7 +489,10 @@ class SchemaTest extends TestCase
 
     public function testReferenceByQualifiedNameAmongUnqualifiedNames(): void
     {
-        $schema = new Schema([$this->createTable('t')]);
+        $schema = Schema::editor()
+            ->addTable(
+                $this->createTable('t'),
+            )->create();
 
         $this->expectDeprecationWithIdentifier(
             'https://github.com/doctrine/dbal/pull/6677#user-content-qualified-names',
@@ -437,7 +503,10 @@ class SchemaTest extends TestCase
 
     public function testReferenceByUnqualifiedNameAmongQualifiedNames(): void
     {
-        $schema = new Schema([$this->createTable('t', 'public')]);
+        $schema = Schema::editor()
+            ->addTable(
+                $this->createTable('t', 'public'),
+            )->create();
 
         $this->expectDeprecationWithIdentifier(
             'https://github.com/doctrine/dbal/pull/6677#user-content-unqualified-names',
@@ -481,9 +550,12 @@ class SchemaTest extends TestCase
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setName('public');
 
-        $schema = new Schema([
-            $this->createTable('t', 'public'),
-        ], [], $schemaConfig);
+        $schema = Schema::editor()
+            ->setSchemaConfig($schemaConfig)
+            ->addTable(
+                $this->createTable('t', 'public'),
+            )
+            ->create();
 
         self::assertTrue($schema->hasTable('t'));
         self::assertTrue($schema->hasTable('public.t'));
@@ -506,6 +578,17 @@ class SchemaTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->create();
+    }
+
+    /**
+     * @param non-empty-string  $unqualifiedName
+     * @param ?non-empty-string $qualifier
+     */
+    private function createSequence(string $unqualifiedName, ?string $qualifier = null): Sequence
+    {
+        return Sequence::editor()
+            ->setUnquotedName($unqualifiedName, $qualifier)
             ->create();
     }
 }


### PR DESCRIPTION
The introduction of the schema editor complements all previously introduced database object editors and should (at least partially) unblock doctrine/orm#12357. It should also unblock deprecation of the `Table` and `Column` object mutators, since it enables editing the corresponding object within a schema by creating a copy instead of mutation.