### PR TITLE
Deduplicate SQLite3 transaction control SQL

### DIFF
--- a/src/Driver/SQLite3/Connection.php
+++ b/src/Driver/SQLite3/Connection.php
@@ -72,29 +72,17 @@ final class Connection implements ConnectionInterface
 
     public function beginTransaction(): void
     {
-        try {
-            $this->connection->exec('BEGIN');
-        } catch (\Exception $e) {
-            throw Exception::new($e);
-        }
+        $this->exec('BEGIN');
     }
 
     public function commit(): void
     {
-        try {
-            $this->connection->exec('COMMIT');
-        } catch (\Exception $e) {
-            throw Exception::new($e);
-        }
+        $this->exec('COMMIT');
     }
 
     public function rollBack(): void
     {
-        try {
-            $this->connection->exec('ROLLBACK');
-        } catch (\Exception $e) {
-            throw Exception::new($e);
-        }
+        $this->exec('ROLLBACK');
     }
 
     public function getNativeConnection(): SQLite3


### PR DESCRIPTION
`beginTransaction()`, `commit()`, and `rollBack()` repeated the error handling that `exec()` already performs: https://github.com/doctrine/dbal/blob/b5d66772921f69b10ba80f1a40bac00bc778201e/src/Driver/SQLite3/Connection.php#L52-L58

Delegate to it so the conversion to a driver exception lives in one place. Otherwise, the reworked code required extra testing for coverage.

UPD: Technically, it's a bug since the original exception is wrapped into a driver exception twice. We can backport it to `4.4.x` if anyone reports it.