### PR TITLE
Detect renamed foreign keys in schema comparator

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -268,6 +268,13 @@ class Comparator
             foreach ($newForeignKeys as $newKey => $newForeignKey) {
                 if ($this->diffForeignKey($oldForeignKey, $newForeignKey) === false) {
                     unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
+
+                    if (strtolower($oldForeignKey->getName()) !== strtolower($newForeignKey->getName())) {
+                        $droppedForeignKeys[$oldKey] = $oldForeignKey;
+                        $addedForeignKeys[$newKey]   = $newForeignKey;
+                    }
+
+                    break;
                 } else {
                     if (strtolower($oldForeignKey->getName()) === strtolower($newForeignKey->getName())) {
                         $droppedForeignKeys[$oldKey] = $oldForeignKey;

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Tests\Functional\Platform\RenameColumnTest;
+use Doctrine\DBAL\Types\Exception\TypesException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -637,10 +638,10 @@ abstract class AbstractComparatorTestCase extends TestCase
             )
             ->create();
 
-        self::assertEquals(
-            new TableDiff($tableA),
-            $this->comparator->compareTables($tableA, $tableB),
-        );
+        $tableDiff = $this->comparator->compareTables($tableA, $tableB);
+
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
+        self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 
     public function testDetectRenameColumn(): void
@@ -1354,5 +1355,52 @@ abstract class AbstractComparatorTestCase extends TestCase
                     ->create(),
             )
             ->create();
+    }
+
+    /**
+     * @throws TypesException
+     */
+    public function testTableRenamedForeignKeyIsDetected(): void
+    {
+        $table1 = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('fk')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setName(UnqualifiedName::unquoted('old_fk_name'))
+                    ->setUnquotedReferencingColumnNames('fk')
+                    ->setUnquotedReferencedTableName('bar')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $table2 = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('fk')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setName(UnqualifiedName::unquoted('new_fk_name'))
+                    ->setUnquotedReferencingColumnNames('fk')
+                    ->setUnquotedReferencedTableName('bar')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $tableDiff = $this->comparator->compareTables($table1, $table2);
+
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
+        self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #7410

#### Summary

The schema comparator detected renamed columns and indexes, but not renamed foreign keys. A foreign key differing from the database only by its name produced no diff, causing `schema:update` to report the schema as in sync and the old constraint name to never be reconciled.

**Root cause:** in `Comparator::compareTables()`, when two FKs are structurally equal (`diffForeignKey() === false`), both are removed from the comparison arrays without checking whether their names differ. The rename is silently discarded.

**Fix:** after finding a structurally equal FK pair, check if the names differ. If so, emit the old FK as dropped and the new FK as added — the same approach already used for renamed indexes.

Also updated the existing `testCompareForeignKeyBasedOnPropertiesNotName` test which previously asserted the (incorrect) behavior that FK renames were ignored.