### PR TITLE
Track renamed columns in the table editor

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -47,7 +47,7 @@ class Table extends AbstractNamedObject
     protected array $_columns = [];
 
     /** @var array<string, string> keys are new names, values are old names */
-    protected array $renamedColumns = [];
+    protected array $renamedColumns;
 
     /** @var Index[] */
     protected array $_indexes = [];
@@ -90,6 +90,7 @@ class Table extends AbstractNamedObject
      * @param array<UniqueConstraint>     $uniqueConstraints
      * @param array<ForeignKeyConstraint> $fkConstraints
      * @param array<string, mixed>        $options
+     * @param array<string, string>       $renamedColumns
      */
     public function __construct(
         string $name,
@@ -100,6 +101,7 @@ class Table extends AbstractNamedObject
         array $options = [],
         ?TableConfiguration $configuration = null,
         ?PrimaryKeyConstraint $primaryKeyConstraint = null,
+        array $renamedColumns = [],
     ) {
         if ($name === '') {
             throw InvalidTableName::new($name);
@@ -132,6 +134,8 @@ class Table extends AbstractNamedObject
         }
 
         $this->_options = array_merge($this->_options, $options);
+
+        $this->renamedColumns = $renamedColumns;
     }
 
     protected function getNameParser(): OptionallyQualifiedNameParser

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 
 use function strcasecmp;
+use function strtolower;
 
 final class TableEditor
 {
@@ -21,6 +22,9 @@ final class TableEditor
 
     /** @var UnqualifiedNamedObjectSet<Column> */
     private readonly UnqualifiedNamedObjectSet $columns;
+
+    /** @var array<string, string> keys are new names, values are old names */
+    private array $renamedColumns = [];
 
     /** @var UnqualifiedNamedObjectSet<Index> */
     private UnqualifiedNamedObjectSet $indexes;
@@ -140,6 +144,10 @@ final class TableEditor
         return $this->modifyColumn(UnqualifiedName::unquoted($columnName), $modification);
     }
 
+    /**
+     * Renames a column and records it in {@see Table::getRenamedColumns()} of the resulting table. The record spans
+     * only this edit: a table derived from the result does not inherit it.
+     */
     public function renameColumn(UnqualifiedName $oldColumnName, UnqualifiedName $newColumnName): self
     {
         $this->modifyColumn($oldColumnName, static function (ColumnEditor $editor) use ($newColumnName): void {
@@ -150,6 +158,19 @@ final class TableEditor
         $this->renameColumnInPrimaryKeyConstraint($oldColumnName, $newColumnName);
         $this->renameColumnInForeignKeyConstraints($oldColumnName, $newColumnName);
         $this->renameColumnInUniqueConstraints($oldColumnName, $newColumnName);
+
+        $oldKey = $this->getColumnKey($oldColumnName);
+        $newKey = $this->getColumnKey($newColumnName);
+
+        // If a column is renamed multiple times, only the original and the last new name are kept.
+        if (isset($this->renamedColumns[$oldKey])) {
+            $oldKey = $this->renamedColumns[$oldKey];
+            unset($this->renamedColumns[$this->getColumnKey($oldColumnName)]);
+        }
+
+        if ($newKey !== $oldKey) {
+            $this->renamedColumns[$newKey] = $oldKey;
+        }
 
         return $this;
     }
@@ -509,6 +530,11 @@ final class TableEditor
         return strcasecmp($name1->getIdentifier()->getValue(), $name2->getIdentifier()->getValue()) === 0;
     }
 
+    private function getColumnKey(UnqualifiedName $name): string
+    {
+        return strtolower($name->getIdentifier()->getValue());
+    }
+
     public function setComment(string $comment): self
     {
         $this->comment = $comment;
@@ -556,6 +582,7 @@ final class TableEditor
             $options,
             $this->configuration,
             $this->primaryKeyConstraint,
+            $this->renamedColumns,
         );
     }
 }

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -197,6 +197,8 @@ class TableEditorTest extends TestCase
                 ->create(),
             $table->getPrimaryKeyConstraint(),
         );
+
+        self::assertEquals(['user_name' => 'username'], $table->getRenamedColumns());
     }
 
     public function testRenameColumnToExistingName(): void

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -124,6 +124,41 @@ class TableTest extends TestCase
         self::assertCount(1, $table->getColumns());
     }
 
+    public function testRenameColumnThroughEditor(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('foo')
+                    ->setTypeName(Types::STRING)
+                    ->create(),
+            )
+            ->create();
+
+        $table = $table->edit()
+            ->renameColumnByUnquotedName('foo', 'bar')
+            ->create();
+
+        self::assertTrue($table->hasColumn('bar'), 'Should now have bar column');
+        self::assertFalse($table->hasColumn('foo'), 'Should not have foo column anymore');
+        self::assertCount(1, $table->getColumns());
+        self::assertEquals(['bar' => 'foo'], $table->getRenamedColumns());
+
+        $table = $table->edit()
+            ->renameColumnByUnquotedName('bar', 'baz')
+            ->create();
+
+        self::assertTrue($table->hasColumn('baz'), 'Should now have baz column');
+        self::assertFalse($table->hasColumn('bar'), 'Should not have bar column anymore');
+
+        // The result of multiple consecutive edit-rename-column-and-create operations is different from
+        // Table::renameColumn(): each edit records the rename relative to the table it started from, so the renames
+        // do not chain across edits.
+        self::assertEquals(['baz' => 'bar'], $table->getRenamedColumns());
+        self::assertCount(1, $table->getColumns());
+    }
+
     public function testRenameColumnException(): void
     {
         $table = Table::editor()
@@ -157,6 +192,27 @@ class TableTest extends TestCase
         $table->renameColumn('baz', '`foo`');
         self::assertCount(1, $table->getRenamedColumns());
         $table->renameColumn('foo', 'Baz');
+        self::assertCount(1, $table->getColumns());
+        self::assertCount(0, $table->getRenamedColumns());
+    }
+
+    public function testRenameColumnLoopThroughEditor(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('baz')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $table = $table->edit()
+            ->renameColumnByUnquotedName('baz', 'foo')
+            ->renameColumnByUnquotedName('foo', 'Baz')
+            ->create();
+
         self::assertCount(1, $table->getColumns());
         self::assertCount(0, $table->getRenamedColumns());
     }


### PR DESCRIPTION
As of https://github.com/doctrine/dbal/pull/6280, `Table` keeps track of the columns renamed via `Table::renameColumn()` and exposes the state of renames via `Table::getRenamedColumns()`. This design is quite unfortunate: a `Table` should represent _table schema_, not table schema _migrations_. At the time of introduction, this feature was innocent, but now it's in direct conflict with the initiative to make schema objects immutable. An immutable object cannot and should not keep track of its mutations.

In order to provide an upgrade path towards using `TableEditor` across the board, we have to add support for tracking column renames in the immutable version of this API.

What this PR does:
1. `TableEditor` keeps track of column renames and passes the result to the `Table` constructor at creation time.
2. `Table` exposes them via the same `Table::getRenamedColumns()` method.

## Behavior across edits

`Comparator::compareTables()` reads `getRenamedColumns()` of the new table to detect renames. The record is scoped to a single edit. The editor records each rename relative to the table the edit started from, which is exactly what the comparator needs: you `edit()` the old table, rename, create, and compare the result against the old one. A table derived from the result via a further `edit()` does not inherit the record, so renames don't chain across edits. This differs from the mutating `Table::renameColumn()`, which accumulates renames on the same object.

## Future scope

Once I finalize the changes around object names, and the ORM migrates to using the new API, I'd like to introduce a proper API for expressing schema migrations. The DDL built to represent the migration will be derived from explicit steps (e.g. rename column) rather than guessing operations from a static schema diff.
