### PR TITLE
Unseal error arrays

### DIFF
--- a/src/Driver/IBMDB2/Exception/CannotCopyStreamToStream.php
+++ b/src/Driver/IBMDB2/Exception/CannotCopyStreamToStream.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Driver\AbstractException;
 /** @internal */
 final class CannotCopyStreamToStream extends AbstractException
 {
-    /** @param array{message: string}|null $error */
+    /** @param array{message: string, ...}|null $error */
     public static function new(?array $error): self
     {
         $message = 'Could not copy source stream to temporary file';

--- a/src/Driver/IBMDB2/Exception/CannotCreateTemporaryFile.php
+++ b/src/Driver/IBMDB2/Exception/CannotCreateTemporaryFile.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Driver\AbstractException;
 /** @internal */
 final class CannotCreateTemporaryFile extends AbstractException
 {
-    /** @param array{message: string}|null $error */
+    /** @param array{message: string, ...}|null $error */
     public static function new(?array $error): self
     {
         $message = 'Could not create temporary file';

--- a/src/Driver/IBMDB2/Exception/PrepareFailed.php
+++ b/src/Driver/IBMDB2/Exception/PrepareFailed.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Driver\AbstractException;
 /** @internal */
 final class PrepareFailed extends AbstractException
 {
-    /** @param array{message: string}|null $error */
+    /** @param array{message: string, ...}|null $error */
     public static function new(?array $error): self
     {
         if ($error === null) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

In all three cases, we expect an error array structure from PHP, but we only ever care about the `message` key. I'm unsealing the array shapes to make them more accessible for more recent PHPStan version.
