### PR TITLE
Fix dropping a column used by an index or foreign key on SQLite

### DIFF
--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint\Deferrability;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexType;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\SQLiteSchemaManager;
@@ -580,22 +581,14 @@ class SQLitePlatform extends AbstractPlatform
         $newColumnNames = [];
 
         foreach ($table->getColumns() as $column) {
-            $columnKey = strtolower(
-                $column->getObjectName()
-                    ->getIdentifier()
-                    ->getValue(),
-            );
+            $columnKey = $this->getKey($column->getObjectName());
 
             $columns[$columnKey]        = $column;
             $oldColumnNames[$columnKey] = $newColumnNames[$columnKey] = $column->getObjectName()->toSQL($this);
         }
 
         foreach ($diff->getDroppedColumns() as $column) {
-            $columnKey = strtolower(
-                $column->getObjectName()
-                    ->getIdentifier()
-                    ->getValue(),
-            );
+            $columnKey = $this->getKey($column->getObjectName());
 
             if (isset($columns[$columnKey])) {
                 unset(
@@ -609,7 +602,7 @@ class SQLitePlatform extends AbstractPlatform
         foreach ($diff->getChangedColumns() as $columnDiff) {
             $oldColumn     = $columnDiff->getOldColumn();
             $oldColumnName = $oldColumn->getObjectName();
-            $oldColumnKey  = strtolower($oldColumnName->getIdentifier()->getValue());
+            $oldColumnKey  = $this->getKey($oldColumnName);
             $newColumn     = $columnDiff->getNewColumn();
 
             if (! isset($columns[$oldColumnKey])) {
@@ -761,6 +754,12 @@ class SQLitePlatform extends AbstractPlatform
         return $map;
     }
 
+    /** The key by which SQLite matches this name, folding away the case it ignores. */
+    private function getKey(UnqualifiedName $name): string
+    {
+        return strtolower($name->getIdentifier()->getValue());
+    }
+
     /** @return array<Index> */
     private function getIndexesInAlteredTable(TableDiff $diff): array
     {
@@ -772,8 +771,8 @@ class SQLitePlatform extends AbstractPlatform
             $indexName = $index->getObjectName();
             foreach ($diff->getIndexRenames() as $rename) {
                 if (
-                    strtolower($indexName->getIdentifier()->getValue())
-                    === strtolower($rename->getOldName()->getIdentifier()->getValue())
+                    $this->getKey($indexName)
+                    === $this->getKey($rename->getOldName())
                 ) {
                     $indexes->remove($indexName);
                 }
@@ -831,7 +830,7 @@ class SQLitePlatform extends AbstractPlatform
             $referencingColumnNames = [];
             foreach ($constraint->getReferencingColumnNames() as $columnName) {
                 $originalColumnName   = $columnName->getIdentifier()->getValue();
-                $normalizedColumnName = strtolower($originalColumnName);
+                $normalizedColumnName = $this->getKey($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($foreignKeys[$key]);
                     continue 2;
@@ -847,10 +846,7 @@ class SQLitePlatform extends AbstractPlatform
             $constraintName = $constraint->getObjectName();
 
             if ($constraintName !== null) {
-                $constraintKey = strtolower(
-                    $constraintName->getIdentifier()
-                        ->getValue(),
-                );
+                $constraintKey = $this->getKey($constraintName);
 
                 $keysByName[$constraintKey] = $key;
             }
@@ -863,10 +859,7 @@ class SQLitePlatform extends AbstractPlatform
         }
 
         foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
-            $constraintKey = strtolower(
-                $constraintName->getIdentifier()
-                    ->getValue(),
-            );
+            $constraintKey = $this->getKey($constraintName);
 
             assert(isset($keysByName[$constraintKey]));
             unset($foreignKeys[$keysByName[$constraintKey]], $keysByName[$constraintKey]);
@@ -876,10 +869,7 @@ class SQLitePlatform extends AbstractPlatform
             $constraintName = $constraint->getObjectName();
 
             if ($constraintName !== null) {
-                $constraintKey = strtolower(
-                    $constraintName->getIdentifier()
-                        ->getValue(),
-                );
+                $constraintKey = $this->getKey($constraintName);
 
                 assert(! isset($keysByName[$constraintKey]));
                 $foreignKeys[] = $constraint;
@@ -918,7 +908,7 @@ class SQLitePlatform extends AbstractPlatform
         $columnNames = [];
         foreach ($primaryKeyConstraint->getColumnNames() as $columnName) {
             $originalColumnName   = $columnName->getIdentifier()->getValue();
-            $normalizedColumnName = strtolower($originalColumnName);
+            $normalizedColumnName = $this->getKey($columnName);
             if (! isset($nameMap[$normalizedColumnName])) {
                 return null;
             }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -767,6 +767,8 @@ class SQLitePlatform extends AbstractPlatform
         $indexes  = new UnqualifiedNamedObjectSet(...$oldTable->getIndexes());
         $nameMap  = $this->getDiffColumnNameMap($diff);
 
+        $alreadyDropped = [];
+
         foreach ($indexes as $index) {
             $indexName = $index->getObjectName();
             foreach ($diff->getIndexRenames() as $rename) {
@@ -784,6 +786,8 @@ class SQLitePlatform extends AbstractPlatform
                 $name = $column->getColumnName()->getIdentifier()->getValue();
                 if (! isset($nameMap[$name])) {
                     $indexes->remove($indexName);
+                    $alreadyDropped[$this->getKey($indexName)] = true;
+
                     continue 2;
                 }
 
@@ -802,7 +806,13 @@ class SQLitePlatform extends AbstractPlatform
         }
 
         foreach ($diff->getDroppedIndexes() as $index) {
-            $indexes->remove($index->getObjectName());
+            $indexName = $index->getObjectName();
+
+            if (isset($alreadyDropped[$this->getKey($indexName)])) {
+                continue;
+            }
+
+            $indexes->remove($indexName);
         }
 
         foreach ($diff->getAddedIndexes() as $index) {
@@ -819,12 +829,21 @@ class SQLitePlatform extends AbstractPlatform
     /** @return array<ForeignKeyConstraint> */
     private function getForeignKeysInAlteredTable(TableDiff $diff): array
     {
-        $oldTable    = $diff->getOldTable();
-        $foreignKeys = $oldTable->getForeignKeys();
-        $nameMap     = $this->getDiffColumnNameMap($diff);
-        $keysByName  = [];
+        $oldTable       = $diff->getOldTable();
+        $foreignKeys    = $oldTable->getForeignKeys();
+        $nameMap        = $this->getDiffColumnNameMap($diff);
+        $keysByName     = [];
+        $alreadyDropped = [];
 
         foreach ($foreignKeys as $key => $constraint) {
+            $constraintName = $constraint->getObjectName();
+
+            if ($constraintName !== null) {
+                $constraintKey = $this->getKey($constraintName);
+            } else {
+                $constraintKey = null;
+            }
+
             $changed = false;
 
             $referencingColumnNames = [];
@@ -833,6 +852,11 @@ class SQLitePlatform extends AbstractPlatform
                 $normalizedColumnName = $this->getKey($columnName);
                 if (! isset($nameMap[$normalizedColumnName])) {
                     unset($foreignKeys[$key]);
+
+                    if ($constraintKey !== null) {
+                        $alreadyDropped[$constraintKey] = true;
+                    }
+
                     continue 2;
                 }
 
@@ -843,11 +867,7 @@ class SQLitePlatform extends AbstractPlatform
                 }
             }
 
-            $constraintName = $constraint->getObjectName();
-
-            if ($constraintName !== null) {
-                $constraintKey = $this->getKey($constraintName);
-
+            if ($constraintKey !== null) {
                 $keysByName[$constraintKey] = $key;
             }
 
@@ -860,6 +880,10 @@ class SQLitePlatform extends AbstractPlatform
 
         foreach ($diff->getDroppedForeignKeyConstraintNames() as $constraintName) {
             $constraintKey = $this->getKey($constraintName);
+
+            if (isset($alreadyDropped[$constraintKey])) {
+                continue;
+            }
 
             assert(isset($keysByName[$constraintKey]));
             unset($foreignKeys[$keysByName[$constraintKey]], $keysByName[$constraintKey]);

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableEditor;
@@ -356,6 +357,147 @@ class AlterTableTest extends FunctionalTestCase
                         ->create(),
                 );
         });
+    }
+
+    public function testDropColumnCoveredByForeignKey(): void
+    {
+        $referenced = Table::editor()
+            ->setUnquotedName('alter_referenced')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $referencing = Table::editor()
+            ->setUnquotedName('alter_referencing')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+                Column::editor()
+                    ->setUnquotedName('referenced_id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setForeignKeyConstraints(
+                ForeignKeyConstraint::editor()
+                    ->setUnquotedName('alter_referencing_fk')
+                    ->setUnquotedReferencingColumnNames('referenced_id')
+                    ->setUnquotedReferencedTableName('alter_referenced')
+                    ->setUnquotedReferencedColumnNames('id')
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropTableIfExists('alter_referencing');
+        $this->dropTableIfExists('alter_referenced');
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager->createTable($referenced);
+        $schemaManager->createTable($referencing);
+
+        // testMigration() can't be used here: it introspects the table, which hits
+        // https://github.com/doctrine/dbal/issues/7481.
+        $desired = $referencing->edit()
+            ->dropColumnByUnquotedName('referenced_id')
+            ->dropForeignKeyConstraintByUnquotedName('alter_referencing_fk')
+            ->create();
+
+        $comparator = $schemaManager->createComparator();
+
+        $diff = $comparator->compareTables($referencing, $desired);
+        self::assertFalse($diff->isEmpty());
+
+        $schemaManager->alterTable($diff);
+
+        $introspected = $schemaManager->introspectTable($desired->getObjectName());
+
+        self::assertTrue(
+            $comparator->compareTables($desired, $introspected)->isEmpty(),
+        );
+    }
+
+    public function testDropOneColumnCoveredByCompositeIndex(): void
+    {
+        $table = $this->indexedTable(
+            Index::editor()
+                ->setUnquotedName('alter_names_idx')
+                ->setUnquotedColumnNames('first_name', 'last_name')
+                ->create(),
+        );
+
+        $this->testMigration($table, static function (TableEditor $editor): void {
+            $editor
+                ->dropColumnByUnquotedName('last_name')
+                ->dropIndexByUnquotedName('alter_names_idx')
+                ->addIndex(
+                    Index::editor()
+                        ->setUnquotedName('alter_names_idx')
+                        ->setUnquotedColumnNames('first_name')
+                        ->create(),
+                );
+        });
+    }
+
+    public function testDropAllColumnsCoveredByIndex(): void
+    {
+        $table = $this->indexedTable(
+            Index::editor()
+                ->setUnquotedName('alter_name_idx')
+                ->setUnquotedColumnNames('first_name')
+                ->create(),
+        );
+
+        $this->testMigration($table, static function (TableEditor $editor): void {
+            $editor
+                ->dropColumnByUnquotedName('first_name')
+                ->dropIndexByUnquotedName('alter_name_idx');
+        });
+    }
+
+    private function indexedTable(Index $index): Table
+    {
+        $editor = Table::editor()
+            ->setUnquotedName('alter_indexed')
+            ->addColumn(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            );
+
+        foreach ($index->getIndexedColumns() as $indexedColumn) {
+            $editor->addColumn(
+                Column::editor()
+                    ->setName($indexedColumn->getColumnName())
+                    ->setTypeName(Types::STRING)
+                    ->setLength(64)
+                    ->create(),
+            );
+        }
+
+        return $editor
+            ->setPrimaryKeyConstraint(
+                PrimaryKeyConstraint::editor()
+                    ->setUnquotedColumnNames('id')
+                    ->create(),
+            )
+            ->setIndexes($index)
+            ->create();
     }
 
     /** @param callable(TableEditor): void $migration */


### PR DESCRIPTION
On 5.0.x, dropping a column that an index or a foreign key covers throws while the ALTER SQL is generated.

During the table rebuild, the platform removes any index or FK that loses a column, then removes the ones the diff lists as dropped. When it's the same object, the second removal runs against one that's already gone. An index throws `ObjectDoesNotExist`; a foreign key fails an `assert()`.

The index throw was introduced in #7116, the foreign-key `assert()` in #7158.

The fix skips objects the first step already removed.

Additionally, the first commit introduces `getKey()` to reduce code duplication. Eventually, names should be compared with the platform's folding and collation taken into account (SQLite is case-insensitive). We don't have the collation API for platforms yet, so we're doing it the old `strtolower` way.