### PR TITLE
fix(MySQL): combine the drop and the creation of an index over the same columns

### DIFF
--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -466,8 +466,10 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         foreach ($diff->getDroppedIndexes() as $droppedIndex) {
             $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
 
+            $droppedIndexColumns = $droppedIndex->getUnquotedColumns();
+
             foreach ($diff->getAddedIndexes() as $addedIndex) {
-                if (! $this->indexesSpanSameColumns($droppedIndex, $addedIndex)) {
+                if ($droppedIndexColumns !== $addedIndex->getUnquotedColumns()) {
                     continue;
                 }
 
@@ -498,29 +500,6 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             parent::getPreAlterTableIndexForeignKeySQL($diff),
             $this->getPreAlterTableRenameIndexForeignKeySQL($diff),
         );
-    }
-
-    /**
-     * Returns whether the two indexes span the same columns in the same order.
-     */
-    private function indexesSpanSameColumns(Index $index1, Index $index2): bool
-    {
-        $columns1 = $index1->getIndexedColumns();
-        $columns2 = $index2->getIndexedColumns();
-
-        if (count($columns1) !== count($columns2)) {
-            return false;
-        }
-
-        $folding = $this->getUnquotedIdentifierFolding();
-
-        foreach ($columns1 as $i => $column1) {
-            if (! $column1->getColumnName()->equals($columns2[$i]->getColumnName(), $folding)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /** @return list<string> */

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Platforms\MySQL\MySQLMetadataProvider;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -466,8 +467,10 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         foreach ($diff->getDroppedIndexes() as $droppedIndex) {
             $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
 
+            $droppedIndexColumnNames = self::getUnquotedIndexedColumnNames($droppedIndex);
+
             foreach ($diff->getAddedIndexes() as $addedIndex) {
-                if ($droppedIndex->getColumns() !== $addedIndex->getColumns()) {
+                if ($droppedIndexColumnNames !== self::getUnquotedIndexedColumnNames($addedIndex)) {
                     continue;
                 }
 
@@ -497,6 +500,25 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
             $this->getPreAlterTableAlterIndexForeignKeySQL($diff),
             parent::getPreAlterTableIndexForeignKeySQL($diff),
             $this->getPreAlterTableRenameIndexForeignKeySQL($diff),
+        );
+    }
+
+    /**
+     * Returns the names of the columns the index spans, unquoted.
+     *
+     * The names are read via the non-deprecated API so that the result does not
+     * depend on whether the index was introspected, in which case the
+     * introspection marks its column names as quoted, or built in memory.
+     *
+     * @return list<string>
+     */
+    private static function getUnquotedIndexedColumnNames(Index $index): array
+    {
+        return array_map(
+            static function (IndexedColumn $indexedColumn): string {
+                return $indexedColumn->getColumnName()->getIdentifier()->getValue();
+            },
+            $index->getIndexedColumns(),
         );
     }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -466,10 +466,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         foreach ($diff->getDroppedIndexes() as $droppedIndex) {
             $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
 
-            $droppedIndexColumns = $droppedIndex->getUnquotedColumns();
-
             foreach ($diff->getAddedIndexes() as $addedIndex) {
-                if ($droppedIndexColumns !== $addedIndex->getUnquotedColumns()) {
+                if ($droppedIndex->getUnquotedColumns() !== $addedIndex->getUnquotedColumns()) {
                     continue;
                 }
 

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Platforms\Keywords\MySQLKeywords;
 use Doctrine\DBAL\Platforms\MySQL\MySQLMetadataProvider;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\TableDiff;
@@ -467,10 +466,8 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
         foreach ($diff->getDroppedIndexes() as $droppedIndex) {
             $sql = array_merge($sql, $this->getPreAlterTableAlterPrimaryKeySQL($diff, $droppedIndex));
 
-            $droppedIndexColumnNames = self::getUnquotedIndexedColumnNames($droppedIndex);
-
             foreach ($diff->getAddedIndexes() as $addedIndex) {
-                if ($droppedIndexColumnNames !== self::getUnquotedIndexedColumnNames($addedIndex)) {
+                if (! $this->indexesSpanSameColumns($droppedIndex, $addedIndex)) {
                     continue;
                 }
 
@@ -504,22 +501,26 @@ abstract class AbstractMySQLPlatform extends AbstractPlatform
     }
 
     /**
-     * Returns the names of the columns the index spans, unquoted.
-     *
-     * The names are read via the non-deprecated API so that the result does not
-     * depend on whether the index was introspected, in which case the
-     * introspection marks its column names as quoted, or built in memory.
-     *
-     * @return list<string>
+     * Returns whether the two indexes span the same columns in the same order.
      */
-    private static function getUnquotedIndexedColumnNames(Index $index): array
+    private function indexesSpanSameColumns(Index $index1, Index $index2): bool
     {
-        return array_map(
-            static function (IndexedColumn $indexedColumn): string {
-                return $indexedColumn->getColumnName()->getIdentifier()->getValue();
-            },
-            $index->getIndexedColumns(),
-        );
+        $columns1 = $index1->getIndexedColumns();
+        $columns2 = $index2->getIndexedColumns();
+
+        if (count($columns1) !== count($columns2)) {
+            return false;
+        }
+
+        $folding = $this->getUnquotedIdentifierFolding();
+
+        foreach ($columns1 as $i => $column1) {
+            if (! $column1->getColumnName()->equals($columns2[$i]->getColumnName(), $folding)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /** @return list<string> */

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -894,54 +894,6 @@ SQL;
         self::assertTrue($diff->isEmpty(), 'Tables should be identical.');
     }
 
-    public function testAlterIntrospectedTableReplacesIndexBackingForeignKey(): void
-    {
-        $this->connection->executeStatement('DROP TABLE IF EXISTS index_replacement_child');
-        $this->connection->executeStatement('DROP TABLE IF EXISTS index_replacement_parent');
-        $this->connection->executeStatement(
-            'CREATE TABLE index_replacement_parent (id INT NOT NULL, PRIMARY KEY (id)) ENGINE = InnoDB',
-        );
-
-        // The unique key is the only index covering the foreign key column, so
-        // InnoDB refuses to drop it unless another index takes over the cover
-        // in the same statement.
-        $this->connection->executeStatement(<<<'SQL'
-        CREATE TABLE index_replacement_child (
-            id INT NOT NULL,
-            parent_id INT NOT NULL,
-            val INT NOT NULL,
-            PRIMARY KEY (id),
-            UNIQUE KEY uniq_parent_val (parent_id, val),
-            CONSTRAINT fk_index_replacement FOREIGN KEY (parent_id)
-                REFERENCES index_replacement_parent (id)
-        ) ENGINE = InnoDB
-        SQL);
-
-        $oldTable = $this->schemaManager->introspectTableByUnquotedName('index_replacement_child');
-        $newTable = $oldTable->edit()
-            ->setIndexes(
-                Index::editor()
-                    ->setUnquotedName('idx_parent_val')
-                    ->setUnquotedColumnNames('parent_id', 'val')
-                    ->create(),
-            )
-            ->create();
-
-        $diff = $this->schemaManager->createComparator()->compareTables($oldTable, $newTable);
-
-        // Dropping the unique key and adding its replacement have to be combined
-        // into a single ALTER TABLE statement, which they are not when the
-        // dropped index comes from introspection and its column names are
-        // therefore quoted.
-        $this->schemaManager->alterTable($diff);
-
-        $table = $this->schemaManager->introspectTableByUnquotedName('index_replacement_child');
-
-        self::assertFalse($table->hasIndex('uniq_parent_val'));
-        self::assertTrue($table->hasIndex('idx_parent_val'));
-        self::assertSame(IndexType::REGULAR, $table->getIndex('idx_parent_val')->getType());
-    }
-
     public function getExpectedDefaultSchemaName(): ?string
     {
         return null;

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -894,6 +894,54 @@ SQL;
         self::assertTrue($diff->isEmpty(), 'Tables should be identical.');
     }
 
+    public function testAlterIntrospectedTableReplacesIndexBackingForeignKey(): void
+    {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS index_replacement_child');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS index_replacement_parent');
+        $this->connection->executeStatement(
+            'CREATE TABLE index_replacement_parent (id INT NOT NULL, PRIMARY KEY (id)) ENGINE = InnoDB',
+        );
+
+        // The unique key is the only index covering the foreign key column, so
+        // InnoDB refuses to drop it unless another index takes over the cover
+        // in the same statement.
+        $this->connection->executeStatement(<<<'SQL'
+        CREATE TABLE index_replacement_child (
+            id INT NOT NULL,
+            parent_id INT NOT NULL,
+            val INT NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uniq_parent_val (parent_id, val),
+            CONSTRAINT fk_index_replacement FOREIGN KEY (parent_id)
+                REFERENCES index_replacement_parent (id)
+        ) ENGINE = InnoDB
+        SQL);
+
+        $oldTable = $this->schemaManager->introspectTableByUnquotedName('index_replacement_child');
+        $newTable = $oldTable->edit()
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('idx_parent_val')
+                    ->setUnquotedColumnNames('parent_id', 'val')
+                    ->create(),
+            )
+            ->create();
+
+        $diff = $this->schemaManager->createComparator()->compareTables($oldTable, $newTable);
+
+        // Dropping the unique key and adding its replacement have to be combined
+        // into a single ALTER TABLE statement, which they are not when the
+        // dropped index comes from introspection and its column names are
+        // therefore quoted.
+        $this->schemaManager->alterTable($diff);
+
+        $table = $this->schemaManager->introspectTableByUnquotedName('index_replacement_child');
+
+        self::assertFalse($table->hasIndex('uniq_parent_val'));
+        self::assertTrue($table->hasIndex('idx_parent_val'));
+        self::assertSame(IndexType::REGULAR, $table->getIndex('idx_parent_val')->getType());
+    }
+
     public function getExpectedDefaultSchemaName(): ?string
     {
         return null;

--- a/tests/Functional/Schema/SchemaManagerTest.php
+++ b/tests/Functional/Schema/SchemaManagerTest.php
@@ -505,6 +505,87 @@ final class SchemaManagerTest extends FunctionalTestCase
         );
     }
 
+    public function testReplaceIndexBackingForeignKey(): void
+    {
+        $this->dropTableIfExists('index_replacement_child');
+        $this->dropTableIfExists('index_replacement_parent');
+
+        $parentTable = Table::editor()
+            ->setUnquotedName('index_replacement_parent')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        // The unique index spans exactly the referencing column of the foreign key, so no implicit
+        // index is created, and it remains the only index covering the constraint. On MySQL, InnoDB
+        // refuses to drop such an index unless another index takes over the cover in the same
+        // ALTER TABLE statement.
+        $childTable = Table::editor()
+            ->setUnquotedName('index_replacement_child')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('parent_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setIndexes(
+                Index::editor()
+                    ->setUnquotedName('uniq_parent_id')
+                    ->setUnquotedColumnNames('parent_id')
+                    ->setType(IndexType::UNIQUE)
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('fk_index_replacement')
+                    ->setUnquotedReferencingColumnNames('parent_id')
+                    ->setUnquotedReferencedTableName('index_replacement_parent')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->schemaManager->createTable($parentTable);
+        $this->schemaManager->createTable($childTable);
+
+        $oldTable = $this->schemaManager->introspectTableByUnquotedName('index_replacement_child');
+
+        $newIndex = Index::editor()
+            ->setUnquotedName('idx_parent_id')
+            ->setUnquotedColumnNames('parent_id')
+            ->create();
+
+        $newTable = $oldTable->edit()
+            ->setIndexes($newIndex)
+            ->create();
+
+        $diff = $this->schemaManager->createComparator()->compareTables($oldTable, $newTable);
+        $this->schemaManager->alterTable($diff);
+
+        $table = $this->schemaManager->introspectTableByUnquotedName('index_replacement_child');
+
+        self::assertFalse($table->hasIndex('uniq_parent_id'));
+        $this->assertIndexEquals($newIndex, $table->getIndex('idx_parent_id'));
+    }
+
     /** @param callable(AbstractSchemaManager): list<Index> $introspect */
     #[DataProvider('quotedAndUnquotedIndexIntrospection')]
     public function testIntrospectTableIndexes(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | n/a

#### Summary

`AbstractMySQLPlatform` combines the drop of an index and the creation of another one over the same columns into a single `ALTER TABLE ... DROP INDEX a, ADD INDEX b (...)` statement, so that the columns are never left unindexed in between. The two column lists are compared through the legacy `Index::getColumns()` accessor, which returns the raw map keys: the introspection API marks them as quoted (`'"parent_id"'`), while an index built in memory keeps them bare (`'parent_id'`). They therefore never match when the dropped index comes from an introspected table, the statements are not combined, and the drop is emitted on its own.

That makes `alterTable()` fail whenever the dropped index is the one backing a foreign key. InnoDB rejects the drop even though the added index would provide the same cover, and disabling `foreign_key_checks` does not lift the restriction:

```php
$conn->executeStatement('CREATE TABLE parent (id INT NOT NULL, PRIMARY KEY (id)) ENGINE = InnoDB');
$conn->executeStatement(<<<'SQL'
    CREATE TABLE child (
        id INT NOT NULL,
        parent_id INT NOT NULL,
        val INT NOT NULL,
        PRIMARY KEY (id),
        UNIQUE KEY uniq_parent_val (parent_id, val),
        CONSTRAINT fk_child_parent FOREIGN KEY (parent_id) REFERENCES parent (id)
    ) ENGINE = InnoDB
SQL);

$sm  = $conn->createSchemaManager();
$old = $sm->introspectTableByUnquotedName('child');

// Redeclare the unique key as a plain index over the same columns.
$new = $old->edit()
    ->setIndexes(
        Index::editor()
            ->setUnquotedName('idx_parent_val')
            ->setUnquotedColumnNames('parent_id', 'val')
            ->create(),
    )
    ->create();

$sm->alterTable($sm->createComparator()->compareTables($old, $new));
// SQLSTATE[HY000]: General error: 1553 Cannot drop index 'uniq_parent_val':
// needed in a foreign key constraint
```

Emitted before the fix, where the drop runs on its own and never reaches the creation:

```sql
DROP INDEX `uniq_parent_val` ON child;
CREATE INDEX idx_parent_val ON child (parent_id, val);
```

and after:

```sql
ALTER TABLE child DROP INDEX uniq_parent_val, ADD INDEX idx_parent_val (parent_id, val);
```

#### Fix

Read the column names through the non-deprecated `Index::getIndexedColumns()` accessor and compare their unquoted identifier values, so the comparison is agnostic of whether the index was introspected or built in memory. This is the same treatment #7392 applied to the same accessor in the SQLite table-recreation path.

The regression test goes to `MySQLSchemaManagerTest`: the combining is MySQL-specific, and so is the foreign-key index requirement that makes the uncombined form fail. It errors with 1553 on `4.4.x` and passes with the fix.
