### PR TITLE
Compare foreign key constraints by name

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ awareness about deprecated code.
 
 # Upgrade to 5.0
 
+## BC BREAK: Foreign key constraints are compared by name
+
+`Comparator::compareTables()` compares the names of foreign key constraints, so one whose name differs is reported as
+dropped and added back. A constraint with no name still matches a named one.
+
 ## BC BREAK: `MetadataProvider` requires unique constraint introspection
 
 `Doctrine\DBAL\Schema\Metadata\MetadataProvider` now declares `getUniqueConstraintColumnsForAllTables()` and

--- a/src/Schema/ForeignKeyConstraint.php
+++ b/src/Schema/ForeignKeyConstraint.php
@@ -152,6 +152,10 @@ final readonly class ForeignKeyConstraint implements OptionallyNamedObject
             return false;
         }
 
+        if ($this->name !== null && $other->name !== null && ! $this->name->equals($other->name, $folding)) {
+            return false;
+        }
+
         if (! $this->columnsNamesEqual($this->referencingColumnNames, $other->referencingColumnNames, $folding)) {
             return false;
         }

--- a/tests/Functional/Schema/AlterTableTest.php
+++ b/tests/Functional/Schema/AlterTableTest.php
@@ -331,6 +331,57 @@ class AlterTableTest extends FunctionalTestCase
 
     public function testReplaceForeignKeyConstraint(): void
     {
+        $prototype = ForeignKeyConstraint::editor()
+            ->setUnquotedName('articles_fk')
+            ->setUnquotedReferencedTableName('articles');
+
+        $old = $prototype
+            ->setUnquotedReferencingColumnNames('article_id')
+            ->setUnquotedReferencedColumnNames('id')
+            ->create();
+
+        $new = $prototype
+            ->setUnquotedReferencingColumnNames('article_sku')
+            ->setUnquotedReferencedColumnNames('sku')
+            ->create();
+
+        $this->assertForeignKeyConstraintModification($old, static function (TableEditor $editor) use ($new): void {
+            $editor
+                ->dropForeignKeyConstraintByUnquotedName('articles_fk')
+                ->addForeignKeyConstraint($new);
+        });
+    }
+
+    public function testRenameForeignKeyConstraint(): void
+    {
+        $prototype = ForeignKeyConstraint::editor()
+            ->setUnquotedReferencingColumnNames('article_id')
+            ->setUnquotedReferencedTableName('articles')
+            ->setUnquotedReferencedColumnNames('id');
+
+        $old = $prototype
+            ->setUnquotedName('articles_fk')
+            ->create();
+
+        $new = $prototype
+            ->setUnquotedName('new_fk')
+            ->create();
+
+        $this->assertForeignKeyConstraintModification($old, static function (TableEditor $editor) use ($new): void {
+            $editor
+                ->dropForeignKeyConstraintByUnquotedName('articles_fk')
+                ->addForeignKeyConstraint($new);
+        });
+    }
+
+    /**
+     * Creates a table with the given foreign key, applies the modification and asserts the altered
+     * table introspects back to the desired state.
+     *
+     * @param callable(TableEditor): void $modify
+     */
+    private function assertForeignKeyConstraintModification(ForeignKeyConstraint $old, callable $modify): void
+    {
         $articles = Table::editor()
             ->setUnquotedName('articles')
             ->setColumns(
@@ -371,14 +422,7 @@ class AlterTableTest extends FunctionalTestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
-            ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
-                    ->setUnquotedName('articles_fk')
-                    ->setUnquotedReferencingColumnNames('article_id')
-                    ->setUnquotedReferencedTableName('articles')
-                    ->setUnquotedReferencedColumnNames('id')
-                    ->create(),
-            )
+            ->setForeignKeyConstraints($old)
             ->create();
 
         $this->dropTableIfExists('orders');
@@ -387,18 +431,7 @@ class AlterTableTest extends FunctionalTestCase
         $this->connection->createSchemaManager()
             ->createTable($articles);
 
-        $this->testMigration($orders, static function (TableEditor $editor): void {
-            $editor
-                ->dropForeignKeyConstraintByUnquotedName('articles_fk')
-                ->addForeignKeyConstraint(
-                    ForeignKeyConstraint::editor()
-                        ->setUnquotedName('articles_fk')
-                        ->setUnquotedReferencingColumnNames('article_sku')
-                        ->setUnquotedReferencedTableName('articles')
-                        ->setUnquotedReferencedColumnNames('sku')
-                        ->create(),
-                );
-        });
+        $this->testMigration($orders, $modify);
     }
 
     public function testDropColumnCoveredByForeignKey(): void

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -606,9 +606,36 @@ abstract class AbstractComparatorTestCase extends TestCase
         );
     }
 
-    public function testCompareForeignKeyBasedOnPropertiesNotName(): void
+    public function testRenamedForeignKeyIsDroppedAndAddedBack(): void
     {
-        $tableA = Table::editor()
+        $tableDiff = $this->comparator->compareTables(
+            $this->tableWithForeignKeyNamed(UnqualifiedName::unquoted('foo_constraint')),
+            $this->tableWithForeignKeyNamed(UnqualifiedName::unquoted('bar_constraint')),
+        );
+
+        self::assertCount(1, $tableDiff->getDroppedForeignKeyConstraintNames());
+        self::assertCount(1, $tableDiff->getAddedForeignKeys());
+    }
+
+    public function testUnnamedForeignKeyMatchesANamedOne(): void
+    {
+        $tableDiff = $this->comparator->compareTables(
+            $this->tableWithForeignKeyNamed(UnqualifiedName::unquoted('foo_constraint')),
+            $this->tableWithForeignKeyNamed(null),
+        );
+
+        self::assertTrue($tableDiff->isEmpty());
+    }
+
+    private function tableWithForeignKeyNamed(?UnqualifiedName $name): Table
+    {
+        $editor = ForeignKeyConstraint::editor()
+            ->setName($name)
+            ->setUnquotedReferencingColumnNames('id')
+            ->setUnquotedReferencedTableName('bar')
+            ->setUnquotedReferencedColumnNames('id');
+
+        return Table::editor()
             ->setUnquotedName('foo')
             ->setColumns(
                 Column::editor()
@@ -616,38 +643,8 @@ abstract class AbstractComparatorTestCase extends TestCase
                     ->setTypeName(Types::INTEGER)
                     ->create(),
             )
-            ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
-                    ->setUnquotedName('foo_constraint')
-                    ->setUnquotedReferencingColumnNames('id')
-                    ->setUnquotedReferencedTableName('bar')
-                    ->setUnquotedReferencedColumnNames('id')
-                    ->create(),
-            )
+            ->setForeignKeyConstraints($editor->create())
             ->create();
-
-        $tableB = Table::editor()
-            ->setUnquotedName('foo')
-            ->setColumns(
-                Column::editor()
-                    ->setUnquotedName('ID')
-                    ->setTypeName(Types::INTEGER)
-                    ->create(),
-            )
-            ->setForeignKeyConstraints(
-                ForeignKeyConstraint::editor()
-                    ->setUnquotedName('bar_constraint')
-                    ->setUnquotedReferencingColumnNames('id')
-                    ->setUnquotedReferencedTableName('bar')
-                    ->setUnquotedReferencedColumnNames('id')
-                    ->create(),
-            )
-            ->create();
-
-        self::assertEquals(
-            new TableDiff($tableA),
-            $this->comparator->compareTables($tableA, $tableB),
-        );
     }
 
     public function testDetectRenameColumn(): void


### PR DESCRIPTION
Fixes #7410

Currently, the schema comparator ignores the name of a foreign key constraint: two constraints on the same columns are equal, whatever they're called.

If the application defines a schema with an FK named `old_fk`, deploys it to the database, then renames it to `new_fk` and performs a migration, the FK in the database will remain named `old_fk` without a diff reported.

This way, the resulting schema in the database is defined not only by the application-defined schema, but also by the path taken to reach it. This behavior is quite counterintuitive and isn't typical for DBAL.

#6413 attempted to make this change before and was reverted in #6445 due to the issue reported in #6437. The fact that an upgrade to a patch release (3.8.5) started reporting a schema mismatch was considered a breaking change. The change itself was right, but it was made in the wrong release.

### ORM Behavior Considerations

From #6437, it looks like the ORM generates the FK name based on the columns it covers, but its users don't expect a rename when the underlying columns change. This expectation directly contradicts the "deployed schema is a function of the application-defined schema" idea.

If the ORM wants to retain this behavior (which is quite questionable), it needs to maintain a stable FK identity (once created and named, it stays named that way forever). However, even a migration to this behavior may itself result in a schema change, which is exactly the issue it would attempt to solve.

The most natural way to handle this is to accept schema changes.

### Consistency with #7477

#7477 makes the comparator diff unique constraints. That's new functionality, so it gets the behavior right from the start and compares them by name. Neither leaving the current FK name comparison logic as is, nor mimicking it in the new functionality looks right to me.
