### PR TITLE
Cover schema management edge cases

### DIFF
--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -446,6 +446,170 @@ final class SchemaManagerTest extends FunctionalTestCase
         );
     }
 
+    /** @param callable(AbstractSchemaManager): list<Index> $introspect */
+    #[DataProvider('quotedAndUnquotedIndexIntrospection')]
+    public function testIntrospectTableIndexes(
+        OptionallyQualifiedName $tableName,
+        UnqualifiedName $indexName,
+        callable $introspect,
+    ): void {
+        $this->createTableWithIndex($tableName, $indexName);
+
+        self::assertNotEmpty($introspect($this->schemaManager));
+    }
+
+    /** @return iterable<string, array{
+     *     OptionallyQualifiedName,
+     *     UnqualifiedName,
+     *     callable(AbstractSchemaManager): list<Index>,
+     *  }> */
+    public static function quotedAndUnquotedIndexIntrospection(): iterable
+    {
+        yield 'unquoted name' => [
+            OptionallyQualifiedName::unquoted('Orders'),
+            UnqualifiedName::unquoted('Orders_index'),
+            static fn (AbstractSchemaManager $sm): array => $sm->introspectTableIndexesByUnquotedName('Orders'),
+        ];
+
+        yield 'quoted name' => [
+            OptionallyQualifiedName::quoted('Orders'),
+            UnqualifiedName::quoted('Orders_index'),
+            static fn (AbstractSchemaManager $sm): array => $sm->introspectTableIndexesByQuotedName('Orders'),
+        ];
+    }
+
+    /** @param callable(AbstractSchemaManager): list<ForeignKeyConstraint> $introspect */
+    #[DataProvider('quotedAndUnquotedForeignKeyIntrospection')]
+    public function testIntrospectTableForeignKeyConstraints(
+        OptionallyQualifiedName $referencedTableName,
+        OptionallyQualifiedName $referencingTableName,
+        UnqualifiedName $indexName,
+        UnqualifiedName $foreignKeyName,
+        callable $introspect,
+    ): void {
+        $this->createTablesWithForeignKey($referencedTableName, $referencingTableName, $indexName, $foreignKeyName);
+
+        self::assertNotEmpty($introspect($this->schemaManager));
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     OptionallyQualifiedName,
+     *     OptionallyQualifiedName,
+     *     UnqualifiedName,
+     *     UnqualifiedName,
+     *     callable(AbstractSchemaManager): list<ForeignKeyConstraint>,
+     * }>
+     */
+    public static function quotedAndUnquotedForeignKeyIntrospection(): iterable
+    {
+        yield 'unquoted name' => [
+            OptionallyQualifiedName::unquoted('Articles'),
+            OptionallyQualifiedName::unquoted('Orders'),
+            UnqualifiedName::unquoted('Orders_article_id_index'),
+            UnqualifiedName::unquoted('Articles_fk'),
+            static function (AbstractSchemaManager $sm): array {
+                return $sm->introspectTableForeignKeyConstraintsByUnquotedName('Orders');
+            },
+        ];
+
+        yield 'quoted name' => [
+            OptionallyQualifiedName::quoted('Articles'),
+            OptionallyQualifiedName::quoted('Orders'),
+            UnqualifiedName::quoted('Orders_article_id_index'),
+            UnqualifiedName::quoted('Articles_fk'),
+            static function (AbstractSchemaManager $sm): array {
+                return $sm->introspectTableForeignKeyConstraintsByQuotedName('Orders');
+            },
+        ];
+    }
+
+    private function createTableWithIndex(OptionallyQualifiedName $tableName, UnqualifiedName $indexName): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        $table = Table::editor()
+            ->setName($tableName)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setName($indexName)
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropTableIfExists($table->getObjectName()->toSQL($platform));
+
+        $this->schemaManager->createTable($table);
+    }
+
+    private function createTablesWithForeignKey(
+        OptionallyQualifiedName $referencedTableName,
+        OptionallyQualifiedName $referencingTableName,
+        UnqualifiedName $indexName,
+        UnqualifiedName $foreignKeyName,
+    ): void {
+        $platform = $this->connection->getDatabasePlatform();
+
+        $referencedTable = Table::editor()
+            ->setName($referencedTableName)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $referencingTable = Table::editor()
+            ->setName($referencingTableName)
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('article_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            // Create the index explicitly to prevent the implicit one, whose name is auto-generated.
+            // That generation is faulty for names that differ only in whether they are quoted.
+            // See https://github.com/doctrine/dbal/issues/7434
+            ->setIndexes(
+                Index::editor()
+                    ->setName($indexName)
+                    ->setUnquotedColumnNames('article_id')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setName($foreignKeyName)
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setReferencedTableName($referencedTableName)
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropTableIfExists($referencingTable->getObjectName()->toSQL($platform));
+        $this->dropTableIfExists($referencedTable->getObjectName()->toSQL($platform));
+
+        $this->schemaManager->createTable($referencedTable);
+        $this->schemaManager->createTable($referencingTable);
+    }
+
     /** @param array<Sequence> $sequences */
     private function findSequence(array $sequences, string $name): ?Sequence
     {

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
@@ -608,6 +609,43 @@ final class SchemaManagerTest extends FunctionalTestCase
 
         $this->schemaManager->createTable($referencedTable);
         $this->schemaManager->createTable($referencingTable);
+    }
+
+    public function testIntrospectSchemaNamesOnSchemalessPlatform(): void
+    {
+        if ($this->connection->getDatabasePlatform()->supportsSchemas()) {
+            self::markTestSkipped('The platform supports schemas.');
+        }
+
+        $this->expectException(NotSupported::class);
+
+        $this->schemaManager->introspectSchemaNames();
+    }
+
+    public function testIntrospectSequencesWithoutSequenceSupport(): void
+    {
+        if ($this->connection->getDatabasePlatform()->supportsSequences()) {
+            self::markTestSkipped('The platform supports sequences.');
+        }
+
+        $this->expectException(NotSupported::class);
+
+        $this->schemaManager->introspectSequences();
+    }
+
+    public function testCreateSequenceWithoutSequenceSupport(): void
+    {
+        if ($this->connection->getDatabasePlatform()->supportsSequences()) {
+            self::markTestSkipped('The platform supports sequences.');
+        }
+
+        $this->expectException(NotSupported::class);
+
+        $this->schemaManager->createSequence(
+            Sequence::editor()
+                ->setUnquotedName('s')
+                ->create(),
+        );
     }
 
     /** @param array<Sequence> $sequences */

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -393,6 +393,59 @@ final class SchemaManagerTest extends FunctionalTestCase
         self::assertSame(5, $sequence->getAllocationSize());
     }
 
+    public function testDropForeignKey(): void
+    {
+        $this->dropTableIfExists('orders');
+        $this->dropTableIfExists('articles');
+
+        $articles = Table::editor()
+            ->setUnquotedName('articles')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $orders = Table::editor()
+            ->setUnquotedName('orders')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('article_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('articles_fk')
+                    ->setUnquotedReferencingColumnNames('article_id')
+                    ->setUnquotedReferencedTableName('articles')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->schemaManager->createTable($articles);
+        $this->schemaManager->createTable($orders);
+
+        $this->schemaManager->dropForeignKey('articles_fk', 'orders');
+
+        self::assertEmpty(
+            $this->schemaManager->introspectTableByUnquotedName('orders')
+                ->getForeignKeys(),
+        );
+    }
+
     /** @param array<Sequence> $sequences */
     private function findSequence(array $sequences, string $name): ?Sequence
     {


### PR DESCRIPTION
The newly added index and foreign key introspection tests establish a pattern for testing identifier-related logic.

In the code, we have methods that accept names as objects, as strings interpreted as unquoted names and strings as quoted names. For example: https://github.com/doctrine/dbal/blob/e33aed84e97d4ab28bff365ba95832c56323ad0a/src/Schema/AbstractSchemaManager.php#L775 https://github.com/doctrine/dbal/blob/e33aed84e97d4ab28bff365ba95832c56323ad0a/src/Schema/AbstractSchemaManager.php#L798 https://github.com/doctrine/dbal/blob/e33aed84e97d4ab28bff365ba95832c56323ad0a/src/Schema/AbstractSchemaManager.php#L818

In the test suite, we write one parameterized test that accepts input names as objects and the callbacks wrapping the methods to be tested:

https://github.com/doctrine/dbal/blob/ebbc8d0bfc9a16428956b87db6f989914c61635b/tests/Functional/Schema/SchemaManagerTest.php#L452-L456

They set up the schema using the names and call the method being tested via the callbacks. This way, they exercise the "by name as object" path via the two "by unqualified name" and "by qualified name" entry points. As a result, both kinds of identifiers will be first-class citizens from the test coverage standpoint.