### PR TITLE
Cover edge-case runtime behaviors

### DIFF
--- a/tests/Driver/VersionAwarePlatformDriverTest.php
+++ b/tests/Driver/VersionAwarePlatformDriverTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Driver;
 use Doctrine\DBAL\Connection\StaticServerVersionProvider;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Exception\InvalidPlatformVersion;
 use Doctrine\DBAL\Platforms\MariaDB1010Platform;
 use Doctrine\DBAL\Platforms\MariaDB1052Platform;
 use Doctrine\DBAL\Platforms\MariaDB1060Platform;
@@ -50,6 +51,16 @@ class VersionAwarePlatformDriverTest extends TestCase
             ['10.9.3-MariaDB-1~lenny-log', MariaDB1060Platform::class],
             ['11.0.2-MariaDB-1:11.0.2+maria~ubu2204', MariaDB1010Platform::class],
         ];
+    }
+
+    public function testMalformedMariaDBVersionThrows(): void
+    {
+        $driver          = new Driver\Mysqli\Driver();
+        $versionProvider = new StaticServerVersionProvider('mariadb-invalid');
+
+        $this->expectException(InvalidPlatformVersion::class);
+
+        $driver->getDatabasePlatform($versionProvider);
     }
 
     #[DataProvider('postgreSQLVersionProvider')]

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -39,6 +39,11 @@ class ConnectionTest extends FunctionalTestCase
         $this->markConnectionNotReusable();
     }
 
+    public function testServerVersion(): void
+    {
+        self::assertNotEmpty($this->connection->getServerVersion());
+    }
+
     public function testCommitWithRollbackOnlyThrowsException(): void
     {
         $this->connection->beginTransaction();

--- a/tests/Functional/ResultMetadataTest.php
+++ b/tests/Functional/ResultMetadataTest.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Exception\InvalidColumnIndex;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Tests\TestUtil;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\TestWith;
 
 use function strtolower;
+
+use const PHP_VERSION_ID;
 
 class ResultMetadataTest extends FunctionalTestCase
 {
@@ -65,6 +69,53 @@ class ResultMetadataTest extends FunctionalTestCase
         $this->expectException(InvalidColumnIndex::class);
 
         $result->getColumnName($index);
+    }
+
+    public function testColumnNameAfterFree(): void
+    {
+        // Whether a freed result reports an invalid column index is driver-specific.
+        if (! TestUtil::isDriverOneOf('sqlite3', 'pdo_sqlite', 'pgsql', 'pdo_mysql')) {
+            self::markTestSkipped('This driver does not report an invalid column index for a freed result.');
+        }
+
+        // pdo_sqlite's getColumnMeta() returns false for a freed statement only since the fix
+        // for https://github.com/php/php-src/issues/17837, shipped in PHP 8.3.18 and 8.4.5.
+        if (
+            TestUtil::isDriverOneOf('pdo_sqlite')
+            && (PHP_VERSION_ID < 80318 || (PHP_VERSION_ID >= 80400 && PHP_VERSION_ID < 80405))
+        ) {
+            self::markTestSkipped('pdo_sqlite reports getColumnMeta() failure only since PHP 8.3.18/8.4.5.');
+        }
+
+        $result = $this->getFreedResult();
+
+        $this->expectException(InvalidColumnIndex::class);
+
+        $result->getColumnName(0);
+    }
+
+    public function testColumnCountAfterFree(): void
+    {
+        // Whether a freed result reports zero columns is driver-specific.
+        if (! TestUtil::isDriverOneOf('sqlite3', 'pgsql')) {
+            self::markTestSkipped('This driver does not report zero columns for a freed result.');
+        }
+
+        $result = $this->getFreedResult();
+
+        self::assertSame(0, $result->columnCount());
+    }
+
+    private function getFreedResult(): Result
+    {
+        $result = $this->connection->executeQuery(
+            $this->connection->getDatabasePlatform()
+                ->getDummySelectSQL(),
+        );
+
+        $result->free();
+
+        return $result;
     }
 
     public function testColumnNameWithoutResults(): void


### PR DESCRIPTION
Add a few tests to improve code coverage:
1. Malformed MariaDB version parsing.
2. Result access after free. Various drivers and even various versions of the same underlying driver behave differently there, so the test just documents this issue and covers the consistently behaving drivers.
3. Server-version reporting. There's nothing to assert here (all versions have different syntax), but we at least should execute that code path.