### PR TITLE
Don't rely on Name::toString() being parseable

### DIFF
--- a/src/Schema/Name.php
+++ b/src/Schema/Name.php
@@ -19,7 +19,9 @@ interface Name
     /**
      * Returns the string representation of the name.
      *
-     * If passed to the corresponding parser, the name should be parsed back to an equivalent object.
+     * The representation is intended for display, such as in error messages, not for parsing back into a name:
+     * parsing does not always reproduce the original. If an unquoted part of the name contains whitespace, a dot,
+     * or a quote character (", `, [, ]), parsing it will return a different name or fail.
      */
     public function toString(): string;
 }

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -1098,7 +1098,7 @@ abstract class AbstractComparatorTestCase extends TestCase
 
         $newSchema = Schema::editor()
             ->setDefaultNamespace('foo')
-            ->addTable($this->createTable('foo.bar'))
+            ->addTable($this->createTable('bar', 'foo'))
             ->create();
 
         self::assertEquals(
@@ -1113,16 +1113,16 @@ abstract class AbstractComparatorTestCase extends TestCase
             ->setDefaultNamespace('schemaName')
             ->setTables(
                 $this->createTable('taz'),
-                $this->createTable('war.tab'),
+                $this->createTable('tab', 'war'),
             )
             ->create();
 
         $newSchema = Schema::editor()
             ->setDefaultNamespace('schemaName')
             ->setTables(
-                $this->createTable('bar.tab'),
-                $this->createTable('baz.tab'),
-                $this->createTable('war.tab'),
+                $this->createTable('tab', 'bar'),
+                $this->createTable('tab', 'baz'),
+                $this->createTable('tab', 'war'),
             )
             ->create();
 
@@ -1431,11 +1431,14 @@ abstract class AbstractComparatorTestCase extends TestCase
         return $names;
     }
 
-    /** @param non-empty-string $name */
-    private function createTable(string $name): Table
+    /**
+     * @param non-empty-string  $name
+     * @param ?non-empty-string $qualifier
+     */
+    private function createTable(string $name, ?string $qualifier = null): Table
     {
         return Table::editor()
-            ->setUnquotedName($name)
+            ->setUnquotedName($name, $qualifier)
             ->setColumns(
                 Column::editor()
                     ->setUnquotedName('id')

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -27,7 +27,7 @@ class SchemaTest extends TestCase
     {
         $tableName = 'public.foo';
         $table     = Table::editor()
-            ->setUnquotedName($tableName)
+            ->setUnquotedName('foo', 'public')
             ->setColumns(
                 Column::editor()
                     ->setUnquotedName('id')


### PR DESCRIPTION
## Problem

#6972 mechanically reworked `AbstractComparatorTestCase::createTable(string $name)` such that instead of passing the name to the `Table` constructor, it passes it as-is to `TableEditor::setUnquotedName()`. It would have been correct if all passed values were unqualified, but in fact, some of them are qualified (e.g. `foo.bar`).

At the time of the work, the incorrectly reworked test should have failed, but it passes today by accident:
1. The editor stores `foo.bar` as an _unqualified_ name.
2. It serializes it to a string via `toString()` for the string-based `Table` constructor.
3. The constructor re-parses it into the _qualified_ name `foo`.`bar` — exactly what the test wanted.

`5.0.x` will remove the round-trip: its `Table` constructor will accept an `OptionallyQualifiedName` instead of a string, so nothing will re-parse the name and the unqualified `foo.bar` will stay unqualified. This test will start failing, as expected.

### Why `toString()` can't satisfy the round-trip

`Name::toString()` documents a round-trip contract: https://github.com/doctrine/dbal/blob/defd18d4306574ce735334ff13594319a99c0e9e/src/Schema/Name.php#L22

That contract can't hold for an unquoted identifier whose value contains any character the parser treats specially: the qualifier separator (`.`), the identifier quote (`"`), whitespace, and so on. There are two ways to implement `toString()`, and both are wrong in the round-trip case:

1. If `toString()` emits the value as-is (`foo.bar`), the parser reads it as a qualified name, so it's a different object. A value containing a `"` is worse: it doesn't round-trip at all — it fails to parse.
2. If we make `toString()` quote the value (`"foo.bar"`) to keep it a single identifier, the name becomes _quoted_, so an SQL-92 platform retains its case instead of folding it. That's also a different object.

The root cause isn't a loose `toString()`. Initially, it was meant for display (error messages), where the loss is acceptable. The round-trip requirement was retrofitted onto it later (16d2e6330b399b78559df62e4503c9ee2891734d) to satisfy the string-based name APIs, and that's where it breaks.

## Solution

1. Fix the test by passing the qualifier explicitly (`setUnquotedName('bar', 'foo')`).
2. Tighten the `Name::toString()` docblock.

`TableEditor` was released in 4.3.0 (#6660), so technically, someone may have already changed their code the same way the test was. Unless they fix their code, it will break in 5.0.x. Practically, I think this is unlikely. The `Table` constructor is still public, so there's no motivation for developers to rework their code.

The object-based name API sits on top of the older string-based one, reaching it through `toString()` and re-parsing. The loss is inherent to that layering, not a fault in any method — so there's nothing for a runtime deprecation to attach to.
