### PR TITLE
Fix undefined array key in index rename detection

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -357,14 +357,19 @@ class Comparator
      */
     private function detectRenamedIndexes(array &$addedIndexes, array &$removedIndexes): array
     {
-        $candidatesByName = [];
+        $candidatesByName       = [];
+        $removedIndexMatchCount = [];
 
         // Gather possible rename candidates by comparing each added and removed index based on semantics.
         foreach ($addedIndexes as $addedIndexKey => $addedIndex) {
             foreach ($removedIndexes as $removedIndexKey => $removedIndex) {
-                if (! $this->diffIndex($addedIndex, $removedIndex)) {
-                    $candidatesByName[$addedIndex->getName()][] = [$removedIndexKey, $addedIndexKey];
+                if ($this->diffIndex($addedIndex, $removedIndex)) {
+                    continue;
                 }
+
+                $candidatesByName[$addedIndex->getName()][] = [$removedIndexKey, $addedIndexKey];
+
+                $removedIndexMatchCount[$removedIndexKey] = ($removedIndexMatchCount[$removedIndexKey] ?? 0) + 1;
             }
         }
 
@@ -381,12 +386,13 @@ class Comparator
 
             [$removedIndexKey, $addedIndexKey] = $candidates[0];
 
-            $removedIndex     = $removedIndexes[$removedIndexKey];
-            $removedIndexName = strtolower($removedIndex->getName());
-
-            if (isset($renamedIndexes[$removedIndexName])) {
+            // Likewise, a removed index that matches more than one added index is ambiguous.
+            if ($removedIndexMatchCount[$removedIndexKey] > 1) {
                 continue;
             }
+
+            $removedIndex     = $removedIndexes[$removedIndexKey];
+            $removedIndexName = strtolower($removedIndex->getName());
 
             $addedIndex = $addedIndexes[$addedIndexKey];
 

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -869,6 +869,49 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertCount(0, $tableDiff->getRenamedIndexes());
     }
 
+    public function testDetectRenameIndexAmbiguousWithMultipleAddedIndexes(): void
+    {
+        $prototype = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('foo')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $table1 = $prototype->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('idx_foo')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            )
+            ->create();
+
+        $table2 = $prototype->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('idx_bar')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('idx_baz')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            )
+            ->create();
+
+        $tableDiff = $this->comparator->compareTables($table1, $table2);
+
+        self::assertEquals(['idx_bar', 'idx_baz'], $this->getObjectNames($tableDiff->getAddedIndexes()));
+        self::assertEquals(['idx_foo'], $this->getObjectNames($tableDiff->getDroppedIndexes()));
+        self::assertCount(0, $tableDiff->getRenamedIndexes());
+    }
+
     public function testDetectChangeIdentifierType(): void
     {
         $tableA = Table::editor()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7323

#### Summary

`detectRenamedIndexes()` crashes with an undefined array key when one removed index is semantically equal to more than one added index. That match is ambiguous. The removed index is now dropped and the added ones created, the same as the mirror case where several removed indexes match one added.
