### PR TITLE
PHPUnit 13.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpstan/phpstan": "2.1.30",
         "phpstan/phpstan-phpunit": "2.0.7",
         "phpstan/phpstan-strict-rules": "^2",
-        "phpunit/phpunit": "12.5.8",
+        "phpunit/phpunit": "13.3.0",
         "slevomat/coding-standard": "8.27.1",
         "squizlabs/php_codesniffer": "4.0.4",
         "symfony/cache": "^7.4|^8.0",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | N/A

#### Summary

We should be able to run the latest and greatest PHPUnit on the 5.0.x branch.
