### PR TITLE
Fix phantom schema diff for an index prefix length equal to the column length

### DIFF
--- a/src/Platforms/MySQL/Comparator.php
+++ b/src/Platforms/MySQL/Comparator.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 
 use function array_diff_assoc;
+use function array_filter;
 
 /**
  * Compares schemas in the context of MySQL platform.
@@ -64,6 +65,8 @@ class Comparator extends BaseComparator
 
         $table = clone $table;
 
+        $this->normalizeIndexLengths($table);
+
         foreach ($table->getColumns() as $column) {
             $originalOptions   = $column->getPlatformOptions();
             $normalizedOptions = $this->normalizeOptions($originalOptions);
@@ -79,6 +82,64 @@ class Comparator extends BaseComparator
         }
 
         return $table;
+    }
+
+    /**
+     * MySQL silently drops an index prefix length that equals the indexed column's length, so introspecting
+     * a table declared with such a length returns the index without it. Both representations must be
+     * considered equal during comparison.
+     */
+    private function normalizeIndexLengths(Table $table): void
+    {
+        foreach ($table->getIndexes() as $index) {
+            if (! $index->hasOption('lengths')) {
+                continue;
+            }
+
+            /** @var array<int, int|null> $lengths */
+            $lengths = $index->getOption('lengths');
+            $changed = false;
+
+            foreach ($index->getUnquotedColumns() as $position => $columnName) {
+                if (! isset($lengths[$position]) || ! $table->hasColumn($columnName)) {
+                    continue;
+                }
+
+                if ($lengths[$position] !== $table->getColumn($columnName)->getLength()) {
+                    continue;
+                }
+
+                $lengths[$position] = null;
+                $changed            = true;
+            }
+
+            if (! $changed) {
+                continue;
+            }
+
+            $remainingLengths = array_filter($lengths, static fn (?int $length): bool => $length !== null);
+
+            if ($index->isPrimary()) {
+                // rebuilding a primary key goes through a dedicated, richer API; prefix lengths on primary
+                // keys are exotic enough to leave them as they are
+                continue;
+            }
+
+            $options = $index->getOptions();
+            if ($remainingLengths === []) {
+                unset($options['lengths']);
+            } else {
+                $options['lengths'] = $lengths;
+            }
+
+            $table->dropIndex($index->getName());
+
+            if ($index->isUnique()) {
+                $table->addUniqueIndex($index->getUnquotedColumns(), $index->getName(), $options);
+            } else {
+                $table->addIndex($index->getUnquotedColumns(), $index->getName(), $index->getFlags(), $options);
+            }
+        }
     }
 
     /**

--- a/tests/Functional/Schema/MySQL/ComparatorTest.php
+++ b/tests/Functional/Schema/MySQL/ComparatorTest.php
@@ -270,6 +270,28 @@ final class ComparatorTest extends FunctionalTestCase
         ComparatorTestUtils::assertDiffNotEmpty($this->connection, $this->comparator, $table);
     }
 
+    public function testIndexPrefixLengthEqualToColumnLengthGeneratesNoDiff(): void
+    {
+        // https://github.com/doctrine/dbal/issues/5989 MySQL silently drops such a prefix on creation
+        $table = new Table('comparator_test');
+        $table->addColumn('my_col', Types::STRING, ['length' => 20]);
+        $table->addIndex(['my_col'], 'idx_col', [], ['lengths' => [20]]);
+
+        $this->dropAndCreateTable($table);
+
+        self::assertTrue(ComparatorTestUtils::diffFromActualToDesiredTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table,
+        )->isEmpty());
+
+        self::assertTrue(ComparatorTestUtils::diffFromDesiredToActualTable(
+            $this->schemaManager,
+            $this->comparator,
+            $table,
+        )->isEmpty());
+    }
+
     private function createCollationTable(): Table
     {
         $table = Table::editor()

--- a/tests/Platforms/MySQL/ComparatorTest.php
+++ b/tests/Platforms/MySQL/ComparatorTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Platforms\MySQL\Comparator;
 use Doctrine\DBAL\Platforms\MySQL\DefaultTableOptions;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\Schema\AbstractComparatorTestCase;
 
 class ComparatorTest extends AbstractComparatorTestCase
@@ -23,5 +24,61 @@ class ComparatorTest extends AbstractComparatorTestCase
             new DefaultTableOptions('utf8mb4', 'utf8mb4_general_ci'),
             $config,
         );
+    }
+
+    public function testIndexPrefixLengthEqualToColumnLengthIsIgnored(): void
+    {
+        // MySQL silently drops such a prefix, so the introspected table comes back without it
+        $introspectedTable = new Table('my_table');
+        $introspectedTable->addColumn('my_col', 'string', ['length' => 20]);
+        $introspectedTable->addIndex(['my_col'], 'idx_col');
+
+        $declaredTable = new Table('my_table');
+        $declaredTable->addColumn('my_col', 'string', ['length' => 20]);
+        $declaredTable->addIndex(['my_col'], 'idx_col', [], ['lengths' => [20]]);
+
+        self::assertTrue($this->createComparator(new ComparatorConfig())->compareTables($introspectedTable, $declaredTable)->isEmpty());
+        self::assertTrue($this->createComparator(new ComparatorConfig())->compareTables($declaredTable, $introspectedTable)->isEmpty());
+    }
+
+    public function testIndexPrefixLengthSmallerThanColumnLengthIsPreserved(): void
+    {
+        $introspectedTable = new Table('my_table');
+        $introspectedTable->addColumn('my_col', 'string', ['length' => 20]);
+        $introspectedTable->addIndex(['my_col'], 'idx_col');
+
+        $declaredTable = new Table('my_table');
+        $declaredTable->addColumn('my_col', 'string', ['length' => 20]);
+        $declaredTable->addIndex(['my_col'], 'idx_col', [], ['lengths' => [5]]);
+
+        self::assertFalse($this->createComparator(new ComparatorConfig())->compareTables($introspectedTable, $declaredTable)->isEmpty());
+    }
+
+    public function testUniqueIndexPrefixLengthEqualToColumnLengthIsIgnored(): void
+    {
+        $introspectedTable = new Table('my_table');
+        $introspectedTable->addColumn('my_col', 'string', ['length' => 20]);
+        $introspectedTable->addUniqueIndex(['my_col'], 'uniq_col');
+
+        $declaredTable = new Table('my_table');
+        $declaredTable->addColumn('my_col', 'string', ['length' => 20]);
+        $declaredTable->addUniqueIndex(['my_col'], 'uniq_col', ['lengths' => [20]]);
+
+        self::assertTrue($this->createComparator(new ComparatorConfig())->compareTables($introspectedTable, $declaredTable)->isEmpty());
+    }
+
+    public function testCompositeIndexOnlyEqualLengthsAreDropped(): void
+    {
+        $introspectedTable = new Table('my_table');
+        $introspectedTable->addColumn('col_a', 'string', ['length' => 20]);
+        $introspectedTable->addColumn('col_b', 'string', ['length' => 30]);
+        $introspectedTable->addIndex(['col_a', 'col_b'], 'idx_composite', [], ['lengths' => [null, 10]]);
+
+        $declaredTable = new Table('my_table');
+        $declaredTable->addColumn('col_a', 'string', ['length' => 20]);
+        $declaredTable->addColumn('col_b', 'string', ['length' => 30]);
+        $declaredTable->addIndex(['col_a', 'col_b'], 'idx_composite', [], ['lengths' => [20, 10]]);
+
+        self::assertTrue($this->createComparator(new ComparatorConfig())->compareTables($introspectedTable, $declaredTable)->isEmpty());
     }
 }


### PR DESCRIPTION
Fixes #5989.

MySQL and MariaDB silently drop an index prefix length that equals the indexed column's length (`KEY idx (col(20))` on a `VARCHAR(20)` comes back as `KEY idx (col)`), so a table declared with such a length keeps producing a drop/create diff against its introspected version, forever. Following the direction discussed in #5976, the MySQL `Comparator` now anticipates this during normalization: a prefix length equal to the column's length is treated as no length. Effective prefixes (shorter than the column) are untouched, composite indexes only lose the lengths that MySQL would drop, and primary keys are left as is. Same normalization family as the recent float-default phantom-diff fix.
