### PR TITLE
Fix adding a commented column on SQLite

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -762,7 +762,9 @@ class SQLitePlatform extends AbstractPlatform
             $type = $definition['type'];
 
             switch (true) {
-                case isset($definition['columnDefinition']) || $definition['autoincrement']:
+                case isset($definition['columnDefinition']):
+                case $definition['autoincrement']:
+                case $definition['comment'] !== '':
                 case $type instanceof Types\DateTimeType && $definition['default'] === $this->getCurrentTimestampSQL():
                 case $type instanceof Types\DateType && $definition['default'] === $this->getCurrentDateSQL():
                 case $type instanceof Types\TimeType && $definition['default'] === $this->getCurrentTimeSQL():

--- a/tests/Functional/Schema/ColumnCommentTest.php
+++ b/tests/Functional/Schema/ColumnCommentTest.php
@@ -110,6 +110,40 @@ class ColumnCommentTest extends FunctionalTestCase
         ];
     }
 
+    public function testAddColumnWithComment(): void
+    {
+        $table1 = Table::editor()
+            ->setUnquotedName('column_comments')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropAndCreateTable($table1);
+
+        $table2 = $table1->edit()
+            ->addColumn(
+                Column::editor()
+                    ->setUnquotedName('added')
+                    ->setTypeName(Types::INTEGER)
+                    ->setComment('added column comment')
+                    ->create(),
+            )
+            ->create();
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $diff = $schemaManager->createComparator()
+            ->compareTables($table1, $table2);
+
+        $schemaManager->alterTable($diff);
+
+        $this->assertColumnComment('added', 'added column comment');
+    }
+
     private function assertColumnComment(string $columnName, string $expectedComment): void
     {
         self::assertSame(


### PR DESCRIPTION
SQLite cannot add a column with a comment via `ALTER TABLE ADD COLUMN` because this statement cannot carry the comment. In this case, the table needs to be recreated.