### PR TITLE
Add index auto-naming to the table editor

### DIFF
--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -139,8 +139,49 @@ final class IndexEditor
             throw InvalidIndexDefinition::nameNotSet();
         }
 
+        [$columnNames, $flags, $options] = $this->toIndexParameters($this->name);
+
+        return new Index(
+            $this->name->toString(),
+            $columnNames,
+            $this->type === IndexType::UNIQUE,
+            false,
+            $flags,
+            $options,
+        );
+    }
+
+    /**
+     * Adds the index described by this editor to the given table, generating its name from the table when no name is
+     * set.
+     *
+     * @internal Used by {@link TableEditor} to add an editor-described index to a table.
+     */
+    public function addToTable(Table $table): void
+    {
+        [$columnNames, $flags, $options] = $this->toIndexParameters($this->name ?? UnqualifiedName::unquoted('index'));
+
+        $indexName = $this->name?->toString();
+
+        if ($this->type === IndexType::UNIQUE) {
+            $table->addUniqueIndex($columnNames, $indexName, $options);
+
+            return;
+        }
+
+        $table->addIndex($columnNames, $indexName, $flags, $options);
+    }
+
+    /**
+     * Maps the editor's columns, flags, and options to the arguments the {@see Index} constructor and the
+     * {@see Table} index methods expect.
+     *
+     * @return array{non-empty-list<string>, list<string>, array<string, mixed>} the column names, flags, and options
+     */
+    private function toIndexParameters(UnqualifiedName $name): array
+    {
         if (count($this->columns) < 1) {
-            throw InvalidIndexDefinition::columnsNotSet($this->name);
+            throw InvalidIndexDefinition::columnsNotSet($name);
         }
 
         $columnNames = $lengths = $options = $flags = [];
@@ -173,13 +214,6 @@ final class IndexEditor
             $options['where'] = $this->predicate;
         }
 
-        return new Index(
-            $this->name->toString(),
-            $columnNames,
-            $this->type === IndexType::UNIQUE,
-            false,
-            $flags,
-            $options,
-        );
+        return [$columnNames, $flags, $options];
     }
 }

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -25,6 +25,9 @@ final class TableEditor
     /** @var UnqualifiedNamedObjectSet<Index> */
     private UnqualifiedNamedObjectSet $indexes;
 
+    /** @var list<IndexEditor> */
+    private array $indexEditors = [];
+
     private ?PrimaryKeyConstraint $primaryKeyConstraint = null;
 
     /** @var OptionallyUnqualifiedNamedObjectSet<UniqueConstraint> */
@@ -325,9 +328,11 @@ final class TableEditor
         return $this->dropColumn(UnqualifiedName::unquoted($columnName));
     }
 
-    public function setIndexes(Index ...$indexes): self
+    /** Replaces the indexes, accepting {@see Index} objects and editors alike, as {@see addIndex()}. */
+    public function setIndexes(Index|IndexEditor ...$indexes): self
     {
         $this->indexes->clear();
+        $this->indexEditors = [];
 
         foreach ($indexes as $index) {
             $this->addIndex($index);
@@ -336,8 +341,18 @@ final class TableEditor
         return $this;
     }
 
-    public function addIndex(Index $index): self
+    /**
+     * Adds an index. An {@see Index} is added as is; an {@see IndexEditor} without a name produces an index whose
+     * name is generated from this table and the indexed columns.
+     */
+    public function addIndex(Index|IndexEditor $index): self
     {
+        if ($index instanceof IndexEditor) {
+            $this->indexEditors[] = $index;
+
+            return $this;
+        }
+
         try {
             $this->indexes->add($index);
         } catch (ObjectAlreadyExists $e) {
@@ -547,7 +562,7 @@ final class TableEditor
             $options['comment'] = $this->comment;
         }
 
-        return new Table(
+        $table = new Table(
             $this->name->toString(),
             $this->columns->toList(),
             $this->indexes->toList(),
@@ -557,5 +572,11 @@ final class TableEditor
             $this->configuration,
             $this->primaryKeyConstraint,
         );
+
+        foreach ($this->indexEditors as $indexEditor) {
+            $indexEditor->addToTable($table);
+        }
+
+        return $table;
     }
 }

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -184,9 +186,12 @@ class ExceptionTest extends FunctionalTestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('id'),
+            )
             ->create();
-
-        $table->addUniqueIndex(['id']);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Functional/Platform/OtherSchemaTest.php
+++ b/tests/Functional/Platform/OtherSchemaTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional\Platform;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Tools\DsnParser;
@@ -31,9 +32,11 @@ class OtherSchemaTest extends FunctionalTestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('id'),
+            )
             ->create();
-
-        $table->addIndex(['id']);
 
         $this->dropAndCreateTable($table);
         $this->connection->insert('other.test_other_schema', ['id' => 1]);

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1392,9 +1392,11 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
                     ->setUnquotedReferencedColumnNames('id')
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('bar'),
+            )
             ->create();
-
-        $table->addIndex(['bar']);
 
         $this->dropAndCreateTable($table);
 

--- a/tests/Platforms/AbstractMySQLPlatformTestCase.php
+++ b/tests/Platforms/AbstractMySQLPlatformTestCase.php
@@ -171,9 +171,12 @@ abstract class AbstractMySQLPlatformTestCase extends AbstractPlatformTestCase
                     ->setUnquotedColumnNames('bar')
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('baz'),
+            )
             ->create();
-
-        $keyTable->addUniqueIndex(['baz']);
 
         $diff = $this->createComparator()
             ->compareTables($oldTable, $keyTable);

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\DefaultExpression\CurrentDate;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -192,9 +193,12 @@ abstract class AbstractPlatformTestCase extends TestCase
                     ->setNotNull(false)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('foo', 'bar'),
+            )
             ->create();
-
-        $table->addUniqueIndex(['foo', 'bar']);
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals($this->getGenerateTableWithMultiColumnUniqueIndexSql(), $sql);
@@ -425,9 +429,11 @@ abstract class AbstractPlatformTestCase extends TestCase
                     ->setLength(255)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('create'),
+            )
             ->create();
-
-        $table->addIndex(['create']);
 
         $sql = $this->platform->getCreateTableSQL($table);
         self::assertEquals($this->getQuotedColumnInIndexSQL(), $sql);

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -135,10 +135,16 @@ class DB2PlatformTest extends AbstractPlatformTestCase
                     ->setUnquotedColumnNames('id')
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('name'),
+            )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('composite_idx')
+                    ->setUnquotedColumnNames('id', 'name'),
+            )
             ->create();
-
-        $table->addIndex(['name']);
-        $table->addIndex(['id', 'name'], 'composite_idx');
 
         self::assertEquals(
             [

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -763,6 +763,63 @@ class TableTest extends TestCase
         self::assertCount(1, $table->getIndexes());
     }
 
+    public function testAddIndexViaEditorGeneratesSameNamesAsMutators(): void
+    {
+        $columns = [
+            Column::editor()
+                ->setUnquotedName('a')
+                ->setTypeName(Types::INTEGER)
+                ->create(),
+            Column::editor()
+                ->setUnquotedName('b')
+                ->setTypeName(Types::INTEGER)
+                ->create(),
+        ];
+
+        $viaEditor = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(...$columns)
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('a', 'b'),
+            )
+            ->addIndex(
+                Index::editor()
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('a', 'b'),
+            )
+            ->create();
+
+        $viaMutators = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(...$columns)
+            ->create();
+        $viaMutators->addIndex(['a', 'b']);
+        $viaMutators->addUniqueIndex(['a', 'b']);
+
+        self::assertEquals($viaMutators->getIndexes(), $viaEditor->getIndexes());
+    }
+
+    public function testAddIndexEditorWithExplicitNameKeepsIt(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('a')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('my_idx')
+                    ->setUnquotedColumnNames('a'),
+            )
+            ->create();
+
+        self::assertTrue($table->hasIndex('my_idx'));
+    }
+
     public function testAddForeignKeyIndexImplicitly(): void
     {
         $table = Table::editor()


### PR DESCRIPTION
## Problem

Currently, the combination of `TableEditor` and `IndexEditor` doesn't allow adding unnamed indexes. The thing is:

1. `TableEditor::addIndex()` expects an `Index` instance.
2. `Index` needs a name; an unnamed index is not representable by design.
3. `IndexEditor` cannot generate the name automatically because, besides column names and index type, it depends on the name and configuration of the table to which this index will be added.

This is one of a couple of gaps in the upgrade path from mutating `Table` to using `TableEditor`.

## Solution

1. Have `TableEditor::addIndex()` and `setIndexes()` accept `Index|IndexEditor`.
2. Add an internal `IndexEditor::addToTable(Table $table)` method that generates the name in the context of a table and adds the index to the table.

This way, the DBAL API consumer will be able to pass a partially configured `IndexEditor` to `TableEditor`, and the two editors will collaborate to auto-generate the index name.

## Upgrade path

1. On `4.5.x`, `IndexEditor::addToTable()` will delegate to the existing mutating methods, which generate the name using the existing code.
2. On `5.0.x`, `IndexEditor::addToTable()` will be replaced with another internal method, `IndexEditor::createForTable(Identifier $tableName, int $maxIdentifierLength)`. Additionally, the logic of generating the index name will naturally move from `Table` to `IndexEditor`. The combined behavior will remain the same, except that there will be no mutation.

## Documentation

Existing documentation doesn't cover adding unnamed indexes, and I don't want to cover it (this feature is sloppy and shouldn't be promoted). The upgrade path will be documented in `UPGRADE.md` alongside the deprecation.

## Future scope

The precedent of expanding `<T>Editor::add<E>()` method signatures from accepting `<E>` to accepting `<E>|<E>Editor` can technically be applied to all other editors — it would spare the consumer a call to `->create()`. I'm not actively for or against it; it can be done separately any time, so I'm not doing it now.
