### PR TITLE
fix(SQLite): preserve indexes and foreign keys when altering an introspected table

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -837,6 +837,9 @@ class SQLitePlatform extends AbstractPlatform
             $changed      = false;
             $indexColumns = [];
             foreach ($index->getColumns() as $columnName) {
+                // the column names of an introspected index are quoted while the name map is keyed
+                // by the unquoted column names, so unquote before the lookup
+                $columnName           = (new Identifier($columnName))->getName();
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($indexes[$key]);
@@ -904,6 +907,9 @@ class SQLitePlatform extends AbstractPlatform
             $changed      = false;
             $localColumns = [];
             foreach ($constraint->getLocalColumns() as $columnName) {
+                // the referencing column names of an introspected foreign key constraint are quoted
+                // while the name map is keyed by the unquoted column names, so unquote before the lookup
+                $columnName           = (new Identifier($columnName))->getName();
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($foreignKeys[$key]);

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -836,10 +836,10 @@ class SQLitePlatform extends AbstractPlatform
 
             $changed      = false;
             $indexColumns = [];
-            foreach ($index->getColumns() as $columnName) {
-                // the column names of an introspected index are quoted while the name map is keyed
-                // by the unquoted column names, so unquote before the lookup
-                $columnName           = (new Identifier($columnName))->getName();
+            foreach ($index->getIndexedColumns() as $indexedColumn) {
+                // Use the unquoted identifier value so the lookup is agnostic of whether the index
+                // was introspected (which marks its column names as quoted) or built in memory.
+                $columnName           = $indexedColumn->getColumnName()->getIdentifier()->getValue();
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($indexes[$key]);
@@ -906,10 +906,10 @@ class SQLitePlatform extends AbstractPlatform
         foreach ($foreignKeys as $key => $constraint) {
             $changed      = false;
             $localColumns = [];
-            foreach ($constraint->getLocalColumns() as $columnName) {
-                // the referencing column names of an introspected foreign key constraint are quoted
-                // while the name map is keyed by the unquoted column names, so unquote before the lookup
-                $columnName           = (new Identifier($columnName))->getName();
+            foreach ($constraint->getReferencingColumnNames() as $referencingColumnName) {
+                // Use the unquoted identifier value so the lookup is agnostic of whether the constraint
+                // was introspected (which marks its column names as quoted) or built in memory.
+                $columnName           = $referencingColumnName->getIdentifier()->getValue();
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($foreignKeys[$key]);

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -836,10 +836,9 @@ class SQLitePlatform extends AbstractPlatform
 
             $changed      = false;
             $indexColumns = [];
-            foreach ($index->getIndexedColumns() as $indexedColumn) {
-                // Use the unquoted identifier value so the lookup is agnostic of whether the index
-                // was introspected (which marks its column names as quoted) or built in memory.
-                $columnName           = $indexedColumn->getColumnName()->getIdentifier()->getValue();
+            // Use the unquoted column names so the lookup is agnostic of whether the index
+            // was introspected (which marks its column names as quoted) or built in memory.
+            foreach ($index->getUnquotedColumns() as $columnName) {
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($indexes[$key]);
@@ -906,10 +905,9 @@ class SQLitePlatform extends AbstractPlatform
         foreach ($foreignKeys as $key => $constraint) {
             $changed      = false;
             $localColumns = [];
-            foreach ($constraint->getReferencingColumnNames() as $referencingColumnName) {
-                // Use the unquoted identifier value so the lookup is agnostic of whether the constraint
-                // was introspected (which marks its column names as quoted) or built in memory.
-                $columnName           = $referencingColumnName->getIdentifier()->getValue();
+            // Use the unquoted column names so the lookup is agnostic of whether the constraint
+            // was introspected (which marks its column names as quoted) or built in memory.
+            foreach ($constraint->getUnquotedLocalColumns() as $columnName) {
                 $normalizedColumnName = strtolower($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($foreignKeys[$key]);

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -9,8 +9,10 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
@@ -26,6 +28,7 @@ use function array_map;
 use function array_shift;
 use function array_values;
 use function assert;
+use function ksort;
 
 class SQLiteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -314,6 +317,66 @@ SQL;
         $table = $schemaManager->introspectTable('nodes');
         $index = $table->getIndex('idx_name');
         self::assertSame(['name'], $index->getColumns());
+    }
+
+    public function testAlterIntrospectedTablePreservesIndexesAndForeignKeys(): void
+    {
+        $this->dropTableIfExists('tree_nodes');
+
+        $ddl = <<<'DDL'
+        CREATE TABLE tree_nodes (
+            id        INTEGER NOT NULL,
+            parent_id INTEGER,
+            name      TEXT,
+            weight    INTEGER,
+            PRIMARY KEY (id),
+            FOREIGN KEY (parent_id) REFERENCES tree_nodes (id)
+        )
+        DDL;
+
+        $this->connection->executeStatement($ddl);
+        $this->connection->executeStatement('CREATE UNIQUE INDEX idx_tree_name ON tree_nodes (name)');
+        $this->connection->executeStatement('CREATE INDEX idx_tree_parent ON tree_nodes (parent_id)');
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $oldTable = $schemaManager->introspectTableByUnquotedName('tree_nodes');
+        $newTable = $oldTable->edit()
+            ->modifyColumnByUnquotedName(
+                'weight',
+                static function (ColumnEditor $editor): void {
+                    $editor->setTypeName(Types::STRING)
+                        ->setLength(32);
+                },
+            )
+            ->create();
+
+        $diff = $schemaManager->createComparator()->compareTables($oldTable, $newTable);
+        $schemaManager->alterTable($diff);
+
+        $table = $schemaManager->introspectTableByUnquotedName('tree_nodes');
+
+        self::assertCount(1, $table->getForeignKeys());
+
+        $indexes = [];
+        foreach ($table->getIndexes() as $index) {
+            $indexName = $index->getObjectName()->getIdentifier()->getValue();
+            if ($indexName === 'primary') {
+                continue;
+            }
+
+            $indexes[$indexName] = array_map(
+                static fn (IndexedColumn $indexedColumn): string => $indexedColumn
+                    ->getColumnName()
+                    ->getIdentifier()
+                    ->getValue(),
+                $index->getIndexedColumns(),
+            );
+        }
+
+        ksort($indexes);
+
+        self::assertSame(['idx_tree_name' => ['name'], 'idx_tree_parent' => ['parent_id']], $indexes);
     }
 
     public function testAlterTableWithSchema(): void

--- a/tests/Functional/Schema/SQLiteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLiteSchemaManagerTest.php
@@ -9,10 +9,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
-use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
@@ -28,7 +26,6 @@ use function array_map;
 use function array_shift;
 use function array_values;
 use function assert;
-use function ksort;
 
 class SQLiteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -317,66 +314,6 @@ SQL;
         $table = $schemaManager->introspectTable('nodes');
         $index = $table->getIndex('idx_name');
         self::assertSame(['name'], $index->getColumns());
-    }
-
-    public function testAlterIntrospectedTablePreservesIndexesAndForeignKeys(): void
-    {
-        $this->dropTableIfExists('tree_nodes');
-
-        $ddl = <<<'DDL'
-        CREATE TABLE tree_nodes (
-            id        INTEGER NOT NULL,
-            parent_id INTEGER,
-            name      TEXT,
-            weight    INTEGER,
-            PRIMARY KEY (id),
-            FOREIGN KEY (parent_id) REFERENCES tree_nodes (id)
-        )
-        DDL;
-
-        $this->connection->executeStatement($ddl);
-        $this->connection->executeStatement('CREATE UNIQUE INDEX idx_tree_name ON tree_nodes (name)');
-        $this->connection->executeStatement('CREATE INDEX idx_tree_parent ON tree_nodes (parent_id)');
-
-        $schemaManager = $this->connection->createSchemaManager();
-
-        $oldTable = $schemaManager->introspectTableByUnquotedName('tree_nodes');
-        $newTable = $oldTable->edit()
-            ->modifyColumnByUnquotedName(
-                'weight',
-                static function (ColumnEditor $editor): void {
-                    $editor->setTypeName(Types::STRING)
-                        ->setLength(32);
-                },
-            )
-            ->create();
-
-        $diff = $schemaManager->createComparator()->compareTables($oldTable, $newTable);
-        $schemaManager->alterTable($diff);
-
-        $table = $schemaManager->introspectTableByUnquotedName('tree_nodes');
-
-        self::assertCount(1, $table->getForeignKeys());
-
-        $indexes = [];
-        foreach ($table->getIndexes() as $index) {
-            $indexName = $index->getObjectName()->getIdentifier()->getValue();
-            if ($indexName === 'primary') {
-                continue;
-            }
-
-            $indexes[$indexName] = array_map(
-                static fn (IndexedColumn $indexedColumn): string => $indexedColumn
-                    ->getColumnName()
-                    ->getIdentifier()
-                    ->getValue(),
-                $index->getIndexedColumns(),
-            );
-        }
-
-        ksort($indexes);
-
-        self::assertSame(['idx_tree_name' => ['name'], 'idx_tree_parent' => ['parent_id']], $indexes);
     }
 
     public function testAlterTableWithSchema(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -780,6 +780,27 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             )
             ->create();
 
+        $indexes = [
+            Index::editor()
+                ->setUnquotedName('idx_intro_name')
+                ->setUnquotedColumnNames('name')
+                ->setType(IndexType::UNIQUE)
+                ->create(),
+            Index::editor()
+                ->setUnquotedName('idx_intro_ref')
+                ->setUnquotedColumnNames('ref_id')
+                ->create(),
+        ];
+
+        $foreignKeyConstraints = [
+            ForeignKeyConstraint::editor()
+                ->setUnquotedName('fk_intro_ref')
+                ->setUnquotedReferencingColumnNames('ref_id')
+                ->setUnquotedReferencedTableName('alter_introspected_ref')
+                ->setUnquotedReferencedColumnNames('id')
+                ->create(),
+        ];
+
         $table = Table::editor()
             ->setUnquotedName('alter_introspected')
             ->setColumns(
@@ -806,25 +827,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
                     ->setUnquotedColumnNames('id')
                     ->create(),
             )
-            ->setIndexes(
-                Index::editor()
-                    ->setUnquotedName('idx_intro_name')
-                    ->setUnquotedColumnNames('name')
-                    ->setType(IndexType::UNIQUE)
-                    ->create(),
-                Index::editor()
-                    ->setUnquotedName('idx_intro_ref')
-                    ->setUnquotedColumnNames('ref_id')
-                    ->create(),
-            )
-            ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
-                    ->setUnquotedName('fk_intro_ref')
-                    ->setUnquotedReferencingColumnNames('ref_id')
-                    ->setUnquotedReferencedTableName('alter_introspected_ref')
-                    ->setUnquotedReferencedColumnNames('id')
-                    ->create(),
-            )
+            ->setIndexes(...$indexes)
+            ->setForeignKeyConstraints(...$foreignKeyConstraints)
             ->create();
 
         $platform = $this->connection->getDatabasePlatform();
@@ -850,39 +854,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $table = $this->schemaManager->introspectTableByUnquotedName('alter_introspected');
 
-        // Read indexed column names through the non-deprecated accessors so the result is independent
-        // of how the index was obtained (introspection marks the column names as quoted).
-        $indexedColumnNames = static function (Index $index): array {
-            return array_map(
-                static function (IndexedColumn $column): string {
-                    return strtolower($column->getColumnName()->getIdentifier()->getValue());
-                },
-                $index->getIndexedColumns(),
-            );
-        };
-
         // The indexes and foreign keys must survive the alteration.
-        self::assertTrue($table->hasIndex('idx_intro_name'));
-        self::assertSame(['name'], $indexedColumnNames($table->getIndex('idx_intro_name')));
-        self::assertSame(IndexType::UNIQUE, $table->getIndex('idx_intro_name')->getType());
-
-        self::assertTrue($table->hasIndex('idx_intro_ref'));
-        self::assertSame(['ref_id'], $indexedColumnNames($table->getIndex('idx_intro_ref')));
-
-        /** @var list<ForeignKeyConstraint> $foreignKeys */
-        $foreignKeys = array_values($table->getForeignKeys());
-        self::assertCount(1, $foreignKeys);
-        self::assertSame(
-            ['ref_id'],
-            array_map(
-                static fn (UnqualifiedName $name): string => strtolower($name->getIdentifier()->getValue()),
-                $foreignKeys[0]->getReferencingColumnNames(),
-            ),
-        );
-        self::assertSame(
-            'alter_introspected_ref',
-            strtolower($foreignKeys[0]->getReferencedTableName()->getUnqualifiedName()->getValue()),
-        );
+        $this->assertIndexEquals($indexes[0], $table->getIndex('idx_intro_name'));
+        $this->assertIndexEquals($indexes[1], $table->getIndex('idx_intro_ref'));
+        $this->assertForeignKeyConstraintListEquals($foreignKeyConstraints, array_values($table->getForeignKeys()));
     }
 
     public function testTableInNamespace(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -839,9 +839,13 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         $this->schemaManager->createTable($referencedTable);
         $this->schemaManager->createTable($table);
 
+        $oldTable = $this->schemaManager->introspectTableByUnquotedName('alter_introspected');
+
+        // Guard against a vacuous comparison of the foreign keys below.
+        self::assertCount(1, $oldTable->getForeignKeys());
+
         // Modify an unrelated column to force a table alteration that does not touch
         // the indexed or referencing columns.
-        $oldTable = $this->schemaManager->introspectTableByUnquotedName('alter_introspected');
         $newTable = $oldTable->edit()
             ->modifyColumnByUnquotedName('weight', static function (ColumnEditor $editor): void {
                 $editor->setTypeName(Types::STRING)
@@ -854,10 +858,15 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
 
         $table = $this->schemaManager->introspectTableByUnquotedName('alter_introspected');
 
-        // The indexes and foreign keys must survive the alteration.
+        // The indexes and foreign keys must survive the alteration. The foreign keys are compared against
+        // the pre-alteration introspection because the referential actions of a foreign key created without
+        // explicit actions are reported inconsistently across platforms (e.g. MariaDB reports RESTRICT).
         $this->assertIndexEquals($indexes[0], $table->getIndex('idx_intro_name'));
         $this->assertIndexEquals($indexes[1], $table->getIndex('idx_intro_ref'));
-        $this->assertForeignKeyConstraintListEquals($foreignKeyConstraints, array_values($table->getForeignKeys()));
+        $this->assertForeignKeyConstraintListEquals(
+            array_values($oldTable->getForeignKeys()),
+            array_values($table->getForeignKeys()),
+        );
     }
 
     public function testTableInNamespace(): void

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -763,6 +763,128 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertEquals(['id'], array_map('strtolower', $foreignKey->getForeignColumns()));
     }
 
+    public function testAlterIntrospectedTablePreservesIndexesAndForeignKeys(): void
+    {
+        $referencedTable = Table::editor()
+            ->setUnquotedName('alter_introspected_ref')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $table = Table::editor()
+            ->setUnquotedName('alter_introspected')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('ref_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('name')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(32)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('weight')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_intro_name')
+                    ->setUnquotedColumnNames('name')
+                    ->setType(IndexType::UNIQUE)
+                    ->create(),
+                Index::editor()
+                    ->setUnquotedName('idx_intro_ref')
+                    ->setUnquotedColumnNames('ref_id')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_intro_ref')
+                    ->setUnquotedReferencingColumnNames('ref_id')
+                    ->setUnquotedReferencedTableName('alter_introspected_ref')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        $this->dropTableIfExists($table->getObjectName()->toSQL($platform));
+        $this->dropTableIfExists($referencedTable->getObjectName()->toSQL($platform));
+
+        $this->schemaManager->createTable($referencedTable);
+        $this->schemaManager->createTable($table);
+
+        // Modify an unrelated column to force a table alteration that does not touch
+        // the indexed or referencing columns.
+        $oldTable = $this->schemaManager->introspectTableByUnquotedName('alter_introspected');
+        $newTable = $oldTable->edit()
+            ->modifyColumnByUnquotedName('weight', static function (ColumnEditor $editor): void {
+                $editor->setTypeName(Types::STRING)
+                    ->setLength(32);
+            })
+            ->create();
+
+        $diff = $this->schemaManager->createComparator()->compareTables($oldTable, $newTable);
+        $this->schemaManager->alterTable($diff);
+
+        $table = $this->schemaManager->introspectTableByUnquotedName('alter_introspected');
+
+        // Read indexed column names through the non-deprecated accessors so the result is independent
+        // of how the index was obtained (introspection marks the column names as quoted).
+        $indexedColumnNames = static function (Index $index): array {
+            return array_map(
+                static function (IndexedColumn $column): string {
+                    return strtolower($column->getColumnName()->getIdentifier()->getValue());
+                },
+                $index->getIndexedColumns(),
+            );
+        };
+
+        // The indexes and foreign keys must survive the alteration.
+        self::assertTrue($table->hasIndex('idx_intro_name'));
+        self::assertSame(['name'], $indexedColumnNames($table->getIndex('idx_intro_name')));
+        self::assertSame(IndexType::UNIQUE, $table->getIndex('idx_intro_name')->getType());
+
+        self::assertTrue($table->hasIndex('idx_intro_ref'));
+        self::assertSame(['ref_id'], $indexedColumnNames($table->getIndex('idx_intro_ref')));
+
+        /** @var list<ForeignKeyConstraint> $foreignKeys */
+        $foreignKeys = array_values($table->getForeignKeys());
+        self::assertCount(1, $foreignKeys);
+        self::assertSame(
+            ['ref_id'],
+            array_map(
+                static fn (UnqualifiedName $name): string => strtolower($name->getIdentifier()->getValue()),
+                $foreignKeys[0]->getReferencingColumnNames(),
+            ),
+        );
+        self::assertSame(
+            'alter_introspected_ref',
+            strtolower($foreignKeys[0]->getReferencedTableName()->getUnqualifiedName()->getValue()),
+        );
+    }
+
     public function testTableInNamespace(): void
     {
         $platform = $this->connection->getDatabasePlatform();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

`alterTable()` on SQLite silently drops **every index and foreign key** (and the primary key) of the altered table whenever the table was obtained through the new introspection API. Rows survive the recreation; the indexes and foreign keys are gone, with no error or deprecation.

```php
$conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
$sm = $conn->createSchemaManager();

$conn->executeStatement('CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, qty INTEGER)');
$conn->executeStatement('CREATE UNIQUE INDEX idx_sku ON products (sku)');
$conn->executeStatement('CREATE INDEX idx_qty ON products (qty)');

$old = $sm->introspectTableByUnquotedName('products');
$new = $old->edit()
    ->modifyColumnByUnquotedName('qty', static function (ColumnEditor $e): void {
        $e->setTypeName(Types::STRING)->setLength(32);
    })
    ->create();
$sm->alterTable($sm->createComparator()->compareTables($old, $new));

// idx_sku and idx_qty are gone
```

#### Root cause

The legacy column-name accessors of an introspected table are inconsistent. `Column::getName()` returns the bare, unquoted name (`sku`), but `Index::getColumns()` and `ForeignKeyConstraint::getLocalColumns()`/`getForeignColumns()` return the raw map keys, which the new introspection API marks as quoted (`"sku"`). The SQLite table-recreation path maps index and foreign-key columns to the altered table through `getDiffColumnNameMap()`, which is keyed by the unquoted column names, so every lookup misses and the branch meant to drop indexes referencing *dropped columns*:

```php
if (! isset($nameMap[$normalizedColumnName])) {
    unset($indexes[$key]);
    continue 2;
}
```

fires for every index and foreign key of the table.

The existing `testNonSimpleAlterTableCreatedFromDDL` does not catch this because it uses the deprecated `introspectTable()`, which returns legacy-unquoted names that happen to match the map.

#### Fix

The table-recreation path now reads the referencing column names through the non-deprecated `Index::getIndexedColumns()` and `ForeignKeyConstraint::getReferencingColumnNames()` accessors and compares their unquoted identifier values. This makes the lookup agnostic of whether the table was introspected (which marks its column names as quoted) or built in memory, without relying on the quoted form of the deprecated `getColumns()` / `getLocalColumns()` accessors.

Note: normalizing those deprecated accessors to return unquoted names was considered but rejected, because their quoted form is load-bearing for quoting propagation in user-built schemas (it would break `testQuotedColumnInForeignKeyPropagation` across all platforms).

The regression test, which is not platform-specific, is added to `SchemaManagerFunctionalTestCase` so it runs against every platform. It is built through the Schema API and fails without the fix (indexes and foreign keys dropped) and passes with it.


