### PR TITLE
Fix #7330: Support configurable identifier folding and fix Oracle met…

### DIFF
--- a/src/Platforms/Oracle/OracleMetadataProvider.php
+++ b/src/Platforms/Oracle/OracleMetadataProvider.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Metadata\DatabaseMetadataRow;
 use Doctrine\DBAL\Schema\Metadata\ForeignKeyConstraintColumnMetadataRow;
@@ -522,14 +523,17 @@ SQL,
             $qualifier    = $relation !== null ? $relation . '.' : '';
             $conditions[] = $qualifier . 'TABLE_NAME = :TABLE_NAME';
 
-            $params['TABLE_NAME'] = $tableName;
+            $identifier = new Identifier($tableName);
+
+            $params['TABLE_NAME'] = $identifier->isQuoted()
+                ? $identifier->getName()
+                : strtoupper($identifier->getName());
         } else {
             $conditions[] = '1 = 1';
         }
 
         return implode(' AND ', $conditions);
     }
-
     /**
      * {@inheritDoc}
      *

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -37,9 +37,9 @@ use function substr;
  */
 class OraclePlatform extends AbstractPlatform
 {
-    public function __construct()
+    public function __construct(?UnquotedIdentifierFolding $unquotedIdentifierFolding = null)
     {
-        parent::__construct(UnquotedIdentifierFolding::UPPER);
+        parent::__construct($unquotedIdentifierFolding ?? UnquotedIdentifierFolding::UPPER);
     }
 
     public function getSubstringExpression(string $string, string $start, ?string $length = null): string

--- a/tests/Functional/Schema/OracleSchemaManagerTest.php
+++ b/tests/Functional/Schema/OracleSchemaManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
@@ -11,6 +12,8 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\DBAL\Schema\OracleSchemaManager;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\TestUtil;
@@ -18,6 +21,7 @@ use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\DateTimeTzType;
 use Doctrine\DBAL\Types\DateType;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Types;
 
 use function array_map;
@@ -242,5 +246,36 @@ class OracleSchemaManagerTest extends SchemaManagerFunctionalTestCase
     public function getExpectedDefaultSchemaName(): ?string
     {
         return null;
+    }
+
+    /**
+     * @throws Exception
+     * @throws TypesException
+     */
+    public function testIntrospectTableByUnquotedNameWithLowerFolding(): void
+    {
+        $tableName = 'test_folding_fix';
+        $table = Table::editor()
+            ->setUnquotedName($tableName)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropAndCreateTable($table);
+
+        $platform = new OraclePlatform(UnquotedIdentifierFolding::LOWER);
+
+        $schemaManager = new OracleSchemaManager($this->connection, $platform);
+
+        $introspectedTable = $schemaManager->introspectTableByUnquotedName($tableName);
+
+        self::assertSame(
+            'TEST_FOLDING_FIX',
+            $introspectedTable->getObjectName()->getUnqualifiedName()->getName()
+        );
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7330

#### Summary

Fixes Oracle table introspection when using non-default identifier folding. Unquoted identifiers are now normalized to uppercase before querying the Oracle data dictionary, ensuring tables are found regardless of the platform's folding configuration.

Also updated `OraclePlatform` constructor to allow configuring `UnquotedIdentifierFolding` without reflection.