### PR TITLE
Add an `insertMany` for the Connection class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpstan/phpstan-strict-rules": "^2",
         "phpunit/phpunit": "11.5.50",
         "slevomat/coding-standard": "8.27.1",
-        "squizlabs/php_codesniffer": "4.0.1",
+        "squizlabs/php_codesniffer": "4.0.4",
         "symfony/cache": "^6.3.8|^7.0|^8.0",
         "symfony/console": "^5.4|^6.3|^7.0|^8.0"
     },

--- a/docs/en/reference/data-retrieval-and-manipulation.rst
+++ b/docs/en/reference/data-retrieval-and-manipulation.rst
@@ -530,6 +530,18 @@ data.
     $conn->insert('user', ['username' => 'jwage']);
     // INSERT INTO user (username) VALUES (?) (jwage)
 
+insertMany()
+~~~~~~~~~
+
+Insert multiple rows into the given table name using the key value pairs of
+data.
+
+.. code-block:: php
+
+    <?php
+    $conn->insertMany('user', [['username' => 'jwage'], ['username' => 'zezima']]);
+    // INSERT INTO user (username) VALUES (?), (?) (jwage, zezima)
+
 update()
 ~~~~~~~~~
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -33,6 +33,7 @@ use Doctrine\DBAL\Schema\SchemaManagerFactory;
 use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
+use Exception;
 use InvalidArgumentException;
 use SensitiveParameter;
 use Throwable;
@@ -523,44 +524,52 @@ class Connection implements ServerVersionProvider
      * Inserts multiple table rows with specified data.
      *
      * Table expression and columns are not escaped and are not safe for user-input.
-     * Each array within data should have the same keys.
+     * Each row should have the same keys
      *
-     * @param array<array<string, mixed>>                                                           $data
-     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     * @param array<array<string, mixed>>              $rows
+     * @param array<string, string|ParameterType|Type> $types
      *
      * @return int|numeric-string The number of affected rows.
      *
      * @throws Exception
      */
-    public function insertMany(string $table, array $data, array $types = []): int|string
+    public function insertMany(string $table, array $rows, array $types = []): int|string
     {
-        $numRows = count($data);
+        $numRows = count($rows);
         if ($numRows === 0) {
-            return $this->executeStatement('INSERT INTO ' . $table . ' () VALUES ()');
+            return 0;
         }
 
         $columns = [];
         $values  = [];
         $set     = [];
 
-        $first = true;
-        foreach ($data as $row) {
+        $first       = true;
+        $columnCount = 0;
+        foreach ($rows as $row) {
             if ($first) {
-                $first   = false;
-                $columns = array_keys($row);
-                $set     = array_fill(0, count($columns), '?');
+                $first       = false;
+                $columns     = array_keys($row);
+                $columnCount = count($columns);
+                $set         = array_fill(0, count($columns), '?');
+            }
+
+            if ($columnCount !== count($row)) {
+                // TODO: add a custom exception
+                throw new Exception('Column count mismatch');
             }
 
             foreach ($columns as $column) {
-                $values[] = $row[$column];
+                // TODO: add a custom exception
+                $values[] = $row[$column] ?? throw new Exception('Column ' . $column . ' does not exist');
             }
         }
 
         $setParams = '(' . implode(',', $set) . ')';
 
-        $calculatedTypes = is_string(key($types))
+        $calculatedTypes = $types
             ? $this->extractTypeValues($columns, $types)
-            : array_merge($types, array_fill(0, count($columns) - count($types), ParameterType::STRING));
+            : [];
 
         return $this->executeStatement(
             'INSERT INTO ' . $table . ' (' . implode(', ', $columns) . ') VALUES '

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -38,7 +38,9 @@ use SensitiveParameter;
 use Throwable;
 use Traversable;
 
+use function array_fill;
 use function array_key_exists;
+use function array_keys;
 use function array_merge;
 use function count;
 use function implode;
@@ -514,6 +516,57 @@ class Connection implements ServerVersionProvider
             ' VALUES (' . implode(', ', $set) . ')',
             $values,
             is_string(key($types)) ? $this->extractTypeValues($columns, $types) : $types,
+        );
+    }
+
+    /**
+     * Inserts multiple table rows with specified data.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     * Each array within data should have the same keys.
+     *
+     * @param array<array<string, mixed>>                                                           $data
+     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     *
+     * @return int|numeric-string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function insertMany(string $table, array $data, array $types = []): int|string
+    {
+        $numRows = count($data);
+        if ($numRows === 0) {
+            return $this->executeStatement('INSERT INTO ' . $table . ' () VALUES ()');
+        }
+
+        $columns = [];
+        $values  = [];
+        $set     = [];
+
+        $first = true;
+        foreach ($data as $row) {
+            if ($first) {
+                $first   = false;
+                $columns = array_keys($row);
+                $set     = array_fill(0, count($columns), '?');
+            }
+
+            foreach ($columns as $column) {
+                $values[] = $row[$column];
+            }
+        }
+
+        $setParams = '(' . implode(',', $set) . ')';
+
+        $calculatedTypes = is_string(key($types))
+            ? $this->extractTypeValues($columns, $types)
+            : array_merge($types, array_fill(0, count($columns) - count($types), ParameterType::STRING));
+
+        return $this->executeStatement(
+            'INSERT INTO ' . $table . ' (' . implode(', ', $columns) . ') VALUES '
+            . implode(', ', array_fill(0, $numRows, $setParams)),
+            $values,
+            array_merge(...array_fill(0, $numRows, $calculatedTypes)),
         );
     }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -14,17 +14,20 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception as TheDriverException;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Doctrine\DBAL\Exception\BatchInsertsDontMatch;
 use Doctrine\DBAL\Exception\CommitFailedRollbackOnly;
 use Doctrine\DBAL\Exception\ConnectionLost;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\MaxBoundParamsExceeded;
 use Doctrine\DBAL\Exception\NoActiveTransaction;
 use Doctrine\DBAL\Exception\ParseError;
 use Doctrine\DBAL\Exception\SavepointsNotSupported;
 use Doctrine\DBAL\Exception\TransactionRolledBack;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\Exception\NotSupported;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -537,9 +540,8 @@ class Connection implements ServerVersionProvider
     {
         $platform = $this->getDatabasePlatform();
 
-        if (! $platform->supportsBulkInserts($this)) {
-            // TODO: custom exception
-            throw new Exception('Bulk insert operation not supported by this platform');
+        if (! $platform->supportsBulkInserts()) {
+            throw NotSupported::new('bulk insert');
         }
 
         $numRows = count($rows);
@@ -562,29 +564,24 @@ class Connection implements ServerVersionProvider
                 $columnCount = count($columns);
 
                 if ($columnCount * $numRows > $maxBoundParams) {
-                    // TODO: add a custom exception
-                    throw new Exception('Too many bound params');
+                    throw MaxBoundParamsExceeded::new($maxBoundParams, $columnCount * $numRows);
                 }
 
                 $set = array_fill(0, count($columns), '?');
             }
 
             if ($columnCount !== count($row)) {
-                // TODO: add a custom exception
-                throw new Exception('Column count mismatch');
+                throw BatchInsertsDontMatch::new();
             }
 
             foreach ($columns as $column) {
-                // TODO: add a custom exception
-                $values[] = $row[$column] ?? throw new Exception('Column ' . $column . ' does not exist');
+                $values[] = $row[$column] ?? throw BatchInsertsDontMatch::new();
             }
         }
 
         $setParams = '(' . implode(',', $set) . ')';
 
-        $calculatedTypes = $types
-            ? $this->extractTypeValues($columns, $types)
-            : [];
+        $calculatedTypes =  $this->extractTypeValues($columns, $types);
 
         return $this->executeStatement(
             'INSERT INTO ' . $table . ' (' . implode(', ', $columns) . ') VALUES '

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -535,10 +535,19 @@ class Connection implements ServerVersionProvider
      */
     public function insertMany(string $table, array $rows, array $types = []): int|string
     {
+        $platform = $this->getDatabasePlatform();
+
+        if (! $platform->supportsBulkInserts($this)) {
+            // TODO: custom exception
+            throw new Exception('Bulk insert operation not supported by this platform');
+        }
+
         $numRows = count($rows);
         if ($numRows === 0) {
             return 0;
         }
+
+        $maxBoundParams = $platform->getMaximumAmountOfBoundParameters($this);
 
         $columns = [];
         $values  = [];
@@ -551,7 +560,13 @@ class Connection implements ServerVersionProvider
                 $first       = false;
                 $columns     = array_keys($row);
                 $columnCount = count($columns);
-                $set         = array_fill(0, count($columns), '?');
+
+                if ($columnCount * $numRows > $maxBoundParams) {
+                    // TODO: add a custom exception
+                    throw new Exception('Too many bound params');
+                }
+
+                $set = array_fill(0, count($columns), '?');
             }
 
             if ($columnCount !== count($row)) {

--- a/src/Driver/AbstractOracleDriver.php
+++ b/src/Driver/AbstractOracleDriver.php
@@ -8,8 +8,11 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractOracleDriver\EasyConnectString;
 use Doctrine\DBAL\Driver\API\ExceptionConverter as ExceptionConverterInterface;
 use Doctrine\DBAL\Driver\API\OCI\ExceptionConverter;
+use Doctrine\DBAL\Platforms\Oracle23Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\ServerVersionProvider;
+
+use function version_compare;
 
 /**
  * Abstract base implementation of the {@see Driver} interface for Oracle based drivers.
@@ -18,6 +21,10 @@ abstract class AbstractOracleDriver implements Driver
 {
     public function getDatabasePlatform(ServerVersionProvider $versionProvider): OraclePlatform
     {
+        if (version_compare($versionProvider->getServerVersion(), '23.0.0', '>=')) {
+            return new Oracle23Platform();
+        }
+
         return new OraclePlatform();
     }
 

--- a/src/Exception/BatchInsertsDontMatch.php
+++ b/src/Exception/BatchInsertsDontMatch.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+final class BatchInsertsDontMatch extends INvalidARgumentException
+{
+    public static function new(): self
+    {
+        return new self('For batch inserts, all rows must have identical columns.');
+    }
+}

--- a/src/Exception/MaxBoundParamsExceeded.php
+++ b/src/Exception/MaxBoundParamsExceeded.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Exception;
+
+use function sprintf;
+
+final class MaxBoundParamsExceeded extends InvalidArgumentException
+{
+    public static function new(int $boundParams, int $maximum): self
+    {
+        return new self(sprintf(
+            'The platform only supports %d bound parameters, this query uses %d.',
+            $maximum,
+            $boundParams,
+        ));
+    }
+}

--- a/src/Platforms/AbstractMySQLPlatform.php
+++ b/src/Platforms/AbstractMySQLPlatform.php
@@ -929,4 +929,13 @@ SQL;
     {
         return new Parser(true);
     }
+
+    /**
+     * Sources: https://dev.mysql.com/worklog/task/?id=1803
+     * https://stackoverflow.com/a/6582902
+     */
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        return 65535;
+    }
 }

--- a/src/Platforms/AbstractPlatform.php
+++ b/src/Platforms/AbstractPlatform.php
@@ -2482,4 +2482,15 @@ abstract class AbstractPlatform
      * database schema according to the dialect of the platform.
      */
     abstract public function createSchemaManager(Connection $connection): AbstractSchemaManager;
+
+    /** @throws Exception */
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        throw NotSupported::new(__METHOD__);
+    }
+
+    public function supportsBulkInserts(): bool
+    {
+        return true;
+    }
 }

--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -597,4 +597,12 @@ class DB2Platform extends AbstractPlatform
     {
         return new DB2SchemaManager($connection, $this);
     }
+
+    /**
+     * Source: https://www.bmc.com/blogs/db2-limits/
+     */
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        return 16000;
+    }
 }

--- a/src/Platforms/Oracle23Platform.php
+++ b/src/Platforms/Oracle23Platform.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\DBAL\Platforms;
+
+use Doctrine\DBAL\Connection;
+
+class Oracle23Platform extends OraclePlatform
+{
+    public function supportsBulkInserts(): bool
+    {
+        return true;
+    }
+}

--- a/src/Platforms/Oracle23Platform.php
+++ b/src/Platforms/Oracle23Platform.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Platforms;
 
-use Doctrine\DBAL\Connection;
-
 class Oracle23Platform extends OraclePlatform
 {
     public function supportsBulkInserts(): bool

--- a/src/Platforms/OraclePlatform.php
+++ b/src/Platforms/OraclePlatform.php
@@ -858,4 +858,17 @@ SQL,
     {
         return new OracleSchemaManager($connection, $this);
     }
+
+    /**
+     * https://docs.oracle.com/cd/B10501_01/appdev.920/a96624/e_limits.htm#LNPLS018
+     */
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        return 64000;
+    }
+
+    public function supportsBulkInserts(): bool
+    {
+        return false;
+    }
 }

--- a/src/Platforms/PostgreSQLPlatform.php
+++ b/src/Platforms/PostgreSQLPlatform.php
@@ -843,4 +843,9 @@ class PostgreSQLPlatform extends AbstractPlatform
     {
         return new PostgreSQLSchemaManager($connection, $this);
     }
+
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        return 34464;
+    }
 }

--- a/src/Platforms/SQLServerPlatform.php
+++ b/src/Platforms/SQLServerPlatform.php
@@ -1334,4 +1334,12 @@ class SQLServerPlatform extends AbstractPlatform
     {
         return new SQLServerSchemaManager($connection, $this);
     }
+
+    /**
+     * Source: https://learn.microsoft.com/en-us/sql/sql-server/maximum-capacity-specifications-for-sql-server?view=sql-server-ver17
+     */
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        return 2100;
+    }
 }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -976,4 +976,16 @@ class SQLitePlatform extends AbstractPlatform
     {
         return $subQuery;
     }
+
+    /**
+     * @see https://www.sqlite.org/limits.html Secition 9:
+     * To prevent excessive memory allocations, the maximum value of a host parameter number is SQLITE_MAX_VARIABLE_NUMBER,
+     * which defaults to 999 for SQLite versions prior to 3.32.0 (2020-05-22) or 32766 for SQLite versions after 3.32.0.
+     *
+     * TODO: Should we create a new SQLite platform version which returns `32766` for post 3.32.0?, or read the SQLITE_MAX_VARIABLE_NUMBER?
+     */
+    public function getMaximumAmountOfBoundParameters(Connection $connection): int
+    {
+        return 999;
+    }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -314,6 +314,140 @@ class ConnectionTest extends TestCase
         $conn->insert('footable', []);
     }
 
+    public function testInsertMany(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'INSERT INTO footable (c1, c2, c3, c4) VALUES (?,?,?,?), (?,?,?,?)',
+                [
+                    'i1-c1',
+                    'i1-c2',
+                    'i1-c3',
+                    4,
+                    'i2-c1',
+                    'i2-c2',
+                    'i2-c3',
+                    4,
+                ],
+                [
+                    'string',
+                    'string',
+                    'string',
+                    'integer',
+                    'string',
+                    'string',
+                    'string',
+                    'integer',
+                ],
+            );
+
+        $conn->insertMany(
+            'footable',
+            [
+                [
+                    'c1' => 'i1-c1',
+                    'c2' => 'i1-c2',
+                    'c3' => 'i1-c3',
+                    'c4' => 4,
+                ],
+                [
+                    'c3' => 'i2-c3',
+                    'c1' => 'i2-c1',
+                    'c2' => 'i2-c2',
+                    'c4' => 4,
+                ],
+
+            ],
+            [
+                'c3' => 'string',
+                'c1' => 'string',
+                'c2' => 'string',
+                'c4' => 'integer',
+            ],
+        );
+    }
+
+    public function testInsertManySpecifyingFirstKeyOnly(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'INSERT INTO footable (c1, c2) VALUES (?,?), (?,?)',
+                [
+                    1,
+                    'i1-c2',
+                    1,
+                    'i2-c2',
+                ],
+                [
+                    'integer',
+                    ParameterType::STRING,
+                    'integer',
+                    ParameterType::STRING,
+                ],
+            );
+
+        $conn->insertMany(
+            'footable',
+            [
+                [
+                    'c1' => 1,
+                    'c2' => 'i1-c2',
+                ],
+                [
+                    'c1' => 1,
+                    'c2' => 'i2-c2',
+                ],
+
+            ],
+            ['integer'],
+        );
+    }
+
+    public function testInsertManyWithoutTypes(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'INSERT INTO footable (c1, c2) VALUES (?,?), (?,?)',
+                [
+                    1,
+                    'i1-c2',
+                    1,
+                    'i2-c2',
+                ],
+                [
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                ],
+            );
+
+        $conn->insertMany(
+            'footable',
+            [
+                [
+                    'c1' => 1,
+                    'c2' => 'i1-c2',
+                ],
+                [
+                    'c1' => 1,
+                    'c2' => 'i2-c2',
+                ],
+
+            ],
+            [],
+        );
+    }
+
     public function testUpdateWithDifferentColumnsInDataAndIdentifiers(): void
     {
         $conn = $this->getExecuteStatementMockConnection();

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -405,7 +405,38 @@ class ConnectionTest extends TestCase
                 ],
 
             ],
-            ['integer'],
+            ['c1' => 'integer'],
+        );
+    }
+
+    public function testInsertManyWithEmptyValues(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'INSERT INTO footable () VALUES (), ()',
+                [],
+                [],
+            );
+
+        $conn->insertMany(
+            'footable',
+            [[], []],
+        );
+    }
+
+    public function testInsertManyWithNoValues(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::never())
+            ->method('executeStatement');
+
+        $conn->insertMany(
+            'footable',
+            [],
         );
     }
 
@@ -423,12 +454,7 @@ class ConnectionTest extends TestCase
                     1,
                     'i2-c2',
                 ],
-                [
-                    ParameterType::STRING,
-                    ParameterType::STRING,
-                    ParameterType::STRING,
-                    ParameterType::STRING,
-                ],
+                [],
             );
 
         $conn->insertMany(

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -460,7 +460,12 @@ class ConnectionTest extends TestCase
                     1,
                     'i2-c2',
                 ],
-                [],
+                [
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                ],
             );
 
         $conn->insertMany(

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -51,7 +51,13 @@ class ConnectionTest extends TestCase
 
     private function getExecuteStatementMockConnection(): Connection&MockObject
     {
+        $platform = self::createStub(AbstractPlatform::class);
+        $platform->method('getMaximumAmountOfBoundParameters')->willReturn(1000);
+        $platform->method('supportsBulkInserts')->willReturn(true);
         $driver = self::createStub(Driver::class);
+
+        $driver->method('getDatabasePlatform')
+            ->willReturn($platform);
 
         return $this->getMockBuilder(Connection::class)
             ->onlyMethods(['executeStatement'])
@@ -471,6 +477,63 @@ class ConnectionTest extends TestCase
 
             ],
             [],
+        );
+    }
+
+    public function testInsertManyWithTooManyTypes(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+
+        $conn->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                'INSERT INTO footable (c1, c2, c3, c4) VALUES (?,?,?,?), (?,?,?,?)',
+                [
+                    'i1-c1',
+                    'i1-c2',
+                    'i1-c3',
+                    4,
+                    'i2-c1',
+                    'i2-c2',
+                    'i2-c3',
+                    4,
+                ],
+                [
+                    'string',
+                    'string',
+                    'string',
+                    'integer',
+                    'string',
+                    'string',
+                    'string',
+                    'integer',
+                ],
+            );
+
+        $conn->insertMany(
+            'footable',
+            [
+                [
+                    'c1' => 'i1-c1',
+                    'c2' => 'i1-c2',
+                    'c3' => 'i1-c3',
+                    'c4' => 4,
+                ],
+                [
+                    'c3' => 'i2-c3',
+                    'c1' => 'i2-c1',
+                    'c2' => 'i2-c2',
+                    'c4' => 4,
+                ],
+
+            ],
+            [
+                'c3' => 'string',
+                'c1' => 'string',
+                'c2' => 'string',
+                'c4' => 'integer',
+                'c5' => 'datetime',
+            ],
         );
     }
 

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -373,6 +373,34 @@ class WriteTest extends FunctionalTestCase
         self::assertCount(0, $data);
     }
 
+    public function testInsertMany(): void
+    {
+        $count = $this->connection->insertMany(
+            'write_table',
+            [
+                ['test_int' => '30', 'test_string' => 'one'],
+                ['test_int' => '20', 'test_string' => 'two'],
+                ['test_string' => 'three', 'test_int' => '10' ],
+            ],
+            ['test_int' => 'integer'],
+        );
+
+        $data = $this->connection->fetchFirstColumn(
+            'SELECT test_string FROM write_table WHERE test_int IN(10,20,30) ORDER BY test_int',
+        );
+
+        self::assertSame(3, $count);
+
+        self::assertEquals(
+            [
+                'three',
+                'two',
+                'one',
+            ],
+            $data,
+        );
+    }
+
     /** @param class-string<Driver\Exception> $expectedClass */
     private function expectDriverException(string $expectedClass, Closure $test): void
     {

--- a/tests/Functional/WriteTest.php
+++ b/tests/Functional/WriteTest.php
@@ -375,6 +375,10 @@ class WriteTest extends FunctionalTestCase
 
     public function testInsertMany(): void
     {
+        if (! $this->connection->getDatabasePlatform()->supportsBulkInserts()) {
+            self::markTestSkipped('This test targets platforms that support bulk inserts.');
+        }
+
         $count = $this->connection->insertMany(
             'write_table',
             [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| Fixed issues | #2981 

#### Summary

It's quite a common use case to have to insert many values into the database at once.
With the current API of the `Connection` class you can either: insert them 1 by 1, or insert batches by wrapping them inside a transaction.

This PR introduces the `insertMany` method, which inserts multiple rows at once with the `INSERT INTO <table> (<columns>) VALUES (<row1>), (row2)...` syntax.

**What this method doesn't do**

This method is not responsible for splitting the inserts into multiples when they become to big, instead the user should use something like array_chunk to decide how many inserts should be done at once:

```php
$chunked = array_chunk($values, 1000);
foreach($chunked as $rows) {
    $this->connection->insertMany('my_table', $rows, $types);
}
```

There is no validation on whether the keys for the rows are the same for each entry. This method takes the first insert, and makes that the source of truth. They keys don't need to be in exactly the same order, as that would probably be the cause of hard to bebug issues.

**Notes for reviewers**
I'm not too happy with the logic for the types, but i'm not sure how to improve it. I'm open to suggestions