### PR TITLE
Mark named object base classes as internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Marked `AbstractNamedObject` and `AbstractOptionallyNamedObject` classes as internal
+
+The `AbstractNamedObject` and `AbstractOptionallyNamedObject` classes have been marked as internal. Use the
+`NamedObject` and `OptionallyNamedObject` interfaces instead.
+
 ## Deprecated `Schema` features
 
 The `Schema` constructor has been marked as internal. Use `Schema::editor()` to instantiate an editor and

--- a/src/Schema/AbstractNamedObject.php
+++ b/src/Schema/AbstractNamedObject.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Schema\Exception\InvalidState;
 /**
  * An abstract {@see NamedObject}.
  *
+ * @internal since doctrine/dbal 4.5, use {@see NamedObject} instead.
+ *
  * @template N of Name
  * @extends AbstractAsset<N>
  * @implements NamedObject<N>

--- a/src/Schema/AbstractOptionallyNamedObject.php
+++ b/src/Schema/AbstractOptionallyNamedObject.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Schema\Exception\InvalidState;
 /**
  * An abstract {@see OptionallyNamedObject}.
  *
+ * @internal since doctrine/dbal 4.5, use {@see OptionallyNamedObject} instead.
+ *
  * @template N of Name
  * @extends AbstractAsset<N>
  * @implements OptionallyNamedObject<N>


### PR DESCRIPTION
`AbstractNamedObject` and `AbstractOptionallyNamedObject` are the base classes of the named schema objects (`Table`, `Column`, `Index`, etc.) and the optionally named ones (constraints). On `4.5.x` they carry the common name handling that the concrete classes inherit from `AbstractAsset`. On `5.0.x`, once `AbstractAsset` is out of the chain, each of them shrinks to a name property and a one-line getter.

They don't expose any public API beyond the `NamedObject` and `OptionallyNamedObject` interfaces, they are not meant to be extended by users and should have been marked as internal since the beginning.

So since they are almost empty on `5.0.x` ([1](https://github.com/doctrine/dbal/blob/5.0.x/src/Schema/AbstractNamedObject.php), [2](https://github.com/doctrine/dbal/blob/5.0.x/src/Schema/AbstractOptionallyNamedObject.php)), there is no reason to keep them.
