### PR TITLE
Remove AbstractPlatform::getRenameIndexSQL()

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1266,17 +1266,6 @@ abstract class AbstractPlatform
     }
 
     /**
-     * Returns the SQL for renaming an index on a table.
-     *
-     * @param string $oldIndexName The name of the index to rename from.
-     * @param Index  $index        The definition of the index to rename to.
-     * @param string $tableName    The table to rename the given index on.
-     *
-     * @return list<string> The sequence of SQL statements for renaming the given index.
-     */
-    abstract protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array;
-
-    /**
      * Returns the SQL for renaming a column
      *
      * @param string $tableName     The table to rename the column on.

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -350,13 +350,10 @@ class DB2Platform extends AbstractPlatform
         }
 
         foreach ($diff->getIndexRenames() as $rename) {
-            $sql = array_merge(
-                $sql,
-                $this->getRenameIndexSQL(
-                    $rename->getOldName()->toSQL($this),
-                    $rename->getNewIndex(),
-                    $tableNameSQL,
-                ),
+            $sql[] = sprintf(
+                'RENAME INDEX %s TO %s',
+                $this->deriveQualifier($rename->getOldName(), $tableName)->toSQL($this),
+                $rename->getNewIndex()->getObjectName()->toSQL($this),
             );
         }
 
@@ -476,21 +473,6 @@ class DB2Platform extends AbstractPlatform
         }
 
         return $clauses;
-    }
-
-    #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-        $parsedTableName    = $this->parseOptionallyQualifiedName($tableName);
-
-        return [
-            sprintf(
-                'RENAME INDEX %s TO %s',
-                $this->deriveQualifier($parsedOldIndexName, $parsedTableName)->toSQL($this),
-                $index->getObjectName()->toSQL($this),
-            ),
-        ];
     }
 
     #[Override]

--- a/src/Platforms/MariaDBPlatform.php
+++ b/src/Platforms/MariaDBPlatform.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
-use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Types\JsonType;
 use Override;
 
@@ -16,22 +15,6 @@ use function sprintf;
  */
 class MariaDBPlatform extends AbstractMySQLPlatform
 {
-    #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-        $parsedTableName    = $this->parseOptionallyQualifiedName($tableName);
-
-        return [
-            sprintf(
-                'ALTER TABLE %s RENAME INDEX %s TO %s',
-                $parsedTableName->toSQL($this),
-                $parsedOldIndexName->toSQL($this),
-                $index->getObjectName()->toSQL($this),
-            ),
-        ];
-    }
-
     /**
      * Generate SQL snippets to reverse the aliasing of JSON to LONGTEXT.
      *

--- a/src/Platforms/MySQLPlatform.php
+++ b/src/Platforms/MySQLPlatform.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Platforms;
 
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
-use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\TextType;
 use Override;
-
-use function sprintf;
 
 /**
  * Provides the behavior, features and SQL dialect of the Oracle MySQL database platform
@@ -43,21 +40,5 @@ class MySQLPlatform extends AbstractMySQLPlatform
     public function getCurrentTimeSQL(): string
     {
         throw NotSupported::new(__METHOD__);
-    }
-
-    #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-        $parsedTableName    = $this->parseOptionallyQualifiedName($tableName);
-
-        return [
-            sprintf(
-                'ALTER TABLE %s RENAME INDEX %s TO %s',
-                $parsedTableName->toSQL($this),
-                $parsedOldIndexName->toSQL($this),
-                $index->getObjectName()->toSQL($this),
-            ),
-        ];
     }
 }

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -640,13 +640,10 @@ SQL,
         }
 
         foreach ($diff->getIndexRenames() as $rename) {
-            $sql = array_merge(
-                $sql,
-                $this->getRenameIndexSQL(
-                    $rename->getOldName()->toSQL($this),
-                    $rename->getNewIndex(),
-                    $tableNameSQL,
-                ),
+            $sql[] = sprintf(
+                'ALTER INDEX %s RENAME TO %s',
+                $this->deriveQualifier($rename->getOldName(), $tableName)->toSQL($this),
+                $rename->getNewIndex()->getObjectName()->toSQL($this),
             );
         }
 
@@ -672,21 +669,6 @@ SQL,
         }
 
         return $column['name']->toSQL($this) . ' ' . $declaration;
-    }
-
-    #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-        $parsedTableName    = $this->parseOptionallyQualifiedName($tableName);
-
-        return [
-            sprintf(
-                'ALTER INDEX %s RENAME TO %s',
-                $this->deriveQualifier($parsedOldIndexName, $parsedTableName)->toSQL($this),
-                $index->getObjectName()->toSQL($this),
-            ),
-        ];
     }
 
     private function generateAutoincrementSequenceName(OptionallyQualifiedName $tableName): OptionallyQualifiedName

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -314,13 +314,10 @@ class PostgreSQLPlatform extends AbstractPlatform
         }
 
         foreach ($diff->getIndexRenames() as $rename) {
-            $sql = array_merge(
-                $sql,
-                $this->getRenameIndexSQL(
-                    $rename->getOldName()->toSQL($this),
-                    $rename->getNewIndex(),
-                    $tableNameSQL,
-                ),
+            $sql[] = sprintf(
+                'ALTER INDEX %s RENAME TO %s',
+                $this->deriveQualifier($rename->getOldName(), $tableName)->toSQL($this),
+                $rename->getNewIndex()->getObjectName()->toSQL($this),
             );
         }
 
@@ -336,21 +333,6 @@ class PostgreSQLPlatform extends AbstractPlatform
         $columnDefinition['autoincrement'] = false;
 
         return $type->getSQLDeclaration($columnDefinition, $this);
-    }
-
-    #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-        $parsedTableName    = $this->parseOptionallyQualifiedName($tableName);
-
-        return [
-            sprintf(
-                'ALTER INDEX %s RENAME TO %s',
-                $this->deriveQualifier($parsedOldIndexName, $parsedTableName)->toSQL($this),
-                $index->getObjectName()->toSQL($this),
-            ),
-        ];
     }
 
     #[Override]

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -472,13 +472,14 @@ class SQLServerPlatform extends AbstractPlatform
         }
 
         foreach ($diff->getIndexRenames() as $rename) {
-            $sql = array_merge(
-                $sql,
-                $this->getRenameIndexSQL(
-                    $rename->getOldName()->toSQL($this),
-                    $rename->getNewIndex(),
-                    $tableNameSQL,
-                ),
+            $sql[] = $this->getRenameSQL(
+                $tableNameSQL . '.' . $rename->getOldName()->toSQL($this),
+                $rename->getNewIndex()->getObjectName()
+                    ->getIdentifier()
+                    ->toNormalizedValue(
+                        $this->getUnquotedIdentifierFolding(),
+                    ),
+                'INDEX',
             );
         }
 
@@ -620,25 +621,6 @@ class SQLServerPlatform extends AbstractPlatform
                 ),
             ]),
         );
-    }
-
-    #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        $parsedOldIndexName = $this->parseUnqualifiedName($oldIndexName);
-        $parsedTableName    = $this->parseOptionallyQualifiedName($tableName);
-
-        return [
-            $this->getRenameSQL(
-                $parsedTableName->toSQL($this) . '.' . $parsedOldIndexName->toSQL($this),
-                $index->getObjectName()
-                    ->getIdentifier()
-                    ->toNormalizedValue(
-                        $this->getUnquotedIdentifierFolding(),
-                    ),
-                'INDEX',
-            ),
-        ];
     }
 
     #[Override]

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -542,15 +542,6 @@ class SQLitePlatform extends AbstractPlatform
     }
 
     #[Override]
-    protected function getRenameIndexSQL(string $oldIndexName, Index $index, string $tableName): array
-    {
-        return [
-            $this->getDropIndexSQL($oldIndexName, $tableName),
-            $this->getCreateIndexSQL($index, $tableName),
-        ];
-    }
-
-    #[Override]
     public function getDropTablesSQL(array $tables): array
     {
         $sql = [];


### PR DESCRIPTION
`AbstractPlatform::getRenameIndexSQL()` is defined in the abstract class, but its MySQL/MariaDB and SQLite implementations are dead code: their respective `getAlterTableSQL()` implementations do not and cannot invoke them. Schema managers do not invoke this method either (it's protected).

There is no point in keeping it declared as part of the `AbstractPlatform` API, it's an implementation detail.

This change reduces the amount of code not covered by tests.