### PR TITLE
Add Parsers::parse*Name() methods

### DIFF
--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -324,10 +324,8 @@ abstract class AbstractSchemaManager
 
     private function validateTableName(string $input, string $methodName): void
     {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
-
         try {
-            $tableName = $parser->parse($input);
+            $tableName = Parsers::parseOptionallyQualifiedName($input);
         } catch (Throwable $e) {
             Deprecation::trigger(
                 'doctrine/dbal',

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -601,10 +601,8 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
 
     private function parseReferencedTableName(string $referencedTableName): ?OptionallyQualifiedName
     {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
-
         try {
-            return $parser->parse($referencedTableName);
+            return Parsers::parseOptionallyQualifiedName($referencedTableName);
         } catch (Throwable $e) {
             Deprecation::trigger(
                 'doctrine/dbal',
@@ -624,11 +622,9 @@ class ForeignKeyConstraint extends AbstractOptionallyNamedObject
      */
     private function parseColumnNames(array $columnNames): array
     {
-        $parser = Parsers::getUnqualifiedNameParser();
-
         try {
             return array_map(
-                static fn (string $columnName) => $parser->parse($columnName),
+                static fn (string $columnName) => Parsers::parseUnqualifiedName($columnName),
                 $columnNames,
             );
         } catch (Throwable $e) {

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -651,11 +651,9 @@ class Index extends AbstractNamedObject
     {
         $columns = [];
 
-        $parser = Parsers::getUnqualifiedNameParser();
-
         foreach ($columnNames as $columnName) {
             try {
-                $parsedName = $parser->parse($columnName);
+                $parsedName = Parsers::parseUnqualifiedName($columnName);
             } catch (Throwable $e) {
                 Deprecation::trigger(
                     'doctrine/dbal',

--- a/src/Schema/Name/Parsers.php
+++ b/src/Schema/Name/Parsers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema\Name;
 
+use Doctrine\DBAL\Schema\Name\Parser\Exception;
 use Doctrine\DBAL\Schema\Name\Parser\GenericNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\OptionallyQualifiedNameParser;
 use Doctrine\DBAL\Schema\Name\Parser\UnqualifiedNameParser;
@@ -31,9 +32,21 @@ final class Parsers
         return self::$unqualifiedNameParser ??= new UnqualifiedNameParser(self::getGenericNameParser());
     }
 
+    /** @throws Exception */
+    public static function parseUnqualifiedName(string $input): UnqualifiedName
+    {
+        return self::getUnqualifiedNameParser()->parse($input);
+    }
+
     public static function getOptionallyQualifiedNameParser(): OptionallyQualifiedNameParser
     {
         return self::$optionallyQualifiedNameParser ??= new OptionallyQualifiedNameParser(self::getGenericNameParser());
+    }
+
+    /** @throws Exception */
+    public static function parseOptionallyQualifiedName(string $input): OptionallyQualifiedName
+    {
+        return self::getOptionallyQualifiedNameParser()->parse($input);
     }
 
     public static function getGenericNameParser(): GenericNameParser

--- a/src/Schema/UniqueConstraint.php
+++ b/src/Schema/UniqueConstraint.php
@@ -322,10 +322,8 @@ class UniqueConstraint extends AbstractOptionallyNamedObject
 
         $this->columns[$column] = new Identifier($column);
 
-        $parser = Parsers::getUnqualifiedNameParser();
-
         try {
-            $this->columnNames[] = $parser->parse($column);
+            $this->columnNames[] = Parsers::parseUnqualifiedName($column);
         } catch (Throwable $e) {
             $this->failedToParseColumnNames = true;
 


### PR DESCRIPTION
Most consumers of the `Parsers` helper don't need a parser instance (`Parsers::get*NameParser()`); they need to parse a name. The only exception is `AbstractAsset::_setName()`, which is shared between subclasses that use different parsers for their respective name classes, and which has already been removed in `5.0.x`.

To slightly reduce the boilerplate, we can introduce `Parsers::parse*Name()` methods. They will be more extensively used in DBAL `5.0.x` and also, potentially, the ORM as an upgrade path towards names as objects (e.g. https://github.com/doctrine/orm/pull/12357).