### PR TITLE
Tighten loose type annotations in tests

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -27,7 +27,10 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 
-/** @phpstan-import-type Params from DriverManager */
+/**
+ * @phpstan-import-type Params from DriverManager
+ * @phpstan-import-type WrapperParameterTypeArray from Connection
+ */
 #[RequiresPhpExtension('pdo_mysql')]
 class ConnectionTest extends TestCase
 {
@@ -486,7 +489,11 @@ class ConnectionTest extends TestCase
         self::assertSame($expected, $invoke($conn, $query, $params, $types));
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{
+     *     non-empty-string,
+     *     callable(Connection, string, list<mixed>|array<string, mixed>, WrapperParameterTypeArray): mixed,
+     *     mixed,
+     * }> */
     public static function fetchModeProvider(): iterable
     {
         yield 'numeric' => [

--- a/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
+++ b/tests/Driver/AbstractOracleDriver/EasyConnectStringTest.php
@@ -13,7 +13,7 @@ class EasyConnectStringTest extends TestCase
 {
     use VerifyDeprecations;
 
-    /** @param mixed[] $params */
+    /** @param array<string, mixed> $params */
     #[DataProvider('connectionParametersProvider')]
     public function testFromConnectionParameters(array $params, string $expected): void
     {
@@ -22,7 +22,7 @@ class EasyConnectStringTest extends TestCase
         self::assertSame($expected, (string) $string);
     }
 
-    /** @return iterable<string, array<int, mixed>> */
+    /** @return iterable<string, array{array<string, mixed>, string}> */
     public static function connectionParametersProvider(): iterable
     {
         return [

--- a/tests/Driver/IBMDB2/DataSourceNameTest.php
+++ b/tests/Driver/IBMDB2/DataSourceNameTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class DataSourceNameTest extends TestCase
 {
-    /** @param mixed[] $params */
+    /** @param array<string, mixed> $params */
     #[DataProvider('connectionParametersProvider')]
     public function testFromConnectionParameters(array $params, string $expected): void
     {
@@ -19,7 +19,7 @@ class DataSourceNameTest extends TestCase
         self::assertSame($expected, $dsn->toString());
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{array<string, mixed>, string}> */
     public static function connectionParametersProvider(): iterable
     {
         yield 'empty-params' => [[], ''];

--- a/tests/Driver/OCI8/ConvertPositionalToNamedPlaceholdersTest.php
+++ b/tests/Driver/OCI8/ConvertPositionalToNamedPlaceholdersTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConvertPositionalToNamedPlaceholdersTest extends TestCase
 {
-    /** @param mixed[] $expectedOutputParamsMap */
+    /** @param array<int, string> $expectedOutputParamsMap */
     #[DataProvider('positionalToNamedPlaceholdersProvider')]
     public function testConvertPositionalToNamedParameters(
         string $inputSQL,
@@ -27,7 +27,7 @@ class ConvertPositionalToNamedPlaceholdersTest extends TestCase
         self::assertEquals($expectedOutputParamsMap, $visitor->getParameterMap());
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, string, array<int, string>}> */
     public static function positionalToNamedPlaceholdersProvider(): iterable
     {
         return [

--- a/tests/Functional/DataAccessTest.php
+++ b/tests/Functional/DataAccessTest.php
@@ -329,7 +329,7 @@ class DataAccessTest extends FunctionalTestCase
         self::assertEquals($expectedResult, $row['trimmed']);
     }
 
-    /** @return array<int, array<int, mixed>> */
+    /** @return list<array{string, TrimMode, string|null, string}> */
     public static function getTrimExpressionData(): iterable
     {
         return [
@@ -623,7 +623,7 @@ class DataAccessTest extends FunctionalTestCase
         self::assertEquals($expected, date('Y-m-d H:i:s', strtotime($date)));
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{callable(int): string, callable(Statement, int): void}> */
     public static function modeProvider(): array
     {
         return [
@@ -742,7 +742,7 @@ class DataAccessTest extends FunctionalTestCase
         self::assertEquals($expected, $this->connection->fetchOne($query));
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, string, string|null, string}> */
     public static function substringExpressionProvider(): iterable
     {
         return [

--- a/tests/Functional/Driver/OCI8/StatementTest.php
+++ b/tests/Functional/Driver/OCI8/StatementTest.php
@@ -22,8 +22,8 @@ class StatementTest extends FunctionalTestCase
     }
 
     /**
-     * @param mixed[] $params
-     * @param mixed[] $expected
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<string, mixed>             $expected
      */
     #[DataProvider('queryConversionProvider')]
     public function testQueryConversion(string $query, array $params, array $expected): void
@@ -34,7 +34,7 @@ class StatementTest extends FunctionalTestCase
         );
     }
 
-    /** @return array<string, array<int, mixed>> */
+    /** @return array<string, array{string, list<mixed>|array<string, mixed>, array<string, mixed>}> */
     public static function queryConversionProvider(): iterable
     {
         return [

--- a/tests/Functional/Driver/PDO/PgSQL/ConnectionTest.php
+++ b/tests/Functional/Driver/PDO/PgSQL/ConnectionTest.php
@@ -39,7 +39,7 @@ class ConnectionTest extends FunctionalTestCase
         );
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string}> */
     public static function getValidCharsets(): iterable
     {
         return [

--- a/tests/Functional/ExceptionTest.php
+++ b/tests/Functional/ExceptionTest.php
@@ -308,7 +308,7 @@ class ExceptionTest extends FunctionalTestCase
         $conn->executeQuery($platform->getDummySelectSQL());
     }
 
-    /** @return array<int, array<int, mixed>> */
+    /** @return list<array{array<string, mixed>}> */
     public static function getConnectionParams(): iterable
     {
         return [

--- a/tests/Functional/Platform/AbstractColumnTestCase.php
+++ b/tests/Functional/Platform/AbstractColumnTestCase.php
@@ -63,7 +63,7 @@ abstract class AbstractColumnTestCase extends FunctionalTestCase
         );
     }
 
-    /** @return iterable<string, array<int, mixed>> */
+    /** @return iterable<string, array{string}> */
     public static function string1Provider(): iterable
     {
         return [
@@ -72,7 +72,7 @@ abstract class AbstractColumnTestCase extends FunctionalTestCase
         ];
     }
 
-    /** @return iterable<string, array<int, mixed>> */
+    /** @return iterable<string, array{string}> */
     public static function string8Provider(): iterable
     {
         return [

--- a/tests/Functional/Platform/QuotingTest.php
+++ b/tests/Functional/Platform/QuotingTest.php
@@ -23,7 +23,7 @@ class QuotingTest extends FunctionalTestCase
         self::assertSame($string, $this->connection->fetchOne($query));
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string}> */
     public static function stringLiteralProvider(): iterable
     {
         return [

--- a/tests/Functional/PortabilityTest.php
+++ b/tests/Functional/PortabilityTest.php
@@ -89,7 +89,7 @@ class PortabilityTest extends FunctionalTestCase
         yield 'upper' => [ColumnCase::UPPER, ['TEST_INT', 'TEST_STRING', 'TEST_NULL']];
     }
 
-    /** @param array<int, array<string, mixed>> $rows */
+    /** @param list<array<string, mixed>> $rows */
     private function assertFetchResultRows(array $rows): void
     {
         self::assertCount(2, $rows);
@@ -112,7 +112,7 @@ class PortabilityTest extends FunctionalTestCase
         self::assertArrayNotHasKey(0, $row, 'The row should not contain numerical keys.');
     }
 
-    /** @param mixed[] $expected */
+    /** @param list<mixed> $expected */
     #[DataProvider('fetchColumnProvider')]
     public function testFetchColumn(string $column, array $expected): void
     {
@@ -124,7 +124,7 @@ class PortabilityTest extends FunctionalTestCase
         self::assertEquals($expected, $result->fetchFirstColumn());
     }
 
-    /** @return iterable<string, array<int, mixed>> */
+    /** @return iterable<string, array{string, list<mixed>}> */
     public static function fetchColumnProvider(): iterable
     {
         return [

--- a/tests/Functional/Schema/ColumnCommentTest.php
+++ b/tests/Functional/Schema/ColumnCommentTest.php
@@ -98,7 +98,7 @@ class ColumnCommentTest extends FunctionalTestCase
         $this->assertColumnComment('id', $comment2);
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, string}> */
     public static function alterColumnCommentProvider(): iterable
     {
         return [

--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -142,7 +142,7 @@ class ComparatorTest extends FunctionalTestCase
         self::assertEquals(3, $modifiedOnly->countChangedProperties());
     }
 
-    /** @return iterable<mixed[]> */
+    /** @return list<array{string, mixed}> */
     public static function defaultValueProvider(): iterable
     {
         return [

--- a/tests/Functional/Schema/DefaultValueTest.php
+++ b/tests/Functional/Schema/DefaultValueTest.php
@@ -74,7 +74,7 @@ class DefaultValueTest extends FunctionalTestCase
      * @see http://www.sqlite.org/lang_expr.html
      * @see https://www.postgresql.org/docs/9.6/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE
      *
-     * @return mixed[][]
+     * @return array<string, array{non-empty-string, ?string}>
      */
     public static function columnProvider(): iterable
     {

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -546,7 +546,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertEquals('(-1)', $colString->getDefault());
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string}> */
     public static function serialTypes(): iterable
     {
         return [
@@ -714,7 +714,7 @@ SQL;
         );
     }
 
-    /** @return iterable<mixed[]> */
+    /** @return iterable<string, array{string, string, string}> */
     public static function autoIncrementTypeMigrations(): iterable
     {
         return [

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -1089,15 +1089,10 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
         self::assertFalse($columns[1]->getUnsigned());
     }
 
-    /**
-     * @param non-empty-string $name
-     * @param mixed[]          $data
-     */
-    protected function createTestTable(string $name, array $data = []): Table
+    /** @param non-empty-string $name */
+    protected function createTestTable(string $name): Table
     {
-        $options = $data['options'] ?? [];
-
-        $table = $this->getTestTable($name, $options);
+        $table = $this->getTestTable($name);
 
         $this->dropAndCreateTable($table);
 
@@ -1105,8 +1100,8 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
     }
 
     /**
-     * @param non-empty-string $unquotedName
-     * @param mixed[]          $options
+     * @param non-empty-string     $unquotedName
+     * @param array<string, mixed> $options
      */
     protected function getTestTable(string $unquotedName, array $options = []): Table
     {

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -127,7 +127,7 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertEquals($originalValue, $dbValue);
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, mixed}> */
     public static function booleanProvider(): iterable
     {
         return [
@@ -145,7 +145,7 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertEquals($originalValue, $dbValue);
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, mixed}> */
     public static function integerProvider(): iterable
     {
         return [
@@ -162,7 +162,7 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertEquals($originalValue, $dbValue);
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, mixed}> */
     public static function floatProvider(): iterable
     {
         return [
@@ -186,7 +186,7 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertEquals($originalValue, $dbValue);
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, mixed}> */
     public static function toStringProvider(): iterable
     {
         return [
@@ -218,7 +218,7 @@ class TypeConversionTest extends FunctionalTestCase
         );
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, DateTime}> */
     public static function toDateTimeProvider(): iterable
     {
         return [

--- a/tests/Platforms/AbstractPlatformTestCase.php
+++ b/tests/Platforms/AbstractPlatformTestCase.php
@@ -65,7 +65,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertSame($expectedSQL, $this->platform->getForeignKeyReferentialActionSQL($action));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, string}> */
     public static function getReturnsForeignKeyReferentialActionSQL(): iterable
     {
         return [
@@ -958,7 +958,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         self::assertSame($expectedSql, $this->platform->getInlineColumnCommentSQL($comment));
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{string, string}> */
     public static function getGeneratesInlineColumnCommentSQL(): iterable
     {
         return [
@@ -1115,7 +1115,7 @@ abstract class AbstractPlatformTestCase extends TestCase
     /** @return string[] */
     abstract protected function getGeneratesAlterTableRenameIndexUsedByForeignKeySQL(): array;
 
-    /** @param mixed[] $column */
+    /** @param array<string, mixed> $column */
     #[DataProvider('getGeneratesDecimalTypeDeclarationSQL')]
     public function testGeneratesDecimalTypeDeclarationSQL(array $column, string $expectedSql): void
     {
@@ -1129,14 +1129,14 @@ abstract class AbstractPlatformTestCase extends TestCase
         yield [['precision' => 8, 'scale' => 2], 'NUMERIC(8, 2)'];
     }
 
-    /** @param mixed[] $column */
+    /** @param array<string, mixed> $column */
     #[DataProvider('getGeneratesFloatDeclarationSQL')]
     public function testGeneratesFloatDeclarationSQL(array $column, string $expectedSql): void
     {
         self::assertSame($expectedSql, $this->platform->getFloatDeclarationSQL($column));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{array<string, mixed>, string}> */
     public static function getGeneratesFloatDeclarationSQL(): iterable
     {
         return [
@@ -1149,14 +1149,14 @@ abstract class AbstractPlatformTestCase extends TestCase
         ];
     }
 
-    /** @param mixed[] $column */
+    /** @param array<string, mixed> $column */
     #[DataProvider('getGeneratesSmallFloatDeclarationSQL')]
     public function testGeneratesSmallFloatDeclarationSQL(array $column, string $expectedSql): void
     {
         self::assertSame($expectedSql, $this->platform->getSmallFloatDeclarationSQL($column));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{array<string, mixed>, string}> */
     public static function getGeneratesSmallFloatDeclarationSQL(): iterable
     {
         return [
@@ -1262,7 +1262,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         ];
     }
 
-    /** @param array<mixed> $column */
+    /** @param array<string, mixed> $column */
     #[DataProvider('getEnumDeclarationSQLWithInvalidValuesProvider')]
     public function testGetEnumDeclarationSQLWithInvalidValues(array $column): void
     {
@@ -1270,7 +1270,7 @@ abstract class AbstractPlatformTestCase extends TestCase
         $this->platform->getEnumDeclarationSQL($column);
     }
 
-    /** @return array<string, array{array<mixed>}> */
+    /** @return array<string, array{array<string, mixed>}> */
     public static function getEnumDeclarationSQLWithInvalidValuesProvider(): array
     {
         return [

--- a/tests/Platforms/OraclePlatformTest.php
+++ b/tests/Platforms/OraclePlatformTest.php
@@ -142,7 +142,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         return 'ALTER TABLE test ADD FOREIGN KEY (fk_name_id) REFERENCES other_table (id)';
     }
 
-    /** @param mixed[] $options */
+    /** @param array<string, mixed> $options */
     #[DataProvider('getGeneratesAdvancedForeignKeyOptionsSQLData')]
     public function testGeneratesAdvancedForeignKeyOptionsSQL(array $options, string $expectedSql): void
     {
@@ -151,7 +151,7 @@ class OraclePlatformTest extends AbstractPlatformTestCase
         self::assertSame($expectedSql, $this->platform->getAdvancedForeignKeyOptionsSQL($foreignKey));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{array<string, mixed>, string}> */
     public static function getGeneratesAdvancedForeignKeyOptionsSQLData(): iterable
     {
         return [
@@ -479,7 +479,7 @@ SQL
         self::assertSame($expectedSql, $this->platform->getDropAutoincrementSql($table));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, list<string>}> */
     public static function getReturnsDropAutoincrementSQL(): iterable
     {
         return [

--- a/tests/Platforms/PostgreSQLPlatformTest.php
+++ b/tests/Platforms/PostgreSQLPlatformTest.php
@@ -223,7 +223,7 @@ class PostgreSQLPlatformTest extends AbstractPlatformTestCase
         );
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, string}> */
     public static function serialTypes(): iterable
     {
         return [

--- a/tests/Portability/ConverterTest.php
+++ b/tests/Portability/ConverterTest.php
@@ -28,7 +28,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{list<mixed>|false, bool, bool, list<mixed>|false}> */
     public static function convertNumericProvider(): iterable
     {
         $row = ['X ', ''];
@@ -84,7 +84,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{array<string, mixed>|false, bool, bool, Converter::CASE_*|null, array<string, mixed>|false}> */
     public static function convertAssociativeProvider(): iterable
     {
         $row = [
@@ -197,7 +197,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{mixed, bool, bool, mixed}> */
     public static function convertOneProvider(): iterable
     {
         yield 'None, trailing space' => ['X ', false, false, 'X '];
@@ -230,7 +230,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{list<list<mixed>>, bool, bool, list<list<mixed>>}> */
     public static function convertAllNumericProvider(): iterable
     {
         $data = [
@@ -297,7 +297,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{list<array<string, mixed>>, bool, bool, Converter::CASE_*|null, list<array<string, mixed>>}> */
     public static function convertAllAssociativeProvider(): iterable
     {
         $data = [
@@ -466,7 +466,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{list<mixed>, bool, bool, list<mixed>}> */
     public static function convertFirstColumnProvider(): iterable
     {
         $column = ['X ', ''];

--- a/tests/Portability/ResultTest.php
+++ b/tests/Portability/ResultTest.php
@@ -26,7 +26,7 @@ class ResultTest extends TestCase
         self::assertSame($return, $fetch($result));
     }
 
-    /** @return iterable<string,array<int,mixed>> */
+    /** @return iterable<string, array{non-empty-string, callable(Result): mixed, mixed}> */
     public static function fetchProvider(): iterable
     {
         yield 'numeric' => [

--- a/tests/Query/Expression/CompositeExpressionTest.php
+++ b/tests/Query/Expression/CompositeExpressionTest.php
@@ -47,7 +47,7 @@ class CompositeExpressionTest extends TestCase
         self::assertEquals($expects, (string) $expr);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{CompositeExpression, string}> */
     public static function provideDataForConvertToString(): iterable
     {
         return [

--- a/tests/Query/Expression/ExpressionBuilderTest.php
+++ b/tests/Query/Expression/ExpressionBuilderTest.php
@@ -34,7 +34,7 @@ class ExpressionBuilderTest extends TestCase
         self::assertEquals($expected, (string) $composite);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{list<string|CompositeExpression>, string}> */
     public static function provideDataForAnd(): iterable
     {
         return [
@@ -86,7 +86,7 @@ class ExpressionBuilderTest extends TestCase
         self::assertEquals($expected, (string) $composite);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{list<string|CompositeExpression>, string}> */
     public static function provideDataForOr(): iterable
     {
         return [
@@ -137,7 +137,7 @@ class ExpressionBuilderTest extends TestCase
         self::assertEquals($expected, $part);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, string, string, string}> */
     public static function provideDataForComparison(): iterable
     {
         return [

--- a/tests/Query/QueryBuilderTest.php
+++ b/tests/Query/QueryBuilderTest.php
@@ -507,7 +507,7 @@ class QueryBuilderTest extends TestCase
         self::assertEquals($maxResults, $qb->getMaxResults());
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{?int}> */
     public static function maxResultsProvider(): iterable
     {
         return [

--- a/tests/SQL/ParserTest.php
+++ b/tests/SQL/ParserTest.php
@@ -27,7 +27,7 @@ class ParserTest extends TestCase implements Visitor
         $this->assertParsed($expected);
     }
 
-    /** @return iterable<string,list<mixed>> */
+    /** @return iterable<string, array{bool, string, string}> */
     public static function statementsWithParametersProvider(): iterable
     {
         foreach (self::getModes() as $mode => $mySQLStringEscaping) {
@@ -37,7 +37,7 @@ class ParserTest extends TestCase implements Visitor
         }
     }
 
-    /** @return iterable<list<string>> */
+    /** @return iterable<array{string, string}> */
     private static function getStatementsWithParameters(): iterable
     {
         yield [
@@ -314,7 +314,7 @@ SQL
         $this->assertParsed($sql);
     }
 
-    /** @return iterable<string,list<mixed>> */
+    /** @return iterable<string, array{bool, string}> */
     public static function statementsWithoutParametersProvider(): iterable
     {
         foreach (self::getModes() as $mode => $mySQLStringEscaping) {

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -1195,7 +1195,7 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertSame(! $equals, $diff2->hasCommentChanged());
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, string, bool}> */
     public static function getCompareColumnComments(): iterable
     {
         return [

--- a/tests/Schema/ColumnTest.php
+++ b/tests/Schema/ColumnTest.php
@@ -139,7 +139,7 @@ class ColumnTest extends TestCase
         self::assertSame($isQuoted, $column->isQuoted());
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, bool}> */
     public static function getIsQuoted(): iterable
     {
         return [

--- a/tests/Schema/ForeignKeyConstraintTest.php
+++ b/tests/Schema/ForeignKeyConstraintTest.php
@@ -33,7 +33,7 @@ class ForeignKeyConstraintTest extends TestCase
         self::assertSame($expectedResult, $foreignKey->intersectsIndexColumns($index));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{non-empty-list<string>, bool}> */
     public static function getIntersectsIndexColumnsData(): iterable
     {
         return [
@@ -70,7 +70,7 @@ class ForeignKeyConstraintTest extends TestCase
         self::assertSame($expectedUnqualifiedTableName, $foreignKey->getUnqualifiedForeignTableName());
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string, string}> */
     public static function getUnqualifiedForeignTableNameData(): iterable
     {
         return [

--- a/tests/Schema/IndexTest.php
+++ b/tests/Schema/IndexTest.php
@@ -19,7 +19,7 @@ class IndexTest extends TestCase
 {
     use VerifyDeprecations;
 
-    /** @param mixed[] $options */
+    /** @param array<string, mixed> $options */
     private function createIndex(bool $unique = false, bool $primary = false, array $options = []): Index
     {
         return new Index('foo', ['bar', 'baz'], $unique, $primary, [], $options);
@@ -127,7 +127,7 @@ class IndexTest extends TestCase
         self::assertSame($expected, $index2->isFulfilledBy($index1));
     }
 
-    /** @return mixed[][] */
+    /** @return array<string, array{non-empty-list<string>, list<?int>, array<int, ?int>, bool}> */
     public static function indexLengthProvider(): iterable
     {
         return [

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -1477,7 +1477,7 @@ class TableTest extends TestCase
         self::assertFalse($table->hasForeignKey('foo'));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string}> */
     public static function getNormalizesAssetNames(): iterable
     {
         return [

--- a/tests/Types/BaseDateTypeTestCase.php
+++ b/tests/Types/BaseDateTypeTestCase.php
@@ -60,7 +60,7 @@ abstract class BaseDateTypeTestCase extends TestCase
         self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed}> */
     public static function invalidPHPValuesProvider(): iterable
     {
         return [

--- a/tests/Types/BinaryTest.php
+++ b/tests/Types/BinaryTest.php
@@ -71,7 +71,7 @@ class BinaryTest extends TestCase
         $this->type->convertToPHPValue($value, $this->platform);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed}> */
     public static function getInvalidDatabaseValues(): iterable
     {
         return [

--- a/tests/Types/ConversionExceptionTest.php
+++ b/tests/Types/ConversionExceptionTest.php
@@ -71,7 +71,7 @@ class ConversionExceptionTest extends TestCase
         self::assertSame($previous, $exception->getPrevious());
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed}> */
     public static function nonScalarsProvider(): iterable
     {
         return [
@@ -81,7 +81,7 @@ class ConversionExceptionTest extends TestCase
         ];
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed, string}> */
     public static function scalarsProvider(): iterable
     {
         return [

--- a/tests/Types/DateIntervalTest.php
+++ b/tests/Types/DateIntervalTest.php
@@ -96,7 +96,7 @@ final class DateIntervalTest extends TestCase
         $this->type->convertToDatabaseValue($value, $this->platform);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed}> */
     public static function invalidPHPValuesProvider(): iterable
     {
         return [

--- a/tests/Types/JsonObjectTest.php
+++ b/tests/Types/JsonObjectTest.php
@@ -60,7 +60,7 @@ class JsonObjectTest extends TestCase
         self::assertEquals($expectedValue, $phpValue);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed, mixed}> */
     public static function providerJsonString(): iterable
     {
         $value         = new stdClass();
@@ -83,7 +83,7 @@ class JsonObjectTest extends TestCase
         $this->type->convertToPHPValue($data, $this->platform);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string}> */
     public static function providerFailure(): iterable
     {
         return [['a'], ['{']];
@@ -118,7 +118,7 @@ class JsonObjectTest extends TestCase
         self::assertSame($expectedValue, $databaseValue);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{mixed, mixed}> */
     public static function providerPHPValue(): iterable
     {
         $source         = new stdClass();

--- a/tests/Types/JsonTest.php
+++ b/tests/Types/JsonTest.php
@@ -69,7 +69,7 @@ class JsonTest extends TestCase
         $this->type->convertToPHPValue($data, $this->platform);
     }
 
-    /** @return mixed[][] */
+    /** @return list<array{string}> */
     public static function providerFailure(): iterable
     {
         return [['a'], ['{']];


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/doctrine/dbal/pull/7436#discussion_r3491379519. It provides more specific type definitions for test methods and data providers. The primary goal is to establish well-defined types as an example for future tests.

PHPStan can't match the types of a data provider's tuple elements with those of the parameters of the test method that uses it, so it can't enforce their compatibility. The types are therefore specified on a best-effort basis.

