### PR TITLE
feat: output table and column when an InvalidColumnDeclaration is thrown

### DIFF
--- a/src/Exception/InvalidColumnDeclaration.php
+++ b/src/Exception/InvalidColumnDeclaration.php
@@ -11,8 +11,31 @@ use function sprintf;
 
 final class InvalidColumnDeclaration extends LogicException implements Exception
 {
+
+    public string $column;
+    public string $table;
+
     public static function fromInvalidColumnType(string $columnName, InvalidColumnType $e): self
     {
-        return new self(sprintf('Column "%s" has invalid type', $columnName), 0, $e);
+        $e->setColumn($columnName);
+        return (new self('Column "%s" has invalid type', 0, $e))->setColumn($columnName);
+    }
+
+    public function setColumn(string $column): self
+    {
+        $this->column = $column;
+        return $this;
+    }
+
+    public function setTable(string $table): self
+    {
+        $this->table = $table;
+        return $this;
+    }
+
+    public function updateErrorMessage(): self
+    {
+        $this->message = sprintf('Column "%s" in table "%s" has invalid type', $this->column, $this->table);
+        return $this;
     }
 }

--- a/src/Exception/InvalidColumnDeclaration.php
+++ b/src/Exception/InvalidColumnDeclaration.php
@@ -11,31 +11,34 @@ use function sprintf;
 
 final class InvalidColumnDeclaration extends LogicException implements Exception
 {
-
     public string $column;
     public string $table;
 
     public static function fromInvalidColumnType(string $columnName, InvalidColumnType $e): self
     {
         $e->setColumn($columnName);
+
         return (new self('Column "%s" has invalid type', 0, $e))->setColumn($columnName);
     }
 
     public function setColumn(string $column): self
     {
         $this->column = $column;
+
         return $this;
     }
 
     public function setTable(string $table): self
     {
         $this->table = $table;
+
         return $this;
     }
 
     public function updateErrorMessage(): self
     {
         $this->message = sprintf('Column "%s" in table "%s" has invalid type', $this->column, $this->table);
+
         return $this;
     }
 }

--- a/src/Exception/InvalidColumnType.php
+++ b/src/Exception/InvalidColumnType.php
@@ -7,27 +7,31 @@ namespace Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception;
 use LogicException;
 
+use function sprintf;
+
 abstract class InvalidColumnType extends LogicException implements Exception
 {
-  public string $tableName;
-  public string $columnName;
+    public string $tableName;
+    public string $columnName;
 
-  public function updateErrorMessage(): self
-  {
-    $this->message = sprintf('Column "%s" in table "%s": %s', $this->columnName, $this->tableName, $this->message);
-    return $this;
-  }
+    public function updateErrorMessage(): self
+    {
+        $this->message = sprintf('Column "%s" in table "%s": %s', $this->columnName, $this->tableName, $this->message);
 
-  public function setTable(string $table): self
-  {
-      $this->tableName = $table;
-      return $this;
-  }
+        return $this;
+    }
 
-  public function setColumn(string $column): self
-  {
-      $this->columnName = $column;
-      return $this;
-  }
+    public function setTable(string $table): self
+    {
+        $this->tableName = $table;
 
+        return $this;
+    }
+
+    public function setColumn(string $column): self
+    {
+        $this->columnName = $column;
+
+        return $this;
+    }
 }

--- a/src/Exception/InvalidColumnType.php
+++ b/src/Exception/InvalidColumnType.php
@@ -9,4 +9,25 @@ use LogicException;
 
 abstract class InvalidColumnType extends LogicException implements Exception
 {
+  public string $tableName;
+  public string $columnName;
+
+  public function updateErrorMessage(): self
+  {
+    $this->message = sprintf('Column "%s" in table "%s": %s', $this->columnName, $this->tableName, $this->message);
+    return $this;
+  }
+
+  public function setTable(string $table): self
+  {
+      $this->tableName = $table;
+      return $this;
+  }
+
+  public function setColumn(string $column): self
+  {
+      $this->columnName = $column;
+      return $this;
+  }
+
 }

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -208,6 +208,7 @@ class Comparator
                     $prev->setTable($newTableName);
                     $prev->updateErrorMessage();
                 }
+
                 throw $e;
             }
 

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Schema;
 
+use Doctrine\DBAL\Exception\InvalidColumnDeclaration;
+use Doctrine\DBAL\Exception\InvalidColumnType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
 
@@ -193,8 +195,20 @@ class Comparator
 
             $newColumn = $newTable->getColumn($oldColumnName);
 
-            if ($this->columnsEqual($oldColumn, $newColumn)) {
-                continue;
+            try {
+                if ($this->columnsEqual($oldColumn, $newColumn)) {
+                    continue;
+                }
+            } catch (InvalidColumnDeclaration $e) {
+                $newTableName = $newTable->getObjectName()->toString();
+                $e->setTable($newTableName)
+                  ->updateErrorMessage();
+                $prev = $e->getPrevious();
+                if ($prev instanceof InvalidColumnType) {
+                    $prev->setTable($newTableName);
+                    $prev->updateErrorMessage();
+                }
+                throw $e;
             }
 
             $modifiedColumns[$oldColumnName] = new ColumnDiff($oldColumn, $newColumn);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Issue | #7406 

#### Summary

Added table name to the error message of `InvalidColumnDeclaration`.
`InvalidColumnType` Exceptions are now prefixed by table name and column.
