### PR TITLE
Cover Table constraint lookup failures

### DIFF
--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -8,9 +8,11 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Exception\ForeignKeyDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\IndexDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\InvalidState;
 use Doctrine\DBAL\Schema\Exception\PrimaryKeyAlreadyExists;
+use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
@@ -450,12 +452,42 @@ class TableTest extends TestCase
 
     public function testGetUnknownIndexThrowsException(): void
     {
-        $this->expectException(SchemaException::class);
+        $table = $this->createTableWithSingleColumn();
 
-        $table = Table::editor()
-            ->setUnquotedName('foo')
+        $this->expectException(IndexDoesNotExist::class);
+
+        $table->getIndex('unknown');
+    }
+
+    public function testGetUnknownForeignKeyThrowsException(): void
+    {
+        $table = $this->createTableWithSingleColumn();
+
+        $this->expectException(ForeignKeyDoesNotExist::class);
+
+        $table->getForeignKey('unknown');
+    }
+
+    public function testGetUnknownUniqueConstraintThrowsException(): void
+    {
+        $table = $this->createTableWithSingleColumn();
+
+        $this->expectException(UniqueConstraintDoesNotExist::class);
+
+        $table->getUniqueConstraint('unknown');
+    }
+
+    private function createTableWithSingleColumn(): Table
+    {
+        return Table::editor()
+            ->setUnquotedName('users')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
             ->create();
-        $table->getIndex('unknownIndex');
     }
 
     public function testAddTwoPrimaryThrowsException(): void


### PR DESCRIPTION
The `testGetUnknownIndexThrowsException()` test passes for the wrong reason: it creates a table with no columns, so the `SchemaException` is thrown because of that, not because the index cannot be found. As a result, the code it is meant to cover is left uncovered. Fix the test and add two more for symmetry.

This change reduces the amount of code not covered by tests.