### PR TITLE
Fix quoted SQLite collation parsing

### DIFF
--- a/src/Schema/SqliteSchemaManager.php
+++ b/src/Schema/SqliteSchemaManager.php
@@ -26,8 +26,10 @@ use function preg_replace;
 use function rtrim;
 use function str_replace;
 use function strcasecmp;
+use function strlen;
 use function strpos;
 use function strtolower;
+use function substr;
 use function trim;
 use function unlink;
 use function usort;
@@ -317,7 +319,8 @@ class SqliteSchemaManager extends AbstractSchemaManager
         }
 
         // inspect column collation and comments
-        $createSql = $this->getCreateTableSQL($table);
+        $createSql        = $this->getCreateTableSQL($table);
+        $columnCollations = $this->parseColumnCollationsFromSQL($createSql);
 
         foreach ($list as $columnName => $column) {
             $type = $column->getType();
@@ -325,7 +328,7 @@ class SqliteSchemaManager extends AbstractSchemaManager
             if ($type instanceof StringType || $type instanceof TextType) {
                 $column->setPlatformOption(
                     'collation',
-                    $this->parseColumnCollationFromSQL($columnName, $createSql) ?? 'BINARY',
+                    $columnCollations[strtolower($column->getName())] ?? 'BINARY',
                 );
             }
 
@@ -506,16 +509,164 @@ class SqliteSchemaManager extends AbstractSchemaManager
         );
     }
 
-    private function parseColumnCollationFromSQL(string $column, string $sql): ?string
+    /** @return array<string, string> */
+    private function parseColumnCollationsFromSQL(string $sql): array
     {
-        $pattern = '{' . $this->buildIdentifierPattern($column)
-            . '[^,(]+(?:\([^()]+\)[^,]*)?(?:(?:DEFAULT|CHECK)\s*(?:\(.*?\))?[^,]*)*COLLATE\s+["\']?([^\s,"\')]+)}is';
+        $collations       = [];
+        $column           = null;
+        $depth            = -1;
+        $expectsCollation = false;
 
-        if (preg_match($pattern, $sql, $match) !== 1) {
-            return null;
+        foreach ($this->tokenizeSQL($sql) as [$token, $quoted]) {
+            if (! $quoted && $token === '(') {
+                $depth++;
+
+                continue;
+            }
+
+            if (! $quoted && $token === ')') {
+                if ($depth === 0) {
+                    break;
+                }
+
+                $depth--;
+
+                continue;
+            }
+
+            if (! $quoted && $token === ',' && $depth === 0) {
+                $column           = null;
+                $expectsCollation = false;
+
+                continue;
+            }
+
+            if ($depth !== 0) {
+                continue;
+            }
+
+            if ($column === null) {
+                $column = $token;
+
+                continue;
+            }
+
+            if ($expectsCollation) {
+                $collations[strtolower($column)] = $token;
+                $expectsCollation                = false;
+
+                continue;
+            }
+
+            if ($quoted) {
+                continue;
+            }
+
+            if (strcasecmp($token, 'COLLATE') !== 0) {
+                continue;
+            }
+
+            $expectsCollation = true;
         }
 
-        return $match[1];
+        return $collations;
+    }
+
+    /** @return iterable<array{string, bool}> */
+    private function tokenizeSQL(string $sql): iterable
+    {
+        $length = strlen($sql);
+
+        for ($offset = 0; $offset < $length;) {
+            $character = $sql[$offset];
+
+            if (strpos("\"'`[", $character) !== false) {
+                yield [$this->parseQuotedToken($sql, $offset), true];
+
+                continue;
+            }
+
+            if ($character === '-' && $offset + 1 < $length && $sql[$offset + 1] === '-') {
+                $commentEnd = strpos($sql, "\n", $offset + 2);
+                $offset     = $commentEnd === false ? $length : $commentEnd + 1;
+
+                continue;
+            }
+
+            if ($character === '/' && $offset + 1 < $length && $sql[$offset + 1] === '*') {
+                $commentEnd = strpos($sql, '*/', $offset + 2);
+                $offset     = $commentEnd === false ? $length : $commentEnd + 2;
+
+                continue;
+            }
+
+            if (strpos('(),', $character) !== false) {
+                $offset++;
+
+                yield [$character, false];
+
+                continue;
+            }
+
+            if (trim($character) === '') {
+                $offset++;
+
+                continue;
+            }
+
+            $tokenStart = $offset;
+            while ($offset < $length) {
+                $character = $sql[$offset];
+                if (
+                    trim($character) === ''
+                    || strpos("(),\"'`[", $character) !== false
+                    || ($character === '-' && $offset + 1 < $length && $sql[$offset + 1] === '-')
+                    || ($character === '/' && $offset + 1 < $length && $sql[$offset + 1] === '*')
+                ) {
+                    break;
+                }
+
+                $offset++;
+            }
+
+            yield [substr($sql, $tokenStart, $offset - $tokenStart), false];
+        }
+    }
+
+    private function parseQuotedToken(string $sql, int &$offset): string
+    {
+        $openingDelimiter = $sql[$offset];
+        $closingDelimiter = $openingDelimiter === '[' ? ']' : $openingDelimiter;
+        $token            = '';
+        $length           = strlen($sql);
+        $offset++;
+
+        while ($offset < $length) {
+            $character = $sql[$offset];
+            if ($character !== $closingDelimiter) {
+                $token .= $character;
+                $offset++;
+
+                continue;
+            }
+
+            if (
+                $openingDelimiter !== '['
+                && $offset + 1 < $length
+                && $sql[$offset + 1] === $closingDelimiter
+            ) {
+                $token  .= $closingDelimiter;
+                $offset += 2;
+
+                continue;
+            }
+
+            $offset++;
+
+            break;
+        }
+
+        return $token;
     }
 
     private function parseTableCommentFromSQL(string $table, string $sql): ?string

--- a/tests/Functional/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Functional/Schema/SqliteSchemaManagerTest.php
@@ -19,6 +19,8 @@ use function array_map;
 use function array_shift;
 use function assert;
 use function dirname;
+use function implode;
+use function sprintf;
 
 class SqliteSchemaManagerTest extends SchemaManagerFunctionalTestCase
 {
@@ -109,6 +111,103 @@ EOS);
         self::assertEquals('BINARY', $columns['text']->getPlatformOption('collation'));
         self::assertEquals('BINARY', $columns['foo']->getPlatformOption('collation'));
         self::assertEquals('NOCASE', $columns['bar']->getPlatformOption('collation'));
+    }
+
+    public function testColumnCollationIdentifierQuoting(): void
+    {
+        $this->dropTableIfExists('test_collation_quoting');
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE test_collation_quoting (
+    backtick TEXT COLLATE `NOCASE`,
+    double_quote TEXT COLLATE "RTRIM",
+    bracket TEXT COLLATE [BINARY],
+    unquoted TEXT cOlLaTe nOcAsE,
+    `escaped``backtick` TEXT DEFAULT ('COLLATE "BINARY"')
+        CHECK (`escaped``backtick` <> '') COLLATE `RTRIM`,
+    "escaped""double" TEXT DEFAULT 'COLLATE BINARY'
+        CHECK ("escaped""double" COLLATE RTRIM <> '') COLLATE "NOCASE",
+    no_collation TEXT DEFAULT 'COLLATE NOCASE'
+        CHECK (no_collation COLLATE RTRIM <> '')
+)
+SQL);
+
+        $columns = $this->schemaManager->listTableColumns('test_collation_quoting');
+
+        self::assertSame('NOCASE', $columns['backtick']->getPlatformOption('collation'));
+        self::assertSame('RTRIM', $columns['double_quote']->getPlatformOption('collation'));
+        self::assertSame('BINARY', $columns['bracket']->getPlatformOption('collation'));
+        self::assertSame('nOcAsE', $columns['unquoted']->getPlatformOption('collation'));
+        self::assertSame('RTRIM', $columns['escaped`backtick']->getPlatformOption('collation'));
+        self::assertSame('NOCASE', $columns['escaped"double']->getPlatformOption('collation'));
+        self::assertSame('BINARY', $columns['no_collation']->getPlatformOption('collation'));
+        self::assertSame('COLLATE NOCASE', $columns['no_collation']->getDefault());
+    }
+
+    public function testColumnCollationOnQuotedReservedWordColumns(): void
+    {
+        $this->dropTableIfExists('test_collation_reserved_words');
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE test_collation_reserved_words (
+    "DEFAULT" TEXT COLLATE NOCASE,
+    "CHECK" TEXT COLLATE RTRIM
+)
+SQL);
+
+        $columns = $this->schemaManager->listTableColumns('test_collation_reserved_words');
+
+        self::assertSame('NOCASE', $columns['"default"']->getPlatformOption('collation'));
+        self::assertSame('RTRIM', $columns['"check"']->getPlatformOption('collation'));
+    }
+
+    /** @dataProvider quotedCollationTokenProvider */
+    public function testDoesNotMisidentifyQuotedCollationToken(string $ddl): void
+    {
+        $this->dropTableIfExists('test_collation_token');
+        $this->connection->executeStatement($ddl);
+
+        $columns = $this->schemaManager->listTableColumns('test_collation_token');
+
+        self::assertSame('BINARY', $columns['value']->getPlatformOption('collation'));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function quotedCollationTokenProvider(): iterable
+    {
+        $ddl = "CREATE TABLE test_collation_token (value TEXT DEFAULT 'COLLATE' NOT NULL)";
+
+        yield 'single-quoted default' => [$ddl];
+
+        $ddl = 'CREATE TABLE test_collation_token (value TEXT DEFAULT "COLLATE" NOT NULL)';
+
+        yield 'double-quoted default' => [$ddl];
+
+        $ddl = 'CREATE TABLE test_collation_token (value TEXT REFERENCES "COLLATE" (id) NOT NULL)';
+
+        yield 'quoted referenced table' => [$ddl];
+
+        $ddl = 'CREATE TABLE test_collation_token (value TEXT CONSTRAINT "COLLATE" NOT NULL)';
+
+        yield 'quoted constraint name' => [$ddl];
+    }
+
+    public function testColumnCollationsAreParsedForWideTable(): void
+    {
+        $this->dropTableIfExists('test_collation_count');
+        $definitions = [];
+        for ($index = 0; $index < 1000; $index++) {
+            $definitions[] = sprintf('column_%d TEXT COLLATE NOCASE', $index);
+        }
+
+        $this->connection->executeStatement(sprintf(
+            'CREATE TABLE test_collation_count (%s)',
+            implode(', ', $definitions),
+        ));
+
+        $columns = $this->schemaManager->listTableColumns('test_collation_count');
+
+        self::assertCount(1000, $columns);
+        self::assertSame('NOCASE', $columns['column_0']->getPlatformOption('collation'));
+        self::assertSame('NOCASE', $columns['column_999']->getPlatformOption('collation'));
     }
 
     /**

--- a/tests/Schema/SqliteSchemaManagerTest.php
+++ b/tests/Schema/SqliteSchemaManagerTest.php
@@ -9,6 +9,9 @@ use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
+use function implode;
+use function sprintf;
+
 use const PHP_VERSION_ID;
 
 class SqliteSchemaManagerTest extends TestCase
@@ -19,12 +22,14 @@ class SqliteSchemaManagerTest extends TestCase
         $conn = $this->createMock(Connection::class);
 
         $manager = new SqliteSchemaManager($conn, new SqlitePlatform());
-        $ref     = new ReflectionMethod($manager, 'parseColumnCollationFromSQL');
+        $ref     = new ReflectionMethod($manager, 'parseColumnCollationsFromSQL');
         if (PHP_VERSION_ID < 80100) {
             $ref->setAccessible(true);
         }
 
-        self::assertSame($collation, $ref->invoke($manager, $column, $sql));
+        $collations = $ref->invoke($manager, $sql);
+        self::assertIsArray($collations);
+        self::assertSame($collation, $collations[$column] ?? null);
     }
 
     /** @return mixed[][] */
@@ -47,6 +52,16 @@ class SqliteSchemaManagerTest extends TestCase
                 'a',
                 'CREATE TABLE "a" ("a" text DEFAULT (lower(ltrim(" a") || rtrim("a ")))'
                     . ' CHECK ("a") NOT NULL COLLATE NOCASE UNIQUE, "b" text COLLATE RTRIM)',
+            ],
+            [
+                'RTRIM',
+                'a',
+                'CREATE TABLE "a" ("a" text COLLATE NOCASE COLLATE RTRIM)',
+            ],
+            [
+                null,
+                'a',
+                'CREATE TABLE "a" ("a" "COLLATE" NOT NULL)',
             ],
             [
                 null,
@@ -125,6 +140,30 @@ class SqliteSchemaManagerTest extends TestCase
                     . ' "bar/" INTEGER NOT NULL, baz VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
             ],
         ];
+    }
+
+    public function testParseColumnCollationsFromWideTable(): void
+    {
+        $definitions = [];
+        $expected    = [];
+
+        for ($index = 0; $index < 1000; $index++) {
+            $column            = sprintf('column_%d', $index);
+            $definitions[]     = sprintf('%s TEXT COLLATE NOCASE', $column);
+            $expected[$column] = 'NOCASE';
+        }
+
+        $conn    = $this->createMock(Connection::class);
+        $manager = new SqliteSchemaManager($conn, new SqlitePlatform());
+        $ref     = new ReflectionMethod($manager, 'parseColumnCollationsFromSQL');
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
+
+        self::assertSame(
+            $expected,
+            $ref->invoke($manager, sprintf('CREATE TABLE wide_table (%s)', implode(', ', $definitions))),
+        );
     }
 
     /** @dataProvider getDataColumnComment */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #6129

#### Summary

SQLite schema introspection now parses quoted collation identifiers according to SQLite quoting rules and returns their logical, unquoted names.

The parser distinguishes quoted tokens from the unquoted `COLLATE` keyword, ignores nested DEFAULT and CHECK expressions, and scans each CREATE TABLE statement once. Collations are matched through `Column::getName()`, so quoted reserved-word columns such as `"DEFAULT"` and `"CHECK"` retain their declared collation.

#### Testing

- `vendor/bin/phpunit tests/Schema/SqliteSchemaManagerTest.php` (42 tests, 62 assertions)
- `vendor/bin/phpunit tests/Functional/Schema/SqliteSchemaManagerTest.php` (109 tests, 483 assertions, 15 skipped)
- Full PHPUnit suite (5098 tests, 7403 assertions, 859 skipped, 5 incomplete)
- `vendor/bin/phpcs` (571 files)
- `vendor/bin/phpstan --no-progress`