### PR TITLE
Deprecate values that are not shaped like a GUID in GuidType

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,18 @@ awareness about deprecated code.
 
 # Upgrade to 4.5
 
+## Deprecated passing a value that is not shaped like a GUID to `GuidType`
+
+`GuidType` now expects a value shaped like a GUID, that is 32 hexadecimal digits, with optional surrounding braces and
+an optional hyphen after any group of four digits. Handling anything else is deprecated, both when converting to a
+database value and when converting to a PHP value. The value is still returned unchanged in 4.5, and will be rejected
+with a conversion exception in 5.0.
+
+Until now, a malformed value reached the database as is. On platforms with a native GUID type, the driver rejected it,
+for instance PostgreSQL reporting `SQLSTATE[22P02]: Invalid text representation: invalid input syntax for uuid`. On
+platforms without a native GUID type, the column is a plain `CHAR(36)` and could hold anything. If you store values
+that are not GUIDs in such a column, use the `string` type instead.
+
 ## Deprecated not implementing unique constraint introspection in `MetadataProvider`
 
 `Doctrine\DBAL\Schema\Metadata\MetadataProvider` implementations should now implement

--- a/docs/en/reference/types.rst
+++ b/docs/en/reference/types.rst
@@ -200,6 +200,8 @@ If you want to store a GUID, you should consider using this type, as some
 database vendors have a native data type for this kind of data which offers
 the most efficient way to store it. For vendors that do not support this
 type natively, this type is mapped to the ``string`` type internally.
+Values are expected to be shaped like a GUID, that is 32 hexadecimal digits, with
+optional surrounding braces and an optional hyphen after any group of four digits.
 Values retrieved from the database are always converted to PHP's ``string`` type
 or ``null`` if no data is present.
 

--- a/src/Types/GuidType.php
+++ b/src/Types/GuidType.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\Deprecations\Deprecation;
+
+use function is_string;
+use function preg_match;
 
 /**
  * Represents a GUID/UUID datatype (both are actually synonyms) in the database.
@@ -12,10 +16,54 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 class GuidType extends StringType
 {
     /**
+     * 32 hexadecimal digits, with optional surrounding braces and an optional hyphen after any group of four digits.
+     *
+     * This accepts everything PostgreSQL accepts for its native UUID type, so that no value the database could have
+     * stored is reported as malformed. The `(?(1)\})` conditional requires the closing brace only when an opening
+     * brace was matched.
+     */
+    private const FORMAT = '/^(\{)?[0-9a-f]{4}(?:-?[0-9a-f]{4}){7}(?(1)\})$/i';
+
+    /**
      * {@inheritDoc}
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         return $platform->getGuidTypeDeclarationSQL($column);
+    }
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        $this->deprecateMalformedValue($value, __METHOD__);
+
+        return $value;
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
+    {
+        $this->deprecateMalformedValue($value, __METHOD__);
+
+        return $value;
+    }
+
+    private function deprecateMalformedValue(mixed $value, string $method): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (is_string($value) && preg_match(self::FORMAT, $value) === 1) {
+            return;
+        }
+
+        Deprecation::trigger(
+            'doctrine/dbal',
+            'https://github.com/doctrine/dbal/pull/7504',
+            <<<'DEPRECATION'
+            Handling a value that is not shaped like a GUID in %s is deprecated.
+            In 5.0, such a value will be rejected with a conversion exception.
+            DEPRECATION,
+            $method,
+        );
     }
 }

--- a/tests/Types/GuidTypeTest.php
+++ b/tests/Types/GuidTypeTest.php
@@ -6,11 +6,18 @@ namespace Doctrine\DBAL\Tests\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\GuidType;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class GuidTypeTest extends TestCase
 {
+    use VerifyDeprecations;
+
+    private const DEPRECATION = 'https://github.com/doctrine/dbal/pull/7504';
+
     private AbstractPlatform&Stub $platform;
     private GuidType $type;
 
@@ -20,14 +27,57 @@ class GuidTypeTest extends TestCase
         $this->type     = new GuidType();
     }
 
-    public function testConvertToPHPValue(): void
-    {
-        self::assertIsString($this->type->convertToPHPValue('foo', $this->platform));
-        self::assertIsString($this->type->convertToPHPValue('', $this->platform));
-    }
-
     public function testNullConversion(): void
     {
+        $this->expectNoDeprecationWithIdentifier(self::DEPRECATION);
+
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function testValidValueIsPassedThrough(string $value): void
+    {
+        $this->expectNoDeprecationWithIdentifier(self::DEPRECATION);
+
+        self::assertSame($value, $this->type->convertToDatabaseValue($value, $this->platform));
+        self::assertSame($value, $this->type->convertToPHPValue($value, $this->platform));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function validValuesProvider(): iterable
+    {
+        yield 'canonical' => ['7c620eda-ea79-11eb-9a03-0242ac130003'];
+        yield 'canonical in upper case' => ['7C620EDA-EA79-11EB-9A03-0242AC130003'];
+        yield 'without hyphens' => ['7c620edaea7911eb9a030242ac130003'];
+        yield 'with braces' => ['{7c620eda-ea79-11eb-9a03-0242ac130003}'];
+        yield 'with hyphens after other groups' => ['7c620eda-ea7911eb-9a030242-ac130003'];
+    }
+
+    #[DataProvider('malformedValuesProvider')]
+    public function testMalformedValueTriggersDeprecation(mixed $value): void
+    {
+        $this->expectDeprecationWithIdentifier(self::DEPRECATION);
+
+        self::assertSame($value, $this->type->convertToDatabaseValue($value, $this->platform));
+        self::assertSame($value, $this->type->convertToPHPValue($value, $this->platform));
+    }
+
+    /** @return iterable<string, array{mixed}> */
+    public static function malformedValuesProvider(): iterable
+    {
+        yield 'arbitrary string' => ['foo'];
+        yield 'empty string' => [''];
+        yield 'single digit' => ['1'];
+        yield 'unbalanced brace' => ['{7c620eda-ea79-11eb-9a03-0242ac130003'];
+        yield 'one digit too few' => ['7c620eda-ea79-11eb-9a03-0242ac13000'];
+        yield 'one digit too many' => ['7c620eda-ea79-11eb-9a03-0242ac1300031'];
+        yield 'non hexadecimal digit' => ['7c620eda-ea79-11eb-9a03-0242ac13000z'];
+        yield 'misplaced hyphen' => ['7c620ed-aea79-11eb-9a03-0242ac130003'];
+        yield 'integer' => [0];
+        yield 'float' => [1.2];
+        yield 'boolean' => [true];
+        yield 'array' => [[]];
+        yield 'object' => [new stdClass()];
     }
 }


### PR DESCRIPTION
Fix https://github.com/symfony/symfony/issues/17488

`GuidType` extends `StringType` and converts nothing, so any value reaches the database as is.

On a platform with a native GUID type, the driver is the one that rejects a malformed value. PostgreSQL answers `SQLSTATE[22P02]: Invalid text representation: invalid input syntax for uuid: "asdf"`, which surfaces as a driver exception rather than as a conversion exception. On a platform without a native GUID type, the column is a plain `CHAR(36)` and holds anything, so the same value is silently stored and read back.

That inconsistency leaks into the ecosystem. In the Symfony Doctrine bridge, the `uuid` and `ulid` types refuse what they cannot convert ([`AbstractUidType`](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php)), so a consumer can catch a `ConversionException` and report an invalid value. The `guid` type gives no such guarantee, which is why https://github.com/symfony/symfony/pull/65497 proposed to re-implement a GUID shape check in `ORMQueryBuilderLoader`.

This patch deprecates handling a value that is not shaped like a GUID, in both conversion directions. The value is still returned unchanged in 4.5. The exception is announced for 5.0, in line with how making a type stricter was handled before (`BC BREAK: Stricter DateTime types`, `BC BREAK: BIGINT values are cast to int if possible`).

The accepted shape is 32 hexadecimal digits, with optional surrounding braces and an optional hyphen after any group of four digits. That is everything PostgreSQL accepts for its native `uuid` type, so no value the database could have stored is reported as malformed. Braces must be balanced.

The case to watch when 5.0 lands: an application storing something other than a GUID in a `guid` column on a platform without a native type. Such a column should use the `string` type instead.
