### PR TITLE
Deprecate table mutators

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -51,6 +51,30 @@ method instead:
 - `Column::setComment()` - use `ColumnEditor::setComment()`.
 - `Column::setValues()` - use `ColumnEditor::setValues()`.
 
+## Deprecated `Table` features
+
+The `Table` constructor has been marked as internal. Use `Table::editor()` to instantiate an editor and
+`TableEditor::create()` to create a table.
+
+The following `Table` mutators have been deprecated. Use `Table::edit()` and the corresponding `TableEditor` method
+instead:
+
+- `Table::addColumn()` - use `TableEditor::addColumn()`.
+- `Table::renameColumn()` - use `TableEditor::renameColumn()`.
+- `Table::modifyColumn()` - use `TableEditor::modifyColumn()`.
+- `Table::dropColumn()` - use `TableEditor::dropColumn()`.
+- `Table::addIndex()` and `Table::addUniqueIndex()` - use `TableEditor::addIndex()`.
+- `Table::renameIndex()` - use `TableEditor::renameIndex()`.
+- `Table::dropIndex()` - use `TableEditor::dropIndex()`.
+- `Table::addPrimaryKeyConstraint()` - use `TableEditor::addPrimaryKeyConstraint()`.
+- `Table::dropPrimaryKey()` - use `TableEditor::dropPrimaryKeyConstraint()`.
+- `Table::addUniqueConstraint()` - use `TableEditor::addUniqueConstraint()`.
+- `Table::dropUniqueConstraint()` - use `TableEditor::dropUniqueConstraint()`.
+- `Table::addForeignKeyConstraint()` - use `TableEditor::addForeignKeyConstraint()`.
+- `Table::dropForeignKey()` - use `TableEditor::dropForeignKeyConstraint()`.
+- `Table::addOption()` - use `TableEditor::setOptions()`.
+- `Table::setComment()` - use `TableEditor::setComment()`.
+
 ## Deprecated `TableDiff::getRenamedIndexes()`
 
 The `TableDiff::getRenamedIndexes()` method has been deprecated. Use `TableDiff::getIndexRenames()` instead, which

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -85,6 +85,9 @@ class Table extends AbstractNamedObject
     private bool $failedToParsePrimaryKeyConstraint = false;
 
     /**
+     * @internal since doctrine/dbal 4.5. Use {@link Table::editor()} to instantiate an editor and
+     *           {@link TableEditor::create()} to create a table.
+     *
      * @param array<Column>               $columns
      * @param array<Index>                $indexes
      * @param array<UniqueConstraint>     $uniqueConstraints
@@ -199,8 +202,16 @@ class Table extends AbstractNamedObject
         return $this;
     }
 
+    /** @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::addPrimaryKeyConstraint()} instead. */
     public function addPrimaryKeyConstraint(PrimaryKeyConstraint $primaryKeyConstraint): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::addPrimaryKeyConstraint() instead.',
+            __METHOD__,
+        );
+
         $this->setPrimaryKey(
             array_map(
                 static fn (UnqualifiedName $columnName): string => $columnName->toString(),
@@ -222,6 +233,8 @@ class Table extends AbstractNamedObject
     }
 
     /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::addUniqueConstraint()} instead.
+     *
      * @param non-empty-list<string> $columnNames
      * @param array<int, string>     $flags
      * @param array<string, mixed>   $options
@@ -232,6 +245,13 @@ class Table extends AbstractNamedObject
         array $flags = [],
         array $options = [],
     ): self {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::addUniqueConstraint() instead.',
+            __METHOD__,
+        );
+
         $indexName ??= $this->_generateIdentifierName(
             array_merge([$this->getName()], $columnNames),
             'uniq',
@@ -242,6 +262,8 @@ class Table extends AbstractNamedObject
     }
 
     /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::addIndex()} instead.
+     *
      * @param non-empty-list<string> $columnNames
      * @param array<int, string>     $flags
      * @param array<string, mixed>   $options
@@ -252,6 +274,13 @@ class Table extends AbstractNamedObject
         array $flags = [],
         array $options = [],
     ): self {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::addIndex() instead.',
+            __METHOD__,
+        );
+
         $indexName ??= $this->_generateIdentifierName(
             array_merge([$this->getName()], $columnNames),
             'idx',
@@ -263,9 +292,19 @@ class Table extends AbstractNamedObject
 
     /**
      * Drops the primary key from this table.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::dropPrimaryKeyConstraint()}
+     *             instead.
      */
     public function dropPrimaryKey(): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::dropPrimaryKeyConstraint() instead.',
+            __METHOD__,
+        );
+
         $this->primaryKeyConstraint              = null;
         $this->failedToParsePrimaryKeyConstraint = false;
 
@@ -279,9 +318,18 @@ class Table extends AbstractNamedObject
 
     /**
      * Drops an index from this table.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::dropIndex()} instead.
      */
     public function dropIndex(string $name): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::dropIndex() instead.',
+            __METHOD__,
+        );
+
         $name = $this->normalizeIdentifier($name);
 
         if (! $this->hasIndex($name)) {
@@ -292,11 +340,20 @@ class Table extends AbstractNamedObject
     }
 
     /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::addIndex()} instead.
+     *
      * @param non-empty-list<string> $columnNames
      * @param array<string, mixed>   $options
      */
     public function addUniqueIndex(array $columnNames, ?string $indexName = null, array $options = []): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::addIndex() instead.',
+            __METHOD__,
+        );
+
         $indexName ??= $this->_generateIdentifierName(
             array_merge([$this->getName()], $columnNames),
             'uniq',
@@ -309,12 +366,21 @@ class Table extends AbstractNamedObject
     /**
      * Renames an index.
      *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::renameIndex()} instead.
+     *
      * @param string      $oldName The name of the index to rename from.
      * @param string|null $newName The name of the index to rename to. If null is given, the index name
      *                             will be auto-generated.
      */
     public function renameIndex(string $oldName, ?string $newName = null): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::renameIndex() instead.',
+            __METHOD__,
+        );
+
         if (! $this->hasIndex($oldName)) {
             throw IndexDoesNotExist::new($oldName, $this->_name);
         }
@@ -384,12 +450,21 @@ class Table extends AbstractNamedObject
     }
 
     /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::addColumn()} instead.
+     *
      * @param array<string, mixed> $options
      *
      * @throws TypesException
      */
     public function addColumn(string $name, string $typeName, array $options = []): Column
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::addColumn() instead.',
+            __METHOD__,
+        );
+
         $column = new Column($name, Type::getType($typeName), $options);
 
         $this->_addColumn($column);
@@ -404,6 +479,8 @@ class Table extends AbstractNamedObject
     }
 
     /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::renameColumn()} instead.
+     *
      * @param non-empty-string $oldName
      * @param non-empty-string $newName
      *
@@ -411,6 +488,13 @@ class Table extends AbstractNamedObject
      */
     final public function renameColumn(string $oldName, string $newName): Column
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::renameColumn() instead.',
+            __METHOD__,
+        );
+
         $oldName = $this->normalizeIdentifier($oldName);
         $newName = $this->normalizeIdentifier($newName);
 
@@ -446,9 +530,20 @@ class Table extends AbstractNamedObject
         return $column;
     }
 
-    /** @param array<string, mixed> $options */
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::modifyColumn()} instead.
+     *
+     * @param array<string, mixed> $options
+     */
     public function modifyColumn(string $name, array $options): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::modifyColumn() instead.',
+            __METHOD__,
+        );
+
         $column = $this->getColumn($name);
         $column->setOptions($options);
 
@@ -457,9 +552,18 @@ class Table extends AbstractNamedObject
 
     /**
      * Drops a Column from the Table.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::dropColumn()} instead.
      */
     public function dropColumn(string $name): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::dropColumn() instead.',
+            __METHOD__,
+        );
+
         $name = $this->normalizeIdentifier($name);
 
         $foreignKeyConstraintNames = $this->getForeignKeyConstraintNamesByLocalColumnName($name);
@@ -496,6 +600,8 @@ class Table extends AbstractNamedObject
      *
      * Name is inferred from the local columns.
      *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::addForeignKeyConstraint()} instead.
+     *
      * @param non-empty-list<string> $localColumnNames
      * @param non-empty-list<string> $foreignColumnNames
      * @param array<string, mixed>   $options
@@ -507,6 +613,13 @@ class Table extends AbstractNamedObject
         array $options = [],
         ?string $name = null,
     ): self {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::addForeignKeyConstraint() instead.',
+            __METHOD__,
+        );
+
         $name ??= $this->_generateIdentifierName(
             array_merge([$this->getName()], $localColumnNames),
             'fk',
@@ -530,8 +643,20 @@ class Table extends AbstractNamedObject
         return $this->_addForeignKeyConstraint($constraint);
     }
 
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::setOptions()} instead.
+     *
+     * @return $this
+     */
     public function addOption(string $name, mixed $value): self
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::setOptions() instead.',
+            __METHOD__,
+        );
+
         $this->_options[$name] = $value;
 
         return $this;
@@ -579,9 +704,19 @@ class Table extends AbstractNamedObject
 
     /**
      * Drops the foreign key constraint with the given name.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::dropForeignKeyConstraint()}
+     *             instead.
      */
     public function dropForeignKey(string $name): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::dropForeignKeyConstraint() instead.',
+            __METHOD__,
+        );
+
         $name = $this->normalizeIdentifier($name);
 
         if (! $this->hasForeignKey($name)) {
@@ -633,9 +768,18 @@ class Table extends AbstractNamedObject
 
     /**
      * Drops the unique constraint with the given name.
+     *
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::dropUniqueConstraint()} instead.
      */
     public function dropUniqueConstraint(string $name): void
     {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::dropUniqueConstraint() instead.',
+            __METHOD__,
+        );
+
         $name = $this->normalizeIdentifier($name);
 
         if (! $this->hasUniqueConstraint($name)) {
@@ -990,8 +1134,20 @@ class Table extends AbstractNamedObject
         return $this->trimQuotes(strtolower($identifier));
     }
 
+    /**
+     * @deprecated since doctrine/dbal 4.5. Use {@see edit()} and {@see TableEditor::setComment()} instead.
+     *
+     * @return $this
+     */
     public function setComment(string $comment): self
     {
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7389',
+            '%s is deprecated. Use Table::edit() and TableEditor::setComment() instead.',
+            __METHOD__,
+        );
+
         // For keeping backward compatibility with MySQL in previous releases, table comments are stored as options.
         $this->addOption('comment', $comment);
 

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -361,6 +361,30 @@ class TableTest extends TestCase
         self::assertFalse($table->hasColumn('bar'));
     }
 
+    public function testDropColumnThroughEditor(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('foo')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('bar')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $table = $table->edit()
+            ->dropColumnByUnquotedName('foo')
+            ->create();
+
+        self::assertFalse($table->hasColumn('foo'));
+        self::assertTrue($table->hasColumn('bar'));
+    }
+
     public function testGetUnknownColumnThrowsException(): void
     {
         $table = Table::editor()
@@ -724,7 +748,7 @@ class TableTest extends TestCase
 
     public function testAddForeignKeyConstraintUnknownLocalColumnThrowsException(): void
     {
-        $table = Table::editor()
+        $editor = Table::editor()
             ->setUnquotedName('foo')
             ->setColumns(
                 Column::editor()
@@ -732,11 +756,17 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
-            ->create();
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedReferencingColumnNames('foo')
+                    ->setUnquotedReferencedTableName('bar')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            );
 
         $this->expectException(SchemaException::class);
 
-        $table->addForeignKeyConstraint('bar', ['foo'], ['id']);
+        $editor->create();
     }
 
     public function testAddForeignKeyConstraint(): void
@@ -749,9 +779,10 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addForeignKeyConstraint(
+                new ForeignKeyConstraint(['id'], 'bar', ['id'], '', ['foo' => 'bar']),
+            )
             ->create();
-
-        $table->addForeignKeyConstraint('bar', ['id'], ['id'], ['foo' => 'bar']);
 
         $constraints = $table->getForeignKeys();
         self::assertCount(1, $constraints);
@@ -773,9 +804,13 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('my_idx')
+                    ->setUnquotedColumnNames('ID')
+                    ->create(),
+            )
             ->create();
-
-        $table->addIndex(['ID'], 'my_idx');
 
         self::assertTrue($table->hasIndex('my_idx'));
         self::assertEquals(['ID'], $table->getIndex('my_idx')->getColumns());
@@ -812,9 +847,11 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('baz'),
+            )
             ->create();
-
-        $table->addIndex(['baz']);
 
         self::assertCount(1, $table->getIndexes());
     }
@@ -886,9 +923,14 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedReferencingColumnNames('id')
+                    ->setUnquotedReferencedTableName('bar')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
             ->create();
-
-        $table->addForeignKeyConstraint('bar', ['id'], ['id'], ['foo' => 'bar']);
 
         $indexes = $table->getIndexes();
         self::assertCount(1, $indexes);
@@ -947,6 +989,16 @@ class TableTest extends TestCase
                     ->setTypeName(Types::STRING)
                     ->create(),
             )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('composite_idx')
+                    ->setUnquotedColumnNames('baz', 'bar')
+                    ->create(),
+                Index::editor()
+                    ->setUnquotedName('full_idx')
+                    ->setUnquotedColumnNames('bar', 'baz', 'bloo')
+                    ->create(),
+            )
             ->setForeignKeyConstraints(
                 ForeignKeyConstraint::editor()
                     ->setUnquotedReferencingColumnNames('bar', 'baz')
@@ -955,10 +1007,6 @@ class TableTest extends TestCase
                     ->create(),
             )
             ->create();
-
-        $table->addIndex(['baz', 'bar'], 'composite_idx');
-        $table->addIndex(['bar', 'baz', 'bloo'], 'full_idx');
-        $table->addForeignKeyConstraint('bar', ['bar', 'baz'], ['foo', 'baz']);
 
         self::assertCount(3, $table->getIndexes());
         self::assertTrue($table->hasIndex('composite_idx'));
@@ -979,16 +1027,25 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedColumnNames('baz'),
+            )
             ->create();
-
-        $table->addIndex(['baz']);
 
         $indexes = $table->getIndexes();
         self::assertCount(1, $indexes);
         $index = array_shift($indexes);
         self::assertNotNull($index);
 
-        $table->addUniqueIndex(['baz']);
+        $table = $table->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setType(IndexType::UNIQUE)
+                    ->setUnquotedColumnNames('baz'),
+            )
+            ->create();
+
         self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex($index->getName()));
     }
@@ -1003,10 +1060,17 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('bar_idx')
+                    ->setUnquotedColumnNames('bar')
+                    ->create(),
+                Index::editor()
+                    ->setUnquotedName('duplicate_idx')
+                    ->setUnquotedColumnNames('bar')
+                    ->create(),
+            )
             ->create();
-
-        $table->addIndex(['bar'], 'bar_idx');
-        $table->addIndex(['bar'], 'duplicate_idx');
 
         self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex('bar_idx'));
@@ -1029,10 +1093,17 @@ class TableTest extends TestCase
                     ->setTypeName(Types::STRING)
                     ->create(),
             )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('bar_idx')
+                    ->setUnquotedColumnNames('bar')
+                    ->create(),
+                Index::editor()
+                    ->setUnquotedName('fulfilling_idx')
+                    ->setUnquotedColumnNames('bar', 'baz')
+                    ->create(),
+            )
             ->create();
-
-        $table->addIndex(['bar'], 'bar_idx');
-        $table->addIndex(['bar', 'baz'], 'fulfilling_idx');
 
         self::assertCount(2, $table->getIndexes());
         self::assertTrue($table->hasIndex('bar_idx'));
@@ -1092,7 +1163,14 @@ class TableTest extends TestCase
 
         self::assertCount(1, $localTable->getIndexes());
 
-        $localTable->addIndex(['id'], 'explicit_idx');
+        $localTable = $localTable->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('explicit_idx')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
 
         self::assertCount(1, $localTable->getIndexes());
         self::assertTrue($localTable->hasIndex('explicit_idx'));
@@ -1165,16 +1243,28 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedReferencingColumnNames('id')
+                    ->setUnquotedReferencedTableName('foreign')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
             ->create();
-
-        $localTable->addForeignKeyConstraint('foreign', ['id'], ['id']);
 
         self::assertCount(1, $localTable->getIndexes());
         self::assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));
 
         $implicitIndex = $localTable->getIndex('IDX_8BD688E8BF396750');
 
-        $localTable->addIndex(['id'], 'IDX_8BD688E8BF396750');
+        $localTable = $localTable->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('IDX_8BD688E8BF396750')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
 
         self::assertCount(1, $localTable->getIndexes());
         self::assertTrue($localTable->hasIndex('IDX_8BD688E8BF396750'));
@@ -1234,9 +1324,11 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addIndex(
+                Index::editor()
+                    ->setQuotedColumnNames('foo', 'bar'),
+            )
             ->create();
-
-        $table->addIndex(['"foo"', '"bar"']);
 
         self::assertTrue($table->columnsAreIndexed(['"foo"', '"bar"']));
     }
@@ -1255,9 +1347,14 @@ class TableTest extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
+            ->addForeignKeyConstraint(
+                ForeignKeyConstraint::editor()
+                    ->setQuotedReferencingColumnNames('foo', 'bar')
+                    ->setQuotedReferencedTableName('boing')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
             ->create();
-
-        $table->addForeignKeyConstraint('"boing"', ['"foo"', '"bar"'], ['id']);
 
         self::assertCount(1, $table->getForeignKeys());
     }
@@ -1298,6 +1395,33 @@ class TableTest extends TestCase
         self::assertFalse($table->hasIndex('idx'));
     }
 
+    public function testDropIndexThroughEditor(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('test')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        self::assertTrue($table->hasIndex('idx'));
+
+        $table = $table->edit()
+            ->dropIndexByUnquotedName('idx')
+            ->create();
+
+        self::assertFalse($table->hasIndex('idx'));
+    }
+
     public function testDropPrimaryKey(): void
     {
         $table = Table::editor()
@@ -1318,6 +1442,32 @@ class TableTest extends TestCase
         self::assertNotNull($table->getPrimaryKey());
 
         $table->dropPrimaryKey();
+        self::assertNull($table->getPrimaryKey());
+    }
+
+    public function testDropPrimaryKeyConstraintThroughEditor(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('test')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        self::assertNotNull($table->getPrimaryKey());
+
+        $table = $table->edit()
+            ->dropPrimaryKeyConstraint()
+            ->create();
+
         self::assertNull($table->getPrimaryKey());
     }
 
@@ -1410,6 +1560,32 @@ class TableTest extends TestCase
         self::assertTrue($table->hasIndex('primary'));
         self::assertTrue($table->hasIndex('IDX_D87F7E0C8C736521'));
         self::assertTrue($table->hasIndex('UNIQ_D87F7E0C76FF8CAA78240498'));
+    }
+
+    public function testRenameIndexThroughEditor(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('test')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx')
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $table = $table->edit()
+            ->renameIndexByUnquotedName('idx', 'idx_new')
+            ->create();
+
+        self::assertFalse($table->hasIndex('idx'));
+        self::assertTrue($table->hasIndex('idx_new'));
     }
 
     public function testRenameNonExistingIndexToTheSameName(): void


### PR DESCRIPTION
As with the column mutators (#7381), `Table`'s mutating methods are deprecated in favor of `Table::edit()` and `TableEditor`. The `Table` constructor is marked as internal.

A second commit migrates `TableTest`:
1. The scenarios that add objects to a table move to the editor, since both APIs share that code path.
2. The ones that drop and rename have separate implementations, so their mutator tests stay and each gains an editor sibling.
