### PR TITLE
fix(MariaDb): add support of new reserved word `TO_DATE` (12.3+)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -156,7 +156,7 @@ jobs:
           - "10.11" # LTS (Feb 2028) We have code specific to ^10.10
           - "11.4"  # LTS (May 2029)
           - "11.8"  # LTS (Jun 2028)
-          - "12.1"  # Rolling Release (Q1 2026)
+          - "12.3"  # LTS (EOL TBC) We have code specific to ^12.3
         extension:
           - "mysqli"
           - "pdo_mysql"

--- a/src/Driver/AbstractMySQLDriver.php
+++ b/src/Driver/AbstractMySQLDriver.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Platforms\MariaDb1043Platform;
 use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MariaDb1060Platform;
 use Doctrine\DBAL\Platforms\MariaDb110700Platform;
+use Doctrine\DBAL\Platforms\MariaDb120300Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQL84Platform;
@@ -43,6 +44,10 @@ abstract class AbstractMySQLDriver implements VersionAwarePlatformDriver
 
         if ($mariadb) {
             $mariaDbVersion = $this->getMariaDbMysqlVersionNumber($version);
+            if (version_compare($mariaDbVersion, '12.3.0', '>=')) {
+                return new MariaDb120300Platform();
+            }
+
             if (version_compare($mariaDbVersion, '11.7.0', '>=')) {
                 return new MariaDb110700Platform();
             }

--- a/src/Platforms/Keywords/MariaDb123Keywords.php
+++ b/src/Platforms/Keywords/MariaDb123Keywords.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms\Keywords;
+
+use Doctrine\Deprecations\Deprecation;
+
+use function array_merge;
+
+/**
+ * MariaDB 12.3 reserved keywords list.
+ */
+class MariaDb123Keywords extends MariaDb117Keywords
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated
+     */
+    public function getName(): string
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/5433',
+            'MariaDb123Keywords::getName() is deprecated.',
+        );
+
+        return 'MariaDb123';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @link https://jira.mariadb.org/browse/MDEV-19683
+     */
+    protected function getKeywords(): array
+    {
+        $keywords = parent::getKeywords();
+
+        // TO_DATE() was added as an Oracle-compatible function in MariaDB 12.3
+        // and is implemented as a parser-level keyword, so it can no longer be
+        // used as an unquoted identifier.
+        $keywords = array_merge($keywords, ['TO_DATE']);
+
+        return $keywords;
+    }
+}

--- a/src/Platforms/MariaDb120300Platform.php
+++ b/src/Platforms/MariaDb120300Platform.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\Deprecations\Deprecation;
+
+/**
+ * Provides the behavior, features and SQL dialect of the MariaDB 12.3 database platform.
+ */
+class MariaDb120300Platform extends MariaDb110700Platform
+{
+    /** @deprecated Implement {@see createReservedKeywordsList()} instead. */
+    protected function getReservedKeywordsClass(): string
+    {
+        Deprecation::triggerIfCalledFromOutside(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/issues/4510',
+            'MariaDb120300Platform::getReservedKeywordsClass() is deprecated,'
+                . ' use MariaDb120300Platform::createReservedKeywordsList() instead.',
+        );
+
+        return Keywords\MariaDb123Keywords::class;
+    }
+}

--- a/src/Tools/Console/Command/ReservedWordsCommand.php
+++ b/src/Tools/Console/Command/ReservedWordsCommand.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\Keywords\DB2Keywords;
 use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\MariaDb102Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MariaDb117Keywords;
+use Doctrine\DBAL\Platforms\Keywords\MariaDb123Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL57Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL80Keywords;
 use Doctrine\DBAL\Platforms\Keywords\MySQL84Keywords;
@@ -59,6 +60,7 @@ class ReservedWordsCommand extends Command
             'db2'        => new DB2Keywords(),
             'mariadb102' => new MariaDb102Keywords(),
             'mariadb117' => new MariaDb117Keywords(),
+            'mariadb123' => new MariaDb123Keywords(),
             'mysql'      => new MySQLKeywords(),
             'mysql57'    => new MySQL57Keywords(),
             'mysql80'    => new MySQL80Keywords(),
@@ -131,6 +133,7 @@ The following keyword lists are currently shipped with Doctrine:
     * db2
     * mariadb102
     * mariadb117
+    * mariadb123
     * mysql
     * mysql57
     * mysql80

--- a/tests/Platforms/MariaDb120300PlatformTest.php
+++ b/tests/Platforms/MariaDb120300PlatformTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Platforms;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Keywords\KeywordList;
+use Doctrine\DBAL\Platforms\MariaDb120300Platform;
+
+class MariaDb120300PlatformTest extends MariaDb110700PlatformTest
+{
+    public function createPlatform(): AbstractPlatform
+    {
+        return new MariaDb120300Platform();
+    }
+
+    public function testMariaDb123KeywordList(): void
+    {
+        $keywordList = $this->platform->getReservedKeywordsList();
+        self::assertInstanceOf(KeywordList::class, $keywordList);
+
+        self::assertTrue($keywordList->isKeyword('to_date'));
+        self::assertTrue($keywordList->isKeyword('vector'));
+        self::assertTrue($keywordList->isKeyword('distinctrow'));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

MariaDB 12.3 added the Oracle-compatible `TO_DATE()` function ([MDEV-19683](https://jira.mariadb.org/browse/MDEV-19683)), implemented as a parser-level keyword: a bare `to_date` identifier is now a syntax error, with the default `sql_mode` (not only in `ORACLE` mode), even though the word is not (yet) listed on the [documented reserved words page](https://mariadb.com/docs/server/reference/sql-structure/sql-language-structure/reserved-words):

```
MariaDB [test]> SELECT VERSION();
+------------------------+
| 12.3.2-MariaDB-ubu2404 |
+------------------------+

MariaDB [test]> CREATE TABLE t1 (from_date DATE DEFAULT NULL, to_date DATE DEFAULT NULL);
ERROR 1064 (42000): You have an error in your SQL syntax; ... near 'to_date DATE DEFAULT NULL)' at line 1

MariaDB [test]> CREATE TABLE t1 (from_date DATE DEFAULT NULL, `to_date` DATE DEFAULT NULL);
Query OK, 0 rows affected
```

Since DBAL does not know the keyword, it emits `to_date` unquoted in generated DDL, so any schema containing such a column can no longer be created or migrated on MariaDB 12.3 (every Magento/OpenMage-lineage application has several, e.g. the `catalogrule` and `salesrule` tables).

The other Oracle-compatible functions added in the same release (`TO_NUMBER()`, `TRUNC()`, and the `TO_CHAR()` enhancements) are **not** reserved; verified against MariaDB 12.3.2 that they still parse as bare column identifiers, so `TO_DATE` is the only word added.

This follows the exact pattern of #7061 (`VECTOR`, MariaDB 11.7): a new `MariaDb123Keywords` list and `MariaDb120300Platform`, selected for MariaDB >= 12.3.
