### PR TITLE
Simplify FK comparison to detect renamed foreign keys

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -266,15 +266,12 @@ class Comparator
 
         foreach ($oldForeignKeys as $oldKey => $oldForeignKey) {
             foreach ($newForeignKeys as $newKey => $newForeignKey) {
-                if ($this->diffForeignKey($oldForeignKey, $newForeignKey) === false) {
+                if (
+                    $this->diffForeignKey($oldForeignKey, $newForeignKey) === false
+                    && strtolower($oldForeignKey->getName()) === strtolower($newForeignKey->getName())
+                ) {
                     unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
-                } else {
-                    if (strtolower($oldForeignKey->getName()) === strtolower($newForeignKey->getName())) {
-                        $droppedForeignKeys[$oldKey] = $oldForeignKey;
-                        $addedForeignKeys[$newKey]   = $newForeignKey;
-
-                        unset($oldForeignKeys[$oldKey], $newForeignKeys[$newKey]);
-                    }
+                    continue 2;
                 }
             }
         }

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 
 use function sprintf;
+use function array_values;
 
 final class SchemaManagerTest extends FunctionalTestCase
 {
@@ -356,6 +357,84 @@ final class SchemaManagerTest extends FunctionalTestCase
                 ->getColumn('val')
                 ->getNotnull(),
         );
+    }
+
+    public function testAlterTableRenameForeignKey(): void
+    {
+        $tableForeign = Table::editor()
+            ->setUnquotedName('fk_referenced')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropAndCreateTable($tableForeign);
+
+        $fk = ForeignKeyConstraint::editor()
+            ->setUnquotedName('foo_constraint')
+            ->setUnquotedReferencingColumnNames('foreign_id')
+            ->setReferencedTableName(OptionallyQualifiedName::unquoted('fk_referenced'))
+            ->setUnquotedReferencedColumnNames('id')
+            ->create();
+
+        $tableFrom = Table::editor()
+            ->setUnquotedName('fk_referencing')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('foreign_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints($fk)
+            ->create();
+
+        $this->dropAndCreateTable($tableFrom);
+
+        $tableTo = $tableFrom->edit()
+            ->setForeignKeyConstraints(
+                $fk->edit()
+                    ->setUnquotedName('bar_constraint')
+                    ->create(),
+            )
+            ->create();
+
+        $diff = $this->schemaManager->createComparator()->compareTables($tableFrom, $tableTo);
+        self::assertFalse($diff->isEmpty());
+
+        $this->schemaManager->alterTable($diff);
+
+        $foreignKeys = $this->schemaManager->introspectTableByUnquotedName('fk_referencing')->getForeignKeys();
+        self::assertCount(1, $foreignKeys);
+
+        $foreignKey = array_values($foreignKeys)[0];
+        self::assertNotNull($foreignKey);
+
+        self::assertTrue(
+            $foreignKey->getObjectName()->equals(
+                UnqualifiedName::unquoted('bar_constraint'),
+                $this->connection->getDatabasePlatform()->getUnquotedIdentifierFolding(),
+            ),
+        );
+
+        $this->dropTableIfExists('fk_referencing');
+        $this->dropTableIfExists('fk_referenced');
     }
 
     public function testAlterSequence(): void

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -636,8 +636,15 @@ abstract class AbstractComparatorTestCase extends TestCase
         );
     }
 
-    public function testCompareForeignKeyBasedOnPropertiesNotName(): void
+    public function testDetectForeignKeyNameChange(): void
     {
+        $fk = ForeignKeyConstraint::editor()
+            ->setUnquotedName('foo_constraint')
+            ->setUnquotedReferencingColumnNames('id')
+            ->setUnquotedReferencedTableName('bar')
+            ->setUnquotedReferencedColumnNames('id')
+            ->create();
+
         $tableA = Table::editor()
             ->setUnquotedName('foo')
             ->setColumns(
@@ -646,38 +653,21 @@ abstract class AbstractComparatorTestCase extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
-            ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
-                    ->setUnquotedName('foo_constraint')
-                    ->setUnquotedReferencingColumnNames('id')
-                    ->setUnquotedReferencedTableName('bar')
-                    ->setUnquotedReferencedColumnNames('id')
-                    ->create(),
-            )
+            ->setForeignKeyConstraints($fk)
             ->create();
 
-        $tableB = Table::editor()
-            ->setUnquotedName('foo')
-            ->setColumns(
-                Column::editor()
-                    ->setUnquotedName('ID')
-                    ->setTypeName(Types::INTEGER)
-                    ->create(),
-            )
+        $tableB = $tableA->edit()
             ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
+                $fk->edit()
                     ->setUnquotedName('bar_constraint')
-                    ->setUnquotedReferencingColumnNames('id')
-                    ->setUnquotedReferencedTableName('bar')
-                    ->setUnquotedReferencedColumnNames('id')
                     ->create(),
             )
             ->create();
 
-        self::assertEquals(
-            new TableDiff($tableA),
-            $this->comparator->compareTables($tableA, $tableB),
-        );
+        $tableDiff = $this->comparator->compareTables($tableA, $tableB);
+
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
+        self::assertCount(1, $tableDiff->getAddedForeignKeys());
     }
 
     public function testDetectRenameColumn(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #7410

#### Summary

The comparator detected renamed columns and indexes but not renamed foreign keys, causing `schema:update` to report the schema as in sync when only a FK name changed.

Simplifies the FK comparison loop: a pair is skipped only when structure AND name are identical. Renames are naturally detected as drop + add.