### PR TITLE
Compare the introspected table to the declared one

### DIFF
--- a/tests/Functional/Schema/ComparatorTest.php
+++ b/tests/Functional/Schema/ComparatorTest.php
@@ -56,7 +56,7 @@ class ComparatorTest extends FunctionalTestCase
 
         self::assertTrue(
             $this->schemaManager->createComparator()
-                ->compareTables($table, $onlineTable)
+                ->compareTables($onlineTable, $table)
                 ->isEmpty(),
         );
     }

--- a/tests/Functional/Schema/MySQL/JsonCollationTest.php
+++ b/tests/Functional/Schema/MySQL/JsonCollationTest.php
@@ -134,7 +134,7 @@ final class JsonCollationTest extends FunctionalTestCase
         $this->dropAndCreateTable($originalTable);
 
         $onlineTable = $this->schemaManager->introspectTableByUnquotedName('mariadb_json_column_comparator_test');
-        $diff        = $this->comparator->compareTables($originalTable, $onlineTable);
+        $diff        = $this->comparator->compareTables($onlineTable, $originalTable);
 
         self::assertTrue($diff->isEmpty(), 'Tables should be identical.');
 
@@ -146,7 +146,7 @@ final class JsonCollationTest extends FunctionalTestCase
             })
             ->create();
 
-        $diff = $this->comparator->compareTables($table, $onlineTable);
+        $diff = $this->comparator->compareTables($onlineTable, $table);
         self::assertTrue($diff->isEmpty(), 'Tables should be unchanged after attempted collation change.');
 
         $diff = $this->comparator->compareTables($table, $originalTable);

--- a/tests/Functional/Schema/MySQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/MySQLSchemaManagerTest.php
@@ -232,7 +232,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         self::assertTrue(
             $this->schemaManager->createComparator()
-                ->compareTables($table, $onlineTable)
+                ->compareTables($onlineTable, $table)
                 ->isEmpty(),
         );
     }
@@ -623,7 +623,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue(
             $this->schemaManager
                 ->createComparator()
-                ->compareTables($table, $onlineTable)
+                ->compareTables($onlineTable, $table)
                 ->isEmpty(),
         );
     }
@@ -742,7 +742,7 @@ class MySQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
         self::assertTrue(
             $this->schemaManager
                 ->createComparator()
-                ->compareTables($table, $onlineTable)
+                ->compareTables($onlineTable, $table)
                 ->isEmpty(),
         );
     }
@@ -819,7 +819,7 @@ SQL;
 
         $onlineTable = $this->schemaManager->introspectTableByUnquotedName('test_column_introspection');
 
-        $diff = $this->schemaManager->createComparator()->compareTables($table, $onlineTable);
+        $diff = $this->schemaManager->createComparator()->compareTables($onlineTable, $table);
 
         self::assertTrue($diff->isEmpty(), 'Tables should be identical.');
     }

--- a/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
+++ b/tests/Functional/Schema/PostgreSQLSchemaManagerTest.php
@@ -293,7 +293,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         self::assertTrue(
             $this->schemaManager->createComparator()
-                ->compareTables($table, $databaseTable)
+                ->compareTables($databaseTable, $table)
                 ->isEmpty(),
         );
     }
@@ -329,7 +329,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         self::assertTrue(
             $this->schemaManager->createComparator()
-                ->compareTables($table, $databaseTable)
+                ->compareTables($databaseTable, $table)
                 ->isEmpty(),
         );
     }
@@ -458,7 +458,7 @@ class PostgreSQLSchemaManagerTest extends SchemaManagerFunctionalTestCase
 
         self::assertTrue(
             $this->schemaManager->createComparator()
-                ->compareTables($offlineTable, $onlineTable)
+                ->compareTables($onlineTable, $offlineTable)
                 ->isEmpty(),
         );
         self::assertTrue($onlineTable->hasIndex('simple_partial_index'));

--- a/tests/Functional/Types/EnumTypeTest.php
+++ b/tests/Functional/Types/EnumTypeTest.php
@@ -74,7 +74,7 @@ final class EnumTypeTest extends FunctionalTestCase
 
         $introspectedTable = $schemaManager->introspectTableByUnquotedName('my_enum_table');
 
-        self::assertTrue($schemaManager->createComparator()->compareTables($table, $introspectedTable)->isEmpty());
+        self::assertTrue($schemaManager->createComparator()->compareTables($introspectedTable, $table)->isEmpty());
 
         $this->connection->insert('my_enum_table', ['id' => 1, 'suit' => 'hearts'], ['suit' => Types::ENUM]);
         $this->connection->insert(


### PR DESCRIPTION
Several tests introspect a table and compare it against the schema they declared, but pass the arguments the wrong way round: the declared table first, the introspected one second.

The comparator takes the current schema first and the desired one second, and the comparison isn't symmetric. Some of this asymmetry was introduced #4746 and some more may be introduced in https://github.com/doctrine/dbal/pull/7477 (e.g. indexes automatically created by the database are expected to exist in the database but not in the application schema).

