### PR TITLE
Add name-based column helpers to index/key editors

### DIFF
--- a/src/Schema/ForeignKeyConstraintEditor.php
+++ b/src/Schema/ForeignKeyConstraintEditor.php
@@ -115,6 +115,18 @@ final class ForeignKeyConstraintEditor
         return $this;
     }
 
+    /** @param non-empty-string $name */
+    public function addUnquotedReferencingColumnName(string $name): self
+    {
+        return $this->addReferencingColumnName(UnqualifiedName::unquoted($name));
+    }
+
+    /** @param non-empty-string $name */
+    public function addQuotedReferencingColumnName(string $name): self
+    {
+        return $this->addReferencingColumnName(UnqualifiedName::quoted($name));
+    }
+
     public function setReferencedTableName(OptionallyQualifiedName $referencedTableName): self
     {
         $this->referencedTableName = $referencedTableName;
@@ -196,6 +208,18 @@ final class ForeignKeyConstraintEditor
         $this->referencedColumnNames[] = $columName;
 
         return $this;
+    }
+
+    /** @param non-empty-string $name */
+    public function addUnquotedReferencedColumnName(string $name): self
+    {
+        return $this->addReferencedColumnName(UnqualifiedName::unquoted($name));
+    }
+
+    /** @param non-empty-string $name */
+    public function addQuotedReferencedColumnName(string $name): self
+    {
+        return $this->addReferencedColumnName(UnqualifiedName::quoted($name));
     }
 
     public function setMatchType(MatchType $matchType): self

--- a/src/Schema/IndexEditor.php
+++ b/src/Schema/IndexEditor.php
@@ -76,6 +76,24 @@ final class IndexEditor
         return $this;
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?positive-int    $length
+     */
+    public function addUnquotedColumnName(string $name, ?int $length = null): self
+    {
+        return $this->addColumn(new IndexedColumn(UnqualifiedName::unquoted($name), $length));
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @param ?positive-int    $length
+     */
+    public function addQuotedColumnName(string $name, ?int $length = null): self
+    {
+        return $this->addColumn(new IndexedColumn(UnqualifiedName::quoted($name), $length));
+    }
+
     public function setColumnNames(UnqualifiedName $firstColumnName, UnqualifiedName ...$otherColumnNames): self
     {
         $this->columns = array_map(

--- a/src/Schema/Introspection/MetadataProcessor/ForeignKeyConstraintColumnMetadataProcessor.php
+++ b/src/Schema/Introspection/MetadataProcessor/ForeignKeyConstraintColumnMetadataProcessor.php
@@ -61,11 +61,7 @@ final readonly class ForeignKeyConstraintColumnMetadataProcessor
     public function applyRow(ForeignKeyConstraintEditor $editor, ForeignKeyConstraintColumnMetadataRow $row): void
     {
         $editor
-            ->addReferencingColumnName(
-                UnqualifiedName::quoted($row->getReferencingColumnName()),
-            )
-            ->addReferencedColumnName(
-                UnqualifiedName::quoted($row->getReferencedColumnName()),
-            );
+            ->addQuotedReferencingColumnName($row->getReferencingColumnName())
+            ->addQuotedReferencedColumnName($row->getReferencedColumnName());
     }
 }

--- a/src/Schema/Introspection/MetadataProcessor/IndexColumnMetadataProcessor.php
+++ b/src/Schema/Introspection/MetadataProcessor/IndexColumnMetadataProcessor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema\Introspection\MetadataProcessor;
 
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\IndexEditor;
 use Doctrine\DBAL\Schema\Metadata\IndexColumnMetadataRow;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -30,11 +29,6 @@ final readonly class IndexColumnMetadataProcessor
 
     public function applyRow(IndexEditor $editor, IndexColumnMetadataRow $row): void
     {
-        $editor->addColumn(
-            new IndexedColumn(
-                UnqualifiedName::quoted($row->getColumnName()),
-                $row->getColumnLength(),
-            ),
-        );
+        $editor->addQuotedColumnName($row->getColumnName(), $row->getColumnLength());
     }
 }

--- a/src/Schema/Introspection/MetadataProcessor/PrimaryKeyConstraintColumnMetadataProcessor.php
+++ b/src/Schema/Introspection/MetadataProcessor/PrimaryKeyConstraintColumnMetadataProcessor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Schema\Introspection\MetadataProcessor;
 
 use Doctrine\DBAL\Schema\Metadata\PrimaryKeyConstraintColumnRow;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 
@@ -26,8 +25,6 @@ final readonly class PrimaryKeyConstraintColumnMetadataProcessor
 
     public function applyRow(PrimaryKeyConstraintEditor $editor, PrimaryKeyConstraintColumnRow $row): void
     {
-        $editor->addColumnName(
-            UnqualifiedName::quoted($row->getColumnName()),
-        );
+        $editor->addQuotedColumnName($row->getColumnName());
     }
 }

--- a/src/Schema/PrimaryKeyConstraintEditor.php
+++ b/src/Schema/PrimaryKeyConstraintEditor.php
@@ -97,6 +97,18 @@ final class PrimaryKeyConstraintEditor
         return $this;
     }
 
+    /** @param non-empty-string $name */
+    public function addUnquotedColumnName(string $name): self
+    {
+        return $this->addColumnName(UnqualifiedName::unquoted($name));
+    }
+
+    /** @param non-empty-string $name */
+    public function addQuotedColumnName(string $name): self
+    {
+        return $this->addColumnName(UnqualifiedName::quoted($name));
+    }
+
     public function setIsClustered(bool $isClustered): self
     {
         $this->isClustered = $isClustered;

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -13,9 +13,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
-use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Functional\Schema\MySQL\CustomType;
@@ -115,9 +113,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
     {
         $index = Index::editor()
             ->setUnquotedName('text_index')
-            ->setColumns(
-                new IndexedColumn(UnqualifiedName::unquoted('text'), 128),
-            )
+            ->addUnquotedColumnName('text', 128)
             ->create();
 
         $table = Table::editor()

--- a/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
+++ b/tests/Functional/Schema/SchemaManagerFunctionalTestCase.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Schema\ColumnEditor;
 use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -1623,17 +1622,12 @@ abstract class SchemaManagerFunctionalTestCase extends FunctionalTestCase
             ->setIndexes(
                 Index::editor()
                     ->setUnquotedName('partial_long_column_idx')
-                    ->setColumns(
-                        new IndexedColumn(UnqualifiedName::unquoted('long_column'), 4),
-                    )
+                    ->addUnquotedColumnName('long_column', 4)
                     ->create(),
                 Index::editor()
                     ->setUnquotedName('standard_and_partial_idx')
-                    ->setColumns(
-                        new IndexedColumn(UnqualifiedName::unquoted('standard_column'), null),
-                        new IndexedColumn(UnqualifiedName::unquoted('long_column'), 2),
-                    )
-                    ->setUnquotedColumnNames('standard_column', 'long_column')
+                    ->addUnquotedColumnName('standard_column')
+                    ->addUnquotedColumnName('long_column', 2)
                     ->create(),
             )
             ->create();

--- a/tests/Schema/ForeignKeyConstraintEditorTest.php
+++ b/tests/Schema/ForeignKeyConstraintEditorTest.php
@@ -172,6 +172,36 @@ class ForeignKeyConstraintEditorTest extends TestCase
         ], $constraint->getReferencedColumnNames());
     }
 
+    public function testAddReferencingColumnName(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->addUnquotedReferencingColumnName('account_id')
+            ->addQuotedReferencingColumnName('user_id')
+            ->setReferencedTableName($this->createTableName())
+            ->setUnquotedReferencedColumnNames('unused1', 'unused2')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::quoted('user_id'),
+        ], $constraint->getReferencingColumnNames());
+    }
+
+    public function testAddReferencedColumnName(): void
+    {
+        $constraint = ForeignKeyConstraint::editor()
+            ->setUnquotedReferencingColumnNames('unused1', 'unused2')
+            ->setReferencedTableName($this->createTableName())
+            ->addUnquotedReferencedColumnName('account_id')
+            ->addQuotedReferencedColumnName('id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::quoted('id'),
+        ], $constraint->getReferencedColumnNames());
+    }
+
     public function testSetMatchType(): void
     {
         $editor = $this->createMinimalValidEditor();

--- a/tests/Schema/IndexEditorTest.php
+++ b/tests/Schema/IndexEditorTest.php
@@ -98,6 +98,20 @@ class IndexEditorTest extends TestCase
         self::assertEquals([$userId, $lastName], $index->getIndexedColumns());
     }
 
+    public function testAddColumn(): void
+    {
+        $index = Index::editor()
+            ->setName($this->createName())
+            ->addUnquotedColumnName('last_name', 16)
+            ->addQuotedColumnName('user_id')
+            ->create();
+
+        self::assertEquals([
+            new IndexedColumn(UnqualifiedName::unquoted('last_name'), 16),
+            new IndexedColumn(UnqualifiedName::quoted('user_id'), null),
+        ], $index->getIndexedColumns());
+    }
+
     public function testPreservesRegularIndexProperties(): void
     {
         $index1 = new Index(

--- a/tests/Schema/PrimaryKeyConstraintEditorTest.php
+++ b/tests/Schema/PrimaryKeyConstraintEditorTest.php
@@ -70,6 +70,19 @@ class PrimaryKeyConstraintEditorTest extends TestCase
         ], $constraint->getColumnNames());
     }
 
+    public function testAddColumnName(): void
+    {
+        $constraint = PrimaryKeyConstraint::editor()
+            ->addUnquotedColumnName('account_id')
+            ->addQuotedColumnName('user_id')
+            ->create();
+
+        self::assertEquals([
+            UnqualifiedName::unquoted('account_id'),
+            UnqualifiedName::quoted('user_id'),
+        ], $constraint->getColumnNames());
+    }
+
     public function testSetIsClustered(): void
     {
         $constraint = PrimaryKeyConstraint::editor()


### PR DESCRIPTION
Schema editor methods that accept names as objects have helper methods that accept names as quoted or unquoted strings. Some methods are currently missing these helpers, so this PR adds them.

The new string helpers simplify schema-related tests and schema introspection code.
