### PR TITLE
Preserve quoting when detecting renamed indexes

### DIFF
--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -392,7 +392,7 @@ class Comparator
             }
 
             $removedIndex     = $removedIndexes[$removedIndexKey];
-            $removedIndexName = strtolower($removedIndex->getName());
+            $removedIndexName = $removedIndex->getQuotedName($this->platform);
 
             $addedIndex = $addedIndexes[$addedIndexKey];
 

--- a/tests/Schema/AbstractComparatorTestCase.php
+++ b/tests/Schema/AbstractComparatorTestCase.php
@@ -783,6 +783,57 @@ abstract class AbstractComparatorTestCase extends TestCase
         self::assertEquals('idx_bar', $renamedIndexes['idx_foo']->getObjectName()->toString());
     }
 
+    /**
+     * A quoted index name carries case-sensitivity and quoting information that must be preserved
+     * when it becomes the array key of a renamed index, so that platforms which need to emit an
+     * explicitly quoted identifier for the old name (e.g. Oracle's ALTER INDEX ... RENAME TO) can
+     * still tell the name was quoted.
+     */
+    public function testDetectRenameIndexPreservesQuoting(): void
+    {
+        $prototype = Table::editor()
+            ->setUnquotedName('foo')
+            ->setColumns(
+                Column::editor()
+                    ->setUnquotedName('foo')
+                    ->setTypeName(Types::INTEGER)
+                    ->create(),
+            )
+            ->create();
+
+        $table1 = $prototype->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setQuotedName('Idx_Foo')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            )
+            ->create();
+
+        $table2 = $prototype->edit()
+            ->addIndex(
+                Index::editor()
+                    ->setUnquotedName('idx_bar')
+                    ->setUnquotedColumnNames('foo')
+                    ->create(),
+            )
+            ->create();
+
+        $tableDiff = $this->comparator->compareTables($table1, $table2);
+
+        self::assertCount(0, $tableDiff->getDroppedIndexes());
+
+        $renamedIndexes = $tableDiff->getRenamedIndexes();
+        self::assertCount(1, $renamedIndexes);
+
+        // The old index name must still be recognizable as quoted (wrapped in the platform's
+        // quote characters) and must preserve the original case, regardless of which character
+        // the platform uses for quoting (e.g. "Idx_Foo", `Idx_Foo` or [Idx_Foo]).
+        $oldIndexName = current(array_keys($renamedIndexes));
+        self::assertMatchesRegularExpression('/^(["`]Idx_Foo["`]|\[Idx_Foo])$/', $oldIndexName);
+        self::assertEquals('idx_bar', $renamedIndexes[$oldIndexName]->getObjectName()->toString());
+    }
+
     public function testDetectRenameIndexDisabled(): void
     {
         $prototype = Table::editor()


### PR DESCRIPTION
## Summary

Fixes #6565

`Comparator::detectRenamedIndexes()` used `strtolower($index->getName())` as the array key for a renamed index's old name. `getName()` strips quoting metadata and returns the bare identifier, so any information about whether the original index name was quoted was lost, and the name was unconditionally folded to lower case regardless of the target platform's identifier folding rules.

Downstream, `AbstractPlatform::getAlterTableSQL()` re-wraps this bare string in a `new Identifier()` to decide whether to quote the old name in the generated SQL. Since the quoting information was already gone, the old name was never quoted, even when it originally required quoting to preserve case (e.g. Oracle, which folds unquoted identifiers to upper case). This produced statements like:

```sql
ALTER INDEX idx_test_col RENAME TO "idx_test_type"
```

instead of:

```sql
ALTER INDEX "idx_test_col" RENAME TO "idx_test_type"
```

which Oracle rejects with an index-not-found error, since the generated statement no longer refers to the original, case-sensitive index name.

## Fix

Use `getQuotedName($this->platform)` instead, which already contains the exact logic needed to conditionally quote the identifier (based on whether it was originally quoted, or is a reserved keyword) while leaving already-safe unquoted names untouched — this is the same mechanism `AbstractPlatform::getAlterTableSQL()` and other index/column name handling already rely on elsewhere.

## Test plan

- Added `AbstractComparatorTestCase::testDetectRenameIndexPreservesQuoting()`, exercised against all three concrete `Comparator` subclasses (SQLite, MySQL, SQLServer) so the assertion works across each platform's own quoting character (`"`, `` ` ``, `[...]`).
- Verified the new test fails against the pre-fix code with the exact reported symptom (old index name silently un-quoted / case-folded), and passes with the fix.
- Reproduced the original report directly against `OraclePlatform` + `Comparator::compareTables()`: before the fix, `ALTER INDEX idx_test_col RENAME TO "idx_test_type"`; after the fix, `ALTER INDEX "idx_test_col" RENAME TO "idx_test_type"`.
- Confirmed no regression for unquoted index renames (still emitted unquoted, unchanged).
- Ran the full test suite (`vendor/bin/phpunit tests --exclude-group=performance`): 3932 tests, all passing (3929 pre-existing + 3 new), same pre-existing skip/incomplete counts (604 skipped / 13 incomplete, all DB-connection-dependent functional tests unrelated to this change).
- `vendor/bin/phpcs` and `vendor/bin/phpstan` on the changed files: clean.