### PR TITLE
Deprecate SimpleArrayType

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,15 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Deprecated the `simple_array` type
+
+The `simple_array` type has been deprecated. Use the `json` type instead.
+
+The following class and constant have been deprecated:
+
+- `SimpleArrayType`,
+- `Types::SIMPLE_ARRAY`.
+
 ## Marked `AbstractNamedObject` and `AbstractOptionallyNamedObject` classes as internal
 
 The `AbstractNamedObject` and `AbstractOptionallyNamedObject` classes have been marked as internal. Use the

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -407,6 +407,10 @@ real arrays or JSON format arrays.
 simple_array
 ^^^^^^^^^^^^
 
+.. warning::
+
+    This type is deprecated, you should use the ``json`` type instead.
+
 Maps and converts array data based on PHP comma delimited imploding and exploding.
 If you know that the data to be stored always is a scalar value based one-dimensional
 array, you should consider using this type as it uses simple PHP imploding and

--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -17,6 +17,8 @@ use function stream_get_contents;
  * Array Type which can be used for simple values.
  *
  * Only use this type if you are sure that your values cannot contain a ",".
+ *
+ * @deprecated Use {@see JsonType} instead.
  */
 class SimpleArrayType extends Type
 {

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -31,13 +31,16 @@ final class Types
     public const JSON_OBJECT          = 'json_object';
     public const JSONB                = 'jsonb';
     public const JSONB_OBJECT         = 'jsonb_object';
-    public const SIMPLE_ARRAY         = 'simple_array';
-    public const SMALLFLOAT           = 'smallfloat';
-    public const SMALLINT             = 'smallint';
-    public const STRING               = 'string';
-    public const TEXT                 = 'text';
-    public const TIME_MUTABLE         = 'time';
-    public const TIME_IMMUTABLE       = 'time_immutable';
+
+    /** @deprecated Use {@see Types::JSON} instead. */
+    public const SIMPLE_ARRAY = 'simple_array';
+
+    public const SMALLFLOAT     = 'smallfloat';
+    public const SMALLINT       = 'smallint';
+    public const STRING         = 'string';
+    public const TEXT           = 'text';
+    public const TIME_MUTABLE   = 'time';
+    public const TIME_IMMUTABLE = 'time_immutable';
 
     /** @codeCoverageIgnore */
     private function __construct()


### PR DESCRIPTION
`SimpleArrayType` is an untested footgun (a value containing comma doesn't survive a roundtrip). The proposal to remove it rather than maintain was previously raised in https://github.com/doctrine/dbal/issues/7098#issuecomment-3255695400. Its siblings `ArrayType` and `ObjectType` were removed in https://github.com/doctrine/dbal/pull/5477.

Closes https://github.com/doctrine/dbal/issues/7098.