### PR TITLE
Forward libpq TCP keepalive / tcp_user_timeout parameters in the PostgreSQL drivers

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -287,6 +287,24 @@ pdo_pgsql / pgsql
 -  ``persistent`` (boolean): Whether to establish a persistent connection (currently supported only by ``pdo_pgsql``).
 -  ``application_name`` (string): Name of the application that is
    connecting to database. Optional. It will be displayed at ``pg_stat_activity``.
+-  ``connect_timeout`` (integer): Maximum time to wait while connecting, in seconds.
+   See `www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT>`_
+-  ``keepalives`` (integer): Controls whether client-side TCP keepalives are used (``1`` to
+   enable, ``0`` to disable).
+   See `www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-KEEPALIVES <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-KEEPALIVES>`_
+-  ``keepalives_idle`` (integer): Number of seconds of inactivity after which a TCP keepalive
+   message is sent to the server.
+-  ``keepalives_interval`` (integer): Number of seconds after which an unacknowledged TCP
+   keepalive message is retransmitted.
+-  ``keepalives_count`` (integer): Number of TCP keepalives that can be lost before the
+   connection is considered dead.
+-  ``tcp_user_timeout`` (integer): Number of milliseconds that transmitted data may remain
+   unacknowledged before the connection is forcibly closed. Useful to bound how long a
+   query blocks when a connection is silently dropped.
+   See `www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-TCP-USER-TIMEOUT <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-TCP-USER-TIMEOUT>`_
+
+These keepalive and timeout parameters are forwarded to libpq and apply to both the
+``pdo_pgsql`` and ``pgsql`` drivers.
 
 PostgreSQL behaves differently with regard to booleans when you use
 ``PDO::ATTR_EMULATE_PREPARES`` or not. To switch from using ``'true'``

--- a/src/Driver/PDO/PgSQL/Driver.php
+++ b/src/Driver/PDO/PgSQL/Driver.php
@@ -126,6 +126,30 @@ final class Driver extends AbstractPostgreSQLDriver
             $dsn .= 'gssencmode=' . $params['gssencmode'] . ';';
         }
 
+        if (isset($params['connect_timeout'])) {
+            $dsn .= 'connect_timeout=' . $params['connect_timeout'] . ';';
+        }
+
+        if (isset($params['keepalives'])) {
+            $dsn .= 'keepalives=' . $params['keepalives'] . ';';
+        }
+
+        if (isset($params['keepalives_idle'])) {
+            $dsn .= 'keepalives_idle=' . $params['keepalives_idle'] . ';';
+        }
+
+        if (isset($params['keepalives_interval'])) {
+            $dsn .= 'keepalives_interval=' . $params['keepalives_interval'] . ';';
+        }
+
+        if (isset($params['keepalives_count'])) {
+            $dsn .= 'keepalives_count=' . $params['keepalives_count'] . ';';
+        }
+
+        if (isset($params['tcp_user_timeout'])) {
+            $dsn .= 'tcp_user_timeout=' . $params['tcp_user_timeout'] . ';';
+        }
+
         return $dsn;
     }
 }

--- a/src/Driver/PgSQL/Driver.php
+++ b/src/Driver/PgSQL/Driver.php
@@ -85,6 +85,12 @@ final class Driver extends AbstractPostgreSQLDriver
                 'password' => $params['password'] ?? null,
                 'sslmode' => $params['sslmode'] ?? null,
                 'gssencmode' => $params['gssencmode'] ?? null,
+                'connect_timeout' => $params['connect_timeout'] ?? null,
+                'keepalives' => $params['keepalives'] ?? null,
+                'keepalives_idle' => $params['keepalives_idle'] ?? null,
+                'keepalives_interval' => $params['keepalives_interval'] ?? null,
+                'keepalives_count' => $params['keepalives_count'] ?? null,
+                'tcp_user_timeout' => $params['tcp_user_timeout'] ?? null,
             ],
             static fn (int|string|null $value) => $value !== '' && $value !== null,
         );

--- a/tests/Driver/PDO/PgSQL/DriverTest.php
+++ b/tests/Driver/PDO/PgSQL/DriverTest.php
@@ -60,6 +60,23 @@ class DriverTest extends AbstractDriverTestCase
         );
     }
 
+    public function testConnectionWithTcpKeepaliveParameters(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $this->createDriver()->connect(array_merge(
+            TestUtil::getConnectionParams(),
+            [
+                'connect_timeout' => 5,
+                'keepalives' => 1,
+                'keepalives_idle' => 10,
+                'keepalives_interval' => 5,
+                'keepalives_count' => 3,
+                'tcp_user_timeout' => 15000,
+            ],
+        ));
+    }
+
     public function testUserIsFalse(): void
     {
         $this->expectException(InvalidConfiguration::class);

--- a/tests/Driver/PgSQL/DriverTest.php
+++ b/tests/Driver/PgSQL/DriverTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\PgSQL\Driver;
 use Doctrine\DBAL\Tests\Driver\AbstractDriverTestCase;
 use Doctrine\DBAL\Tests\TestUtil;
 
+use function array_merge;
 use function in_array;
 
 class DriverTest extends AbstractDriverTestCase
@@ -40,6 +41,23 @@ class DriverTest extends AbstractDriverTestCase
         $params['host'] = '[::1]';
 
         $this->driver->connect($params);
+    }
+
+    public function testConnectionWithTcpKeepaliveParameters(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $this->driver->connect(array_merge(
+            TestUtil::getConnectionParams(),
+            [
+                'connect_timeout' => 5,
+                'keepalives' => 1,
+                'keepalives_idle' => 10,
+                'keepalives_interval' => 5,
+                'keepalives_count' => 3,
+                'tcp_user_timeout' => 15000,
+            ],
+        ));
     }
 
     protected function createDriver(): DriverInterface


### PR DESCRIPTION
Fixes #7408.

### Summary

The PostgreSQL drivers build their connection string from a fixed whitelist of parameters and silently drop everything else, so libpq's TCP-resilience keywords cannot be configured through DBAL today. This adds support for:

- `keepalives`
- `keepalives_idle`
- `keepalives_interval`
- `keepalives_count`
- `tcp_user_timeout`
- `connect_timeout`

in **both** PostgreSQL drivers, in the same explicit style already used for the `ssl*` / `gssencmode` keywords.

### Why

When a TCP connection to PostgreSQL is silently cut mid-query (flaky inter-DC link, stateful firewall dropping an idle entry, LB reset without RST), the PHP process blocks in libpq's `recv()` until the **kernel** gives up — with the Linux default `net.ipv4.tcp_retries2 = 15` that is **~15 minutes** per stuck request, which can exhaust the worker/FPM pool. These libpq keywords bound dead-peer detection to a few seconds, but there was previously no way to set them via DBAL. See #7408 for the full context (real-world incident + measurements).

### Changes

- `Driver\PDO\PgSQL\Driver::constructPdoDsn()` — append the keywords to the PDO DSN.
- `Driver\PgSQL\Driver::constructConnectionString()` — add the keywords to the native `pg_connect` connection string.
- Functional connection tests for both drivers (gated on the pgsql/pdo_pgsql phpunit config, like the existing ones).
- Docs: document the new parameters under *pdo_pgsql / pgsql*.

### Verification

- `phpcs` (Doctrine CS) and `phpstan` pass on the changed files.
- DSN/conninfo output verified for both drivers, e.g. PDO: `pgsql:host=...;...;keepalives=1;keepalives_idle=10;keepalives_interval=5;keepalives_count=3;tcp_user_timeout=15000;connect_timeout=5;`

### Notes

- Draft pending the maintainers' answer to the open question in #7408: keep **enumerating** the keywords (this PR), or switch to a **generic passthrough** of a documented libpq keyword set? Happy to adapt.
- Targeted `4.4.x`; glad to retarget to whichever branch you prefer for a feature.
