### PR TITLE
squizlabs/php_codesniffer (4.0.1 => 4.0.4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpstan/phpstan-strict-rules": "^2",
         "phpunit/phpunit": "9.6.34",
         "slevomat/coding-standard": "8.27.1",
-        "squizlabs/php_codesniffer": "4.0.1",
+        "squizlabs/php_codesniffer": "4.0.4",
         "symfony/cache": "^5.4|^6.0|^7.0|^8.0",
         "symfony/console": "^4.4|^5.4|^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | dependency
| Fixed issues | N/A

#### Summary

The version of PHPCS that we've pinned in flagged as vulnerable. Let's upgrade, so Composer won't refuse to install dependencies.
