### PR TITLE
Document savepoint SQL preconditions

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2287,6 +2287,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to create a new savepoint.
+     *
+     * This method should be invoked only if {@see supportsSavepoints()} returns true.
      */
     public function createSavePoint(string $savepoint): string
     {
@@ -2295,6 +2297,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to release a savepoint.
+     *
+     * This method should be invoked only if {@see supportsReleaseSavepoints()} returns true.
      */
     public function releaseSavePoint(string $savepoint): string
     {
@@ -2303,6 +2307,8 @@ abstract class AbstractPlatform
 
     /**
      * Returns the SQL to rollback a savepoint.
+     *
+     * This method should be invoked only if {@see supportsSavepoints()} returns true.
      */
     public function rollbackSavePoint(string $savepoint): string
     {


### PR DESCRIPTION
Platform implementations contain some dead and invalid code related to releasing savepoints. The method is supposed to return SQL but may return an empty string, if the platform doesn't support releasing savepoints: https://github.com/doctrine/dbal/blob/4ae3387ea822331ee6b016c8357ea10179b2f254/src/Platforms/OraclePlatform.php#L826-L829 https://github.com/doctrine/dbal/blob/4ae3387ea822331ee6b016c8357ea10179b2f254/src/Platforms/SQLServerPlatform.php#L1161-L1164

In order to safely delete these overrides in 5.0.x, we need to clearly document the method's contract. The other two documented methods don't have this issue, but their contracts are the same, so they are also documented.