### PR TITLE
Deprecate column mutators

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,6 +25,27 @@ The following `Schema` methods have been deprecated:
 migrating to `SchemaEditor::addTable()` must apply those options themselves, e.g. via
 `Table::editor()->setOptions($schemaConfig->getDefaultTableOptions())`.
 
+## Deprecated `Column` mutators
+
+The following `Column` methods have been deprecated. Use `Column::editor()` and the corresponding `ColumnEditor`
+method instead:
+
+- `Column::setOptions()` - use `Column::editor()` and configure the editor via the option-specific methods.
+- `Column::setType()` - use `ColumnEditor::setType()` or `ColumnEditor::setTypeName()`.
+- `Column::setLength()` - use `ColumnEditor::setLength()`.
+- `Column::setPrecision()` - use `ColumnEditor::setPrecision()`.
+- `Column::setScale()` - use `ColumnEditor::setScale()`.
+- `Column::setUnsigned()` - use `ColumnEditor::setUnsigned()`.
+- `Column::setFixed()` - use `ColumnEditor::setFixed()`.
+- `Column::setNotnull()` - use `ColumnEditor::setNotNull()`.
+- `Column::setDefault()` - use `ColumnEditor::setDefaultValue()`.
+- `Column::setPlatformOptions()` and `Column::setPlatformOption()` - use the option-specific `ColumnEditor` methods
+  (`setCharset()`, `setCollation()`, `setMinimumValue()`, `setMaximumValue()`, `setEnumType()`).
+- `Column::setColumnDefinition()` - use `ColumnEditor::setColumnDefinition()`.
+- `Column::setAutoincrement()` - use `ColumnEditor::setAutoincrement()`.
+- `Column::setComment()` - use `ColumnEditor::setComment()`.
+- `Column::setValues()` - use `ColumnEditor::setValues()`.
+
 ## Deprecated `TableDiff::getRenamedIndexes()`
 
 The `TableDiff::getRenamedIndexes()` method has been deprecated. Use `TableDiff::getIndexRenames()` instead, which

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -90,9 +90,20 @@ class Column extends AbstractNamedObject
         return Parsers::getUnqualifiedNameParser();
     }
 
-    /** @param array<string, mixed> $options */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} instead.
+     *
+     * @param array<string, mixed> $options
+     */
     public function setOptions(array $options): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() instead.',
+            __METHOD__,
+        );
+
         foreach ($options as $name => $value) {
             $method = 'set' . $name;
 
@@ -106,65 +117,151 @@ class Column extends AbstractNamedObject
         return $this;
     }
 
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setType()} or
+     *             {@see ColumnEditor::setTypeName()} instead.
+     */
     public function setType(Type $type): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setType() or ColumnEditor::setTypeName()'
+                . ' instead.',
+            __METHOD__,
+        );
+
         $this->_type = $type;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setLength()} instead. */
     public function setLength(?int $length): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setLength() instead.',
+            __METHOD__,
+        );
+
         $this->_length = $length;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setPrecision()} instead. */
     public function setPrecision(?int $precision): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setPrecision() instead.',
+            __METHOD__,
+        );
+
         $this->_precision = $precision;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setScale()} instead. */
     public function setScale(int $scale): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setScale() instead.',
+            __METHOD__,
+        );
+
         $this->_scale = $scale;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setUnsigned()} instead. */
     public function setUnsigned(bool $unsigned): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setUnsigned() instead.',
+            __METHOD__,
+        );
+
         $this->_unsigned = $unsigned;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setFixed()} instead. */
     public function setFixed(bool $fixed): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setFixed() instead.',
+            __METHOD__,
+        );
+
         $this->_fixed = $fixed;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setNotNull()} instead. */
     public function setNotnull(bool $notnull): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setNotNull() instead.',
+            __METHOD__,
+        );
+
         $this->_notnull = $notnull;
 
         return $this;
     }
 
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setDefaultValue()}
+     *             instead.
+     */
     public function setDefault(mixed $default): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setDefaultValue() instead.',
+            __METHOD__,
+        );
+
         $this->_default = $default;
 
         return $this;
     }
 
-    /** @param PlatformOptions $platformOptions */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and the option-specific {@see ColumnEditor}
+     *             methods ({@see ColumnEditor::setCharset()}, {@see ColumnEditor::setCollation()},
+     *             {@see ColumnEditor::setMinimumValue()}, {@see ColumnEditor::setMaximumValue()},
+     *             {@see ColumnEditor::setEnumType()}) instead.
+     *
+     * @param PlatformOptions $platformOptions
+     */
     public function setPlatformOptions(array $platformOptions): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and the option-specific ColumnEditor methods'
+                . ' (setCharset(), setCollation(), setMinimumValue(), setMaximumValue(), setEnumType()) instead.',
+            __METHOD__,
+        );
+
         if (isset($platformOptions['jsonb']) && $platformOptions['jsonb']) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',
@@ -178,9 +275,24 @@ class Column extends AbstractNamedObject
         return $this;
     }
 
-    /** @param key-of<PlatformOptions> $name */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and the option-specific {@see ColumnEditor}
+     *             methods ({@see ColumnEditor::setCharset()}, {@see ColumnEditor::setCollation()},
+     *             {@see ColumnEditor::setMinimumValue()}, {@see ColumnEditor::setMaximumValue()},
+     *             {@see ColumnEditor::setEnumType()}) instead.
+     *
+     * @param key-of<PlatformOptions> $name
+     */
     public function setPlatformOption(string $name, mixed $value): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and the option-specific ColumnEditor methods'
+                . ' (setCharset(), setCollation(), setMinimumValue(), setMaximumValue(), setEnumType()) instead.',
+            __METHOD__,
+        );
+
         if ($name === 'jsonb' && (bool) $value === true) {
             Deprecation::triggerIfCalledFromOutside(
                 'doctrine/dbal',
@@ -194,9 +306,21 @@ class Column extends AbstractNamedObject
         return $this;
     }
 
-    /** @param  ?non-empty-string $value */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setColumnDefinition()}
+     *             instead.
+     *
+     * @param ?non-empty-string $value
+     */
     public function setColumnDefinition(?string $value): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setColumnDefinition() instead.',
+            __METHOD__,
+        );
+
         $this->_columnDefinition = $value;
 
         return $this;
@@ -344,15 +468,34 @@ class Column extends AbstractNamedObject
         return $this->_autoincrement;
     }
 
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setAutoincrement()}
+     *             instead.
+     */
     public function setAutoincrement(bool $flag): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setAutoincrement() instead.',
+            __METHOD__,
+        );
+
         $this->_autoincrement = $flag;
 
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setComment()} instead. */
     public function setComment(string $comment): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setComment() instead.',
+            __METHOD__,
+        );
+
         $this->_comment = $comment;
 
         return $this;
@@ -364,12 +507,21 @@ class Column extends AbstractNamedObject
     }
 
     /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setValues()} instead.
+     *
      * @param list<string> $values
      *
      * @return $this
      */
     public function setValues(array $values): static
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7381',
+            '%s is deprecated. Use Column::editor() and ColumnEditor::setValues() instead.',
+            __METHOD__,
+        );
+
         $this->_values = $values;
 
         return $this;

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -154,7 +154,7 @@ class ColumnTest extends TestCase
     {
         $column = Column::editor()
             ->setUnquotedName('bar')
-            ->setType(Type::getType(Types::STRING))
+            ->setTypeName(Types::STRING)
             ->create();
         self::assertSame('', $column->getComment());
 
@@ -179,7 +179,7 @@ class ColumnTest extends TestCase
     {
         $column = Column::editor()
             ->setUnquotedName('id')
-            ->setType(Type::getType(Types::INTEGER))
+            ->setTypeName(Types::INTEGER)
             ->create();
 
         self::assertEquals(Identifier::unquoted('id'), $column->getObjectName()->getIdentifier());

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -158,7 +158,9 @@ class ColumnTest extends TestCase
             ->create();
         self::assertSame('', $column->getComment());
 
-        $column->setComment('foo');
+        $column = $column->edit()
+            ->setComment('foo')
+            ->create();
         self::assertEquals('foo', $column->getComment());
 
         $columnArray = $column->toArray();


### PR DESCRIPTION
Deprecation of column mutators was previously blocked by the absence of `SchemaEditor`. If a column belonged to a table, which in turn belonged to a schema, there was no way to modify the column w/o mutating it — a new instance of the schema would have to be created to reference the newly created table and the column.

https://github.com/doctrine/dbal/pull/7373 unblocks this scenario.

Most of the tests that used methods being deprecated have already been reworked in https://github.com/doctrine/dbal/pull/6945.