### PR TITLE
Distinguish table names differing only in case

### DIFF
--- a/src/Platforms/MySQL/MySQLMetadataProvider.php
+++ b/src/Platforms/MySQL/MySQLMetadataProvider.php
@@ -155,6 +155,8 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             $params[]     = $tableName;
         }
 
+        // On MySQL < 8.0 and MariaDB, information_schema compares object names case-insensitively and so
+        // conflates table names that differ only in case. The binary comparison prevents that.
         $sql = sprintf(
             <<<'SQL'
             SELECT c.TABLE_NAME,
@@ -174,6 +176,7 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             FROM information_schema.COLUMNS c
                      INNER JOIN information_schema.TABLES t
                                 ON t.TABLE_NAME = c.TABLE_NAME
+                                    AND CONVERT(t.TABLE_NAME USING binary) = CONVERT(c.TABLE_NAME USING binary)
             WHERE %s
               AND t.TABLE_TYPE = 'BASE TABLE'
             ORDER BY c.TABLE_NAME,
@@ -473,6 +476,8 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             $params[]     = $tableName;
         }
 
+        // On MySQL < 8.0 and MariaDB, information_schema compares object names case-insensitively and so
+        // conflates table names that differ only in case. The binary comparison prevents that.
         $sql = sprintf(
             <<<'SQL'
             SELECT tc.TABLE_NAME,
@@ -481,6 +486,7 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             FROM information_schema.TABLE_CONSTRAINTS tc
                      INNER JOIN information_schema.KEY_COLUMN_USAGE kcu
                                 ON kcu.TABLE_NAME = tc.TABLE_NAME
+                                    AND CONVERT(kcu.TABLE_NAME USING binary) = CONVERT(tc.TABLE_NAME USING binary)
                                     AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
             WHERE %s
               AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
@@ -540,6 +546,8 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
             $params[]     = $tableName;
         }
 
+        // On MySQL < 8.0 and MariaDB, information_schema compares object names case-insensitively and so
+        // conflates table names that differ only in case. The binary comparison prevents that.
         $sql = sprintf(
             <<<'SQL'
             SELECT k.TABLE_NAME,
@@ -553,6 +561,7 @@ final readonly class MySQLMetadataProvider implements MetadataProvider
                      INNER JOIN information_schema.REFERENTIAL_CONSTRAINTS c
                                 ON c.CONSTRAINT_NAME = k.CONSTRAINT_NAME
                                     AND c.TABLE_NAME = k.TABLE_NAME
+                                    AND CONVERT(c.TABLE_NAME USING binary) = CONVERT(k.TABLE_NAME USING binary)
             WHERE %s
               AND k.REFERENCED_COLUMN_NAME IS NOT NULL
             ORDER BY k.TABLE_NAME,

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Schema;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Exception\TableExistsException;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -312,6 +313,63 @@ final class SchemaManagerTest extends FunctionalTestCase
 
         $table = $this->schemaManager->introspectTable('"example');
         self::assertCount(1, $table->getColumns());
+    }
+
+    public function testIntrospectionDistinguishesTablesWhoseNamesDifferOnlyInCase(): void
+    {
+        $id = Column::editor()
+            ->setQuotedName('id')
+            ->setTypeName(Types::INTEGER)
+            ->create();
+
+        $lowerColumn = Column::editor()
+            ->setQuotedName('lower_only')
+            ->setTypeName(Types::INTEGER)
+            ->create();
+
+        $upperColumn = Column::editor()
+            ->setQuotedName('UPPER_ONLY')
+            ->setTypeName(Types::INTEGER)
+            ->create();
+
+        $lowerTable = Table::editor()
+            ->setQuotedName('contract')
+            ->setColumns($id, $lowerColumn)
+            ->create();
+
+        $upperTable = Table::editor()
+            ->setQuotedName('CONTRACT')
+            ->setColumns($id, $upperColumn)
+            ->create();
+
+        $platform = $this->connection->getDatabasePlatform();
+        $this->dropTableIfExists($upperTable->getObjectName()->toSQL($platform));
+        $this->dropTableIfExists($lowerTable->getObjectName()->toSQL($platform));
+
+        $this->schemaManager->createTable($lowerTable);
+
+        try {
+            $this->schemaManager->createTable($upperTable);
+        } catch (TableExistsException) {
+            self::markTestSkipped('The database compares table names case-insensitively.');
+        }
+
+        try {
+            $this->assertColumnNamesEqual(
+                [$id, $lowerColumn],
+                $this->schemaManager->introspectTableColumnsByQuotedName('contract'),
+            );
+
+            $this->assertColumnNamesEqual(
+                [$id, $upperColumn],
+                $this->schemaManager->introspectTableColumnsByQuotedName('CONTRACT'),
+            );
+        } finally {
+            // Leaving tables whose names differ only in case behind would poison the schema for the other tests
+            // that use introspectSchema(), since a Schema cannot represent such tables.
+            $this->schemaManager->dropTable($upperTable->getObjectName()->toSQL($platform));
+            $this->schemaManager->dropTable($lowerTable->getObjectName()->toSQL($platform));
+        }
     }
 
     #[TestWith([true])]

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
 use Doctrine\DBAL\Platforms\Exception\NotSupported;
+use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
@@ -236,7 +237,7 @@ abstract class FunctionalTestCase extends TestCase
 
     /**
      * @param non-empty-list<UnqualifiedName> $expected
-     * @param non-empty-list<UnqualifiedName> $actual
+     * @param list<UnqualifiedName>           $actual
      *
      * @throws Exception
      */
@@ -374,6 +375,49 @@ abstract class FunctionalTestCase extends TestCase
         return array_map(
             fn (UnqualifiedName $name): UnqualifiedName => $this->toQuotedUnqualifiedName($name),
             $names,
+        );
+    }
+
+    /** @throws Exception */
+    protected function toQuotedColumn(Column $column): Column
+    {
+        return $column->edit()
+            ->setName($this->toQuotedUnqualifiedName($column->getObjectName()))
+            ->create();
+    }
+
+    /**
+     * @param non-empty-list<Column> $expected
+     * @param list<Column>           $actual
+     *
+     * @throws Exception
+     */
+    protected function assertColumnNamesEqual(array $expected, array $actual): void
+    {
+        $this->assertUnqualifiedNameListEquals(
+            array_map(
+                static fn (Column $column): UnqualifiedName => $column->getObjectName(),
+                $expected,
+            ),
+            array_map(
+                static fn (Column $column): UnqualifiedName => $column->getObjectName(),
+                $actual,
+            ),
+        );
+    }
+
+    /**
+     * @param list<Column> $columns
+     *
+     * @return ($columns is non-empty-list ? non-empty-list<Column> : list<Column>)
+     *
+     * @throws Exception
+     */
+    protected function toQuotedColumnList(array $columns): array
+    {
+        return array_map(
+            fn (Column $column): Column => $this->toQuotedColumn($column),
+            $columns,
         );
     }
 


### PR DESCRIPTION
Currently, on MySQL before 8.0 and MariaDB, introspecting a table also returns the columns and constraints of any other table in the same schema whose name differs only in case. Depending on whether the names collide:

1. If two columns share a name (say both `contract` and `CONTRACT` have an `id`), building the table fails:

   ```
   Doctrine\DBAL\Schema\Exception\InvalidTableModification:
   Column "id" already exists on table "contract".
   ```
2. If not, the extra columns are merged in silently, and introspection returns a table carrying columns that were never defined on it.

The cause is the collation of the `information_schema` name columns. The columns, PK, and FK queries each join two catalog tables by name:

```sql
FROM information_schema.COLUMNS c
    INNER JOIN information_schema.TABLES t ON t.TABLE_NAME = c.TABLE_NAME
```

On MySQL before 8.0 (`utf8_general_ci`) and every MariaDB version (`utf8mb3_general_ci`, including 11.7), that collation is case-insensitive, so the join also pairs tables whose names differ only in case:

```
MariaDB [doctrine]> SELECT t.TABLE_NAME AS t, c.TABLE_NAME AS c
    -> FROM information_schema.TABLES t
    -> JOIN information_schema.COLUMNS c ON t.TABLE_NAME = c.TABLE_NAME
    -> WHERE t.TABLE_SCHEMA = 'doctrine' AND c.TABLE_SCHEMA = 'doctrine'
    ->   AND t.TABLE_NAME = 'contract' AND c.COLUMN_NAME = 'id';
+----------+----------+
| t        | c        |
+----------+----------+
| contract | CONTRACT |
| contract | contract |
+----------+----------+
```

MySQL 8.0+ uses a case-sensitive collation (`utf8mb3_bin`), so it isn't affected. The bug affects both the metadata-provider-based introspection and the deprecated one. I'm fixing only the former. DBAL doesn't fully support tables whose names differ only in case yet, and by the time it does, the deprecated API will be gone.

## The fix

The join now compares the table names both by their native collation and as binary strings:

```sql
INNER JOIN information_schema.TABLES t
    ON t.TABLE_NAME = c.TABLE_NAME
        AND CONVERT(t.TABLE_NAME USING binary) = CONVERT(c.TABLE_NAME USING binary)
```

The single-table `WHERE t.TABLE_NAME = ?` filter needs no change. Searches for database and table names in `information_schema` are case-sensitive when `lower_case_table_names=0`, unlike a comparison between two of the columns ([MySQL manual](https://dev.mysql.com/doc/refman/5.7/en/charset-collation-information-schema.html)), so the literal filter never conflated:

```
MariaDB [doctrine]> SELECT TABLE_NAME FROM information_schema.TABLES
    -> WHERE TABLE_SCHEMA = 'doctrine' AND TABLE_NAME = 'contract';
+------------+
| TABLE_NAME |
+------------+
| contract   |
+------------+
```

### Performance

The extra condition doesn't change the query plan.

On MySQL 8.0+, where `information_schema` is a real data dictionary, the join still resolves `TABLES` by an indexed name lookup at the same cost as the unpatched query. `EXPLAIN FORMAT=TREE` on MySQL 9.4:

```
-- ON t.TABLE_NAME = c.TABLE_NAME  (unpatched)
-> Single-row index lookup on tbl using schema_id (schema_id = sch.id, name = tbl.`name`)  (cost=0.658 rows=1)
    ...
(root cost=1077 rows=688)

-- ON t.TABLE_NAME = c.TABLE_NAME AND CONVERT(...) = CONVERT(...)  (this PR)
-> Single-row index lookup on tbl using schema_id (schema_id = sch.id, name = tbl.`name`)  (cost=0.658 rows=1)
    ...
(root cost=1077 rows=688)
```

MariaDB (and MySQL before 8.0) generate `information_schema` on the fly and full-scan it either way, so there's no index to lose and the plan is unchanged. `EXPLAIN` on MariaDB 11.7 is identical with and without the condition:

```
table | type | key          | Extra
c     | ALL  | TABLE_SCHEMA | Using where; Open_frm_only; Scanned 1 database
t     | ALL  | TABLE_SCHEMA | Using where; Open_frm_only; Scanned 1 database; Using join buffer (flat, BNL join)
```
