### PR TITLE
Fix RequiresPhp attributes

### DIFF
--- a/tests/Functional/Driver/PDO/PDOSubclassTest.php
+++ b/tests/Functional/Driver/PDO/PDOSubclassTest.php
@@ -11,7 +11,7 @@ use Pdo\Pgsql;
 use Pdo\Sqlite;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
-#[RequiresPhp('8.4')]
+#[RequiresPhp('>= 8.4')]
 final class PDOSubclassTest extends FunctionalTestCase
 {
     public function testMySQLSubclass(): void

--- a/tests/Functional/TypeConversionTest.php
+++ b/tests/Functional/TypeConversionTest.php
@@ -234,7 +234,7 @@ class TypeConversionTest extends FunctionalTestCase
         self::assertSame('13.37', $this->processValue(Types::DECIMAL, '13.37'));
     }
 
-    #[RequiresPhp('8.4')]
+    #[RequiresPhp('>= 8.4')]
     #[RequiresPhpExtension('bcmath')]
     public function testNumber(): void
     {

--- a/tests/Functional/Types/NumberTest.php
+++ b/tests/Functional/Types/NumberTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
 
-#[RequiresPhp('8.4')]
+#[RequiresPhp('>= 8.4')]
 #[RequiresPhpExtension('bcmath')]
 final class NumberTest extends FunctionalTestCase
 {

--- a/tests/Types/NumberTest.php
+++ b/tests/Types/NumberTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-#[RequiresPhp('8.4')]
+#[RequiresPhp('>= 8.4')]
 #[RequiresPhpExtension('bcmath')]
 final class NumberTest extends TestCase
 {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

`#[RequiresPhp('8.4')]` makes PHPUnit skip the test on PHP 8.5 and above which was not the intention here. Let's use `#[RequiresPhp('>= 8.4')]` instead.