### PR TITLE
Describe Db2's index for a primary key as unique

### DIFF
--- a/src/Platforms/Db2/Db2MetadataProvider.php
+++ b/src/Platforms/Db2/Db2MetadataProvider.php
@@ -276,7 +276,7 @@ final readonly class Db2MetadataProvider implements MetadataProvider
                 schemaName: null,
                 tableName: $row[0],
                 indexName: $row[1],
-                type: $row[2] === 'U' ? IndexType::UNIQUE : IndexType::REGULAR,
+                type: $row[2] === 'D' ? IndexType::REGULAR : IndexType::UNIQUE,
                 isClustered: false,
                 predicate: null,
                 columnName: $row[3],


### PR DESCRIPTION
`Db2MetadataProvider` classifies an index as unique only when its `UNIQUERULE` is `'U'`. A primary key's index is unique too, and Db2 [reports](https://www.ibm.com/docs/en/db2/12.1.x?topic=views-syscatindexes) it with `UNIQUERULE = 'P'`, so the check should be "anything but `'D'`" (`'D'` is the only rule that allows duplicates).

It's a no-op change on 4.5.x: the introspection query excludes primary-key indexes, so no `'P'` row ever reaches the mapping:
https://github.com/doctrine/dbal/blob/4f2378da8d40561e45d3a606a0a0b9398d82d211/src/Platforms/Db2/Db2MetadataProvider.php#L266

This will become an issue if schema introspection starts reporting underlying primary key indexes (currently prototyped in https://github.com/doctrine/dbal/pull/7477). Without this change, the introspection will report the primary key indexes as regular.