### PR TITLE
docs: setFirstResult()/setMaxResults() only apply to SELECT queries

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -220,6 +220,17 @@ returned.
         ->setFirstResult(10)
         ->setMaxResults(20);
 
+.. note::
+
+    ``setFirstResult()`` and ``setMaxResults()`` only apply to ``SELECT``
+    queries. They are ignored when building an ``UPDATE`` or ``DELETE``
+    query: some vendors support a vendor-specific syntax such as MySQL's
+    ``DELETE ... LIMIT``, but there is no workaround that works across all
+    supported platforms, so the query builder does not attempt to emulate
+    the clause there. To limit the number of affected rows, restrict the
+    query in the ``WHERE`` clause instead, for example to a set of
+    primary keys selected beforehand.
+
 VALUES Clause
 ~~~~~~~~~~
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| Fixed issues | #7119

#### Summary

Documents in the Limit Clause section of the query builder reference that `setFirstResult()`/`setMaxResults()` only apply to `SELECT` queries and are ignored on `UPDATE`/`DELETE`, as requested in #7119: vendor-specific syntax such as MySQL's `DELETE ... LIMIT` has no portable equivalent, so the query builder does not emulate the clause there. Also points to the `WHERE`-clause alternative (restricting to a set of primary keys selected beforehand).
