### PR TITLE
Follow up changes for schema editor introduction

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,10 @@ The following `Schema` methods have been deprecated:
 - `Schema::createSequence()` - use `Schema::edit()` and `SchemaEditor::addSequence()` instead.
 - `Schema::dropSequence()` - use `Schema::edit()` and `SchemaEditor::dropSequence()` instead.
 
+`Schema::createTable()` applies the default table options from `SchemaConfig` to the table it constructs. Callers
+migrating to `SchemaEditor::addTable()` must apply those options themselves, e.g. via
+`Table::editor()->setOptions($schemaConfig->getDefaultTableOptions())`.
+
 ## Deprecated `TableDiff::getRenamedIndexes()`
 
 The `TableDiff::getRenamedIndexes()` method has been deprecated. Use `TableDiff::getIndexRenames()` instead, which

--- a/docs/en/reference/schema-manager.rst
+++ b/docs/en/reference/schema-manager.rst
@@ -217,14 +217,15 @@ with a schema comparator.
     <?php
     $fromSchema = $schemaManager->introspectSchema();
 
-Now we can clone the ``$fromSchema`` to ``$toSchema`` and drop a
+Now we can derive ``$toSchema`` from ``$fromSchema`` and drop a
 table:
 
 .. code-block:: php
 
     <?php
-    $toSchema = clone $fromSchema;
-    $toSchema->dropTable('user');
+    $toSchema = $fromSchema->edit()
+        ->dropTableByUnquotedName('user')
+        ->create();
 
 Now we can compare the two schema instances in order to calculate
 the differences between them and return the SQL required to make

--- a/docs/en/reference/schema-representation.rst
+++ b/docs/en/reference/schema-representation.rst
@@ -29,6 +29,7 @@ shows:
     use Doctrine\DBAL\Schema\Index\IndexType;
     use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
     use Doctrine\DBAL\Schema\Schema;
+    use Doctrine\DBAL\Schema\Sequence;
     use Doctrine\DBAL\Schema\Table;
 
     $user = Table::editor()
@@ -87,8 +88,14 @@ shows:
         )
         ->create();
 
-    $schema = new Schema([$user, $post]);
-    $schema->createSequence('my_table_seq');
+    $schema = Schema::editor()
+        ->setTables($user, $post)
+        ->addSequence(
+            Sequence::editor()
+                ->setUnquotedName('my_table_seq')
+                ->create()
+        )
+        ->create();
 
     $createSQL = $schema->toSql($myPlatform);     // get queries to create this schema
     $dropSQL   = $schema->toDropSql($myPlatform); // get queries to drop this schema

--- a/src/Schema/Exception/InvalidSchemaModification.php
+++ b/src/Schema/Exception/InvalidSchemaModification.php
@@ -13,10 +13,10 @@ use function sprintf;
 /** @internal */
 final class InvalidSchemaModification extends LogicException implements SchemaException
 {
-    public static function schemaConfigMustBeSetBeforeAddingObjects(): self
+    public static function defaultNamespaceCanOnlyBeSetOnEmptyEditor(): self
     {
         return new self(
-            'The schema config must be set before any tables or sequences are added to the editor.',
+            'The default namespace can only be set on an empty editor.',
         );
     }
 

--- a/src/Schema/Exception/InvalidSchemaModification.php
+++ b/src/Schema/Exception/InvalidSchemaModification.php
@@ -39,4 +39,16 @@ final class InvalidSchemaModification extends LogicException implements SchemaEx
     {
         return new self(sprintf('Sequence %s does not exist in the schema.', $name->toString()));
     }
+
+    public static function cannotChangeTableQualifier(
+        OptionallyQualifiedName $oldName,
+        OptionallyQualifiedName $newName,
+    ): self {
+        return new self(sprintf(
+            'A table\'s namespace cannot be changed through modifyTable (attempted to move %s to %s). '
+            . 'Drop and re-add the table to move it across namespaces.',
+            $oldName->toString(),
+            $newName->toString(),
+        ));
+    }
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -549,7 +549,7 @@ class Schema extends AbstractAsset
     public function edit(): SchemaEditor
     {
         return self::editor()
-            ->setSchemaConfig($this->_schemaConfig)
+            ->setDefaultNamespace($this->_schemaConfig->getName())
             ->setTables(...$this->getTables())
             ->setSequences(...$this->getSequences());
     }

--- a/src/Schema/SchemaEditor.php
+++ b/src/Schema/SchemaEditor.php
@@ -14,7 +14,8 @@ use function strtolower;
 
 final class SchemaEditor
 {
-    private SchemaConfig $schemaConfig;
+    /** @var ?non-empty-string */
+    private ?string $defaultNamespaceName = null;
 
     /** @var array<string, Table> */
     private array $tables = [];
@@ -25,16 +26,16 @@ final class SchemaEditor
     /** @internal Use {@link Schema::editor()} or {@link Schema::edit()} to create an instance */
     public function __construct()
     {
-        $this->schemaConfig = new SchemaConfig();
     }
 
-    public function setSchemaConfig(SchemaConfig $schemaConfig): self
+    /** @param ?non-empty-string $name */
+    public function setDefaultNamespace(?string $name): self
     {
         if ($this->tables !== [] || $this->sequences !== []) {
-            throw InvalidSchemaModification::schemaConfigMustBeSetBeforeAddingObjects();
+            throw InvalidSchemaModification::defaultNamespaceCanOnlyBeSetOnEmptyEditor();
         }
 
-        $this->schemaConfig = $schemaConfig;
+        $this->defaultNamespaceName = $name;
 
         return $this;
     }
@@ -210,7 +211,12 @@ final class SchemaEditor
     {
         $this->ensureUniformQualification();
 
-        return new Schema($this->tables, $this->sequences, $this->schemaConfig);
+        $schemaConfig = new SchemaConfig();
+        if ($this->defaultNamespaceName !== null) {
+            $schemaConfig->setName($this->defaultNamespaceName);
+        }
+
+        return new Schema($this->tables, $this->sequences, $schemaConfig);
     }
 
     private function getKey(OptionallyQualifiedName $name): string
@@ -241,15 +247,13 @@ final class SchemaEditor
             return $name;
         }
 
-        $defaultNamespace = $this->schemaConfig->getName();
-
-        if ($defaultNamespace === null) {
+        if ($this->defaultNamespaceName === null) {
             return $name;
         }
 
         return new OptionallyQualifiedName(
             $name->getUnqualifiedName(),
-            Identifier::quoted($defaultNamespace),
+            Identifier::quoted($this->defaultNamespaceName),
         );
     }
 

--- a/src/Schema/SchemaEditor.php
+++ b/src/Schema/SchemaEditor.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
+use function strcasecmp;
 use function strtolower;
 
 final class SchemaEditor
@@ -78,8 +79,15 @@ final class SchemaEditor
         $modification($editor);
         $newTable = $editor->create();
 
-        $newName = $newTable->getObjectName();
-        $newKey  = $this->getKey($newName);
+        $newName     = $newTable->getObjectName();
+        $oldResolved = $this->resolveName($tableName);
+        $newResolved = $this->resolveName($newName);
+
+        if (! $this->qualifiersEqual($oldResolved->getQualifier(), $newResolved->getQualifier())) {
+            throw InvalidSchemaModification::cannotChangeTableQualifier($oldResolved, $newResolved);
+        }
+
+        $newKey = $this->getKey($newName);
 
         if ($newKey === $key) {
             $this->tables[$key] = $newTable;
@@ -95,6 +103,15 @@ final class SchemaEditor
         $this->tables[$newKey] = $newTable;
 
         return $this;
+    }
+
+    private function qualifiersEqual(?Identifier $a, ?Identifier $b): bool
+    {
+        if ($a === null || $b === null) {
+            return $a === $b;
+        }
+
+        return strcasecmp($a->getValue(), $b->getValue()) === 0;
     }
 
     /**

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -141,12 +141,10 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->create();
 
         $schema1 = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
             ->addTable($table)
             ->create();
 
         $schema2 = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
             ->create();
 
         self::assertEquals(
@@ -171,11 +169,9 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->create();
 
         $schema1 = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
             ->create();
 
         $schema2 = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
             ->addTable($table)
             ->create();
 
@@ -1095,16 +1091,13 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testFqnSchemaComparison(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('foo');
-
         $oldSchema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('foo')
             ->addTable($this->createTable('bar'))
             ->create();
 
         $newSchema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('foo')
             ->addTable($this->createTable('foo.bar'))
             ->create();
 
@@ -1116,11 +1109,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testNamespacesComparison(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('schemaName');
-
         $oldSchema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('schemaName')
             ->setTables(
                 $this->createTable('taz'),
                 $this->createTable('war.tab'),
@@ -1128,7 +1118,7 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->create();
 
         $newSchema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('schemaName')
             ->setTables(
                 $this->createTable('bar.tab'),
                 $this->createTable('baz.tab'),
@@ -1144,11 +1134,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testFqnSchemaComparisonDifferentSchemaNameButSameTableNoDiff(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('foo');
-
         $oldSchema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('foo')
             ->addTable(
                 Table::editor()
                     ->setUnquotedName('bar', 'foo')
@@ -1174,11 +1161,8 @@ abstract class AbstractComparatorTestCase extends TestCase
 
     public function testFqnSchemaComparisonNoSchemaSame(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('foo');
-
         $oldSchema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('foo')
             ->addTable($this->createTable('bar'))
             ->create();
 

--- a/tests/Schema/SchemaEditorTest.php
+++ b/tests/Schema/SchemaEditorTest.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableEditor;
@@ -49,13 +48,10 @@ class SchemaEditorTest extends TestCase
         self::assertSame([$sequence], $result->getSequences());
     }
 
-    public function testEditRoundTripPropagatesSchemaConfig(): void
+    public function testEditRoundTripPropagatesDefaultNamespace(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('public')
             ->addTable($this->createTable('foo'))
             ->create();
 
@@ -248,11 +244,8 @@ class SchemaEditorTest extends TestCase
 
     public function testDefaultNamespaceLookupParity(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $editor = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('public')
             ->addTable($this->createTable('users'));
 
         // Lookup by unqualified name finds it.
@@ -275,11 +268,8 @@ class SchemaEditorTest extends TestCase
 
     public function testSequenceDefaultNamespaceLookupParity(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $editor = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('public')
             ->addSequence(Sequence::editor()->setUnquotedName('s')->create());
 
         // Drop by the qualified form (resolved against the default namespace) finds the entry added unqualified.
@@ -290,11 +280,8 @@ class SchemaEditorTest extends TestCase
 
     public function testQualifiedAndUnqualifiedCollideUnderDefaultNamespace(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $editor = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('public')
             ->addTable($this->createTable('foo'));
 
         $this->expectException(InvalidSchemaModification::class);
@@ -326,11 +313,8 @@ class SchemaEditorTest extends TestCase
 
     public function testMixedQualificationUnderDefaultNamespaceIsAccepted(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('public')
             ->addTable($this->createTable('foo'))
             ->addTable($this->createTable('bar', 'public'))
             ->create();
@@ -342,11 +326,8 @@ class SchemaEditorTest extends TestCase
 
     public function testEditRoundTripPreservesMixedQualificationUnderDefaultNamespace(): void
     {
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($config)
+            ->setDefaultNamespace('public')
             ->setTables(
                 $this->createTable('foo'),
                 $this->createTable('bar', 'public'),
@@ -360,30 +341,24 @@ class SchemaEditorTest extends TestCase
         self::assertTrue($result->hasTable('public.bar'));
     }
 
-    public function testSetSchemaConfigAfterAddingTableThrows(): void
+    public function testSetDefaultNamespaceAfterAddingTableThrows(): void
     {
         $editor = Schema::editor()
             ->addTable($this->createTable('foo'));
 
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $this->expectException(InvalidSchemaModification::class);
 
-        $editor->setSchemaConfig($config);
+        $editor->setDefaultNamespace('public');
     }
 
-    public function testSetSchemaConfigAfterAddingSequenceThrows(): void
+    public function testSetDefaultNamespaceAfterAddingSequenceThrows(): void
     {
         $editor = Schema::editor()
             ->addSequence(Sequence::editor()->setUnquotedName('a_seq')->create());
 
-        $config = new SchemaConfig();
-        $config->setName('public');
-
         $this->expectException(InvalidSchemaModification::class);
 
-        $editor->setSchemaConfig($config);
+        $editor->setDefaultNamespace('public');
     }
 
     public function testWorkedExampleAddingUniqueIndex(): void

--- a/tests/Schema/SchemaEditorTest.php
+++ b/tests/Schema/SchemaEditorTest.php
@@ -167,6 +167,22 @@ class SchemaEditorTest extends TestCase
         });
     }
 
+    public function testModifyTableCannotChangeQualifier(): void
+    {
+        $editor = Schema::editor()
+            ->addTable($this->createTable('t', 'foo'));
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $editor->modifyTableByUnquotedName(
+            't',
+            static function (TableEditor $te): void {
+                $te->setUnquotedName('t', 'bar');
+            },
+            'foo',
+        );
+    }
+
     public function testRenameTablePreservesQualifier(): void
     {
         $schema = Schema::editor()

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -235,9 +235,7 @@ class SchemaTest extends TestCase
         $schemaConfig = new SchemaConfig();
         $schemaConfig->setMaxIdentifierLength(5);
 
-        $schema = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
-            ->create();
+        $schema = new Schema([], [], $schemaConfig);
 
         $table = $schema->createTable('smalltable');
         $table->addColumn('long_id', Types::INTEGER);
@@ -323,11 +321,8 @@ class SchemaTest extends TestCase
 
     public function testHasNamespace(): void
     {
-        $schemaConfig = new SchemaConfig();
-        $schemaConfig->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
+            ->setDefaultNamespace('public')
             ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
@@ -391,11 +386,8 @@ class SchemaTest extends TestCase
 
     public function testCreatesNamespaceThroughAddingTableImplicitly(): void
     {
-        $schemaConfig = new SchemaConfig();
-        $schemaConfig->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
+            ->setDefaultNamespace('public')
             ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
@@ -431,11 +423,8 @@ class SchemaTest extends TestCase
 
     public function testCreatesNamespaceThroughAddingSequenceImplicitly(): void
     {
-        $schemaConfig = new SchemaConfig();
-        $schemaConfig->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
+            ->setDefaultNamespace('public')
             ->create();
 
         self::assertFalse($schema->hasNamespace('foo'));
@@ -547,11 +536,8 @@ class SchemaTest extends TestCase
 
     public function testReferencingByUnqualifiedNameAmongQualifiedNamesWithDefaultNamespace(): void
     {
-        $schemaConfig = new SchemaConfig();
-        $schemaConfig->setName('public');
-
         $schema = Schema::editor()
-            ->setSchemaConfig($schemaConfig)
+            ->setDefaultNamespace('public')
             ->addTable(
                 $this->createTable('t', 'public'),
             )


### PR DESCRIPTION
This is a follow up to https://github.com/doctrine/dbal/pull/7373 identified during the corresponding work on 5.0.x (to be submitted after the merge up).

1. Update documentation to recommend using the editor instead of mutating the schema (follows the deprecation).
2. Clarify the exception message when someone attempts to set the default namespace on a schema that has objects.
3. Forbid changing the qualifier during table or sequence modification. In a real database, you can only rename an object within its schema, so the editor shouldn't allow this through modification either.
4. Have schema editor accept only the default namespace, not the entire `SchemaConfig` (more on that below).

Besides the default namespace, schema config carries table-specific parameters:
1. Max identifier length for automatically named indexes — this will be used by the table editor, not the schema editor.
2. Default table options — this parameter doesn't even belong to the DBAL, it belongs to the logic of _defining_ database schema in a way compatible with the target database platform (e.g. by the ORM's `SchemaTool`). `SchemaTool` has access to `$metadataSchemaConfig` which contains this information.

None of them belong to the schema as an immutable collection of tables, sequences, etc.