### PR TITLE
Introspect NVARCHAR(MAX) as text type in SQL Server schema manager

### DIFF
--- a/src/Schema/SQLServerSchemaManager.php
+++ b/src/Schema/SQLServerSchemaManager.php
@@ -87,6 +87,7 @@ SQL,
 
             case 'nvarchar':
                 if ($length === -1) {
+                    $dbType = 'text';
                     break;
                 }
 

--- a/tests/Functional/Schema/SQLServerSchemaManagerTest.php
+++ b/tests/Functional/Schema/SQLServerSchemaManagerTest.php
@@ -201,6 +201,8 @@ class SQLServerSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         $table = $this->schemaManager->introspectTableByUnquotedName('test_nvarchar_max');
 
+        self::assertSame(Types::TEXT, $table->getColumn('col_nvarchar_max')->getType()->getName());
+        self::assertSame(Types::STRING, $table->getColumn('col_nvarchar')->getType()->getName());
         self::assertSame(-1, $table->getColumn('col_nvarchar_max')->getLength());
         self::assertSame(128, $table->getColumn('col_nvarchar')->getLength());
     }


### PR DESCRIPTION
## Problem

`NVARCHAR(MAX)` in SQL Server represents large text data (up to 2GB), similar to `VARCHAR(MAX)`. Both are returned with `length = -1` by SQL Server, but only `VARCHAR(MAX)` was correctly introspected as the `text` Doctrine type. `NVARCHAR(MAX)` was left as `string`, causing incorrect schema introspection, false diffs in migrations, and wrong SQL generation.

## Solution

Add `$dbType = 'text'` for `nvarchar` when `length === -1`, consistent with the existing handling of `varchar` and `varbinary`.

## Changes

- `src/Schema/SQLServerSchemaManager.php` — introspect `NVARCHAR(MAX)` as `text`
- `tests/Functional/Schema/SQLServerSchemaManagerTest.php` — extend existing `testNvarcharMaxIsLengthMinus1` test to also assert the column type

Fixes #7264