### PR TITLE
Add format string for DateTime with timezone on SQLite

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -250,6 +250,11 @@ class SQLitePlatform extends AbstractPlatform
         return 'TIME';
     }
 
+    public function getDateTimeTzFormatString(): string
+    {
+        return 'Y-m-d H:i:sp';
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Types/DateTimeTzImmutableType.php
+++ b/src/Types/DateTimeTzImmutableType.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
 
@@ -63,6 +64,15 @@ class DateTimeTzImmutableType extends Type implements PhpDateTimeMappingType
 
         if ($dateTime !== false) {
             return $dateTime;
+        }
+
+        // Fallback to DateTime format for SQLite to preserve compatibility with older versions of Doctrine DBAL
+        if ($platform instanceof SQLitePlatform) {
+             $dateTime = DateTimeImmutable::createFromFormat($platform->getDateTimeFormatString(), $value);
+
+            if ($dateTime !== false) {
+                return $dateTime;
+            }
         }
 
         throw InvalidFormat::new(

--- a/src/Types/DateTimeTzType.php
+++ b/src/Types/DateTimeTzType.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Types;
 
 use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\Exception\InvalidType;
 
@@ -76,6 +77,15 @@ class DateTimeTzType extends Type implements PhpDateTimeMappingType
         $dateTime = DateTime::createFromFormat($platform->getDateTimeTzFormatString(), $value);
         if ($dateTime !== false) {
             return $dateTime;
+        }
+
+        // Fallback to DateTime format for SQLite to preserve compatibility with older versions of Doctrine DBAL
+        if ($platform instanceof SQLitePlatform) {
+             $dateTime = DateTime::createFromFormat($platform->getDateTimeFormatString(), $value);
+
+            if ($dateTime !== false) {
+                return $dateTime;
+            }
         }
 
         throw InvalidFormat::new(

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -59,11 +59,6 @@ class TypeConversionTest extends FunctionalTestCase
                     ->setNotNull(false)
                     ->create(),
                 Column::editor()
-                    ->setUnquotedName('test_datetimetz')
-                    ->setTypeName(Types::DATETIMETZ_MUTABLE)
-                    ->setNotNull(false)
-                    ->create(),
-                Column::editor()
                     ->setUnquotedName('test_date')
                     ->setTypeName(Types::DATE_MUTABLE)
                     ->setNotNull(false)
@@ -207,10 +202,6 @@ class TypeConversionTest extends FunctionalTestCase
 
         self::assertInstanceOf(DateTime::class, $dbValue);
 
-        if ($type === Types::DATETIMETZ_MUTABLE) {
-            return;
-        }
-
         self::assertEquals($originalValue, $dbValue);
         self::assertEquals(
             $originalValue->getTimezone(),
@@ -223,7 +214,6 @@ class TypeConversionTest extends FunctionalTestCase
     {
         return [
             'datetime' => [Types::DATETIME_MUTABLE, new DateTime('2010-04-05 10:10:10')],
-            'datetimetz' => [Types::DATETIMETZ_MUTABLE, new DateTime('2010-04-05 10:10:10')],
             'date' => [Types::DATE_MUTABLE, new DateTime('2010-04-05')],
             'time' => [Types::TIME_MUTABLE, new DateTime('1970-01-01 10:10:10')],
         ];

--- a/tests/Functional/Types/DateTimeTzImmutableTest.php
+++ b/tests/Functional/Types/DateTimeTzImmutableTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Tests\Functional\Types;
 
-use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
@@ -13,21 +13,21 @@ use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-final class DateTimeTzTest extends FunctionalTestCase
+final class DateTimeTzImmutableTest extends FunctionalTestCase
 {
-    /** @return list<array{DateTime}> */
+    /** @return list<array{DateTimeImmutable}> */
     public static function dataValuesProvider(): array
     {
         $timezone = new DateTimeZone('Europe/Berlin');
 
         return [
-            [new DateTime('1985-09-01 10:10:10', $timezone)],
-            [new DateTime('2013-10-07T04:23:19-04:00', $timezone)],
+            [new DateTimeImmutable('1985-09-01 10:10:10', $timezone)],
+            [new DateTimeImmutable('2013-10-07T04:23:19-04:00', $timezone)],
         ];
     }
 
     #[DataProvider('dataValuesProvider')]
-    public function testInsertAndRetrieveDateTimeTz(DateTime $expected): void
+    public function testInsertAndRetrieveDateTimeTz(DateTimeImmutable $expected): void
     {
         $platform = $this->connection->getDatabasePlatform();
 
@@ -40,11 +40,11 @@ final class DateTimeTzTest extends FunctionalTestCase
         }
 
         $table = Table::editor()
-            ->setUnquotedName('datetimetz_table')
+            ->setUnquotedName('datetimetz_immutable_table')
             ->setColumns(
                 Column::editor()
                     ->setUnquotedName('val')
-                    ->setTypeName(Types::DATETIMETZ_MUTABLE)
+                    ->setTypeName(Types::DATETIMETZ_IMMUTABLE)
                     ->create(),
             )
             ->create();
@@ -52,17 +52,17 @@ final class DateTimeTzTest extends FunctionalTestCase
         $this->dropAndCreateTable($table);
 
         $this->connection->insert(
-            'datetimetz_table',
+            'datetimetz_immutable_table',
             ['val' => $expected],
-            ['val' => Types::DATETIMETZ_MUTABLE],
+            ['val' => Types::DATETIMETZ_IMMUTABLE],
         );
 
         $value = $this->connection->convertToPHPValue(
-            $this->connection->fetchOne('SELECT val FROM datetimetz_table'),
-            Types::DATETIMETZ_MUTABLE,
+            $this->connection->fetchOne('SELECT val FROM datetimetz_immutable_table'),
+            Types::DATETIMETZ_IMMUTABLE,
         );
 
-        self::assertInstanceOf(DateTime::class, $value);
+        self::assertInstanceOf(DateTimeImmutable::class, $value);
         self::assertEquals($expected, $value);
     }
 }

--- a/tests/Functional/Types/DateTimeTzImmutableTest.php
+++ b/tests/Functional/Types/DateTimeTzImmutableTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 use DateTimeImmutable;
 use DateTimeZone;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -15,6 +16,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 final class DateTimeTzImmutableTest extends FunctionalTestCase
 {
+    private const TABLE_NAME = 'datetimetz_immutable_table';
+
     /** @return list<array{DateTimeImmutable}> */
     public static function dataValuesProvider(): array
     {
@@ -39,8 +42,57 @@ final class DateTimeTzImmutableTest extends FunctionalTestCase
             self::markTestSkipped('Oracle driver have a bug in DateTimeTz format string.');
         }
 
+        $this->createDatabase();
+
+        $this->connection->insert(
+            self::TABLE_NAME,
+            ['val' => $expected],
+            ['val' => Types::DATETIMETZ_IMMUTABLE],
+        );
+
+        $value = $this->connection->convertToPHPValue(
+            $this->connection->fetchOne('SELECT val FROM ' . self::TABLE_NAME),
+            Types::DATETIMETZ_IMMUTABLE,
+        );
+
+        self::assertInstanceOf(DateTimeImmutable::class, $value);
+        self::assertEquals($expected, $value);
+    }
+
+    #[DataProvider('dataValuesProvider')]
+    public function testRetrievalLegacyValue(DateTimeImmutable $value): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform instanceof SQLitePlatform) {
+            self::markTestSkipped('This test requires the platform to be SQLite.');
+        }
+
+        $this->createDatabase();
+
+        $this->connection->insert(
+            self::TABLE_NAME,
+            ['val' => $value],
+            ['val' => Types::DATETIME_IMMUTABLE],
+        );
+
+        $actual = $this->connection->convertToPHPValue(
+            $this->connection->fetchOne('SELECT val FROM ' . self::TABLE_NAME),
+            Types::DATETIMETZ_IMMUTABLE,
+        );
+
+        self::assertInstanceOf(DateTimeImmutable::class, $actual);
+        $expected = DateTimeImmutable::createFromFormat(
+            $platform->getDateTimeFormatString(),
+            $value->format($platform->getDateTimeFormatString()),
+        );
+        self::assertEquals($expected, $actual);
+    }
+
+    private function createDatabase(): void
+    {
         $table = Table::editor()
-            ->setUnquotedName('datetimetz_immutable_table')
+            ->setUnquotedName(self::TABLE_NAME)
             ->setColumns(
                 Column::editor()
                     ->setUnquotedName('val')
@@ -50,19 +102,5 @@ final class DateTimeTzImmutableTest extends FunctionalTestCase
             ->create();
 
         $this->dropAndCreateTable($table);
-
-        $this->connection->insert(
-            'datetimetz_immutable_table',
-            ['val' => $expected],
-            ['val' => Types::DATETIMETZ_IMMUTABLE],
-        );
-
-        $value = $this->connection->convertToPHPValue(
-            $this->connection->fetchOne('SELECT val FROM datetimetz_immutable_table'),
-            Types::DATETIMETZ_IMMUTABLE,
-        );
-
-        self::assertInstanceOf(DateTimeImmutable::class, $value);
-        self::assertEquals($expected, $value);
     }
 }

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Functional\Types;
+
+use DateTime;
+use DateTimeInterface;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Tests\FunctionalTestCase;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class DateTimeTzTest extends FunctionalTestCase
+{
+    /** @return DateTimeInterface[][] */
+    public static function dataValuesProvider(): array
+    {
+        return [
+            [new DateTime('1985-09-01 10:10:10')],
+            [new DateTime('2013-10-07T04:23:19-04:00')],
+        ];
+    }
+
+    #[DataProvider('dataValuesProvider')]
+    public function testInsertAndRetrieveDateTimeTz(DateTimeInterface $expected): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('datetimetz_table')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('val')
+                    ->setTypeName(Types::DATETIMETZ_MUTABLE)
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert(
+            'datetimetz_table',
+            ['val' => $expected],
+            ['val' => Types::DATETIMETZ_MUTABLE],
+        );
+
+        $value = Type::getType(Types::DATETIMETZ_MUTABLE)->convertToPHPValue(
+            $this->connection->fetchOne('SELECT val FROM datetimetz_table'),
+            $this->connection->getDatabasePlatform(),
+        );
+
+        self::assertInstanceOf(DateTime::class, $value);
+        self::assertEquals($expected, $value);
+    }
+}

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 use DateTime;
 use DateTimeZone;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -15,6 +16,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 final class DateTimeTzTest extends FunctionalTestCase
 {
+    private const TABLE_NAME = 'datetimetz_table';
+
     /** @return list<array{DateTime}> */
     public static function dataValuesProvider(): array
     {
@@ -39,8 +42,57 @@ final class DateTimeTzTest extends FunctionalTestCase
             self::markTestSkipped('Oracle driver have a bug in DateTimeTz format string.');
         }
 
+        $this->createDatabase();
+
+        $this->connection->insert(
+            self::TABLE_NAME,
+            ['val' => $expected],
+            ['val' => Types::DATETIMETZ_MUTABLE],
+        );
+
+        $value = $this->connection->convertToPHPValue(
+            $this->connection->fetchOne('SELECT val FROM ' . self::TABLE_NAME),
+            Types::DATETIMETZ_MUTABLE,
+        );
+
+        self::assertInstanceOf(DateTime::class, $value);
+        self::assertEquals($expected, $value);
+    }
+
+    #[DataProvider('dataValuesProvider')]
+    public function testRetrievalLegacyValue(DateTime $value): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if (! $platform instanceof SQLitePlatform) {
+            self::markTestSkipped('This test requires the platform to be SQLite.');
+        }
+
+        $this->createDatabase();
+
+        $this->connection->insert(
+            self::TABLE_NAME,
+            ['val' => $value],
+            ['val' => Types::DATETIME_MUTABLE],
+        );
+
+        $actual = $this->connection->convertToPHPValue(
+            $this->connection->fetchOne('SELECT val FROM ' . self::TABLE_NAME),
+            Types::DATETIMETZ_MUTABLE,
+        );
+
+        self::assertInstanceOf(DateTime::class, $actual);
+        $expected = DateTime::createFromFormat(
+            $platform->getDateTimeFormatString(),
+            $value->format($platform->getDateTimeFormatString()),
+        );
+        self::assertEquals($expected, $actual);
+    }
+
+    private function createDatabase(): void
+    {
         $table = Table::editor()
-            ->setUnquotedName('datetimetz_table')
+            ->setUnquotedName(self::TABLE_NAME)
             ->setColumns(
                 Column::editor()
                     ->setUnquotedName('val')
@@ -50,19 +102,5 @@ final class DateTimeTzTest extends FunctionalTestCase
             ->create();
 
         $this->dropAndCreateTable($table);
-
-        $this->connection->insert(
-            'datetimetz_table',
-            ['val' => $expected],
-            ['val' => Types::DATETIMETZ_MUTABLE],
-        );
-
-        $value = $this->connection->convertToPHPValue(
-            $this->connection->fetchOne('SELECT val FROM datetimetz_table'),
-            Types::DATETIMETZ_MUTABLE,
-        );
-
-        self::assertInstanceOf(DateTime::class, $value);
-        self::assertEquals($expected, $value);
     }
 }

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -27,6 +27,12 @@ final class DateTimeTzTest extends FunctionalTestCase
     #[DataProvider('dataValuesProvider')]
     public function testInsertAndRetrieveDateTimeTz(DateTimeInterface $expected): void
     {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform->getDateTimeTzFormatString() === $platform->getDateTimeFormatString()) {
+            self::markTestSkipped('This test requires the platform to support DateTime with timezone.');
+        }
+
         $table = Table::editor()
             ->setUnquotedName('datetimetz_table')
             ->setColumns(
@@ -47,7 +53,7 @@ final class DateTimeTzTest extends FunctionalTestCase
 
         $value = Type::getType(Types::DATETIMETZ_MUTABLE)->convertToPHPValue(
             $this->connection->fetchOne('SELECT val FROM datetimetz_table'),
-            $this->connection->getDatabasePlatform(),
+            $platform,
         );
 
         self::assertInstanceOf(DateTime::class, $value);

--- a/tests/Functional/Types/DateTimeTzTest.php
+++ b/tests/Functional/Types/DateTimeTzTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Functional\Types;
 
 use DateTime;
 use DateTimeInterface;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -31,6 +32,10 @@ final class DateTimeTzTest extends FunctionalTestCase
 
         if ($platform->getDateTimeTzFormatString() === $platform->getDateTimeFormatString()) {
             self::markTestSkipped('This test requires the platform to support DateTime with timezone.');
+        }
+
+        if ($platform instanceof OraclePlatform) {
+            self::markTestSkipped('Oracle driver have a bug in DateTimeTz format string.');
         }
 
         $table = Table::editor()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #5929 

#### Summary

Saves the timezone information for DateTimeTz type on SQLite3.

##### Information from the [SQLite3 documentation](https://sqlite.org/lang_datefunc.html)
>  Formats 2 through 10 may be optionally followed by a timezone indicator of the form "[+-]HH:MM" or just "Z". The date and time functions use UTC or "zulu" time internally, and so the "Z" suffix is a no-op. Any non-zero "HH:MM" suffix is subtracted from the indicated date and time in order to compute zulu time. For example, all of the following time-values are equivalent:

    2013-10-07 08:23:19.120
    2013-10-07T08:23:19.120Z
    2013-10-07 04:23:19.120-04:00

