### PR TITLE
Decrement the transaction nesting level when a savepoint rollback fails

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1565,10 +1565,14 @@ class Connection
                 $logger->startQuery('"ROLLBACK TO SAVEPOINT"');
             }
 
-            $this->rollbackSavepoint($this->_getNestedTransactionSavePointName());
-            --$this->transactionNestingLevel;
-            if ($logger !== null) {
-                $logger->stopQuery();
+            try {
+                $this->rollbackSavepoint($this->_getNestedTransactionSavePointName());
+            } finally {
+                --$this->transactionNestingLevel;
+
+                if ($logger !== null) {
+                    $logger->stopQuery();
+                }
             }
         } else {
             $this->isRollbackOnly = true;

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1116,6 +1116,35 @@ class ConnectionTest extends TestCase
         $connection->transactional(static function (): void {
         });
     }
+
+    public function testRollBackDecrementsNestingLevelWhenSavepointRollbackFails(): void
+    {
+        $conn = $this->getExecuteStatementMockConnection();
+        $conn->setNestTransactionsWithSavepoints(true);
+
+        $conn->method('executeStatement')
+            ->willReturnCallback(static function (string $sql): int {
+                if ($sql === 'ROLLBACK TO SAVEPOINT DOCTRINE_2') {
+                    throw new Exception('The savepoint no longer exists.');
+                }
+
+                return 1;
+            });
+
+        $conn->beginTransaction();
+        $conn->beginTransaction();
+
+        self::assertSame(2, $conn->getTransactionNestingLevel());
+
+        try {
+            $conn->rollBack();
+        } catch (Exception $e) {
+            self::assertSame('The savepoint no longer exists.', $e->getMessage());
+        }
+
+        // The savepoint is gone either way, so the connection must not stay at the stale level.
+        self::assertSame(1, $conn->getTransactionNestingLevel());
+    }
 }
 
 interface ConnectDispatchEventListener

--- a/tests/Functional/TransactionTest.php
+++ b/tests/Functional/TransactionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Tests\Functional;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Tests\FunctionalTestCase;
@@ -37,6 +38,56 @@ class TransactionTest extends FunctionalTestCase
         } finally {
             $this->connection->close();
         }
+    }
+
+    /**
+     * MySQL implicitly commits the active transaction (and thus discards all savepoints) when a DDL
+     * statement is executed. The same happens on a deadlock. In both cases the savepoint the nested
+     * rollback targets no longer exists, and the rollback fails. The nesting level still has to be
+     * decremented, otherwise the connection is stuck at a level it can never leave.
+     *
+     * @see https://github.com/doctrine/dbal/issues/4279
+     * @see https://github.com/doctrine/dbal/issues/6651
+     */
+    public function testRollBackAfterImplicitCommitDecrementsNestingLevel(): void
+    {
+        if (! $this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+            self::markTestSkipped('Restricted to MySQL.');
+        }
+
+        $this->markConnectionNotReusable();
+
+        $table = new Table('transaction_nesting');
+        $table->addColumn('test_int', Types::INTEGER);
+        $table->setPrimaryKey(['test_int']);
+
+        $this->dropAndCreateTable($table);
+        $this->connection->setNestTransactionsWithSavepoints(true);
+
+        $this->connection->beginTransaction();
+        $this->connection->beginTransaction();
+        $this->connection->insert('transaction_nesting', ['test_int' => 1]);
+
+        // Implicitly commits the transaction and discards SAVEPOINT DOCTRINE_2.
+        $this->connection->executeStatement('CREATE TABLE transaction_nesting_ddl (id INT NOT NULL)');
+
+        self::assertSame(2, $this->connection->getTransactionNestingLevel());
+
+        try {
+            $this->connection->rollBack();
+            self::fail('Rolling back to a discarded savepoint is expected to fail.');
+        } catch (Exception $e) {
+            self::assertSame(
+                1,
+                $this->connection->getTransactionNestingLevel(),
+                'The nesting level must be decremented even though the savepoint is gone.',
+            );
+        }
+
+        // Without decrementing the level above, the connection would be stuck at level 2 and every
+        // further rollBack() would target the same discarded savepoint again.
+        $this->connection->close();
+        $this->connection->executeStatement('DROP TABLE transaction_nesting_ddl');
     }
 
     public function testNestedTransactionWalkthrough(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #4279, #6651

#### Summary

MySQL discards every savepoint when it implicitly commits the active transaction (any DDL statement),
and InnoDB discards them together with the whole transaction when it picks the session as a deadlock
victim. In both cases the savepoint that a nested `rollBack()` targets is already gone, so
`ROLLBACK TO SAVEPOINT` fails with `1305 SAVEPOINT DOCTRINE_x does not exist`.

`rollBack()` only decremented `transactionNestingLevel` *after* `rollbackSavepoint()` returned, so that
failure left the connection at a nesting level it could never leave again:

```
nesting after 1213: 2
rollBack() #1: SQLSTATE[42000] ... 1305 SAVEPOINT DOCTRINE_2 does not exist
nesting after rollBack() #1: 2
rollBack() #2: SQLSTATE[42000] ... 1305 SAVEPOINT DOCTRINE_2 does not exist
nesting after rollBack() #2: 2
```

Every further `rollBack()` targets the same discarded savepoint and throws the same error, so the only
recovery is to throw the connection away. In a long-running process that keeps the connection, it gets
worse: `beginTransaction()` at a stale level only issues a `SAVEPOINT`, which MySQL silently accepts and
ignores when no transaction is active, so the work then runs entirely outside of a transaction and is
committed statement by statement. I confirmed that an `INSERT` issued in that state survives the
subsequent `rollBack()`. This is the data-corruption scenario described in
https://github.com/doctrine/dbal/issues/4279#issuecomment-2731398905.

#### Fix

`commit()` already updates the nesting level in a `finally` for exactly this reason. This does the same in
`rollBack()`, so the level is decremented whether or not the server still knows about the savepoint.

With the fix, the connection unwinds and is reusable again (verified against MySQL 8.4.9, `pdo_mysql`):

```
nesting after 1213: 2
rollBack() #1 (savepoint): ... 1305 SAVEPOINT DOCTRINE_2 does not exist   <- still reported to the caller
nesting: 1
rollBack() #2 (outer): OK
nesting: 0
isTransactionActive: false
-- connection reusable afterwards: beginTransaction / INSERT / rollBack all OK, and the row is gone
```

Deliberately kept minimal:

- **No platform- or exception-specific handling.** Earlier attempts (#5352, #5691, #6103) reset the
  nesting level when a `DeadlockException` was detected. That leaves the identical wedge on the implicit
  commit path, which involves no deadlock at all. Restoring the `commit()`/`rollBack()` symmetry covers
  both with no knowledge of the platform.
- **The `1305` is still thrown.** The savepoint rollback really did fail and the caller should hear about
  it; the change is only that the connection no longer gets stuck.

#### Tests

- `ConnectionTest::testRollBackDecrementsNestingLevelWhenSavepointRollbackFails` — platform independent,
  no DB, no concurrency: `executeStatement()` is mocked to fail on `ROLLBACK TO SAVEPOINT`.
- `TransactionTest::testRollBackAfterImplicitCommitDecrementsNestingLevel` — functional, MySQL only. It
  uses a DDL implicit commit rather than a real deadlock, so it is deterministic. The deadlock-based test
  in #5691 turned out to be flaky on CI (it produced a `ConnectionLost` instead), and it is not needed:
  the discarded savepoint is what matters, not how it was discarded.

Both tests fail on the current branch and pass with the fix.

#### Not fixed here

DBAL still assumes a server-side transaction exists after the server has already ended it. On the
implicit commit path the outer `rollBack()` therefore surfaces `There is no active transaction` from
PDO (#6049), and `isTransactionActive()` keeps reporting a transaction that is gone (#6107). Fixing
that properly needs a way to observe the real server-side transaction state, which is what #6180 asked
for. All of that is a behaviour change well beyond a patch release, so this PR deliberately stops at
making the connection recoverable.

#### References

Issues this addresses:

- #4279 — `transactional()` doesn't correctly manage nested transactions with savepoints upon MySQL
  deadlock (open since 2020; the daemon data-corruption report is in the comments)
- #6651 — MySQL + deadlock leads to `SAVEPOINT DOCTRINE_x does not exist` (open, still active)

Earlier attempts at a fix, all closed by the stale bot rather than rejected on merit:

- #5352 — Reset transactions' nesting level on deadlock exception
- #5691 — Reset nested transaction level on deadlock exceptions (review stalled on a flaky
  deadlock-based functional test, which is why the test here uses an implicit commit instead)
- #6103 — Reset nested transaction level on deadlock exceptions

Related reports of the same underlying divergence between DBAL's nesting level and the server's actual
transaction state, none of them fixed here:

- #6107 — Incorrect results from `isTransactionActive()` (open)
- #6049 — Rollback fails with "PDOException: There is no active transaction" (closed, not planned)
- #6767 — Wrong exception on deadlock (closed, not planned)
- #7107 — Race condition in `beginTransaction()` causes "SAVEPOINT can only be used in transaction
  blocks" (closed, not planned)
- #6180 — Expose current transaction level in `Driver\Connection` (closed, not planned)

Earlier history of the same code path:

- #2808 — Wrong `_transactionNestingLevel` decrement
- #1758 — Nested transaction emulation doesn't support rollback inside a nested transaction
- #3995 — Failures during commit and rollback are not handled

Downstream fallout and workarounds:

- doctrine/orm#11230 — the ORM-side report that #6651 was split out of
- doctrine/orm#11646 — moved `UnitOfWork`'s `rollBack()` into a `finally` so the original exception is
  no longer replaced (the same `finally` reasoning this PR applies inside DBAL)
- symfony/symfony#59103 — the equivalent fix in `symfony/messenger`
