### PR TITLE
Cover and clean up schema introspection

### DIFF
--- a/src/Schema/Introspection/IntrospectingSchemaProvider.php
+++ b/src/Schema/Introspection/IntrospectingSchemaProvider.php
@@ -15,6 +15,8 @@ use Doctrine\DBAL\Schema\Introspection\MetadataProcessor\IndexColumnMetadataProc
 use Doctrine\DBAL\Schema\Introspection\MetadataProcessor\PrimaryKeyConstraintColumnMetadataProcessor;
 use Doctrine\DBAL\Schema\Introspection\MetadataProcessor\SequenceMetadataProcessor;
 use Doctrine\DBAL\Schema\Introspection\MetadataProcessor\ViewMetadataProcessor;
+use Doctrine\DBAL\Schema\Metadata\ForeignKeyConstraintColumnMetadataRow;
+use Doctrine\DBAL\Schema\Metadata\IndexColumnMetadataRow;
 use Doctrine\DBAL\Schema\Metadata\MetadataProvider;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -217,30 +219,14 @@ final readonly class IntrospectingSchemaProvider implements SchemaProvider
      */
     private function getIndexesForAllTables(): array
     {
-        $editors   = [];
         $processor = new IndexColumnMetadataProcessor();
 
-        foreach ($this->metadataProvider->getIndexColumnsForAllTables() as $row) {
-            $schemaName = $row->getSchemaName() ?? self::NULL_SCHEMA_KEY;
-            $tableName  = $row->getTableName();
-            $indexName  = $row->getIndexName();
-
-            if (! isset($editors[$schemaName][$tableName][$indexName])) {
-                $editors[$schemaName][$tableName][$indexName] = $processor->initializeEditor($row);
-            }
-
-            $processor->applyRow($editors[$schemaName][$tableName][$indexName], $row);
-        }
-
-        return array_map(
-            static fn (array $editors): array => array_map(
-                static fn (array $editors): array => array_map(
-                    static fn (IndexEditor $editor): Index => $editor->create(),
-                    array_values($editors),
-                ),
-                $editors,
-            ),
-            $editors,
+        return $this->groupByTable(
+            static fn (IndexColumnMetadataRow $row): string => $row->getIndexName(),
+            $processor->initializeEditor(...),
+            $processor->applyRow(...),
+            static fn (IndexEditor $editor): Index => $editor->create(),
+            $this->metadataProvider->getIndexColumnsForAllTables(),
         );
     }
 
@@ -325,28 +311,59 @@ final readonly class IntrospectingSchemaProvider implements SchemaProvider
      */
     private function getForeignKeyConstraintsForAllTables(): array
     {
-        $editors   = [];
         $processor = new ForeignKeyConstraintColumnMetadataProcessor($this->currentSchemaName);
 
-        foreach ($this->metadataProvider->getForeignKeyConstraintColumnsForAllTables() as $row) {
+        return $this->groupByTable(
+            static fn (ForeignKeyConstraintColumnMetadataRow $row): int|string => $row->getId(),
+            $processor->initializeEditor(...),
+            $processor->applyRow(...),
+            static fn (ForeignKeyConstraintEditor $editor): ForeignKeyConstraint => $editor->create(),
+            $this->metadataProvider->getForeignKeyConstraintColumnsForAllTables(),
+        );
+    }
+
+    /**
+     * Groups rows by schema and table, builds one editor per grouping key, and creates the objects.
+     *
+     * If the underlying database does not support schemas, the schema key will be {@link NULL_SCHEMA_KEY}.
+     *
+     * @param callable(R): (int|string) $getKey
+     * @param callable(R): E            $initializeEditor
+     * @param callable(E, R): void      $applyRow
+     * @param callable(E): T            $create
+     * @param iterable<R>               $rows
+     *
+     * @return array<string, array<non-empty-string, list<T>>>
+     *
+     * @template R of ForeignKeyConstraintColumnMetadataRow|IndexColumnMetadataRow
+     * @template E of object
+     * @template T of object
+     */
+    private function groupByTable(
+        callable $getKey,
+        callable $initializeEditor,
+        callable $applyRow,
+        callable $create,
+        iterable $rows,
+    ): array {
+        $editors = [];
+
+        foreach ($rows as $row) {
             $schemaName = $row->getSchemaName() ?? self::NULL_SCHEMA_KEY;
             $tableName  = $row->getTableName();
-            $id         = $row->getId();
+            $key        = $getKey($row);
 
-            if (! isset($editors[$schemaName][$tableName][$id])) {
-                $editors[$schemaName][$tableName][$id] = $processor->initializeEditor($row);
+            if (! isset($editors[$schemaName][$tableName][$key])) {
+                $editors[$schemaName][$tableName][$key] = $initializeEditor($row);
             }
 
-            $processor->applyRow($editors[$schemaName][$tableName][$id], $row);
+            $applyRow($editors[$schemaName][$tableName][$key], $row);
         }
 
         return array_map(
-            static fn (array $editors): array => array_map(
-                static fn (array $editors): array => array_map(
-                    static fn (ForeignKeyConstraintEditor $editor): ForeignKeyConstraint => $editor->create(),
-                    array_values($editors),
-                ),
-                $editors,
+            static fn (array $tables): array => array_map(
+                static fn (array $editors): array => array_map($create, array_values($editors)),
+                $tables,
             ),
             $editors,
         );

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -10,9 +10,11 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnEditor;
+use Doctrine\DBAL\Schema\Exception\UnsupportedName;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\Metadata\MetadataProvider;
 use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
@@ -676,5 +678,76 @@ final class SchemaManagerTest extends FunctionalTestCase
         }
 
         return null;
+    }
+
+    /** @param callable(MetadataProvider, ?non-empty-string, non-empty-string): iterable<mixed> $introspect */
+    #[DataProvider('perTableIntrospectionProvider')]
+    public function testIntrospectionWithSchemaNameWithoutSchemaSupport(callable $introspect): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform->supportsSchemas()) {
+            self::markTestSkipped('The platform supports schemas.');
+        }
+
+        $provider = $platform->createMetadataProvider($this->connection);
+
+        $this->expectException(UnsupportedName::class);
+
+        $introspect($provider, 'billing', 'orders');
+    }
+
+    /** @param callable(MetadataProvider, ?non-empty-string, non-empty-string): iterable<mixed> $introspect */
+    #[DataProvider('perTableIntrospectionProvider')]
+    public function testIntrospectionWithoutSchemaNameWithSchemaSupport(callable $introspect): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        if (! $platform->supportsSchemas()) {
+            self::markTestSkipped('The platform does not support schemas.');
+        }
+
+        $provider = $platform->createMetadataProvider($this->connection);
+
+        $this->expectException(UnsupportedName::class);
+
+        $introspect($provider, null, 'orders');
+    }
+
+    /**
+     * @return iterable<string, array{callable(
+     *     MetadataProvider,
+     *     ?non-empty-string,
+     *     non-empty-string,
+     * ): iterable<mixed>}> */
+    public static function perTableIntrospectionProvider(): iterable
+    {
+        yield 'columns' => [
+            static function (MetadataProvider $provider, $schemaName, $tableName): iterable {
+                return $provider->getTableColumnsForTable($schemaName, $tableName);
+            },
+        ];
+
+        yield 'indexes' => [
+            static function (MetadataProvider $provider, $schemaName, $tableName): iterable {
+                return $provider->getIndexColumnsForTable($schemaName, $tableName);
+            },
+        ];
+
+        yield 'primary key constraint' => [
+            static function (MetadataProvider $provider, $schemaName, $tableName): iterable {
+                return $provider->getPrimaryKeyConstraintColumnsForTable($schemaName, $tableName);
+            },
+        ];
+
+        yield 'foreign key constraints' => [
+            static function (MetadataProvider $provider, $schemaName, $tableName): iterable {
+                return $provider->getForeignKeyConstraintColumnsForTable($schemaName, $tableName);
+            },
+        ];
+
+        yield 'options' => [
+            static function (MetadataProvider $provider, $schemaName, $tableName): iterable {
+                return $provider->getTableOptionsForTable($schemaName, $tableName);
+            },
+        ];
     }
 }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -25,7 +25,6 @@ use PHPUnit\Framework\TestCase;
 
 use function array_map;
 use function array_values;
-use function count;
 use function sprintf;
 use function usort;
 
@@ -137,23 +136,24 @@ abstract class FunctionalTestCase extends TestCase
         $normalizedSchemaName = $schemaName->getIdentifier()
             ->toNormalizedValue($folding);
 
-        $schemaManager  = $this->connection->createSchemaManager();
-        $databaseSchema = $schemaManager->introspectSchema();
+        $schemaManager = $this->connection->createSchemaManager();
 
-        $sequencesToDrop = [];
-        foreach ($databaseSchema->getSequences() as $sequence) {
-            $qualifier = $sequence->getObjectName()
-                ->getQualifier();
+        $schemaToDrop = Schema::editor();
 
-            if ($qualifier === null || $qualifier->toNormalizedValue($folding) !== $normalizedSchemaName) {
-                continue;
+        if ($platform->supportsSequences()) {
+            foreach ($schemaManager->introspectSequences() as $sequence) {
+                $qualifier = $sequence->getObjectName()
+                    ->getQualifier();
+
+                if ($qualifier === null || $qualifier->toNormalizedValue($folding) !== $normalizedSchemaName) {
+                    continue;
+                }
+
+                $schemaToDrop->addSequence($sequence);
             }
-
-            $sequencesToDrop[] = $sequence;
         }
 
-        $tablesToDrop = [];
-        foreach ($databaseSchema->getTables() as $table) {
+        foreach ($schemaManager->introspectTables() as $table) {
             $qualifier = $table->getObjectName()
                 ->getQualifier();
 
@@ -161,17 +161,10 @@ abstract class FunctionalTestCase extends TestCase
                 continue;
             }
 
-            $tablesToDrop[] = $table;
+            $schemaToDrop->addTable($table);
         }
 
-        if (count($sequencesToDrop) > 0 || count($tablesToDrop) > 0) {
-            $schemaManager->dropSchemaObjects(
-                Schema::editor()
-                    ->setTables(...$tablesToDrop)
-                    ->setSequences(...$sequencesToDrop)
-                    ->create(),
-            );
-        }
+        $schemaManager->dropSchemaObjects($schemaToDrop->create());
 
         try {
             $schemaManager->dropSchema($schemaName->toSQL($platform));

--- a/tests/Schema/Metadata/ForeignKeyConstraintColumnMetadataRowTest.php
+++ b/tests/Schema/Metadata/ForeignKeyConstraintColumnMetadataRowTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Tests\Schema\Metadata;
+
+use Doctrine\DBAL\Exception\InvalidArgumentException;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\MatchType;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use Doctrine\DBAL\Schema\Metadata\ForeignKeyConstraintColumnMetadataRow;
+use PHPUnit\Framework\TestCase;
+
+class ForeignKeyConstraintColumnMetadataRowTest extends TestCase
+{
+    public function testNeitherIdNorName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ForeignKeyConstraintColumnMetadataRow(
+            referencingSchemaName: null,
+            referencingTableName: 'orders',
+            id: null,
+            name: null,
+            referencedSchemaName: null,
+            referencedTableName: 'customers',
+            matchType: MatchType::SIMPLE,
+            onUpdateAction: ReferentialAction::NO_ACTION,
+            onDeleteAction: ReferentialAction::NO_ACTION,
+            isDeferrable: false,
+            isDeferred: false,
+            referencingColumnName: 'customer_id',
+            referencedColumnName: 'id',
+        );
+    }
+}


### PR DESCRIPTION
I'm working on introspection of unique constraints. It requires some changes to the test suite. Additionally the existing introspection code and test suite can be generalized a bit more and made reusable by the new implementation and tests.

The changes are:

1. **Drop a schema in a database with case-colliding tables.** `dropSchemaIfExists()` introspected the whole database to find the objects to drop, which fails when the database holds tables whose names differ only in identifier case (see https://github.com/doctrine/dbal/issues/4357#issuecomment-911123014). It now enumerates tables and sequences without building a whole-database schema, so it can drop the target schema as long as the colliding tables live in another one.

2. **Test schema name rejection in table introspection.** The metadata providers reject a schema name on schemaless platforms and require one on schema-aware platforms, but neither guard was covered. The tests drive the provider directly, since the schema manager resolves the current schema before the provider sees it. The same requirements will apply to introspection of unique constraints.

3. **Test the foreign key metadata row without an id or a name.** Its constructor requires one of the two and throws otherwise, but that branch was uncovered. The same will apply to unique constraint metadata row.

4. **Extract a helper for all-tables object grouping.** Index and foreign key introspection duplicated the same grouping shape, so I pulled it into a shared helper. Introspection of unique constraints will use it as well.
