### PR TITLE
Cover table-editor rejection and malformed-name lookups

### DIFF
--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\DBAL\Tests\Schema;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\Exception\IndexAlreadyExists;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Exception\InvalidTableModification;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -340,6 +341,28 @@ class TableEditorTest extends TestCase
                 ->setIndexes($index),
             static fn (TableEditor $editor): TableEditor => $editor->addIndex($index),
         );
+    }
+
+    public function testCreateWithSameNamedIndexEditors(): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts')
+            ->setColumns(
+                $this->createColumn('id', Types::INTEGER),
+                $this->createColumn('email', Types::STRING),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_email')
+                    ->setUnquotedColumnNames('email'),
+                Index::editor()
+                    ->setUnquotedName('idx_email')
+                    ->setUnquotedColumnNames('id'),
+            );
+
+        $this->expectException(IndexAlreadyExists::class);
+
+        $editor->create();
     }
 
     public function testRenameIndex(): void

--- a/tests/Schema/TableEditorTest.php
+++ b/tests/Schema/TableEditorTest.php
@@ -86,13 +86,10 @@ class TableEditorTest extends TestCase
     {
         $column = $this->createColumn('id', Types::INTEGER);
 
-        $editor = Table::editor()
-            ->setUnquotedName('accounts')
-            ->setColumns($column);
-
-        $this->expectException(InvalidTableModification::class);
-
-        $editor->addColumn($column);
+        $this->assertModificationRejected(
+            static fn (TableEditor $editor): TableEditor => $editor->setColumns($column),
+            static fn (TableEditor $editor): TableEditor => $editor->addColumn($column),
+        );
     }
 
     public function testModifyColumn(): void
@@ -337,14 +334,12 @@ class TableEditorTest extends TestCase
             ->setUnquotedColumnNames('id')
             ->create();
 
-        $editor = Table::editor()
-            ->setUnquotedName('accounts')
-            ->setColumns($this->createColumn('id', Types::INTEGER))
-            ->setIndexes($index);
-
-        $this->expectException(InvalidTableModification::class);
-
-        $editor->addIndex($index);
+        $this->assertModificationRejected(
+            fn (TableEditor $editor): TableEditor => $editor
+                ->setColumns($this->createColumn('id', Types::INTEGER))
+                ->setIndexes($index),
+            static fn (TableEditor $editor): TableEditor => $editor->addIndex($index),
+        );
     }
 
     public function testRenameIndex(): void
@@ -520,14 +515,12 @@ class TableEditorTest extends TestCase
             ->setUnquotedColumnNames('id')
             ->create();
 
-        $editor = Table::editor()
-            ->setUnquotedName('accounts')
-            ->setColumns($this->createColumn('id', Types::INTEGER))
-            ->addUniqueConstraint($uniqueConstraint);
-
-        $this->expectException(InvalidTableModification::class);
-
-        $editor->addUniqueConstraint($uniqueConstraint);
+        $this->assertModificationRejected(
+            fn (TableEditor $editor): TableEditor => $editor
+                ->setColumns($this->createColumn('id', Types::INTEGER))
+                ->addUniqueConstraint($uniqueConstraint),
+            static fn (TableEditor $editor): TableEditor => $editor->addUniqueConstraint($uniqueConstraint),
+        );
     }
 
     public function testDropUniqueConstraint(): void
@@ -588,16 +581,12 @@ class TableEditorTest extends TestCase
             ->setUnquotedReferencedColumnNames('id')
             ->create();
 
-        $editor = Table::editor()
-            ->setUnquotedName('accounts')
-            ->setColumns(
-                $this->createColumn('user_id', Types::INTEGER),
-            )
-            ->addForeignKeyConstraint($foreignKeyConstraint);
-
-        $this->expectException(InvalidTableModification::class);
-
-        $editor->addForeignKeyConstraint($foreignKeyConstraint);
+        $this->assertModificationRejected(
+            fn (TableEditor $editor): TableEditor => $editor
+                ->setColumns($this->createColumn('user_id', Types::INTEGER))
+                ->addForeignKeyConstraint($foreignKeyConstraint),
+            static fn (TableEditor $editor): TableEditor => $editor->addForeignKeyConstraint($foreignKeyConstraint),
+        );
     }
 
     public function testDropForeignKeyConstraint(): void
@@ -644,6 +633,22 @@ class TableEditorTest extends TestCase
             'This is the "accounts" table',
             $table->getComment(),
         );
+    }
+
+    /**
+     * @param callable(TableEditor): TableEditor $setup
+     * @param callable(TableEditor): TableEditor $modify
+     */
+    private function assertModificationRejected(callable $setup, callable $modify): void
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('accounts');
+
+        $setup($editor);
+
+        $this->expectException(InvalidTableModification::class);
+
+        $modify($editor);
     }
 
     /**

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Exception\ForeignKeyDoesNotExist;
 use Doctrine\DBAL\Schema\Exception\IndexDoesNotExist;
+use Doctrine\DBAL\Schema\Exception\InvalidName;
 use Doctrine\DBAL\Schema\Exception\InvalidTableDefinition;
 use Doctrine\DBAL\Schema\Exception\UniqueConstraintDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
@@ -24,6 +25,7 @@ use Doctrine\DBAL\Schema\TableConfiguration;
 use Doctrine\DBAL\Schema\UniqueConstraint;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function strlen;
@@ -484,6 +486,53 @@ class TableTest extends TestCase
         $this->expectException(UniqueConstraintDoesNotExist::class);
 
         $table->getUniqueConstraint('unknown');
+    }
+
+    /** @param callable(Table): mixed $lookup */
+    #[DataProvider('lookupWithInvalidNameProvider')]
+    public function testLookupWithInvalidName(callable $lookup): void
+    {
+        $table = $this->createTableWithSingleColumn();
+
+        $this->expectException(InvalidName::class);
+
+        $lookup($table);
+    }
+
+    /** @return iterable<string, array{callable(Table): mixed}> */
+    public static function lookupWithInvalidNameProvider(): iterable
+    {
+        yield 'has column' => [
+            static fn (Table $table): bool => $table->hasColumn('"email'),
+        ];
+
+        yield 'get column' => [
+            static fn (Table $table): Column => $table->getColumn('"email'),
+        ];
+
+        yield 'has index' => [
+            static fn (Table $table): bool => $table->hasIndex('"idx_email'),
+        ];
+
+        yield 'get index' => [
+            static fn (Table $table): Index => $table->getIndex('"idx_email'),
+        ];
+
+        yield 'has unique constraint' => [
+            static fn (Table $table): bool => $table->hasUniqueConstraint('"uq_email'),
+        ];
+
+        yield 'get unique constraint' => [
+            static fn (Table $table): UniqueConstraint => $table->getUniqueConstraint('"uq_email'),
+        ];
+
+        yield 'has foreign key' => [
+            static fn (Table $table): bool => $table->hasForeignKey('"fk_users'),
+        ];
+
+        yield 'get foreign key' => [
+            static fn (Table $table): ForeignKeyConstraint => $table->getForeignKey('"fk_users'),
+        ];
     }
 
     private function createTableWithSingleColumn(): Table


### PR DESCRIPTION
Test-only changes that close coverage gaps in the schema object model:

1. Share one helper across the table editor's tests for rejecting a re-added object.
2. Cover rejection of two index editors that produce indexes with the same name.
3. Cover table lookups given an unparseable name.
