### PR TITLE
Mark schema object classess as readonly

### DIFF
--- a/src/Schema/Collections/SchemaObjectSet.php
+++ b/src/Schema/Collections/SchemaObjectSet.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Schema\Exception\ImproperlyQualifiedName;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
 
-use function array_map;
 use function array_values;
 
 /**
@@ -122,15 +121,6 @@ abstract class SchemaObjectSet
 
         /** @phpstan-ignore return.type */
         return $copy;
-    }
-
-    /** Deep-clones contained elements while their classes retain mutators. */
-    public function __clone()
-    {
-        $this->elements = array_map(
-            static fn (NamedObject $element): NamedObject => clone $element,
-            $this->elements,
-        );
     }
 
     /** @throws ImproperlyQualifiedName If the name's qualification form is not the one this set holds. */

--- a/src/Schema/Collections/UnqualifiedNamedObjectSet.php
+++ b/src/Schema/Collections/UnqualifiedNamedObjectSet.php
@@ -13,7 +13,6 @@ use Traversable;
 
 use function array_combine;
 use function array_keys;
-use function array_map;
 use function array_search;
 use function array_values;
 use function assert;
@@ -112,18 +111,6 @@ final class UnqualifiedNamedObjectSet implements ObjectSet
         foreach ($this->elements as $element) {
             yield $element;
         }
-    }
-
-    /**
-     * As long as there are mutable implementations of <code>NamedObject<UnqualifiedName></code>, cloning the set will
-     * require cloning its elements as well.
-     */
-    public function __clone()
-    {
-        $this->elements = array_map(
-            static fn (NamedObject $element): NamedObject => clone $element,
-            $this->elements,
-        );
     }
 
     /**

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -33,7 +33,7 @@ use function array_merge;
  *     enumType?: class-string,
  * }
  */
-final class Column implements NamedObject
+final readonly class Column implements NamedObject
 {
     /**
      * @internal Use {@link Column::editor()} to instantiate an editor and {@link ColumnEditor::create()} to create a
@@ -44,20 +44,20 @@ final class Column implements NamedObject
      * @param ?non-empty-string $columnDefinition
      */
     public function __construct(
-        private readonly UnqualifiedName $name,
-        private readonly Type $type,
-        private readonly ?int $length,
-        private readonly ?int $precision,
-        private readonly int $scale,
-        private readonly bool $unsigned,
-        private readonly bool $fixed,
-        private readonly bool $notnull,
-        private readonly mixed $default,
-        private readonly bool $autoincrement,
-        private readonly array $values,
-        private readonly array $platformOptions,
-        private readonly ?string $columnDefinition,
-        private readonly string $comment,
+        private UnqualifiedName $name,
+        private Type $type,
+        private ?int $length,
+        private ?int $precision,
+        private int $scale,
+        private bool $unsigned,
+        private bool $fixed,
+        private bool $notnull,
+        private mixed $default,
+        private bool $autoincrement,
+        private array $values,
+        private array $platformOptions,
+        private ?string $columnDefinition,
+        private string $comment,
     ) {
     }
 

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -20,7 +20,7 @@ use function count;
  *
  * @implements OptionallyNamedObject<UnqualifiedName>
  */
-final class ForeignKeyConstraint implements OptionallyNamedObject
+final readonly class ForeignKeyConstraint implements OptionallyNamedObject
 {
     /**
      * @internal Use {@link ForeignKeyConstraint::editor()} to instantiate an editor and
@@ -42,14 +42,14 @@ final class ForeignKeyConstraint implements OptionallyNamedObject
      * @param Deferrability                   $deferrability          Whether the constraint is or can be deferred.
      */
     public function __construct(
-        private readonly ?UnqualifiedName $name,
-        private readonly array $referencingColumnNames,
-        private readonly OptionallyQualifiedName $referencedTableName,
-        private readonly array $referencedColumnNames,
-        private readonly MatchType $matchType,
-        private readonly ReferentialAction $onUpdateAction,
-        private readonly ReferentialAction $onDeleteAction,
-        private readonly Deferrability $deferrability,
+        private ?UnqualifiedName $name,
+        private array $referencingColumnNames,
+        private OptionallyQualifiedName $referencedTableName,
+        private array $referencedColumnNames,
+        private MatchType $matchType,
+        private ReferentialAction $onUpdateAction,
+        private ReferentialAction $onDeleteAction,
+        private Deferrability $deferrability,
     ) {
         $referencingColumnCount = count($referencingColumnNames);
         $referencedColumnCount  = count($referencedColumnNames);

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -16,7 +16,7 @@ use function strlen;
 use function strtolower;
 
 /** @implements NamedObject<UnqualifiedName> */
-final class Index implements NamedObject
+final readonly class Index implements NamedObject
 {
     /**
      * @internal Use {@link Index::editor()} to instantiate an editor and {@link IndexEditor::create()} to create an
@@ -26,11 +26,11 @@ final class Index implements NamedObject
      * @param ?non-empty-string             $predicate
      */
     public function __construct(
-        private readonly UnqualifiedName $name,
-        private readonly IndexType $type,
-        private readonly array $columns,
-        private readonly bool $isClustered,
-        private readonly ?string $predicate,
+        private UnqualifiedName $name,
+        private IndexType $type,
+        private array $columns,
+        private bool $isClustered,
+        private ?string $predicate,
     ) {
         if (count($columns) < 1) {
             throw InvalidIndexDefinition::columnsNotSet($name);

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -171,15 +171,6 @@ final readonly class Schema
             ->setSequences(...$this->getSequences());
     }
 
-    /**
-     * Cloning a Schema triggers a deep clone of all related assets.
-     */
-    public function __clone()
-    {
-        /** @phpstan-ignore property.readOnlyAssignNotInConstructor */
-        $this->objects = clone $this->objects;
-    }
-
     private function parseUnqualifiedName(string $input): UnqualifiedName
     {
         $parser = Parsers::getUnqualifiedNameParser();

--- a/src/Schema/SchemaObjects.php
+++ b/src/Schema/SchemaObjects.php
@@ -270,19 +270,6 @@ final class SchemaObjects implements ReadableSchemaObjects
         return $copy;
     }
 
-    public function __clone()
-    {
-        if ($this->tables !== null) {
-            $this->tables = clone $this->tables;
-        }
-
-        if ($this->sequences === null) {
-            return;
-        }
-
-        $this->sequences = clone $this->sequences;
-    }
-
     private function resolve(OptionallyQualifiedName $name): OptionallyQualifiedName
     {
         if ($name->getQualifier() !== null || $this->defaultNamespaceName === null) {

--- a/src/Schema/Sequence.php
+++ b/src/Schema/Sequence.php
@@ -13,7 +13,7 @@ use Override;
  *
  * @implements NamedObject<OptionallyQualifiedName>
  */
-final class Sequence implements NamedObject
+final readonly class Sequence implements NamedObject
 {
     /**
      * @internal Use {@link Sequence::editor()} to instantiate an editor and {@link SequenceEditor::create()} to create
@@ -22,10 +22,10 @@ final class Sequence implements NamedObject
      * @param ?non-negative-int $cacheSize
      */
     public function __construct(
-        private readonly OptionallyQualifiedName $name,
-        private readonly int $allocationSize,
-        private readonly int $initialValue,
-        private readonly ?int $cacheSize = null,
+        private OptionallyQualifiedName $name,
+        private int $allocationSize,
+        private int $initialValue,
+        private ?int $cacheSize = null,
     ) {
         if ($cacheSize < 0) {
             throw InvalidSequenceDefinition::fromNegativeCacheSize($cacheSize);

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -29,24 +29,24 @@ use function array_merge;
  *
  * @implements NamedObject<OptionallyQualifiedName>
  */
-final class Table implements NamedObject
+final readonly class Table implements NamedObject
 {
     /** @var ReadableObjectSet<Column> */
-    private readonly ReadableObjectSet $columns;
+    private ReadableObjectSet $columns;
 
     /** @var ReadableObjectSet<Index> */
-    private readonly ReadableObjectSet $indexes;
+    private ReadableObjectSet $indexes;
 
     /**
      * The names of the indexes that were implicitly created as backing for foreign key constraints.
      */
-    private readonly UnqualifiedNameSet $implicitIndexNames;
+    private UnqualifiedNameSet $implicitIndexNames;
 
     /** @var ReadableObjectSet<UniqueConstraint> */
-    private readonly ReadableObjectSet $uniqueConstraints;
+    private ReadableObjectSet $uniqueConstraints;
 
     /** @var ReadableObjectSet<ForeignKeyConstraint> */
-    private readonly ReadableObjectSet $foreignKeyConstraints;
+    private ReadableObjectSet $foreignKeyConstraints;
 
     /** @var mixed[] */
     private array $options;
@@ -64,16 +64,16 @@ final class Table implements NamedObject
      * @param array<string, string>      $renamedColumns
      */
     public function __construct(
-        private readonly OptionallyQualifiedName $name,
+        private OptionallyQualifiedName $name,
         array $columns,
         array $indexes,
         array $implicitIndexNames,
         array $uniqueConstraints,
         array $foreignKeyConstraints,
         array $options,
-        private readonly TableConfiguration $configuration,
-        private readonly ?PrimaryKeyConstraint $primaryKeyConstraint,
-        private readonly array $renamedColumns,
+        private TableConfiguration $configuration,
+        private ?PrimaryKeyConstraint $primaryKeyConstraint,
+        private array $renamedColumns,
     ) {
         if ($columns === []) {
             throw InvalidTableDefinition::columnsNotSet($name);
@@ -304,21 +304,6 @@ final class Table implements NamedObject
     public function getOptions(): array
     {
         return $this->options;
-    }
-
-    /**
-     * Clone of a Table triggers a deep clone of all affected assets.
-     */
-    public function __clone()
-    {
-        /** @phpstan-ignore property.readOnlyAssignNotInConstructor */
-        $this->columns = clone $this->columns;
-        /** @phpstan-ignore property.readOnlyAssignNotInConstructor */
-        $this->indexes = clone $this->indexes;
-        /** @phpstan-ignore property.readOnlyAssignNotInConstructor */
-        $this->uniqueConstraints = clone $this->uniqueConstraints;
-        /** @phpstan-ignore property.readOnlyAssignNotInConstructor */
-        $this->foreignKeyConstraints = clone $this->foreignKeyConstraints;
     }
 
     public function getComment(): ?string

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -15,7 +15,7 @@ use function count;
  *
  * @implements OptionallyNamedObject<UnqualifiedName>
  */
-final class UniqueConstraint implements OptionallyNamedObject
+final readonly class UniqueConstraint implements OptionallyNamedObject
 {
     /**
      * @internal Use {@link UniqueConstraint::editor()} to instantiate an editor and
@@ -28,9 +28,9 @@ final class UniqueConstraint implements OptionallyNamedObject
      * @param non-empty-list<UnqualifiedName> $columnNames Names of the columns covered by the unique constraint.
      */
     public function __construct(
-        private readonly ?UnqualifiedName $name,
-        private readonly array $columnNames,
-        private readonly bool $isClustered,
+        private ?UnqualifiedName $name,
+        private array $columnNames,
+        private bool $isClustered,
     ) {
         if (count($columnNames) < 1) {
             throw InvalidUniqueConstraintDefinition::columnNamesAreNotSet($name);

--- a/src/Schema/View.php
+++ b/src/Schema/View.php
@@ -12,10 +12,10 @@ use Override;
  *
  * @implements NamedObject<OptionallyQualifiedName>
  */
-final class View implements NamedObject
+final readonly class View implements NamedObject
 {
     /** @internal Use {@link View::editor()} to instantiate an editor and {@link ViewEditor::create()} to create a view. */
-    public function __construct(private readonly OptionallyQualifiedName $name, private readonly string $sql)
+    public function __construct(private OptionallyQualifiedName $name, private string $sql)
     {
     }
 

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\ImproperlyQualifiedName;
-use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -113,57 +112,6 @@ class SchemaTest extends TestCase
         $this->expectException(SchemaException::class);
 
         $schema->getSequence('unknown');
-    }
-
-    public function testDeepClone(): void
-    {
-        $tableA = Table::editor()
-            ->setUnquotedName('foo')
-            ->setColumns(
-                Column::editor()
-                    ->setUnquotedName('id')
-                    ->setTypeName(Types::INTEGER)
-                    ->create(),
-            )
-            ->create();
-
-        $tableB = Table::editor()
-            ->setUnquotedName('bar')
-            ->setColumns(
-                Column::editor()
-                    ->setUnquotedName('id')
-                    ->setTypeName(Types::INTEGER)
-                    ->create(),
-                Column::editor()
-                    ->setUnquotedName('foo_id')
-                    ->setTypeName(Types::INTEGER)
-                    ->create(),
-            )
-            ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
-                    ->setUnquotedReferencingColumnNames('foo_id')
-                    ->setUnquotedReferencedTableName('foo')
-                    ->setUnquotedReferencedColumnNames('id')
-                    ->create(),
-            )
-            ->create();
-
-        $sequence = Sequence::editor()->setUnquotedName('baz')->create();
-
-        $schema = Schema::editor()
-            ->setTables($tableA, $tableB)
-            ->addSequence($sequence)
-            ->create();
-
-        $schemaNew = clone $schema;
-
-        self::assertNotSame($sequence, $schemaNew->getSequence('baz'));
-
-        self::assertNotSame($tableA, $schemaNew->getTable('foo'));
-        self::assertNotSame($tableA->getColumn('id'), $schemaNew->getTable('foo')->getColumn('id'));
-
-        self::assertNotSame($tableB, $schemaNew->getTable('bar'));
-        self::assertNotSame($tableB->getColumn('id'), $schemaNew->getTable('bar')->getColumn('id'));
     }
 
     public function testHasTableForQuotedAsset(): void


### PR DESCRIPTION
The last schema object's mutators were removed in #7395. As of #7394, the schema objects no longer share a common parent class that would force them all to be either readonly or mutable.

The schema object classes are already immutable. This allows us to mark the classes themselves `readonly`. In turn, that eliminates the need to handle object cloning: a clone is indistinguishable from the original, and a deep clone is indistinguishable from a shallow one.
