### PR TITLE
Use trailing ifs for remaining early exits

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -1486,20 +1486,16 @@ abstract class AbstractPlatform
 
     final protected function ensurePrimaryKeyConstraintIsNotNamed(PrimaryKeyConstraint $constraint): void
     {
-        if ($constraint->getObjectName() === null) {
-            return;
+        if ($constraint->getObjectName() !== null) {
+            throw UnsupportedPrimaryKeyConstraintDefinition::fromNamedConstraint(static::class);
         }
-
-        throw UnsupportedPrimaryKeyConstraintDefinition::fromNamedConstraint(static::class);
     }
 
     final protected function ensurePrimaryKeyConstraintIsClustered(PrimaryKeyConstraint $constraint): void
     {
-        if ($constraint->isClustered()) {
-            return;
+        if (! $constraint->isClustered()) {
+            throw UnsupportedPrimaryKeyConstraintDefinition::fromNonClusteredConstraint(static::class);
         }
-
-        throw UnsupportedPrimaryKeyConstraintDefinition::fromNonClusteredConstraint(static::class);
     }
 
     final protected function ensureIndexHasNoColumnLengths(Index $index): void
@@ -1513,38 +1509,30 @@ abstract class AbstractPlatform
 
     final protected function ensureIndexIsNotFulltext(Index $index): void
     {
-        if ($index->getType() !== IndexType::FULLTEXT) {
-            return;
+        if ($index->getType() === IndexType::FULLTEXT) {
+            throw UnsupportedIndexDefinition::fromFulltextIndex(static::class);
         }
-
-        throw UnsupportedIndexDefinition::fromFulltextIndex(static::class);
     }
 
     final protected function ensureIndexIsNotSpatial(Index $index): void
     {
-        if ($index->getType() !== IndexType::SPATIAL) {
-            return;
+        if ($index->getType() === IndexType::SPATIAL) {
+            throw UnsupportedIndexDefinition::fromSpatialIndex(static::class);
         }
-
-        throw UnsupportedIndexDefinition::fromSpatialIndex(static::class);
     }
 
     final protected function ensureIndexIsNotClustered(Index $index): void
     {
-        if (! $index->isClustered()) {
-            return;
+        if ($index->isClustered()) {
+            throw UnsupportedIndexDefinition::fromClusteredIndex(static::class);
         }
-
-        throw UnsupportedIndexDefinition::fromClusteredIndex(static::class);
     }
 
     final protected function ensureIndexIsNotPartial(Index $index): void
     {
-        if ($index->getPredicate() === null) {
-            return;
+        if ($index->getPredicate() !== null) {
+            throw UnsupportedIndexDefinition::fromPartialIndex(static::class);
         }
-
-        throw UnsupportedIndexDefinition::fromPartialIndex(static::class);
     }
 
     /**

--- a/src/Platforms/PostgreSQL/Comparator.php
+++ b/src/Platforms/PostgreSQL/Comparator.php
@@ -32,14 +32,12 @@ class Comparator extends BaseComparator
         $editor = null;
 
         foreach ($table->getColumns() as $column) {
-            if ($column->getCollation() !== 'default') {
-                continue;
+            if ($column->getCollation() === 'default') {
+                ($editor ??= $table->edit())
+                    ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
+                        $editor->setCollation(null);
+                    });
             }
-
-            ($editor ??= $table->edit())
-                ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
-                    $editor->setCollation(null);
-                });
         }
 
         return $editor === null ? $table : $editor->create();

--- a/src/Platforms/SQLServer/Comparator.php
+++ b/src/Platforms/SQLServer/Comparator.php
@@ -44,14 +44,12 @@ class Comparator extends BaseComparator
         foreach ($table->getColumns() as $column) {
             $collation = $column->getCollation();
 
-            if ($collation !== $this->databaseCollation) {
-                continue;
+            if ($collation === $this->databaseCollation) {
+                ($editor ??= $table->edit())
+                    ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
+                        $editor->setCollation(null);
+                    });
             }
-
-            ($editor ??= $table->edit())
-                ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
-                    $editor->setCollation(null);
-                });
         }
 
         return $editor === null ? $table : $editor->create();

--- a/src/Platforms/SQLite/Comparator.php
+++ b/src/Platforms/SQLite/Comparator.php
@@ -43,14 +43,12 @@ class Comparator extends BaseComparator
         foreach ($table->getColumns() as $column) {
             $collation = $column->getCollation();
 
-            if ($collation === null || strcasecmp($collation, 'binary') !== 0) {
-                continue;
+            if ($collation !== null && strcasecmp($collation, 'binary') === 0) {
+                ($editor ??= $table->edit())
+                    ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
+                        $editor->setCollation(null);
+                    });
             }
-
-            ($editor ??= $table->edit())
-                ->modifyColumn($column->getObjectName(), static function (ColumnEditor $editor): void {
-                    $editor->setCollation(null);
-                });
         }
 
         return $editor === null ? $table : $editor->create();

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -325,11 +325,9 @@ final readonly class Table implements NamedObject
         $explicitIndexes = [];
 
         foreach ($this->indexes as $index) {
-            if ($this->implicitIndexNames->contains($index->getObjectName())) {
-                continue;
+            if (! $this->implicitIndexNames->contains($index->getObjectName())) {
+                $explicitIndexes[] = $index;
             }
-
-            $explicitIndexes[] = $index;
         }
 
         $editor = self::editor()

--- a/src/Schema/TableEditor.php
+++ b/src/Schema/TableEditor.php
@@ -656,11 +656,9 @@ final class TableEditor
                 continue;
             }
 
-            if (! $candidate->isFulfilledBy($index)) {
-                continue;
+            if ($candidate->isFulfilledBy($index)) {
+                $replacedImplicitIndexNames->add($implicitIndexName);
             }
-
-            $replacedImplicitIndexNames->add($implicitIndexName);
         }
 
         if ($indexes->get($indexName) !== null && ! $replacedImplicitIndexNames->contains($indexName)) {


### PR DESCRIPTION
This formatting is possible due to the coding standard changes implemented in https://github.com/doctrine/coding-standard/pull/376. Before the new standard is released, #7411 has applied the same configuration at the project level.