### PR TITLE
Reorganize a Db2 table before adding to it

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -332,6 +332,12 @@ class DB2Platform extends AbstractPlatform
             $sql[] = 'ALTER TABLE ' . $tableNameSQL . ' ' . implode(' ', $queryParts);
         }
 
+        // Some column alterations leave the table needing a reorganization before it accepts further
+        // operations, so it must run before any index or constraint is added.
+        if ($needsReorg) {
+            $sql[] = sprintf("CALL SYSPROC.ADMIN_CMD ('REORG TABLE %s')", $tableNameSQL);
+        }
+
         $addedPrimaryKeyConstraint = $diff->getAddedPrimaryKeyConstraint();
 
         if ($addedPrimaryKeyConstraint !== null) {
@@ -353,11 +359,6 @@ class DB2Platform extends AbstractPlatform
                 $this->deriveQualifier($rename->getOldName(), $tableName)->toSQL($this),
                 $rename->getNewIndex()->getObjectName()->toSQL($this),
             );
-        }
-
-        // Some table alteration operations require a table reorganization.
-        if ($needsReorg) {
-            $sql[] = sprintf("CALL SYSPROC.ADMIN_CMD ('REORG TABLE %s')", $tableNameSQL);
         }
 
         return array_merge($sql, $commentsSQL);

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableEditor;
@@ -281,6 +282,48 @@ class AlterTableTest extends FunctionalTestCase
                 ->addPrimaryKeyConstraint(
                     PrimaryKeyConstraint::editor()
                         ->setUnquotedColumnNames('id1', 'id2')
+                        ->create(),
+                );
+        });
+    }
+
+    /**
+     * A single alter that both drops a column and adds an index. Db2 leaves the table pending
+     * reorganization after the drop and rejects the new index until the reorganization runs, so the
+     * two must be ordered correctly.
+     */
+    public function testDropColumnAndAddIndex(): void
+    {
+        $table = Table::editor()
+            ->setUnquotedName('reorg_alter')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('legacy')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('lookup')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->testMigration($table, static function (TableEditor $editor): void {
+            $editor
+                ->dropColumnByUnquotedName('legacy')
+                ->addIndex(
+                    Index::editor()
+                        ->setUnquotedName('reorg_alter_lookup_idx')
+                        ->setUnquotedColumnNames('lookup')
                         ->create(),
                 );
         });


### PR DESCRIPTION
On 5.0.x, starting #7291, altering a Db2 table that drops a column and adds an index or constraint in one operation fails:

```
SQL0668N  Operation not allowed for reason code "7" on table "DB2INST1.REORG_ALTER".  SQLSTATE=57007 SQLCODE=-668
```

Dropping a column leaves the table pending reorganization, and Db2 refuses new indexes and constraints until a `REORG TABLE` runs. `DB2Platform::getAlterTableSQL()` issues the reorganization, but only after the added primary key, foreign keys, unique constraints, and indexes, so each of those runs against the pending table and fails.

The reorganization has to run right after the column changes, before anything is added, so the fix moves it there.