### PR TITLE
Cover invalid and missing names in schema management

### DIFF
--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -799,6 +799,10 @@ abstract class AbstractPlatform
     {
         $parsedName = $this->parseUnqualifiedName($indexName);
 
+        // Validate the table name even though it is unused, so an invalid name is rejected
+        // consistently across platforms.
+        $this->parseOptionallyQualifiedName($tableName);
+
         return sprintf('DROP INDEX %s', $parsedName->toSQL($this));
     }
 

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
@@ -649,6 +650,51 @@ final class SchemaManagerTest extends FunctionalTestCase
 
         yield 'foreign key constraints' => [
             static fn (AbstractSchemaManager $sm): array => $sm->introspectTableForeignKeyConstraints($tableName),
+        ];
+    }
+
+    /** @param callable(AbstractSchemaManager): void $drop */
+    #[DataProvider('dropWithInvalidNameProvider')]
+    public function testDropWithInvalidName(callable $drop): void
+    {
+        $this->expectException(InvalidName::class);
+
+        $drop($this->schemaManager);
+    }
+
+    /** @return iterable<string, array{callable(AbstractSchemaManager): void}> */
+    public static function dropWithInvalidNameProvider(): iterable
+    {
+        yield 'table name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropTable('"orders'),
+        ];
+
+        yield 'index name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropIndex('"idx_article', 'orders'),
+        ];
+
+        yield 'index table name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropIndex('idx_article', '"orders'),
+        ];
+
+        yield 'foreign key constraint name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropForeignKey('"fk_article', 'orders'),
+        ];
+
+        yield 'foreign key constraint table name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropForeignKey('fk_article', '"orders'),
+        ];
+
+        yield 'unique constraint name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropUniqueConstraint('"uq_article', 'orders'),
+        ];
+
+        yield 'unique constraint table name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropUniqueConstraint('uq_article', '"orders'),
+        ];
+
+        yield 'view name' => [
+            static fn (AbstractSchemaManager $sm) => $sm->dropView('"available_articles'),
         ];
     }
 

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
@@ -612,6 +613,43 @@ final class SchemaManagerTest extends FunctionalTestCase
                 ->setUnquotedName('s')
                 ->create(),
         );
+    }
+
+    /** @param callable(AbstractSchemaManager): mixed $introspect */
+    #[DataProvider('introspectionWithSchemaNameProvider')]
+    public function testIntrospectionWithSchemaNameWithoutSchemaSupport(callable $introspect): void
+    {
+        if ($this->connection->getDatabasePlatform()->supportsSchemas()) {
+            self::markTestSkipped('The platform supports schemas.');
+        }
+
+        $this->expectException(UnsupportedName::class);
+
+        $introspect($this->schemaManager);
+    }
+
+    /** @return iterable<string, array{callable(AbstractSchemaManager): mixed}> */
+    public static function introspectionWithSchemaNameProvider(): iterable
+    {
+        $tableName = OptionallyQualifiedName::unquoted('orders', 'billing');
+
+        yield 'table' => [
+            static fn (AbstractSchemaManager $sm): Table => $sm->introspectTable($tableName),
+        ];
+
+        yield 'indexes' => [
+            static fn (AbstractSchemaManager $sm): array => $sm->introspectTableIndexes($tableName),
+        ];
+
+        yield 'primary key constraint' => [
+            static fn (
+                AbstractSchemaManager $sm,
+            ): ?PrimaryKeyConstraint => $sm->introspectTablePrimaryKeyConstraint($tableName),
+        ];
+
+        yield 'foreign key constraints' => [
+            static fn (AbstractSchemaManager $sm): array => $sm->introspectTableForeignKeyConstraints($tableName),
+        ];
     }
 
     /**

--- a/tests/Schema/SchemaEditorTest.php
+++ b/tests/Schema/SchemaEditorTest.php
@@ -13,10 +13,12 @@ use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaEditor;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableEditor;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_map;
@@ -183,6 +185,68 @@ class SchemaEditorTest extends TestCase
         $editor->addSequence(Sequence::editor()->setUnquotedName('a_seq')->create());
     }
 
+    /**
+     * The schema is empty, so the edit fails before the lookup. {@see testEditOnMissingObjectOfPopulatedSchema} covers
+     * the opposite case.
+     *
+     * @param callable(SchemaEditor): SchemaEditor $edit
+     */
+    #[DataProvider('editOnMissingObjectProvider')]
+    public function testEditOnMissingObjectOfEmptySchema(callable $edit): void
+    {
+        $editor = Schema::editor();
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $edit($editor);
+    }
+
+    /**
+     * The schema is non-empty, so the edit reaches the lookup. {@see testEditOnMissingObjectOfEmptySchema} covers the
+     * opposite case.
+     *
+     * @param callable(SchemaEditor): SchemaEditor $edit
+     */
+    #[DataProvider('editOnMissingObjectProvider')]
+    public function testEditOnMissingObjectOfPopulatedSchema(callable $edit): void
+    {
+        $editor = Schema::editor()
+            ->addTable($this->createTable('orders'))
+            ->addSequence(
+                Sequence::editor()
+                    ->setUnquotedName('id_seq')
+                    ->create(),
+            );
+
+        $this->expectException(InvalidSchemaModification::class);
+
+        $edit($editor);
+    }
+
+    /** @return iterable<string, array{callable(SchemaEditor): SchemaEditor}> */
+    public static function editOnMissingObjectProvider(): iterable
+    {
+        yield 'drop table' => [
+            static fn (SchemaEditor $editor) => $editor->dropTableByUnquotedName('invoices'),
+        ];
+
+        yield 'modify table' => [
+            static fn (SchemaEditor $editor) => $editor->modifyTableByUnquotedName(
+                'invoices',
+                static function (TableEditor $editor): void {
+                },
+            ),
+        ];
+
+        yield 'rename table' => [
+            static fn (SchemaEditor $editor) => $editor->renameTableByUnquotedName('invoices', 'receipts'),
+        ];
+
+        yield 'drop sequence' => [
+            static fn (SchemaEditor $editor) => $editor->dropSequenceByUnquotedName('pk_seq'),
+        ];
+    }
+
     public function testModifyTableReplacesInPlacePreservingOrder(): void
     {
         $schema = Schema::editor()
@@ -218,16 +282,6 @@ class SchemaEditorTest extends TestCase
 
         self::assertTrue($schema->hasTable('renamed'));
         self::assertFalse($schema->hasTable('foo'));
-    }
-
-    public function testModifyTableOnAbsentNameThrows(): void
-    {
-        $editor = Schema::editor();
-
-        $this->expectException(InvalidSchemaModification::class);
-
-        $editor->modifyTableByUnquotedName('missing', static function (): void {
-        });
     }
 
     public function testModifyTableRenameCollisionThrows(): void
@@ -307,15 +361,6 @@ class SchemaEditorTest extends TestCase
         self::assertTrue($schema->hasTable('bar'));
     }
 
-    public function testDropTableOnAbsentNameThrows(): void
-    {
-        $editor = Schema::editor();
-
-        $this->expectException(InvalidSchemaModification::class);
-
-        $editor->dropTableByUnquotedName('missing');
-    }
-
     public function testDropSequence(): void
     {
         $foo = Sequence::editor()
@@ -334,15 +379,6 @@ class SchemaEditorTest extends TestCase
 
         self::assertFalse($schema->hasSequence('foo'));
         self::assertTrue($schema->hasSequence('bar'));
-    }
-
-    public function testDropSequenceOnAbsentNameThrows(): void
-    {
-        $editor = Schema::editor();
-
-        $this->expectException(InvalidSchemaModification::class);
-
-        $editor->dropSequenceByUnquotedName('missing');
     }
 
     public function testDefaultNamespaceLookupParity(): void

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -6,12 +6,14 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\ImproperlyQualifiedName;
+use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SchemaTest extends TestCase
@@ -64,6 +66,42 @@ class SchemaTest extends TestCase
         $this->expectException(SchemaException::class);
 
         $schema->getTable('unknown');
+    }
+
+    /** @param callable(Schema): mixed $lookup */
+    #[DataProvider('lookupWithInvalidNameProvider')]
+    public function testLookupWithInvalidName(callable $lookup): void
+    {
+        $schema = Schema::editor()
+            ->create();
+
+        $this->expectException(InvalidName::class);
+
+        $lookup($schema);
+    }
+
+    /** @return iterable<string, array{callable(Schema): mixed}> */
+    public static function lookupWithInvalidNameProvider(): iterable
+    {
+        yield 'get table' => [
+            static fn (Schema $schema): Table => $schema->getTable('"orders'),
+        ];
+
+        yield 'has table' => [
+            static fn (Schema $schema): bool => $schema->hasTable('"orders'),
+        ];
+
+        yield 'get sequence' => [
+            static fn (Schema $schema): Sequence => $schema->getSequence('"id_seq'),
+        ];
+
+        yield 'has sequence' => [
+            static fn (Schema $schema): bool => $schema->hasSequence('"id_seq'),
+        ];
+
+        yield 'has namespace' => [
+            static fn (Schema $schema): bool => $schema->hasNamespace('"billing'),
+        ];
     }
 
     public function testAddSequences(): void


### PR DESCRIPTION
1. A call to `parseOptionallyQualifiedName()` was added to `getDropIndexSQL()` to parse the table name even though it is not used in the SQL. This makes the validation uniform across all platforms, as covered by the new test.
2. The removed tests are superseded by the new one, which uses data providers for more complete and consistent coverage.