### PR TITLE
Remove dead releaseSavePoint() overrides

### DIFF
--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -781,12 +781,6 @@ SQL,
     }
 
     #[Override]
-    public function releaseSavePoint(string $savepoint): string
-    {
-        return '';
-    }
-
-    #[Override]
     public function getBlobTypeDeclarationSQL(array $column): string
     {
         return 'BLOB';

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1030,12 +1030,6 @@ class SQLServerPlatform extends AbstractPlatform
     }
 
     #[Override]
-    public function releaseSavePoint(string $savepoint): string
-    {
-        return '';
-    }
-
-    #[Override]
     public function rollbackSavePoint(string $savepoint): string
     {
         return 'ROLLBACK TRANSACTION ' . $savepoint;


### PR DESCRIPTION
Starting https://github.com/doctrine/dbal/pull/7419, API consumers are explicitly instructed to invoke `AbstractPlatform::releaseSavePoint()` only if `supportsReleaseSavepoints()` returns `true`. For the platforms that don't support that, these overrides are no longer necessary (this is dead code not covered by tests).