### PR TITLE
Remove mutating Column methods and mark the class readonly

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -118,6 +118,26 @@ The following `Column` methods have been removed:
 - `Column::getPlatformOptions()`
 - `Column::hasPlatformOption()`
 
+## BC BREAK: Removed mutating `Column` methods
+
+The following `Column` methods have been removed:
+
+- `Column::setType()`
+- `Column::setLength()`
+- `Column::setPrecision()`
+- `Column::setScale()`
+- `Column::setUnsigned()`
+- `Column::setFixed()`
+- `Column::setNotnull()`
+- `Column::setDefault()`
+- `Column::setPlatformOptions()`
+- `Column::setPlatformOption()`
+- `Column::setColumnDefinition()`
+- `Column::setAutoincrement()`
+- `Column::setComment()`
+- `Column::setValues()`
+- `Column::setOptions()`
+
 ## BC BREAK: Removed support for the `version` column platform option
 
 The `version` column platform option is no longer supported.
@@ -177,6 +197,7 @@ The following classes have been marked as read-only:
 The following classes have been marked as final:
 
 - `StaticServerVersionProvider`
+- `Column`
 - `ColumnDiff`
 - `Table`
 - `TableDiff`

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -5,21 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema;
 
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\DBAL\Schema\Exception\InvalidName;
-use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
-use Doctrine\DBAL\Schema\Name\Parser;
-use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Deprecations\Deprecation;
 
 use function array_merge;
-use function method_exists;
 
 /**
  * Object representation of a database column.
  *
- * @final
  * @extends AbstractNamedObject<UnqualifiedName>
  * @phpstan-type ColumnProperties = array{
  *     name: UnqualifiedName,
@@ -39,317 +32,73 @@ use function method_exists;
  *     enumType?: class-string,
  * }
  */
-class Column extends AbstractNamedObject
+final class Column extends AbstractNamedObject
 {
-    protected Type $_type;
-
-    protected ?int $_length = null;
-
-    protected ?int $_precision = null;
-
-    protected int $_scale = 0;
-
-    protected bool $_unsigned = false;
-
-    protected bool $_fixed = false;
-
-    protected bool $_notnull = true;
-
-    protected mixed $_default = null;
-
-    protected bool $_autoincrement = false;
-
-    /** @var list<string> */
-    protected array $_values = [];
-
-    /** @var PlatformOptions */
-    protected array $_platformOptions = [];
-
-    /** @var ?non-empty-string */
-    protected ?string $_columnDefinition = null;
-
-    protected string $_comment = '';
-
     /**
      * @internal Use {@link Column::editor()} to instantiate an editor and {@link ColumnEditor::create()} to create a
      *           column.
      *
-     * @param array<string, mixed> $options
+     * @param list<string>      $values
+     * @param PlatformOptions   $platformOptions
+     * @param ?non-empty-string $columnDefinition
      */
-    public function __construct(string $name, Type $type, array $options = [])
-    {
-        $parser = Parsers::getUnqualifiedNameParser();
-
-        try {
-            $parsedName = $parser->parse($name);
-        } catch (Parser\Exception $e) {
-            throw InvalidName::fromParserException($name, $e);
-        }
-
-        parent::__construct($parsedName);
-
-        $this->setType($type);
-        $this->setOptions($options);
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} instead.
-     *
-     * @param array<string, mixed> $options
-     */
-    public function setOptions(array $options): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() instead.',
-            __METHOD__,
-        );
-
-        foreach ($options as $name => $value) {
-            $method = 'set' . $name;
-
-            if (! method_exists($this, $method)) {
-                throw UnknownColumnOption::new($name);
-            }
-
-            $this->$method($value);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setType()} or
-     *             {@see ColumnEditor::setTypeName()} instead.
-     */
-    public function setType(Type $type): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setType() or ColumnEditor::setTypeName()'
-                . ' instead.',
-            __METHOD__,
-        );
-
-        $this->_type = $type;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setLength()} instead. */
-    public function setLength(?int $length): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setLength() instead.',
-            __METHOD__,
-        );
-
-        $this->_length = $length;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setPrecision()} instead. */
-    public function setPrecision(?int $precision): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setPrecision() instead.',
-            __METHOD__,
-        );
-
-        $this->_precision = $precision;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setScale()} instead. */
-    public function setScale(int $scale): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setScale() instead.',
-            __METHOD__,
-        );
-
-        $this->_scale = $scale;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setUnsigned()} instead. */
-    public function setUnsigned(bool $unsigned): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setUnsigned() instead.',
-            __METHOD__,
-        );
-
-        $this->_unsigned = $unsigned;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setFixed()} instead. */
-    public function setFixed(bool $fixed): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setFixed() instead.',
-            __METHOD__,
-        );
-
-        $this->_fixed = $fixed;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setNotNull()} instead. */
-    public function setNotnull(bool $notnull): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setNotNull() instead.',
-            __METHOD__,
-        );
-
-        $this->_notnull = $notnull;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setDefaultValue()}
-     *             instead.
-     */
-    public function setDefault(mixed $default): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setDefaultValue() instead.',
-            __METHOD__,
-        );
-
-        $this->_default = $default;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and the option-specific {@see ColumnEditor}
-     *             methods ({@see ColumnEditor::setCharset()}, {@see ColumnEditor::setCollation()},
-     *             {@see ColumnEditor::setMinimumValue()}, {@see ColumnEditor::setMaximumValue()},
-     *             {@see ColumnEditor::setEnumType()}) instead.
-     *
-     * @param PlatformOptions $platformOptions
-     */
-    public function setPlatformOptions(array $platformOptions): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and the option-specific ColumnEditor methods'
-                . ' (setCharset(), setCollation(), setMinimumValue(), setMaximumValue(), setEnumType()) instead.',
-            __METHOD__,
-        );
-
-        $this->_platformOptions = $platformOptions;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and the option-specific {@see ColumnEditor}
-     *             methods ({@see ColumnEditor::setCharset()}, {@see ColumnEditor::setCollation()},
-     *             {@see ColumnEditor::setMinimumValue()}, {@see ColumnEditor::setMaximumValue()},
-     *             {@see ColumnEditor::setEnumType()}) instead.
-     *
-     * @param key-of<PlatformOptions> $name
-     */
-    public function setPlatformOption(string $name, mixed $value): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and the option-specific ColumnEditor methods'
-                . ' (setCharset(), setCollation(), setMinimumValue(), setMaximumValue(), setEnumType()) instead.',
-            __METHOD__,
-        );
-
-        $this->_platformOptions[$name] = $value;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setColumnDefinition()}
-     *             instead.
-     *
-     * @param ?non-empty-string $value
-     */
-    public function setColumnDefinition(?string $value): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setColumnDefinition() instead.',
-            __METHOD__,
-        );
-
-        $this->_columnDefinition = $value;
-
-        return $this;
+    public function __construct(
+        UnqualifiedName $name,
+        private readonly Type $type,
+        private readonly ?int $length,
+        private readonly ?int $precision,
+        private readonly int $scale,
+        private readonly bool $unsigned,
+        private readonly bool $fixed,
+        private readonly bool $notnull,
+        private readonly mixed $default,
+        private readonly bool $autoincrement,
+        private readonly array $values,
+        private readonly array $platformOptions,
+        private readonly ?string $columnDefinition,
+        private readonly string $comment,
+    ) {
+        parent::__construct($name);
     }
 
     public function getType(): Type
     {
-        return $this->_type;
+        return $this->type;
     }
 
     public function getLength(): ?int
     {
-        return $this->_length;
+        return $this->length;
     }
 
     public function getPrecision(): ?int
     {
-        return $this->_precision;
+        return $this->precision;
     }
 
     public function getScale(): int
     {
-        return $this->_scale;
+        return $this->scale;
     }
 
     public function getUnsigned(): bool
     {
-        return $this->_unsigned;
+        return $this->unsigned;
     }
 
     public function getFixed(): bool
     {
-        return $this->_fixed;
+        return $this->fixed;
     }
 
     public function getNotnull(): bool
     {
-        return $this->_notnull;
+        return $this->notnull;
     }
 
     public function getDefault(): mixed
     {
-        return $this->_default;
+        return $this->default;
     }
 
     /**
@@ -359,7 +108,7 @@ class Column extends AbstractNamedObject
      */
     public function getCharset(): ?string
     {
-        return $this->_platformOptions['charset'] ?? null;
+        return $this->platformOptions['charset'] ?? null;
     }
 
     /**
@@ -369,7 +118,7 @@ class Column extends AbstractNamedObject
      */
     public function getCollation(): ?string
     {
-        return $this->_platformOptions['collation'] ?? null;
+        return $this->platformOptions['collation'] ?? null;
     }
 
     /**
@@ -377,7 +126,7 @@ class Column extends AbstractNamedObject
      */
     public function getMinimumValue(): mixed
     {
-        return $this->_platformOptions['min'] ?? null;
+        return $this->platformOptions['min'] ?? null;
     }
 
     /**
@@ -385,7 +134,7 @@ class Column extends AbstractNamedObject
      */
     public function getMaximumValue(): mixed
     {
-        return $this->_platformOptions['max'] ?? null;
+        return $this->platformOptions['max'] ?? null;
     }
 
     /**
@@ -395,7 +144,7 @@ class Column extends AbstractNamedObject
      */
     public function getEnumType(): ?string
     {
-        return $this->_platformOptions['enumType'] ?? null;
+        return $this->platformOptions['enumType'] ?? null;
     }
 
     /**
@@ -407,82 +156,28 @@ class Column extends AbstractNamedObject
      */
     public function getDefaultConstraintName(): ?string
     {
-        return $this->_platformOptions[SQLServerPlatform::OPTION_DEFAULT_CONSTRAINT_NAME] ?? null;
+        return $this->platformOptions[SQLServerPlatform::OPTION_DEFAULT_CONSTRAINT_NAME] ?? null;
     }
 
     public function getColumnDefinition(): ?string
     {
-        return $this->_columnDefinition;
+        return $this->columnDefinition;
     }
 
     public function getAutoincrement(): bool
     {
-        return $this->_autoincrement;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setAutoincrement()}
-     *             instead.
-     */
-    public function setAutoincrement(bool $flag): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setAutoincrement() instead.',
-            __METHOD__,
-        );
-
-        $this->_autoincrement = $flag;
-
-        return $this;
-    }
-
-    /** @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setComment()} instead. */
-    public function setComment(string $comment): self
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setComment() instead.',
-            __METHOD__,
-        );
-
-        $this->_comment = $comment;
-
-        return $this;
+        return $this->autoincrement;
     }
 
     public function getComment(): string
     {
-        return $this->_comment;
-    }
-
-    /**
-     * @deprecated since doctrine/dbal 4.5. Use {@see Column::editor()} and {@see ColumnEditor::setValues()} instead.
-     *
-     * @param list<string> $values
-     *
-     * @return $this
-     */
-    public function setValues(array $values): static
-    {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/7381',
-            '%s is deprecated. Use Column::editor() and ColumnEditor::setValues() instead.',
-            __METHOD__,
-        );
-
-        $this->_values = $values;
-
-        return $this;
+        return $this->comment;
     }
 
     /** @return list<string> */
     public function getValues(): array
     {
-        return $this->_values;
+        return $this->values;
     }
 
     /** @return ColumnProperties */
@@ -490,19 +185,19 @@ class Column extends AbstractNamedObject
     {
         return array_merge([
             'name'             => $this->getObjectName(),
-            'type'             => $this->_type,
-            'default'          => $this->_default,
-            'notnull'          => $this->_notnull,
-            'length'           => $this->_length,
-            'precision'        => $this->_precision,
-            'scale'            => $this->_scale,
-            'fixed'            => $this->_fixed,
-            'unsigned'         => $this->_unsigned,
-            'autoincrement'    => $this->_autoincrement,
-            'columnDefinition' => $this->_columnDefinition,
-            'comment'          => $this->_comment,
-            'values'           => $this->_values,
-        ], $this->_platformOptions);
+            'type'             => $this->type,
+            'default'          => $this->default,
+            'notnull'          => $this->notnull,
+            'length'           => $this->length,
+            'precision'        => $this->precision,
+            'scale'            => $this->scale,
+            'fixed'            => $this->fixed,
+            'unsigned'         => $this->unsigned,
+            'autoincrement'    => $this->autoincrement,
+            'columnDefinition' => $this->columnDefinition,
+            'comment'          => $this->comment,
+            'values'           => $this->values,
+        ], $this->platformOptions);
     }
 
     public static function editor(): ColumnEditor
@@ -514,18 +209,18 @@ class Column extends AbstractNamedObject
     {
         return self::editor()
             ->setName($this->getObjectName())
-            ->setType($this->_type)
-            ->setLength($this->_length)
-            ->setPrecision($this->_precision)
-            ->setScale($this->_scale)
-            ->setUnsigned($this->_unsigned)
-            ->setFixed($this->_fixed)
-            ->setNotNull($this->_notnull)
-            ->setDefaultValue($this->_default)
-            ->setAutoincrement($this->_autoincrement)
-            ->setComment($this->_comment)
-            ->setValues($this->_values)
-            ->setColumnDefinition($this->_columnDefinition)
+            ->setType($this->type)
+            ->setLength($this->length)
+            ->setPrecision($this->precision)
+            ->setScale($this->scale)
+            ->setUnsigned($this->unsigned)
+            ->setFixed($this->fixed)
+            ->setNotNull($this->notnull)
+            ->setDefaultValue($this->default)
+            ->setAutoincrement($this->autoincrement)
+            ->setComment($this->comment)
+            ->setValues($this->values)
+            ->setColumnDefinition($this->columnDefinition)
             ->setCharset($this->getCharset())
             ->setCollation($this->getCollation())
             ->setMinimumValue($this->getMinimumValue())

--- a/src/Schema/ColumnEditor.php
+++ b/src/Schema/ColumnEditor.php
@@ -265,22 +265,20 @@ final class ColumnEditor
         }
 
         return new Column(
-            $this->name->toString(),
+            $this->name,
             $this->type,
-            [
-                'length' => $this->length,
-                'precision' => $this->precision,
-                'scale' => $this->scale,
-                'unsigned' => $this->unsigned,
-                'fixed' => $this->fixed,
-                'notnull' => $this->notNull,
-                'default' => $this->defaultValue,
-                'autoincrement' => $this->autoincrement,
-                'comment' => $this->comment,
-                'values' => $this->values,
-                'platformOptions' => $platformOptions,
-                'columnDefinition' => $this->columnDefinition,
-            ],
+            $this->length,
+            $this->precision,
+            $this->scale,
+            $this->unsigned,
+            $this->fixed,
+            $this->notNull,
+            $this->defaultValue,
+            $this->autoincrement,
+            $this->values,
+            $platformOptions,
+            $this->columnDefinition,
+            $this->comment,
         );
     }
 }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectAlreadyExists;
 use Doctrine\DBAL\Schema\Collections\Exception\ObjectDoesNotExist;
 use Doctrine\DBAL\Schema\Collections\OptionallyUnqualifiedNamedObjectSet;
@@ -19,6 +20,7 @@ use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Exception\InvalidTableModification;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
@@ -29,7 +31,6 @@ use Doctrine\DBAL\Schema\Name\Parser;
 use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Exception\TypesException;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
 
@@ -282,7 +283,15 @@ final class Table extends AbstractNamedObject
      */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {
-        $column = new Column($name, Type::getType($typeName), $options);
+        $parsedName = $this->parseUnqualifiedName($name);
+
+        $editor = Column::editor()
+            ->setName($parsedName)
+            ->setTypeName($typeName);
+
+        $this->applyColumnOptionsToEditor($editor, $options);
+
+        $column = $editor->create();
 
         $this->_addColumn($column);
 
@@ -318,11 +327,9 @@ final class Table extends AbstractNamedObject
         }
 
         $oldColumn = $this->getColumn($oldName);
-        $options   = $oldColumn->toArray();
-
-        unset($options['name'], $options['type']);
-
-        $newColumn = new Column($parsedNewName->toString(), $oldColumn->getType(), $options);
+        $newColumn = $oldColumn->edit()
+            ->setName($parsedNewName)
+            ->create();
 
         $this->columns->remove($parsedOldName);
         $this->_addColumn($newColumn);
@@ -348,10 +355,58 @@ final class Table extends AbstractNamedObject
     /** @param array<string, mixed> $options */
     public function modifyColumn(string $name, array $options): self
     {
-        $column = $this->getColumn($name);
-        $column->setOptions($options);
+        $oldColumn = $this->getColumn($name);
+
+        $editor = $oldColumn->edit();
+        $this->applyColumnOptionsToEditor($editor, $options);
+        $newColumn = $editor->create();
+
+        $this->columns->modify(
+            $oldColumn->getObjectName(),
+            static fn (): Column => $newColumn,
+        );
 
         return $this;
+    }
+
+    /** @param array<string, mixed> $options */
+    private function applyColumnOptionsToEditor(ColumnEditor $editor, array $options): void
+    {
+        foreach ($options as $name => $value) {
+            match ($name) {
+                'type'             => $editor->setType($value),
+                'length'           => $editor->setLength($value),
+                'precision'        => $editor->setPrecision($value),
+                'scale'            => $editor->setScale($value),
+                'unsigned'         => $editor->setUnsigned($value),
+                'fixed'            => $editor->setFixed($value),
+                'notnull'          => $editor->setNotNull($value),
+                'default'          => $editor->setDefaultValue($value),
+                'autoincrement'    => $editor->setAutoincrement($value),
+                'values'           => $editor->setValues($value),
+                'comment'          => $editor->setComment($value),
+                'columnDefinition' => $editor->setColumnDefinition($value),
+                'platformOptions'  => $this->applyPlatformOptionsToEditor($editor, $value),
+                default            => throw UnknownColumnOption::new($name),
+            };
+        }
+    }
+
+    /** @param array<string, mixed> $platformOptions */
+    private function applyPlatformOptionsToEditor(ColumnEditor $editor, array $platformOptions): void
+    {
+        foreach ($platformOptions as $name => $value) {
+            match ($name) {
+                'charset'   => $editor->setCharset($value),
+                'collation' => $editor->setCollation($value),
+                'min'       => $editor->setMinimumValue($value),
+                'max'       => $editor->setMaximumValue($value),
+                'enumType'  => $editor->setEnumType($value),
+                SQLServerPlatform::OPTION_DEFAULT_CONSTRAINT_NAME
+                            => $editor->setDefaultConstraintName($value),
+                default     => throw UnknownColumnOption::new($name),
+            };
+        }
     }
 
     /**

--- a/tests/Functional/Platform/RenameColumnTest.php
+++ b/tests/Functional/Platform/RenameColumnTest.php
@@ -116,9 +116,11 @@ class RenameColumnTest extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         // Force a different type to make sure it's not being caught implicitly
-        $table->renameColumn($oldColumnName, $newColumnName)
-            ->setType(Type::getType(Types::BIGINT))
-            ->setLength(32);
+        $table->renameColumn($oldColumnName, $newColumnName);
+        $table->modifyColumn($newColumnName, [
+            'type'   => Type::getType(Types::BIGINT),
+            'length' => 32,
+        ]);
 
         $sm   = $this->connection->createSchemaManager();
         $diff = $sm->createComparator()

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -97,16 +97,19 @@ class ComparatorTest extends FunctionalTestCase
             ->create();
 
         $onlineTable = clone $table;
-        $table->renameColumn('test', 'baz')
-            ->setLength(40)
-            ->setComment('Comment');
+        $table->renameColumn('test', 'baz');
+        $table->modifyColumn('baz', [
+            'length'  => 40,
+            'comment' => 'Comment',
+        ]);
 
         $table->renameColumn('test2', 'foo');
 
-        $table->getColumn('test3')
-            ->setAutoincrement(true)
-            ->setNotnull(false)
-            ->setType(Type::getType(Types::BIGINT));
+        $table->modifyColumn('test3', [
+            'autoincrement' => true,
+            'notnull'       => false,
+            'type'          => Type::getType(Types::BIGINT),
+        ]);
 
         $compareResult  = $comparator->compareTables($onlineTable, $table);
         $renamedColumns = RenameColumnTest::getRenamedColumns($compareResult);

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Sequence;
@@ -15,7 +16,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Generator;
 use Override;
@@ -394,22 +394,32 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
     }
 
     /**
-     * @param array{platformOptions?: PlatformOptions} $oldOptions
-     * @param array{platformOptions?: PlatformOptions} $newOptions
-     * @param ?non-empty-string                        $newType
-     * @param list<string>                             $expectedSql
+     * @param callable(ColumnEditor): void $initializeOldColumn
+     * @param callable(ColumnEditor): void $initializeNewColumn
+     * @param list<string>                 $expectedSql
      */
     #[DataProvider('provideAlterColumnCollation')]
     public function testAlterColumnCollation(
-        array $oldOptions,
-        array $newOptions,
-        ?string $newType,
+        callable $initializeOldColumn,
+        callable $initializeNewColumn,
         array $expectedSql,
     ): void {
-        $table = new Table('mytable');
+        $oldColumnEditor = Column::editor()
+            ->setUnquotedName('foo')
+            ->setTypeName(Types::STRING);
+        $initializeOldColumn($oldColumnEditor);
+        $oldColumn = $oldColumnEditor->create();
 
-        $oldColumn = $table->addColumn('foo', Types::STRING, $oldOptions);
-        $newColumn = new Column('foo', Type::getType($newType ?? Types::STRING), $newOptions);
+        $newColumnEditor = Column::editor()
+            ->setUnquotedName('foo')
+            ->setTypeName(Types::STRING);
+        $initializeNewColumn($newColumnEditor);
+        $newColumn = $newColumnEditor->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('mytable')
+            ->addColumn($oldColumn)
+            ->create();
 
         $tableDiff = new TableDiff($table, changedColumns: [
             'foo' => new ColumnDiff(
@@ -425,71 +435,86 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
 
     /**
      * @return iterable<string, array{
-     *     array{platformOptions?: PlatformOptions},
-     *     array{platformOptions?: PlatformOptions},
-     *     ?string,
+     *     callable(ColumnEditor): void,
+     *     callable(ColumnEditor): void,
      *     list<string>
      * }>
      */
     public static function provideAlterColumnCollation(): iterable
     {
-        $default  = ['platformOptions' => ['collation' => 'default']];
-        $unicode  = ['platformOptions' => ['collation' => 'unicode']];
-        $ucsBasic = ['platformOptions' => ['collation' => 'ucs_basic']];
-
         yield 'implicit default to implicit default' => [
-            [],
-            [],
-            null,
+            static function (ColumnEditor $editor): void {
+            },
+            static function (ColumnEditor $editor): void {
+            },
             [],
         ];
 
         yield 'implicit default to explicit default' => [
-            [],
-            $default,
-            null,
+            static function (ColumnEditor $editor): void {
+            },
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('default');
+            },
             [],
         ];
 
         yield 'implicit default to unicode' => [
-            [],
-            $unicode,
-            null,
+            static function (ColumnEditor $editor): void {
+            },
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('unicode');
+            },
             ['ALTER TABLE "mytable" ALTER "foo" TYPE VARCHAR COLLATE "unicode"'],
         ];
 
         yield 'unicode to implicit default' => [
-            $unicode,
-            [],
-            null,
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('unicode');
+            },
+            static function (ColumnEditor $editor): void {
+            },
             ['ALTER TABLE "mytable" ALTER "foo" TYPE VARCHAR COLLATE "default"'],
         ];
 
         yield 'unicode to explicit default' => [
-            $unicode,
-            $default,
-            null,
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('unicode');
+            },
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('default');
+            },
             ['ALTER TABLE "mytable" ALTER "foo" TYPE VARCHAR COLLATE "default"'],
         ];
 
         yield 'unicode to ucs_basic' => [
-            $unicode,
-            $ucsBasic,
-            null,
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('unicode');
+            },
+            static function (ColumnEditor $editor): void {
+                $editor->setCollation('ucs_basic');
+            },
             ['ALTER TABLE "mytable" ALTER "foo" TYPE VARCHAR COLLATE "ucs_basic"'],
         ];
 
         yield 'collated string to non-collatable type' => [
-            [],
-            [],
-            Types::INTEGER,
+            static function (ColumnEditor $editor): void {
+            },
+            static function (ColumnEditor $editor): void {
+                $editor->setTypeName(Types::INTEGER);
+            },
             ['ALTER TABLE "mytable" ALTER "foo" TYPE INT'],
         ];
 
         yield 'length change preserves non-default collation' => [
-            ['length' => 50, 'platformOptions' => ['collation' => 'C']],
-            ['length' => 100, 'platformOptions' => ['collation' => 'C']],
-            null,
+            static function (ColumnEditor $editor): void {
+                $editor->setLength(50)
+                    ->setCollation('C');
+            },
+            static function (ColumnEditor $editor): void {
+                $editor->setLength(100)
+                    ->setCollation('C');
+            },
             ['ALTER TABLE "mytable" ALTER "foo" TYPE VARCHAR(100) COLLATE "C"'],
         ];
     }

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -9,8 +9,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\Exception\InvalidName;
-use Doctrine\DBAL\Schema\Exception\UnknownColumnOption;
+use Doctrine\DBAL\Schema\Exception\InvalidIdentifier;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Types\Type;
@@ -60,26 +59,6 @@ class ColumnTest extends TestCase
         ];
 
         self::assertEquals($expected, $this->createColumn()->toArray());
-    }
-
-    public function testSettingUnknownOptionIsStillSupported(): void
-    {
-        $this->expectException(UnknownColumnOption::class);
-        $this->expectExceptionMessage('The "unknown_option" column option is not supported.');
-
-        new Column('foo', self::createStub(Type::class), ['unknown_option' => 'bar']);
-    }
-
-    public function testOptionsShouldNotBeIgnored(): void
-    {
-        $this->expectException(UnknownColumnOption::class);
-        $this->expectExceptionMessage('The "unknown_option" column option is not supported.');
-
-        $col1 = new Column('bar', Type::getType(Types::INTEGER), ['unknown_option' => 'bar', 'notnull' => true]);
-        self::assertTrue($col1->getNotnull());
-
-        $col2 = new Column('bar', Type::getType(Types::INTEGER), ['unknown_option' => 'bar', 'notnull' => false]);
-        self::assertFalse($col2->getNotnull());
     }
 
     public function createColumn(): Column
@@ -145,18 +124,10 @@ class ColumnTest extends TestCase
     /** @throws Exception */
     public function testEmptyName(): void
     {
-        $this->expectException(InvalidName::class);
-
-        new Column('', Type::getType(Types::INTEGER));
-    }
-
-    /** @throws Exception */
-    public function testQualifiedName(): void
-    {
-        $this->expectException(InvalidName::class);
+        $this->expectException(InvalidIdentifier::class);
 
         Column::editor()
-            ->setUnquotedName('t.id')
+            ->setUnquotedName('') /** @phpstan-ignore argument.type */
             ->setType(Type::getType(Types::INTEGER))
             ->create();
     }

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -100,8 +100,7 @@ class TableTest extends TestCase
 
     public function testRenameColumn(): void
     {
-        $typeTxt = Type::getType(Types::TEXT);
-        $table   = Table::editor()
+        $table = Table::editor()
             ->setUnquotedName('foo')
             ->setColumns(
                 Column::editor()
@@ -114,8 +113,7 @@ class TableTest extends TestCase
         self::assertFalse($table->hasColumn('bar'));
         self::assertTrue($table->hasColumn('foo'));
 
-        $column = $table->renameColumn('foo', 'bar');
-        $column->setType($typeTxt);
+        $table->renameColumn('foo', 'bar');
         self::assertTrue($table->hasColumn('bar'), 'Should now have bar column');
         self::assertFalse($table->hasColumn('foo'), 'Should not have foo column anymore');
         self::assertCount(1, $table->getColumns());


### PR DESCRIPTION
The methods being removed were deprecated in https://github.com/doctrine/dbal/pull/7381.

This PR introduces a temporary translation layer from `array<string, mixed> $options` to the `SchemaEditor` API used by `Table::addColumn()` and `Table::modifyColumn()`. Both methods mutate the table and will be deprecated in a subsequent PR in favor of the `TableEditor` API.