### PR TITLE
Fix inconsistent treatment of DATETIME types

### DIFF
--- a/src/Platforms/DB2Platform.php
+++ b/src/Platforms/DB2Platform.php
@@ -18,7 +18,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
 use Doctrine\DBAL\SQL\Builder\SelectSQLBuilder;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 
@@ -486,7 +486,7 @@ class DB2Platform extends AbstractPlatform
                 'The "version" column platform option is deprecated.',
             );
 
-            if ($column['type'] instanceof DateTimeType) {
+            if ($column['type'] instanceof PhpDateTimeMappingType) {
                 $column['default'] = '1';
             }
         }

--- a/src/Platforms/SQLitePlatform.php
+++ b/src/Platforms/SQLitePlatform.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Platforms\Keywords\SQLiteKeywords;
 use Doctrine\DBAL\Platforms\SQLite\SQLiteMetadataProvider;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\DefaultExpression;
 use Doctrine\DBAL\Schema\Exception\ColumnDoesNotExist;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Identifier;
@@ -765,9 +766,13 @@ class SQLitePlatform extends AbstractPlatform
                 case isset($definition['columnDefinition']):
                 case $definition['autoincrement']:
                 case $definition['comment'] !== '':
-                case $type instanceof Types\DateTimeType && $definition['default'] === $this->getCurrentTimestampSQL():
-                case $type instanceof Types\DateType && $definition['default'] === $this->getCurrentDateSQL():
-                case $type instanceof Types\TimeType && $definition['default'] === $this->getCurrentTimeSQL():
+                // A non-constant default expression (e.g. CURRENT_TIMESTAMP) cannot be used with
+                // ALTER TABLE ... ADD COLUMN on a non-empty table, so fall back to a table rebuild.
+                case $definition['default'] instanceof DefaultExpression:
+                case $type instanceof Types\PhpDateTimeMappingType
+                    && $definition['default'] === $this->getCurrentTimestampSQL():
+                case $type instanceof Types\PhpDateMappingType && $definition['default'] === $this->getCurrentDateSQL():
+                case $type instanceof Types\PhpTimeMappingType && $definition['default'] === $this->getCurrentTimeSQL():
                     return false;
             }
 

--- a/tests/Functional/Platform/AddColumnWithDefaultTest.php
+++ b/tests/Functional/Platform/AddColumnWithDefaultTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Tests\Functional\Platform;
 
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class AddColumnWithDefaultTest extends FunctionalTestCase
 {
@@ -51,5 +53,51 @@ class AddColumnWithDefaultTest extends FunctionalTestCase
         $query  = 'SELECT original_field, new_field FROM add_default_test';
         $result = $this->connection->fetchNumeric($query);
         self::assertSame(['one', 'DEFAULT'], $result);
+    }
+
+    #[TestWith([Types::DATETIME_MUTABLE], Types::DATETIME_MUTABLE)]
+    #[TestWith([Types::DATETIME_IMMUTABLE], Types::DATETIME_IMMUTABLE)]
+    public function testAddColumnWithCurrentTimestampDefaultToPopulatedTable(string $type): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        $table = Table::editor()
+            ->setUnquotedName('add_default_test')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('original_field')
+                    ->setTypeName(Types::STRING)
+                    ->setLength(8)
+                    ->create(),
+            )
+            ->create();
+
+        $this->dropAndCreateTable($table);
+
+        $this->connection->insert('add_default_test', ['original_field' => 'one']);
+
+        $table = $table->edit()
+            ->addColumn(
+                Column::editor()
+                    ->setUnquotedName('created_at')
+                    ->setTypeName($type)
+                    ->setDefaultValue(new CurrentTimestamp())
+                    ->create(),
+            )
+            ->create();
+
+        $diff = $schemaManager->createComparator()->compareTables(
+            $schemaManager->introspectTableByUnquotedName('add_default_test'),
+            $table,
+        );
+
+        // A non-constant default such as CURRENT_TIMESTAMP cannot be applied with
+        // ALTER TABLE ... ADD COLUMN on a non-empty table on SQLite; the platform must
+        // therefore fall back to rebuilding the table instead of generating invalid SQL.
+        $schemaManager->alterTable($diff);
+
+        $createdAt = $this->connection->fetchOne('SELECT created_at FROM add_default_test');
+        self::assertNotNull($createdAt);
+        self::assertNotSame('', $createdAt);
     }
 }

--- a/tests/Platforms/DB2PlatformTest.php
+++ b/tests/Platforms/DB2PlatformTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -283,6 +284,32 @@ class DB2PlatformTest extends AbstractPlatformTestCase
 
         self::assertEquals('TIMESTAMP(0)', $this->platform->getDateTimeTypeDeclarationSQL($fullColumnDef));
         self::assertEquals('TIME', $this->platform->getTimeTypeDeclarationSQL($fullColumnDef));
+    }
+
+    public function testVersionColumnDefaultTreatsImmutableLikeMutableDateTime(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/6940');
+
+        $declarationFor = fn (string $typeName): string => $this->platform->getDefaultValueDeclarationSQL([
+            'version' => true,
+            'notnull' => true,
+            'type' => Type::getType($typeName),
+        ]);
+
+        $mutableDeclaration = $declarationFor(Types::DATETIME_MUTABLE);
+
+        self::assertNotSame(
+            '',
+            $mutableDeclaration,
+            'The version-column default should be applied, so the declaration must not be empty.',
+        );
+
+        // ... and the immutable type must be treated identically.
+        self::assertSame(
+            $mutableDeclaration,
+            $declarationFor(Types::DATETIME_IMMUTABLE),
+            'Mutable and immutable DATETIME fields must be treated the same.',
+        );
     }
 
     public function testGeneratesDDLSnippets(): void

--- a/tests/Platforms/SQLitePlatformTest.php
+++ b/tests/Platforms/SQLitePlatformTest.php
@@ -21,7 +21,9 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\TransactionIsolationLevel;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\Attributes\DataProvider;
 
+use function count;
 use function implode;
 
 /** @extends AbstractPlatformTestCase<SQLitePlatform> */
@@ -620,6 +622,58 @@ class SQLitePlatformTest extends AbstractPlatformTestCase
             'INSERT INTO main.t (b) SELECT a FROM __temp__t',
             'DROP TABLE __temp__t',
         ], $this->platform->getAlterTableSQL($tableDiff));
+    }
+
+    #[DataProvider('addedColumnWithCurrentDefaultProvider')]
+    public function testAddedDateTimeColumnWithCurrentDefaultTriggersTableRebuild(
+        string $typeName,
+        string $default,
+    ): void {
+        // Rendering the legacy string CURRENT_* default is deprecated.
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/7195');
+
+        $table = Table::editor()
+            ->setUnquotedName('t')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('id')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $tableDiff = new TableDiff($table, addedColumns: [
+            Column::editor()
+                ->setUnquotedName('c')
+                ->setTypeName($typeName)
+                ->setDefaultValue($default)
+                ->create(),
+        ]);
+
+        // A CURRENT_* default forces the table-rebuild strategy on SQLite, because
+        // ALTER TABLE ... ADD COLUMN cannot use a non-constant default. The rebuild emits
+        // several statements, whereas a simple column addition would be a single one.
+        self::assertGreaterThan(1, count($this->platform->getAlterTableSQL($tableDiff)));
+    }
+
+    /**
+     * Covers the mutable types and, as a regression guard, their immutable siblings, which share
+     * the same database representation and must be treated identically here.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public static function addedColumnWithCurrentDefaultProvider(): iterable
+    {
+        $platform = new SQLitePlatform();
+
+        return [
+            'datetime' => [Types::DATETIME_MUTABLE, $platform->getCurrentTimestampSQL()],
+            'datetime_immutable' => [Types::DATETIME_IMMUTABLE, $platform->getCurrentTimestampSQL()],
+            'date' => [Types::DATE_MUTABLE, $platform->getCurrentDateSQL()],
+            'date_immutable' => [Types::DATE_IMMUTABLE, $platform->getCurrentDateSQL()],
+            'time' => [Types::TIME_MUTABLE, $platform->getCurrentTimeSQL()],
+            'time_immutable' => [Types::TIME_IMMUTABLE, $platform->getCurrentTimeSQL()],
+        ];
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | https://github.com/doctrine/dbal/pull/7488#issuecomment-5169590285

#### Summary

Discovered while working on #7488.

`datetime` and `datetime_immutable` are treated differently by our SQLite and DB2 platforms. This may be a leftover of #6161 where the ineritance between `DateTimeType` and `DateTimeImmutableType` was removed or the result of a bad merge-up from 3.x after #6161.

I have switched both platforms to perform `instanceof` checks against the marker interfaces that we've introduced for this purpose. In the long run, we should try to get rid of those `instanceof` checks against our types because they make it difficult to add custom types without inheriting existing ones.