### PR TITLE
Add Oracle 18 back and document Oracle's weird versioning

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,9 +82,13 @@ jobs:
       matrix:
         php-version:
           - "8.5"
+        # Supported Oracle releases: https://support.oracle.com/knowledgefs?docId=742060
         oracle-version:
-          - "21"
-          - "23"
+          - "18" # There is no XE of Oracle 19 which is why we use the 18c XE image instead.
+                 # Oracle 19c LTR is supported until December 2029
+          - "21" # Supported until July 2027
+          - "23" # Oracle 26ai internally still uses the major version 23
+                 # Oracle 26ai LTR is supported until December 2031
         extension:
           - oci8
           - pdo_oci


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | CI
| Fixed issues | N/A

#### Summary

On the 4.x branches, we test against Oracle 18c, but on 3.10.x, we don't. That feels weird.

Also, I tried to research what Oracle versions we should still support and that gave me quite a headache. I decided to document the Oracle versions that we test against in our CI configuration like we do with other Databases, so a fellow contributor or a later version of myself will have a better time.