### PR TITLE
Reduce name parsing boilerplate

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -148,4 +148,9 @@
     <rule ref="Squiz.Arrays.ArrayDeclaration.KeySpecified">
         <exclude-pattern>src/Platforms/SQLServerPlatform.php</exclude-pattern>
     </rule>
+
+    <!-- See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1435 -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSame">
+        <exclude-pattern>src/Schema/Name/Parsers.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2240,10 +2240,8 @@ abstract class AbstractPlatform
 
     protected function parseUnqualifiedName(string $name): UnqualifiedName
     {
-        $parser = Parsers::getUnqualifiedNameParser();
-
         try {
-            return $parser->parse($name);
+            return Parsers::parseUnqualifiedName($name);
         } catch (Name\Parser\Exception $e) {
             throw InvalidName::fromParserException($name, $e);
         }
@@ -2251,10 +2249,8 @@ abstract class AbstractPlatform
 
     protected function parseOptionallyQualifiedName(string $name): OptionallyQualifiedName
     {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
-
         try {
-            return $parser->parse($name);
+            return Parsers::parseOptionallyQualifiedName($name);
         } catch (Name\Parser\Exception $e) {
             throw InvalidName::fromParserException($name, $e);
         }

--- a/src/Schema/AbstractSchemaManager.php
+++ b/src/Schema/AbstractSchemaManager.php
@@ -894,10 +894,8 @@ abstract class AbstractSchemaManager
 
     protected function parseUnqualifiedName(string $name): UnqualifiedName
     {
-        $parser = Parsers::getUnqualifiedNameParser();
-
         try {
-            return $parser->parse($name);
+            return Parsers::parseUnqualifiedName($name);
         } catch (Parser\Exception $e) {
             throw InvalidName::fromParserException($name, $e);
         }
@@ -905,10 +903,8 @@ abstract class AbstractSchemaManager
 
     protected function parseOptionallyQualifiedName(string $name): OptionallyQualifiedName
     {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
-
         try {
-            return $parser->parse($name);
+            return Parsers::parseOptionallyQualifiedName($name);
         } catch (Parser\Exception $e) {
             throw InvalidName::fromParserException($name, $e);
         }

--- a/src/Schema/Name/Parsers.php
+++ b/src/Schema/Name/Parsers.php
@@ -27,29 +27,25 @@ final class Parsers
     {
     }
 
-    public static function getUnqualifiedNameParser(): UnqualifiedNameParser
-    {
-        return self::$unqualifiedNameParser ??= new UnqualifiedNameParser(self::getGenericNameParser());
-    }
-
     /** @throws Exception */
     public static function parseUnqualifiedName(string $input): UnqualifiedName
     {
-        return self::getUnqualifiedNameParser()->parse($input);
-    }
+        $parser = self::$unqualifiedNameParser
+              ??= new UnqualifiedNameParser(self::getGenericNameParser());
 
-    public static function getOptionallyQualifiedNameParser(): OptionallyQualifiedNameParser
-    {
-        return self::$optionallyQualifiedNameParser ??= new OptionallyQualifiedNameParser(self::getGenericNameParser());
+        return $parser->parse($input);
     }
 
     /** @throws Exception */
     public static function parseOptionallyQualifiedName(string $input): OptionallyQualifiedName
     {
-        return self::getOptionallyQualifiedNameParser()->parse($input);
+        $parser = self::$optionallyQualifiedNameParser
+              ??= new OptionallyQualifiedNameParser(self::getGenericNameParser());
+
+        return $parser->parse($input);
     }
 
-    public static function getGenericNameParser(): GenericNameParser
+    private static function getGenericNameParser(): GenericNameParser
     {
         return self::$genericNameParser ??= new GenericNameParser();
     }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -173,10 +173,8 @@ final readonly class Schema
 
     private function parseUnqualifiedName(string $input): UnqualifiedName
     {
-        $parser = Parsers::getUnqualifiedNameParser();
-
         try {
-            return $parser->parse($input);
+            return Parsers::parseUnqualifiedName($input);
         } catch (Parser\Exception $e) {
             throw InvalidName::fromParserException($input, $e);
         }
@@ -184,10 +182,8 @@ final readonly class Schema
 
     private function parseOptionallyQualifiedName(string $input): OptionallyQualifiedName
     {
-        $parser = Parsers::getOptionallyQualifiedNameParser();
-
         try {
-            return $parser->parse($input);
+            return Parsers::parseOptionallyQualifiedName($input);
         } catch (Parser\Exception $e) {
             throw InvalidName::fromParserException($input, $e);
         }

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -135,10 +135,8 @@ final readonly class Table implements NamedObject
 
     private function parseUnqualifiedName(string $name): UnqualifiedName
     {
-        $parser = Parsers::getUnqualifiedNameParser();
-
         try {
-            return $parser->parse($name);
+            return Parsers::parseUnqualifiedName($name);
         } catch (Parser\Exception $e) {
             throw InvalidName::fromParserException($name, $e);
         }


### PR DESCRIPTION
1. Instead of `Parsers::get*NameParser()->parse()`, call `Parsers::parse*Name()`.
2. Remove `Parsers::getUnqualifiedNameParser()` and `Parsers::getOptionallyQualifiedNameParser()`.
3. Make `Parsers::getGenericNameParser()` private (since https://github.com/doctrine/dbal/pull/7400, it's an internal implementation detail of the other two parsers).