### PR TITLE
Apply index column length to the correct column

### DIFF
--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -144,16 +144,20 @@ final class IndexEditor
         }
 
         $columnNames = $lengths = $options = $flags = [];
-        foreach ($this->columns as $i => $column) {
+        $hasLength   = false;
+
+        foreach ($this->columns as $column) {
             $columnNames[] = $column->getColumnName()->toString();
 
-            $length = $column->getLength();
+            $length    = $column->getLength();
+            $lengths[] = $length;
+
             if ($length !== null) {
-                $lengths[$i] = $column->getLength();
+                $hasLength = true;
             }
         }
 
-        if (count($lengths) !== 0) {
+        if ($hasLength) {
             $options['lengths'] = $lengths;
         }
 

--- a/tests/Schema/IndexEditorTest.php
+++ b/tests/Schema/IndexEditorTest.php
@@ -85,6 +85,19 @@ class IndexEditorTest extends TestCase
         ], $index->getIndexedColumns());
     }
 
+    public function testCreateAppliesColumnLengthToTheCorrectColumn(): void
+    {
+        $userId   = new IndexedColumn(UnqualifiedName::unquoted('user_id'), null);
+        $lastName = new IndexedColumn(UnqualifiedName::unquoted('last_name'), 16);
+
+        $index = Index::editor()
+            ->setName($this->createName())
+            ->setColumns($userId, $lastName)
+            ->create();
+
+        self::assertEquals([$userId, $lastName], $index->getIndexedColumns());
+    }
+
     public function testPreservesRegularIndexProperties(): void
     {
         $index1 = new Index(


### PR DESCRIPTION
`IndexEditor::create()` emitted the "lengths" index option keyed by column position, omitting entries for columns without a length. The `Index` constructor consumes lengths sequentially, so a length on any non-leading column was applied to an earlier column.