### PR TITLE
Skip implicit foreign key index covered by a unique constraint

### DIFF
--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -965,6 +965,14 @@ class Table extends AbstractNamedObject
             }
         }
 
+        foreach ($this->uniqueConstraints as $uniqueConstraint) {
+            $uniqueIndex = $this->_createIndex($uniqueConstraint->getColumns(), $indexName, true, false);
+
+            if ($indexCandidate->isFulfilledBy($uniqueIndex)) {
+                return $this;
+            }
+        }
+
         $this->_addIndex($indexCandidate);
         $this->implicitIndexNames[$this->normalizeIdentifier($indexName)] = true;
 

--- a/tests/Schema/TableTest.php
+++ b/tests/Schema/TableTest.php
@@ -848,6 +848,33 @@ class TableTest extends TestCase
         self::assertSame(['bar'], $table->getIndex('bar_idx')->getColumns());
     }
 
+    public function testAddForeignKeyDoesNotCreateImplicitIndexWhenUniqueConstraintSpansColumns(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('bar')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setUniqueConstraints(
+                UniqueConstraint::editor()
+                    ->setUnquotedColumnNames('bar')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedReferencingColumnNames('bar')
+                    ->setUnquotedReferencedTableName('foo')
+                    ->setUnquotedReferencedColumnNames('foo')
+                    ->create(),
+            )
+            ->create();
+
+        self::assertCount(0, $table->getIndexes());
+    }
+
     public function testAddForeignKeyAddsImplicitIndexIfIndexColumnsDoNotSpan(): void
     {
         $table = Table::editor()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | Fixes #7459

#### Summary

When a foreign key's referencing columns are already covered by a unique constraint, DBAL still added an implicit backing index for the foreign key. On MySQL and MariaDB the unique constraint's own index already backs the foreign key, so that extra index is redundant and just duplicates it. DBAL already skips the implicit index when a regular index spans the same columns. This applies the same check to unique constraints.
